### PR TITLE
fix(dashboard): 400 for non-browser enroll approve/reject errors

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from starlette.responses import RedirectResponse
 
 from mcp_proxy.dashboard.session import (
@@ -3007,6 +3007,33 @@ async def enrollments_page(request: Request):
     ))
 
 
+def _enroll_error_response(
+    request: Request,
+    message: str,
+    *,
+    status_code: int = 400,
+) -> Response:
+    """Content-negotiated error response for dashboard enrollment form handlers.
+
+    Browsers (`Accept: text/html...`) keep the 303 redirect + flash error so
+    the form page re-renders with the message inline. CLI/script callers
+    (curl default `*/*`, `application/json`, fetch JS) get a structured
+    `400` with `{"detail": <message>}` instead of a 303 they would silently
+    follow into a 200 page with the real error buried in the query string.
+    """
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept:
+        from urllib.parse import quote
+        return RedirectResponse(
+            url=f"/proxy/enrollments?error={quote(message)}",
+            status_code=303,
+        )
+    return JSONResponse(
+        status_code=status_code,
+        content={"detail": message},
+    )
+
+
 @router.post("/enrollments/{session_id}/approve")
 async def enrollments_approve(request: Request, session_id: str):
     """Form-based approve handler. Calls the service and redirects back."""
@@ -3025,10 +3052,7 @@ async def enrollments_approve(request: Request, session_id: str):
     groups_raw = str(form.get("groups", "")).strip()
 
     if not agent_id:
-        return RedirectResponse(
-            url="/proxy/enrollments?error=agent_id+is+required",
-            status_code=303,
-        )
+        return _enroll_error_response(request, "agent_id is required")
 
     capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()]
     groups = [g.strip() for g in groups_raw.split(",") if g.strip()]
@@ -3066,11 +3090,7 @@ async def enrollments_approve(request: Request, session_id: str):
                 agent_manager=agent_manager,
             )
     except _enrollment_service.EnrollmentError as exc:
-        from urllib.parse import quote
-        return RedirectResponse(
-            url=f"/proxy/enrollments?error={quote(str(exc))}",
-            status_code=303,
-        )
+        return _enroll_error_response(request, str(exc))
 
     _log.info(
         "enrollment_approved via dashboard: session=%s agent=%s admin=%s",
@@ -3099,10 +3119,7 @@ async def enrollments_reject(request: Request, session_id: str):
     form = await request.form()
     reason = str(form.get("reason", "")).strip()
     if not reason:
-        return RedirectResponse(
-            url="/proxy/enrollments?error=Rejection+reason+is+required",
-            status_code=303,
-        )
+        return _enroll_error_response(request, "Rejection reason is required")
 
     try:
         async with _get_db() as conn:
@@ -3113,11 +3130,7 @@ async def enrollments_reject(request: Request, session_id: str):
                 admin_name=session.role or "admin",
             )
     except _enrollment_service.EnrollmentError as exc:
-        from urllib.parse import quote
-        return RedirectResponse(
-            url=f"/proxy/enrollments?error={quote(str(exc))}",
-            status_code=303,
-        )
+        return _enroll_error_response(request, str(exc))
 
     _log.info(
         "enrollment_rejected via dashboard: session=%s admin=%s",

--- a/tests/test_enrollment_dashboard.py
+++ b/tests/test_enrollment_dashboard.py
@@ -239,6 +239,7 @@ async def test_approve_missing_agent_id_redirects_with_error(proxy_app):
     resp = await client.post(
         f"/proxy/enrollments/{session_id}/approve",
         data={"csrf_token": csrf, "agent_id": ""},
+        headers={"Accept": "text/html,application/xhtml+xml"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
@@ -284,6 +285,7 @@ async def test_reject_missing_reason_redirects_with_error(proxy_app):
     resp = await client.post(
         f"/proxy/enrollments/{session_id}/reject",
         data={"csrf_token": csrf, "reason": ""},
+        headers={"Accept": "text/html,application/xhtml+xml"},
         follow_redirects=False,
     )
     assert resp.status_code == 303

--- a/tests/test_enrollments_approve_content_negotiation.py
+++ b/tests/test_enrollments_approve_content_negotiation.py
@@ -1,0 +1,180 @@
+"""Content negotiation regression tests for enrollment approve/reject.
+
+`mcp_proxy/dashboard/router.py:_enroll_error_response` returns 303+flash
+for browsers (`Accept: text/html`) and 400+JSON for script callers
+(`Accept: */*`, `application/json`). These tests pin both branches so a
+future "let's just always 303" regression breaks here.
+
+Validation branches (missing agent_id / reason) short-circuit before the
+service layer is touched, so they exercise the helper directly. The
+EnrollmentError branch uses a nonexistent session_id to drive the
+service into raising before any CA work is needed.
+"""
+from __future__ import annotations
+
+import json as _json
+import time as _time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+def _admin_cookie(csrf_token: str = "test-csrf-token") -> tuple[str, str]:
+    """Mint a signed session cookie + matching CSRF token."""
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+
+    payload = _json.dumps(
+        {"role": "admin", "csrf_token": csrf_token, "exp": int(_time.time()) + 3600}
+    )
+    return _COOKIE_NAME, _sign(payload)
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    reset_agent_rate_limiter()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+# ── Approve: missing agent_id ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approve_missing_agent_id_returns_400_for_json_client(proxy_app):
+    """CLI/script POST without Accept: text/html gets a 400 JSON."""
+    _, client = proxy_app
+    csrf = "csrf-json"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/some-session-id/approve",
+        data={"csrf_token": csrf, "agent_id": ""},
+        headers={"Accept": "application/json"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "agent_id is required"}
+
+
+@pytest.mark.asyncio
+async def test_approve_missing_agent_id_returns_303_for_browser(proxy_app):
+    """Browser POST with Accept: text/html keeps the 303+flash UX."""
+    _, client = proxy_app
+    csrf = "csrf-html"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/some-session-id/approve",
+        data={"csrf_token": csrf, "agent_id": ""},
+        headers={"Accept": "text/html,application/xhtml+xml"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    # quote() encodes spaces as %20 (unlike quote_plus's '+'). Both are
+    # valid percent-encodings; the dashboard template decodes the message
+    # back from the query string either way.
+    assert "error=agent_id%20is%20required" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_approve_curl_default_accept_gets_400(proxy_app):
+    """curl default Accept */* (no text/html) gets 400, not 303."""
+    _, client = proxy_app
+    csrf = "csrf-curl"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/some-session-id/approve",
+        data={"csrf_token": csrf, "agent_id": ""},
+        headers={"Accept": "*/*"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+# ── Reject: missing reason ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reject_missing_reason_returns_400_for_json_client(proxy_app):
+    """Symmetric: reject without reason → 400 for JSON, 303 for HTML."""
+    _, client = proxy_app
+    csrf = "csrf-reject-json"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/some-session-id/reject",
+        data={"csrf_token": csrf, "reason": ""},
+        headers={"Accept": "application/json"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "Rejection reason is required"}
+
+
+@pytest.mark.asyncio
+async def test_reject_missing_reason_returns_303_for_browser(proxy_app):
+    _, client = proxy_app
+    csrf = "csrf-reject-html"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/some-session-id/reject",
+        data={"csrf_token": csrf, "reason": ""},
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=Rejection%20reason%20is%20required" in resp.headers["location"]
+
+
+# ── EnrollmentError branch (service raises) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approve_enrollment_error_returns_400_for_json_client(proxy_app):
+    """When the service raises EnrollmentError (e.g. session not found),
+    JSON client gets 400 with the error message in detail."""
+    _, client = proxy_app
+    csrf = "csrf-enroll-err"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        "/proxy/enrollments/nonexistent-session-xyz/approve",
+        data={
+            "csrf_token": csrf,
+            "agent_id": "test-agent",
+            "capabilities": "",
+            "groups": "",
+        },
+        headers={"Accept": "application/json"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "detail" in body
+    assert body["detail"]


### PR DESCRIPTION
## Summary

- Add `_enroll_error_response()` in `mcp_proxy/dashboard/router.py` that returns 400+JSON for non-browser callers and preserves 303+flash for browsers (content-negotiation on `Accept: text/html`)
- Apply to 4 error call sites in `enrollments_approve` and `enrollments_reject` (validation + EnrollmentError branches)
- Happy path (`?flash=...` success redirect) untouched
- 6 new regression tests in `tests/test_enrollments_approve_content_negotiation.py` pinning both branches per endpoint
- 2 existing dashboard tests updated to set `Accept: text/html` (they implicitly relied on httpx's default `*/*`, which now correctly drives the 400 JSON path)

Closes the silent-failure papercut where CLI/script enrollment approval would 303 into a 200 page with the actual error buried in the URL.

## UX matrix

| Caller | Accept header | Status | Body |
|---|---|---|---|
| Browser (dashboard form) | `text/html,application/xhtml+xml,...` | 303 | `Location: /proxy/enrollments?error=...` (unchanged) |
| curl default | `*/*` | **400** | `{"detail": "<message>"}` |
| Programmatic JSON | `application/json` | **400** | `{"detail": "<message>"}` |
| fetch JS without Accept | `*/*` | **400** | `{"detail": "<message>"}` |

## Test plan

- [x] `pytest tests/test_enrollments_approve_content_negotiation.py -n 0 -v` — 6/6 green
- [x] `pytest tests/test_enrollment.py tests/test_enrollment_dashboard.py -n 0` — 29/29 green
- [x] `pytest tests/ -n auto --dist=loadfile` — 3587 passed, 31 skipped, 2 failed (pre-existing postgres flake `test_pg_session_and_signed_messages` / `test_pg_nonce_replay_blocked`, unrelated to this change)
- [ ] Manual verify (optional, ok to skip): `curl -i -X POST <mastio>/proxy/enrollments/X/approve -H "Cookie: <admin>" -H "X-CSRF-Token: <csrf>" -d "capabilities=" -d "groups="` → 400 instead of 303

## Note on encoding

The error query-string encoding changes for two missing-field branches from `agent_id+is+required` (manually written `+`) to `agent_id%20is%20required` (`urllib.parse.quote`). Both decode identically server-side; the dashboard template never displayed the raw URL.