### PR TITLE
feat(stress): intra-org baseline benchmark scripts (C2.A.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,8 @@ packaging/frontdesk-bundle/tls/
 # k6 stress test artefacts (transient summary dumps next to the scripts).
 scripts/stress/summary*.json
 scripts/stress/soak-summary*.json
+scripts/stress/stress_agents.json
+scripts/stress/intra-org-results*.json
+scripts/stress/intra-org-results.ndjson
+scripts/stress/intra-org-summary*.json
+scripts/stress/*.log

--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -11,15 +11,17 @@
 |---|---|---|
 | `health-throughput.js` | TLS edge + nginx → mcp-proxy plumbing (cheap read) | live |
 | `soak-stability.js` | Same path, 50 VUs sustained 1h — memory leak detection | live |
+| `intra-org-mastio-burst.js` | Full intra-org auth+audit chain at 50→5k VUs | live (C2.A.1) |
 | `dpop-egress.js` | DPoP signature verification + token issuance | TODO |
 | `a2a-routing.js` | Intra-org A2A message dispatch via PDP + broker | TODO |
 | `enrollment-burst.js` | Concurrent CSR issuance + DB insert | TODO |
 
-`health-throughput.js` and `soak-stability.js` are wired today. The
-remaining scenarios are listed so future work can land in one place.
-Each new scenario should keep the same conventions: human-readable
-`handleSummary` for the maintainer + a JSON dump (`summary.json` or
-`soak-summary.json`) for diffable artefacts.
+`health-throughput.js`, `soak-stability.js`, and `intra-org-mastio-
+burst.js` are wired today. The remaining scenarios are listed so
+future work can land in one place. Each new scenario should keep the
+same conventions: human-readable `handleSummary` for the maintainer +
+a JSON dump (`summary.json`, `soak-summary.json`,
+`intra-org-summary.json`) for diffable artefacts.
 
 ## How to run
 
@@ -77,6 +79,120 @@ The `handleSummary` block prints:
 The thresholds in `health-throughput.js` (p95 < 250 ms, error rate
 < 1 %) make k6 exit non-zero on breach, so the script doubles as a
 pre-release sanity gate.
+
+## Intra-org baseline benchmark
+
+`intra-org-mastio-burst.js` is the C2.A.1 baseline scenario: full
+auth chain (`/v1/auth/token` mint with ES256 client_assertion + DPoP
+proof) + tool execute (`/v1/ingress/execute` Bearer-DPoP with `ath`),
+ramping 50 → 500 → 2k → 5k VUs across 30 minutes. Exercises DPoP
+verify, x509 chain verify, LOCAL_TOKEN issuance, JTI replay store,
+and the per-write audit hash chain end-to-end.
+
+The harness is N pre-enrolled identities. k6 can't run the
+device-code enrollment flow inline (overhead explodes per VU), so
+the agents are seeded directly into `internal_agents` before the run
+and torn down after.
+
+### Pre-requisites
+
+- Mastio reachable on `BASE_URL` (default `https://192.168.122.170:
+  9443`). The bundle's nginx TLS edge is the natural target.
+- SSH access to the VM that runs Mastio, so the bulk-enroll script
+  can shell into the `mcp-proxy` container and the monitoring loops
+  can sample `docker stats` + `audit_log.COUNT(*)`. Defaults assume
+  `cullis@192.168.122.170`; override via `BULK_VM_HOST` /
+  `BULK_CONTAINER`.
+- k6 v1.4+ (uses WebCrypto). `nix-shell -p k6` works on NixOS;
+  upstream binary works everywhere else.
+- Python 3.11 with `cryptography` for the bulk-enroll orchestrator
+  and the smoke harness. `nix-shell -p python311Packages.
+  cryptography python311Packages.pyjwt python311Packages.requests
+  --run "..."` covers all of it on NixOS.
+
+### Setup
+
+```bash
+# 1. Seed N pre-enrolled agents into internal_agents. Idempotent
+#    (INSERT OR REPLACE); --wipe removes any prior <prefix>-* rows
+#    first.
+python scripts/stress/bulk_enroll_agents.py --n 5000 --wipe
+
+# 2. Optional: validate the auth chain on the first agent before
+#    pointing 5000 VUs at the box. Confirms cnf.jkt binding (DPoP
+#    htu / Host port-stripping trap, see _auth_smoke.py header).
+python scripts/stress/_auth_smoke.py
+```
+
+`bulk_enroll_agents.py` writes `stress_agents.json` next to itself
+(~8 MB at 5000 agents) — **gitignored**, carries per-agent PKCS8
+PEMs for the leaf cert + DPoP keypair. Never commit it.
+
+### Run
+
+```bash
+# 3. Launch monitoring streams in 3 background terminals.
+ssh cullis@192.168.122.170 'while true; do docker stats --no-stream \
+    --format "{{.Name}}|{{.CPUPerc}}|{{.MemUsage}}|{{.NetIO}}|{{.BlockIO}}" \
+    cullis-mastio-mcp-proxy-1 cullis-mastio-mastio-nginx-1; sleep 5; \
+done' > scripts/stress/docker-stats.log &
+
+ssh cullis@192.168.122.170 'while true; do docker exec \
+    cullis-mastio-mcp-proxy-1 python3 -c "
+import sqlite3,os
+c=sqlite3.connect(\"/data/mcp_proxy.db\")
+print(c.execute(\"SELECT COUNT(*) FROM audit_log\").fetchone()[0],
+      \"db=\"+str(os.path.getsize(\"/data/mcp_proxy.db\")),
+      \"wal=\"+str(os.path.getsize(\"/data/mcp_proxy.db-wal\")
+                  if os.path.exists(\"/data/mcp_proxy.db-wal\") else 0))"
+sleep 10; done' > scripts/stress/audit-rate.log &
+
+ssh cullis@192.168.122.170 "docker logs -f cullis-mastio-mcp-proxy-1 \
+    2>&1 | grep -iE 'error|warning|429|503|circuit|busy|deadlock'" \
+    > scripts/stress/mastio-errors.log &
+
+# 4. Run k6. Saves the raw ndjson stream + the summary export.
+nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify \
+    --out json=scripts/stress/intra-org-results.ndjson \
+    --summary-export=scripts/stress/intra-org-summary.json \
+    scripts/stress/intra-org-mastio-burst.js"
+```
+
+The k6 scenario can be re-shaped via env:
+
+- `STAGE_OVERRIDE='[{"duration":"60s","target":500}]'` for triage
+  runs that only hit one plateau.
+- `BASE_URL=https://other.host:9443` to point at a different bundle.
+- `HTU_OVERRIDE=https://mastio.example.com` to force a specific
+  DPoP `htu` when nginx Host-stripping doesn't behave like the
+  default :9443 sidecar (the bundled nginx forwards `Host: $host`
+  which strips the port — see the inline doc comment at
+  `DEFAULT_HTU` for the gotcha).
+- `THINK_MS=200` to add a fixed inter-cycle sleep when measuring
+  *sustained* rather than *back-to-back* iterations.
+
+### Analyze
+
+```bash
+# 5. Per-plateau aggregation (mint / ingress p50/p95/p99, error rate,
+#    mcp+nginx CPU, audit/s, DB/WAL growth). Reads the four logs
+#    written by steps 3+4 and emits a markdown table on stdout.
+python scripts/stress/_analyze_burst.py
+```
+
+The analyzer walks the ndjson once (linear scan; 9-10 GB / 30-min
+run takes a few minutes on a modern laptop) and buckets each
+datapoint into a plateau by elapsed time. Plateau bounds match the
+default `STAGES` in the k6 scenario.
+
+For the C2.A.1 reference baseline (Mastio v0.4.3 bundle as-shipped
+against the 4 vCPU disposable VM), see the maintainer-local report
+at `imp/c2-a1-intra-org-baseline-2026-05-16.md`. Headline: the
+bundle is Tier 1 ready at ~130 RPS sustained, but the
+single-uvicorn-worker GIL + global asyncio audit-chain lock cap
+throughput well below Tier 2+ targets. Architectural changes
+(multi-worker uvicorn, Postgres backend, Redis JTI) are required
+before re-running this scenario for Tier 2+ feasibility.
 
 ## Historical baselines
 

--- a/scripts/stress/_analyze_burst.py
+++ b/scripts/stress/_analyze_burst.py
@@ -1,0 +1,387 @@
+"""Aggregate intra-org burst k6 ndjson + monitor logs into a per-plateau table.
+
+Reads:
+  - ``intra-org-results.ndjson``  (k6 --out json= raw stream)
+  - ``intra-org-summary.json``    (k6 handleSummary dump)
+  - ``docker-stats.log``          (5s docker stats sampler)
+  - ``audit-rate.log``            (10s audit_log count + db/wal size)
+
+Emits a CSV + markdown table keyed by ramp plateau. Plateau bounds are
+inferred from the default DEFAULT_STAGES in ``intra-org-mastio-burst.js``
+unless overridden via env.
+
+Run::
+
+    python scripts/stress/_analyze_burst.py > /tmp/c2-a1-plateau.md
+"""
+from __future__ import annotations
+
+import json
+import os
+import statistics as stats
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+NDJSON_PATH = HERE / "intra-org-results.ndjson"
+SUMMARY_PATH = HERE / "intra-org-summary.json"
+DOCKER_LOG = HERE / "docker-stats.log"
+AUDIT_LOG = HERE / "audit-rate.log"
+
+# (label, target_vus, duration_s, kind). ``kind`` is 'ramp' or 'plateau'.
+PLATEAUS = [
+    ("ramp_0_to_50",      50,   60,  "ramp"),
+    ("plateau_50",        50,   300, "plateau"),
+    ("ramp_50_to_500",    500,  60,  "ramp"),
+    ("plateau_500",       500,  300, "plateau"),
+    ("ramp_500_to_2k",    2000, 60,  "ramp"),
+    ("plateau_2k",        2000, 300, "plateau"),
+    ("ramp_2k_to_5k",     5000, 60,  "ramp"),
+    ("plateau_5k",        5000, 600, "plateau"),
+    ("ramp_5k_to_0",      0,    60,  "ramp"),
+]
+
+
+def find_run_window():
+    """Return (start_ts, end_ts) from the ndjson — used to align with
+    the host-clock-based monitor logs.
+    """
+    start_ts = None
+    end_ts = None
+    if not NDJSON_PATH.exists():
+        sys.exit(f"missing {NDJSON_PATH}")
+    with NDJSON_PATH.open() as fh:
+        for line in fh:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") != "Point":
+                continue
+            t = obj["data"]["time"]
+            if start_ts is None:
+                start_ts = t
+            end_ts = t
+    return start_ts, end_ts
+
+
+_TS_RE = __import__("re").compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})"
+    r"(?:\.(?P<frac>\d+))?"
+    r"(?P<tz>Z|[+-]\d{2}:?\d{2})?$"
+)
+
+
+def parse_ts(s: str) -> datetime:
+    # k6 emits RFC3339 with up to nanosecond fractional + numeric TZ
+    # (e.g. ``+02:00``). datetime.fromisoformat in 3.11 accepts numeric
+    # TZ but rejects >6-digit fractional seconds, so we truncate.
+    m = _TS_RE.match(s)
+    if not m:
+        return datetime.fromisoformat(s)  # let it raise upstream
+    date = m["date"]
+    frac = (m["frac"] or "0")[:6].ljust(6, "0")
+    tz = m["tz"] or "+00:00"
+    if tz == "Z":
+        tz = "+00:00"
+    return datetime.fromisoformat(f"{date}.{frac}{tz}")
+
+
+def assign_plateau(t: datetime, run_start: datetime):
+    elapsed = (t - run_start).total_seconds()
+    cursor = 0.0
+    for label, target, duration, kind in PLATEAUS:
+        if cursor <= elapsed < cursor + duration:
+            return label, target, kind
+        cursor += duration
+    return None, None, None
+
+
+def aggregate_ndjson(run_start: datetime):
+    """Returns dict[plateau_label] = {http_req_duration, mint_lat, ingress_lat,
+                                       mint_err, ingress_err, reqs}."""
+    if not NDJSON_PATH.exists():
+        return {}
+    buckets: dict[str, dict] = {}
+    with NDJSON_PATH.open() as fh:
+        for line in fh:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") != "Point":
+                continue
+            data = obj["data"]
+            metric = obj.get("metric", "")
+            t = parse_ts(data["time"])
+            label, target, kind = assign_plateau(t, run_start)
+            if label is None:
+                continue
+            bucket = buckets.setdefault(label, {
+                "label": label, "target_vus": target, "kind": kind,
+                "http_req_duration": [],
+                "cullis_mint_latency_ms": [],
+                "cullis_ingress_latency_ms": [],
+                "mint_err_count": 0, "mint_err_total": 0,
+                "ingress_err_count": 0, "ingress_err_total": 0,
+                "auth_token_reqs": 0, "ingress_execute_reqs": 0,
+                "auth_token_2xx": 0, "ingress_execute_2xx": 0,
+                "auth_token_5xx": 0, "ingress_execute_5xx": 0,
+            })
+            tags = data.get("tags", {}) or {}
+            endpoint = tags.get("endpoint", "")
+            value = data.get("value", 0)
+            if metric == "http_req_duration":
+                bucket["http_req_duration"].append(value)
+                if endpoint == "auth_token":
+                    bucket["auth_token_reqs"] += 1
+                elif endpoint == "ingress_execute":
+                    bucket["ingress_execute_reqs"] += 1
+            elif metric == "cullis_mint_latency_ms":
+                bucket["cullis_mint_latency_ms"].append(value)
+            elif metric == "cullis_ingress_latency_ms":
+                bucket["cullis_ingress_latency_ms"].append(value)
+            elif metric == "cullis_mint_error_rate":
+                bucket["mint_err_total"] += 1
+                if value:
+                    bucket["mint_err_count"] += 1
+            elif metric == "cullis_ingress_error_rate":
+                bucket["ingress_err_total"] += 1
+                if value:
+                    bucket["ingress_err_count"] += 1
+            elif metric == "http_req_failed":
+                expected = (tags.get("expected_response") == "true")
+                if endpoint == "auth_token":
+                    if not value and expected:
+                        bucket["auth_token_2xx"] += 1
+                    if data.get("value") and value:
+                        bucket["auth_token_5xx"] += 1
+                elif endpoint == "ingress_execute":
+                    if not value and expected:
+                        bucket["ingress_execute_2xx"] += 1
+    return buckets
+
+
+def pct(values, q):
+    if not values:
+        return 0
+    values_sorted = sorted(values)
+    idx = max(0, min(len(values_sorted) - 1, int(q * len(values_sorted))))
+    return values_sorted[idx]
+
+
+def assign_plateau_for_host_ts(host_hms: str, run_start: datetime):
+    # Monitor logs come from the VM where TZ is UTC (``ls -la /etc/
+    # localtime`` → ``Etc/UTC``). Normalize the run_start to UTC and
+    # diff the HH:MM:SS against that.
+    from datetime import timezone
+    run_start_utc = run_start.astimezone(timezone.utc)
+    today = run_start_utc.date()
+    t = datetime.combine(today,
+                         datetime.strptime(host_hms, "%H:%M:%S").time(),
+                         tzinfo=timezone.utc)
+    elapsed = (t - run_start_utc).total_seconds()
+    cursor = 0.0
+    for label, target, duration, kind in PLATEAUS:
+        if cursor <= elapsed < cursor + duration:
+            return label
+        cursor += duration
+    return None
+
+
+def aggregate_docker_stats(run_start: datetime):
+    if not DOCKER_LOG.exists():
+        return {}
+    out: dict[str, dict] = {}
+    with DOCKER_LOG.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ts, payload = line.split(" ", 1)
+            except ValueError:
+                continue
+            label = assign_plateau_for_host_ts(ts, run_start)
+            if not label:
+                continue
+            bucket = out.setdefault(label, {
+                "mcp_cpu": [], "mcp_mem_mib": [],
+                "nginx_cpu": [], "nginx_mem_mib": [],
+                "mcp_net_tx_mb": [], "mcp_block_w_mb": [],
+            })
+            # payload format: name|cpu%|mem|net|block;...
+            for part in payload.split(";"):
+                if not part:
+                    continue
+                cols = part.split("|")
+                if len(cols) < 5:
+                    continue
+                name, cpu, mem, net, block = cols[:5]
+                cpu = float(cpu.rstrip("%"))
+                mem_mib = parse_size_mib(mem.split("/")[0].strip())
+                if "nginx" in name:
+                    bucket["nginx_cpu"].append(cpu)
+                    bucket["nginx_mem_mib"].append(mem_mib)
+                else:
+                    bucket["mcp_cpu"].append(cpu)
+                    bucket["mcp_mem_mib"].append(mem_mib)
+                    # Parse net I/O total in MB (tx side after slash).
+                    try:
+                        _, tx = net.split("/")
+                        bucket["mcp_net_tx_mb"].append(parse_size_mib(tx.strip()) / 1024 * 1024)
+                    except Exception:
+                        pass
+                    try:
+                        _, w = block.split("/")
+                        bucket["mcp_block_w_mb"].append(parse_size_mib(w.strip()) / 1024 * 1024)
+                    except Exception:
+                        pass
+    return out
+
+
+def parse_size_mib(s: str) -> float:
+    s = s.strip()
+    if not s:
+        return 0
+    unit = ""
+    n = ""
+    for c in s:
+        if c.isdigit() or c == ".":
+            n += c
+        else:
+            unit += c
+    try:
+        v = float(n)
+    except ValueError:
+        return 0
+    unit = unit.upper().strip()
+    if unit in ("KB", "KIB"):
+        return v / 1024
+    if unit in ("MB", "MIB"):
+        return v
+    if unit in ("GB", "GIB"):
+        return v * 1024
+    if unit in ("B", ""):
+        return v / 1024 / 1024
+    return v
+
+
+def aggregate_audit(run_start: datetime):
+    if not AUDIT_LOG.exists():
+        return {}
+    out: dict[str, dict] = {}
+    samples = []
+    with AUDIT_LOG.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            ts = parts[0]
+            try:
+                count = int(parts[1])
+            except ValueError:
+                continue
+            db_size = 0
+            wal_size = 0
+            for tok in parts[2:]:
+                if tok.startswith("db="):
+                    db_size = int(tok.split("=")[1])
+                if tok.startswith("wal="):
+                    wal_size = int(tok.split("=")[1])
+            samples.append((ts, count, db_size, wal_size))
+
+    for i, (ts, count, db, wal) in enumerate(samples):
+        if i == 0:
+            continue
+        prev_ts, prev_count, prev_db, prev_wal = samples[i - 1]
+        # Wall-time delta in seconds (assume same day).
+        h1, m1, s1 = map(int, ts.split(":"))
+        h0, m0, s0 = map(int, prev_ts.split(":"))
+        dt = (h1 * 3600 + m1 * 60 + s1) - (h0 * 3600 + m0 * 60 + s0)
+        if dt <= 0:
+            continue
+        rate = (count - prev_count) / dt
+        label = assign_plateau_for_host_ts(ts, run_start)
+        if not label:
+            continue
+        bucket = out.setdefault(label, {
+            "audit_rate": [], "db_mb": [], "wal_mb": [],
+            "audit_total": 0,
+        })
+        bucket["audit_rate"].append(rate)
+        bucket["db_mb"].append(db / 1024 / 1024)
+        bucket["wal_mb"].append(wal / 1024 / 1024)
+        bucket["audit_total"] = count
+    return out
+
+
+def main() -> None:
+    start_ts_str, end_ts_str = find_run_window()
+    if not start_ts_str:
+        sys.exit("no ndjson points found")
+    run_start = parse_ts(start_ts_str)
+    print(f"<!-- run window: {start_ts_str} .. {end_ts_str} (local start "
+          f"{run_start.astimezone().strftime('%H:%M:%S')}) -->", file=sys.stderr)
+
+    k6 = aggregate_ndjson(run_start)
+    dstats = aggregate_docker_stats(run_start)
+    audit = aggregate_audit(run_start)
+
+    # Print markdown plateau table.
+    print("| Plateau | VUs | mints | ingress calls | mint p50/p95/p99 ms | "
+          "ingress p50/p95/p99 ms | mint err% | ingress err% | "
+          "mcp CPU% | mcp MEM MiB | nginx CPU% | audit/s | db MB | wal MB |")
+    print("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|")
+    for label, target, duration, kind in PLATEAUS:
+        if kind != "plateau":
+            continue
+        kb = k6.get(label, {})
+        db = dstats.get(label, {})
+        ab = audit.get(label, {})
+        mint = kb.get("cullis_mint_latency_ms", [])
+        ingress = kb.get("cullis_ingress_latency_ms", [])
+        mint_err = (kb.get("mint_err_count", 0) /
+                    max(1, kb.get("mint_err_total", 1))) * 100
+        ingress_err = (kb.get("ingress_err_count", 0) /
+                       max(1, kb.get("ingress_err_total", 1))) * 100
+        mints = kb.get("auth_token_reqs", 0)
+        ingress_calls = kb.get("ingress_execute_reqs", 0)
+        mcp_cpu_avg = stats.mean(db["mcp_cpu"]) if db.get("mcp_cpu") else 0
+        mcp_mem_avg = stats.mean(db["mcp_mem_mib"]) if db.get("mcp_mem_mib") else 0
+        nginx_cpu_avg = stats.mean(db["nginx_cpu"]) if db.get("nginx_cpu") else 0
+        audit_rate = stats.mean(ab["audit_rate"]) if ab.get("audit_rate") else 0
+        db_mb = max(ab["db_mb"]) if ab.get("db_mb") else 0
+        wal_mb = max(ab["wal_mb"]) if ab.get("wal_mb") else 0
+        print(
+            f"| {label} | {target} | {mints} | {ingress_calls} | "
+            f"{pct(mint, 0.50):.1f}/{pct(mint, 0.95):.1f}/"
+            f"{pct(mint, 0.99):.1f} | "
+            f"{pct(ingress, 0.50):.1f}/{pct(ingress, 0.95):.1f}/"
+            f"{pct(ingress, 0.99):.1f} | "
+            f"{mint_err:.2f} | {ingress_err:.2f} | "
+            f"{mcp_cpu_avg:.0f} | {mcp_mem_avg:.0f} | {nginx_cpu_avg:.1f} | "
+            f"{audit_rate:.0f} | {db_mb:.0f} | {wal_mb:.0f} |"
+        )
+
+    # Throughput per plateau (RPS sustained by Mastio).
+    print()
+    print("## Throughput per plateau")
+    print()
+    print("| Plateau | duration s | total ingress | RPS sustained |")
+    print("|---|---|---|---|")
+    for label, target, duration, kind in PLATEAUS:
+        if kind != "plateau":
+            continue
+        kb = k6.get(label, {})
+        ic = kb.get("ingress_execute_reqs", 0)
+        rps = ic / max(1, duration)
+        print(f"| {label} | {duration} | {ic} | {rps:.0f} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/_auth_smoke.py
+++ b/scripts/stress/_auth_smoke.py
@@ -1,0 +1,125 @@
+"""One-shot auth smoke for a stress-enrolled agent.
+
+Picks the first entry from ``stress_agents.json``, builds
+client_assertion + DPoP proof exactly the way ``intra-org-mastio-burst.js``
+will, hits ``POST /v1/auth/token`` on the live Mastio and prints the
+result. Exits non-zero on any 4xx/5xx so we catch wrong-cert or
+DPoP-nonce drift before pointing 5000 VUs at the box.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sys
+import urllib3
+import uuid
+from pathlib import Path
+
+import jwt
+import requests
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+HERE = Path(__file__).resolve().parent
+BASE_URL = os.environ.get("BASE_URL", "https://192.168.122.170:9443")
+DATA_PATH = HERE / "stress_agents.json"
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def main() -> None:
+    bundle = json.loads(DATA_PATH.read_text())
+    agent = bundle["agents"][0]
+    aid = agent["agent_id"]
+
+    cert = x509.load_pem_x509_certificate(agent["cert_pem"].encode())
+    cert_der = cert.public_bytes(serialization.Encoding.DER)
+    x5c = [base64.b64encode(cert_der).decode()]
+
+    now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+    assertion = jwt.encode(
+        {
+            "sub": aid, "iss": aid, "aud": "agent-trust-broker",
+            "iat": now, "exp": now + 300, "jti": str(uuid.uuid4()),
+        },
+        agent["leaf_priv_pkcs8_pem"],
+        algorithm="ES256",
+        headers={"x5c": x5c},
+    )
+
+    # nginx forwards `Host: $host` which strips the port. Mastio rebuilds
+    # request.url without the port, so the DPoP htu we sign must match
+    # the port-less form or _maybe_extract_dpop_jkt_at_mint silently
+    # falls back to unbound mint (200 + no cnf.jkt).
+    htu_url = BASE_URL.replace(":9443", "") + "/v1/auth/token"
+    htu = htu_url  # what we sign into the proof
+    target_url = f"{BASE_URL}/v1/auth/token"  # what we actually POST to
+    dpop_proof = jwt.encode(
+        {
+            "jti": str(uuid.uuid4()), "htm": "POST", "htu": htu,
+            "iat": now,
+        },
+        agent["dpop_priv_pkcs8_pem"],
+        algorithm="ES256",
+        headers={"typ": "dpop+jwt", "jwk": agent["dpop_jwk_pub"]},
+    )
+
+    sess = requests.Session()
+    resp = sess.post(
+        target_url,
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+        verify=False,
+        timeout=10,
+    )
+    if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
+        nonce = resp.headers.get("dpop-nonce")
+        print(f"  → got 401 use_dpop_nonce, retrying with nonce={nonce!r}",
+              file=sys.stderr)
+        dpop_proof = jwt.encode(
+            {
+                "jti": str(uuid.uuid4()), "htm": "POST", "htu": htu,
+                "iat": now, "nonce": nonce,
+            },
+            agent["dpop_priv_pkcs8_pem"],
+            algorithm="ES256",
+            headers={"typ": "dpop+jwt", "jwk": agent["dpop_jwk_pub"]},
+        )
+        resp = sess.post(
+            htu,
+            json={"client_assertion": assertion},
+            headers={"DPoP": dpop_proof},
+            verify=False,
+            timeout=10,
+        )
+
+    print(f"status={resp.status_code} agent={aid}")
+    body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else resp.text
+    print(json.dumps(body, indent=2)[:600])
+    if resp.status_code != 200:
+        sys.exit(1)
+
+    token = body["access_token"]
+    # Validate cnf.jkt binding lands too.
+    parts = token.split(".")
+    payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+    decoded = json.loads(base64.urlsafe_b64decode(payload_b64))
+    print(f"\ntoken claims keys: {sorted(decoded.keys())}")
+    cnf = decoded.get("cnf", {})
+    print(f"cnf.jkt: {cnf.get('jkt')!r}")
+    print(f"agent dpop_jkt (expected): {agent['dpop_jkt']!r}")
+    if cnf.get("jkt") != agent["dpop_jkt"]:
+        print("WARN: cnf.jkt MISMATCH — DPoP binding broken")
+        sys.exit(2)
+    print("OK: cnf.jkt matches agent's dpop_jkt")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/_bulk_inject.py
+++ b/scripts/stress/_bulk_inject.py
@@ -1,0 +1,182 @@
+"""In-container payload for ``bulk_enroll_agents.py``.
+
+Streamed via stdin to ``docker exec -i ... python -`` on the Mastio
+container. Reads config from env, writes the agents into
+``internal_agents`` in one transaction, emits a JSON document with all
+per-agent material to stdout (private keys ride the encrypted SSH
+transport back to the operator's host).
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+DB_PATH = os.environ["DB_PATH"]
+N = int(os.environ["N_AGENTS"])
+PREFIX = os.environ["PREFIX"]
+TRUST_DOMAIN = os.environ.get("TRUST_DOMAIN", "cullis.local")
+WIPE = os.environ.get("WIPE_PREFIX", "0") == "1"
+SET_CAPS = os.environ.get("AGENT_CAPABILITIES", "")
+# Bind across DB writers (Mastio + this script) without hammering each
+# other. 30s busy timeout is the standard SQLite advice for WAL
+# multi-writer setups.
+BUSY_TIMEOUT_MS = int(os.environ.get("BUSY_TIMEOUT_MS", "30000"))
+
+conn = sqlite3.connect(DB_PATH, timeout=BUSY_TIMEOUT_MS / 1000)
+conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+
+
+def cfg(key):
+    row = conn.execute(
+        "SELECT value FROM proxy_config WHERE key = ?", (key,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+org_id = cfg("org_id")
+org_ca_key_pem = cfg("org_ca_key")
+org_ca_cert_pem = cfg("org_ca_cert")
+if not org_id or not org_ca_key_pem or not org_ca_cert_pem:
+    sys.exit("ERR: proxy_config missing org_id/org_ca_key/org_ca_cert")
+
+ca_key = serialization.load_pem_private_key(
+    org_ca_key_pem.encode(), password=None,
+)
+ca_cert = x509.load_pem_x509_certificate(org_ca_cert_pem.encode())
+
+if WIPE:
+    cur = conn.execute(
+        "DELETE FROM internal_agents WHERE agent_id LIKE ?",
+        (f"{org_id}::{PREFIX}-%",),
+    )
+    print(
+        f"WIPE: removed {cur.rowcount} prior {PREFIX}-* agents",
+        file=sys.stderr,
+    )
+
+now = datetime.datetime.now(datetime.timezone.utc)
+now_iso = now.isoformat(timespec="seconds")
+
+
+def b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def jwk_for(pub):
+    nums = pub.public_numbers()
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": b64url(nums.x.to_bytes(32, "big")),
+        "y": b64url(nums.y.to_bytes(32, "big")),
+    }
+
+
+def rfc7638_thumbprint(jwk: dict) -> str:
+    canonical = json.dumps(
+        {"crv": jwk["crv"], "kty": jwk["kty"], "x": jwk["x"], "y": jwk["y"]},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return b64url(hashlib.sha256(canonical).digest())
+
+
+capabilities_json = json.dumps(
+    [c for c in SET_CAPS.split(",") if c]
+)
+
+rows = []
+agents_out = []
+for i in range(N):
+    agent_name = f"{PREFIX}-{i:05d}"
+    agent_id = f"{org_id}::{agent_name}"
+    spiffe = f"spiffe://{TRUST_DOMAIN}/{org_id}/{agent_name}"
+
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe),
+            ]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    leaf_pkcs8 = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    dpop_key = ec.generate_private_key(ec.SECP256R1())
+    dpop_jwk_pub = jwk_for(dpop_key.public_key())
+    dpop_jkt = rfc7638_thumbprint(dpop_jwk_pub)
+    dpop_pkcs8 = dpop_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    rows.append((
+        agent_id, agent_name, capabilities_json, cert_pem, now_iso,
+        1, None, dpop_jkt, "stress", now_iso, spiffe, 1, now_iso,
+        "both", 1,
+    ))
+    agents_out.append({
+        "agent_id": agent_id,
+        "agent_name": agent_name,
+        "leaf_priv_pkcs8_pem": leaf_pkcs8,
+        "cert_pem": cert_pem,
+        "dpop_priv_pkcs8_pem": dpop_pkcs8,
+        "dpop_jwk_pub": dpop_jwk_pub,
+        "dpop_jkt": dpop_jkt,
+    })
+
+INSERT_SQL = (
+    "INSERT OR REPLACE INTO internal_agents "
+    "(agent_id, display_name, capabilities, cert_pem, created_at, "
+    "is_active, device_info, dpop_jkt, enrollment_method, enrolled_at, "
+    "spiffe_id, federated, federated_at, reach, federation_revision) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+conn.executemany(INSERT_SQL, rows)
+conn.commit()
+
+count = conn.execute(
+    "SELECT COUNT(*) FROM internal_agents WHERE agent_id LIKE ?",
+    (f"{org_id}::{PREFIX}-%",),
+).fetchone()[0]
+
+result = {
+    "org_id": org_id,
+    "trust_domain": TRUST_DOMAIN,
+    "prefix": PREFIX,
+    "requested": N,
+    "after_count": count,
+    "agents": agents_out,
+}
+sys.stdout.write(json.dumps(result))
+sys.stdout.flush()
+print(f"OK: {count} {PREFIX}-* agents in internal_agents", file=sys.stderr)

--- a/scripts/stress/bulk_enroll_agents.py
+++ b/scripts/stress/bulk_enroll_agents.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Pre-enroll N agent identities into a running Cullis Mastio for k6 stress.
+
+Reads org_ca_key/org_ca_cert/org_id from the target Mastio's proxy_config
+(via ``docker exec ... python -`` over SSH), then generates N agents
+in-process and bulk-INSERTs them into ``internal_agents`` so the
+subsequent k6 scenario can mint LOCAL_TOKENs without paying the
+device-code flow per VU.
+
+Each agent gets:
+  - EC P-256 keypair signed by the Org CA (matches mcp_proxy
+    ``AgentManager.sign_agent_cert`` format: CN=org::name, O=org,
+    SAN URI = spiffe://<trust_domain>/<org>/<name>)
+  - EC P-256 DPoP keypair (ephemeral but pinned via
+    ``internal_agents.dpop_jkt`` so both /v1/auth/token and
+    /v1/ingress/* binding paths accept it)
+
+Output (``stress_agents.json``) carries enough material for k6 to:
+  1. sign a client_assertion JWT with the agent private key (x5c=cert)
+  2. sign a DPoP proof with the agent's DPoP private key
+  3. derive cnf.jkt matching ``internal_agents.dpop_jkt``
+
+NEVER commit ``stress_agents.json`` — it carries private keys.
+
+Usage::
+
+    nix-shell -p python311Packages.cryptography --run \\
+        "python scripts/stress/bulk_enroll_agents.py --n 50"
+
+    BULK_VM_HOST=cullis@192.168.122.170 \\
+    BULK_CONTAINER=cullis-mastio-mcp-proxy-1 \\
+        python scripts/stress/bulk_enroll_agents.py --n 5000 --wipe
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_HOST = os.environ.get("BULK_VM_HOST", "cullis@192.168.122.170")
+DEFAULT_CONTAINER = os.environ.get("BULK_CONTAINER", "cullis-mastio-mcp-proxy-1")
+DEFAULT_DB_PATH = os.environ.get("BULK_DB_PATH", "/data/mcp_proxy.db")
+
+
+# In-container payload kept in a sibling file so the orchestrator can stay
+# free of escape headaches around the embedded SQL.
+PAYLOAD_PATH = HERE / "_bulk_inject.py"
+CONTAINER_PAYLOAD = PAYLOAD_PATH.read_text()
+
+
+def run_in_container(*, n: int, prefix: str, wipe: bool, capabilities: str,
+                     trust_domain: str, host: str, container: str,
+                     db_path: str) -> dict:
+    env_bits = [
+        f"DB_PATH={db_path}",
+        f"N_AGENTS={n}",
+        f"PREFIX={prefix}",
+        f"TRUST_DOMAIN={trust_domain}",
+        f"WIPE_PREFIX={'1' if wipe else '0'}",
+        f"AGENT_CAPABILITIES={capabilities}",
+    ]
+    remote = (
+        f"docker exec -i -e {' -e '.join(env_bits)} {container} python -"
+    )
+    t0 = time.time()
+    proc = subprocess.run(
+        ["ssh", host, remote],
+        input=CONTAINER_PAYLOAD,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.time() - t0
+    if proc.returncode != 0:
+        sys.stderr.write(
+            f"docker-exec failed (rc={proc.returncode}) in {elapsed:.1f}s\n"
+            f"--- stderr ---\n{proc.stderr}\n"
+            f"--- stdout ---\n{proc.stdout[:2000]}\n"
+        )
+        sys.exit(proc.returncode)
+    sys.stderr.write(
+        f"[bulk_enroll] container payload: {elapsed:.1f}s for "
+        f"{n} agents (≈{n / max(elapsed, 0.001):.0f}/s)\n{proc.stderr}"
+    )
+    # Reuse the env hint as a sanity probe — fail clearly if stdout
+    # carries logs instead of JSON.
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"non-JSON stdout from container: {exc}\n{proc.stdout[:2000]}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--n", type=int, default=50,
+                   help="Number of agents to enroll (default 50)")
+    p.add_argument("--prefix", default="stress",
+                   help="Agent name prefix (default 'stress')")
+    p.add_argument("--wipe", action="store_true",
+                   help="Delete prior <prefix>-* agents before insert")
+    p.add_argument("--capabilities", default="",
+                   help="Comma-separated capability list to seed on each agent")
+    p.add_argument("--trust-domain", default="cullis.local")
+    p.add_argument("--vm-host", default=DEFAULT_HOST,
+                   help="SSH target (user@host) — defaults to BULK_VM_HOST")
+    p.add_argument("--container", default=DEFAULT_CONTAINER,
+                   help="Mastio container name (default %(default)s)")
+    p.add_argument("--db-path", default=DEFAULT_DB_PATH,
+                   help="SQLite path inside the container (default %(default)s)")
+    p.add_argument("--output", default=str(HERE / "stress_agents.json"),
+                   help="Local JSON output path for k6 SharedArray")
+    args = p.parse_args()
+
+    result = run_in_container(
+        n=args.n, prefix=args.prefix, wipe=args.wipe,
+        capabilities=args.capabilities, trust_domain=args.trust_domain,
+        host=args.vm_host, container=args.container, db_path=args.db_path,
+    )
+
+    out_path = Path(args.output)
+    out_path.write_text(json.dumps(result, indent=2))
+    sys.stderr.write(
+        f"[bulk_enroll] wrote {out_path} "
+        f"({len(result['agents'])} agents, requested {result['requested']}, "
+        f"after_count {result['after_count']})\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/intra-org-mastio-burst.js
+++ b/scripts/stress/intra-org-mastio-burst.js
@@ -1,0 +1,437 @@
+// Cullis Mastio intra-org enterprise burst (C2.A.1 baseline).
+//
+// Each VU = one pre-enrolled "stress-NNNNN" agent. VU cycle is:
+//   1. POST /v1/auth/token   — client_assertion (ES256, x5c) + DPoP proof.
+//      Issued LOCAL_TOKEN is cached for the rest of its lifetime so a VU
+//      does not pay mint cost per iteration; the lifecycle still produces
+//      a fresh DPoP proof every call so the JTI replay store sees real
+//      traffic.
+//   2. POST /v1/ingress/execute — fires a deliberately-unknown tool name
+//      so the executor goes through the auth dep + DPoP verify + JTI
+//      replay + log_audit path without invoking a real handler. That
+//      exercises the same hot path real tool calls do for everything
+//      we want to measure (auth, DPoP, audit chain) while keeping
+//      handler cost effectively zero.
+//
+// Pre-conditions:
+//   - ``scripts/stress/bulk_enroll_agents.py --n N --wipe`` has been run
+//     against the target Mastio so ``stress_agents.json`` is present and
+//     N matches the peak VU count below.
+//   - The Mastio's external URL is reachable on BASE_URL (default
+//     ``https://192.168.122.170:9443``).
+//
+// Run:
+//   nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify \\
+//       --out json=intra-org-results.ndjson \\
+//       scripts/stress/intra-org-mastio-burst.js"
+//
+// Output:
+//   - stdout summary (per-stage tag breakdown when using k6's k6/x/output
+//     parsing on the ndjson)
+//   - ``intra-org-summary.json`` next to the script via ``handleSummary``
+//
+// Tuning hooks (env-driven):
+//   - BASE_URL       — Mastio public URL (default
+//                      ``https://192.168.122.170:9443``)
+//   - HTU_OVERRIDE   — explicit htu the DPoP proof signs into (default
+//                      derives from BASE_URL with the port stripped, see
+//                      the smoke note in _auth_smoke.py)
+//   - AGENT_FILE     — path to stress_agents.json (default sibling of
+//                      this script)
+//   - STAGE_OVERRIDE — JSON-encoded ramp override for triage runs:
+//                      ``[{"duration":"60s","target":500},...]``
+//   - THINK_MS       — optional fixed inter-cycle sleep (default 0)
+//   - REQ_TIMEOUT_S  — http timeout (default 30)
+
+import http from "k6/http";
+import encoding from "k6/encoding";
+import { check, sleep, fail } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+import { SharedArray } from "k6/data";
+
+
+// ── Tunables ──────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || "https://192.168.122.170:9443";
+const AGENT_FILE = __ENV.AGENT_FILE || "./stress_agents.json";
+const THINK_MS = parseInt(__ENV.THINK_MS || "0", 10);
+const REQ_TIMEOUT = `${parseInt(__ENV.REQ_TIMEOUT_S || "30", 10)}s`;
+// Token re-mint margin: cull each LOCAL_TOKEN 60s before its true expiry.
+const TOKEN_REUSE_MARGIN_MS = 60 * 1000;
+
+// ``HTU_OVERRIDE`` lets the operator force a specific htu when nginx
+// rewrites the Host header in non-obvious ways (audited gotcha:
+// ``$host`` strips the port, so DPoP htu has to match the port-less
+// form even when the client targets the :9443 sidecar).
+const DEFAULT_HTU = (__ENV.HTU_OVERRIDE
+    || BASE_URL.replace(/:(\d+)$/, "")) + "/v1/auth/token";
+const INGRESS_HTU = (__ENV.HTU_OVERRIDE
+    || BASE_URL.replace(/:(\d+)$/, "")) + "/v1/ingress/execute";
+
+
+// ── Stages ────────────────────────────────────────────────────────────
+
+const DEFAULT_STAGES = [
+    { duration: "60s",  target: 50 },
+    { duration: "300s", target: 50 },
+    { duration: "60s",  target: 500 },
+    { duration: "300s", target: 500 },
+    { duration: "60s",  target: 2000 },
+    { duration: "300s", target: 2000 },
+    { duration: "60s",  target: 5000 },
+    { duration: "600s", target: 5000 },
+    { duration: "60s",  target: 0 },
+];
+
+const STAGES = __ENV.STAGE_OVERRIDE
+    ? JSON.parse(__ENV.STAGE_OVERRIDE)
+    : DEFAULT_STAGES;
+
+
+// ── Shared data ───────────────────────────────────────────────────────
+
+// SharedArray cost: load + JSON-parse once, then VMs share the same
+// underlying memory. For 5000 agents the file is ~8 MB; without
+// SharedArray every VU would deep-copy that into its own VM.
+const AGENTS = new SharedArray("stress-agents", () => {
+    const bundle = JSON.parse(open(AGENT_FILE));
+    if (!bundle.agents || bundle.agents.length === 0) {
+        fail(`AGENT_FILE ${AGENT_FILE} contains no agents`);
+    }
+    return bundle.agents;
+});
+
+
+// ── Metrics ───────────────────────────────────────────────────────────
+
+const mintLatency = new Trend("cullis_mint_latency_ms");
+const ingressLatency = new Trend("cullis_ingress_latency_ms");
+const mintErrors = new Rate("cullis_mint_error_rate");
+const ingressErrors = new Rate("cullis_ingress_error_rate");
+const tokenReuse = new Counter("cullis_token_reuse");
+const tokenMint = new Counter("cullis_token_mint");
+const dpopNonceRetry = new Counter("cullis_dpop_nonce_retry");
+
+
+// ── Options ───────────────────────────────────────────────────────────
+
+export const options = {
+    insecureSkipTLSVerify: true,
+    discardResponseBodies: false,
+    summaryTrendStats: ["avg", "min", "med", "p(95)", "p(99)", "max"],
+    scenarios: {
+        intra_org_burst: {
+            executor: "ramping-vus",
+            startVUs: 0,
+            stages: STAGES,
+            gracefulRampDown: "30s",
+        },
+    },
+    thresholds: {
+        // Stress test, not pre-release gate — keep thresholds loose so
+        // k6 does not exit non-zero on the first plateau spike. We use
+        // the values to flag where the curve goes off rather than to
+        // block CI.
+        "cullis_mint_error_rate": ["rate<0.50"],
+        "cullis_ingress_error_rate": ["rate<0.50"],
+    },
+};
+
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+// 8-bit safe (ASCII) — k6 lacks WHATWG TextEncoder. JWT inputs
+// (base64url JSON, RFC 3339 timestamps, hex jti) are always ASCII so
+// this is sufficient. Multi-byte UTF-8 would need a proper polyfill.
+const enc = {
+    encode(str) {
+        const buf = new Uint8Array(str.length);
+        for (let i = 0; i < str.length; i++) buf[i] = str.charCodeAt(i) & 0xff;
+        return buf.buffer;
+    },
+};
+
+function b64urlEncodeBytes(bytes) {
+    // k6's ``encoding.b64encode`` accepts ArrayBuffer directly. Passing
+    // it through ``String.fromCharCode`` first would re-interpret bytes
+    // >= 0x80 as UTF-16 codepoints, which encoding.b64encode then
+    // UTF-8 encodes — the sig grows from 64 bytes to ~110 and the
+    // server rejects the JWT with "Signature verification failed".
+    const std = encoding.b64encode(bytes);
+    return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlEncodeStr(str) {
+    const std = encoding.b64encode(str);
+    return std.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64stdToBuffer(b64) {
+    // ``b64decode(s, "std")`` returns ArrayBuffer when no 3rd arg.
+    // Required for binary input to crypto.subtle.importKey.
+    return encoding.b64decode(b64, "std");
+}
+
+function pemBodyToBuffer(pem) {
+    const body = pem.replace(/-----[^-]+-----|\s/g, "");
+    return b64stdToBuffer(body);
+}
+
+function randomJti() {
+    // Lightweight UUID-ish: 16 hex chars from Math.random — sufficient
+    // for jti replay collision-avoidance in a single run (DPoP rejects
+    // server-side anyway).
+    let s = "";
+    for (let i = 0; i < 16; i++) {
+        s += Math.floor(Math.random() * 16).toString(16);
+    }
+    return s + "-" + Date.now();
+}
+
+async function importPkcs8(pem) {
+    return await crypto.subtle.importKey(
+        "pkcs8", pemBodyToBuffer(pem),
+        { name: "ECDSA", namedCurve: "P-256" },
+        false, ["sign"],
+    );
+}
+
+async function signJwt(privKey, headerObj, payloadObj) {
+    const headerB64 = b64urlEncodeStr(JSON.stringify(headerObj));
+    const payloadB64 = b64urlEncodeStr(JSON.stringify(payloadObj));
+    const signing = `${headerB64}.${payloadB64}`;
+    const sigBuf = await crypto.subtle.sign(
+        { name: "ECDSA", hash: { name: "SHA-256" } },
+        privKey, enc.encode(signing),
+    );
+    return `${signing}.${b64urlEncodeBytes(sigBuf)}`;
+}
+
+async function ath(token) {
+    // base64url(SHA-256(access_token)). We use the WebCrypto digest
+    // since k6/crypto only exposes the legacy ``sha256`` helper.
+    const digest = await crypto.subtle.digest(
+        "SHA-256", enc.encode(token),
+    );
+    return b64urlEncodeBytes(digest);
+}
+
+
+// ── Per-VU state cache ────────────────────────────────────────────────
+
+const vuCache = new Map();  // keyed by __VU index
+
+async function getAgentState() {
+    let state = vuCache.get(__VU);
+    if (state) return state;
+
+    const agent = AGENTS[(__VU - 1) % AGENTS.length];
+    const [leafKey, dpopKey] = await Promise.all([
+        importPkcs8(agent.leaf_priv_pkcs8_pem),
+        importPkcs8(agent.dpop_priv_pkcs8_pem),
+    ]);
+
+    // Pre-compute the cert DER (base64-std) for x5c — the PEM body is
+    // already standard base64, so re-encoding is a no-op.
+    const certB64 = agent.cert_pem
+        .replace(/-----[^-]+-----|\s/g, "");
+    state = {
+        agent,
+        leafKey,
+        dpopKey,
+        certB64,
+        token: null,
+        tokenExpiresAt: 0,
+        dpopNonce: null,
+    };
+    vuCache.set(__VU, state);
+    return state;
+}
+
+
+// ── Auth + tool call ──────────────────────────────────────────────────
+
+async function dpopProof(state, method, htu, accessToken) {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+        jti: randomJti(),
+        htm: method.toUpperCase(),
+        htu,
+        iat: now,
+    };
+    if (accessToken !== null && accessToken !== undefined) {
+        payload.ath = await ath(accessToken);
+    }
+    if (state.dpopNonce) payload.nonce = state.dpopNonce;
+    return await signJwt(
+        state.dpopKey,
+        { typ: "dpop+jwt", alg: "ES256", jwk: state.agent.dpop_jwk_pub },
+        payload,
+    );
+}
+
+async function clientAssertion(state) {
+    const now = Math.floor(Date.now() / 1000);
+    return await signJwt(
+        state.leafKey,
+        { alg: "ES256", typ: "JWT", x5c: [state.certB64] },
+        {
+            sub: state.agent.agent_id, iss: state.agent.agent_id,
+            aud: "agent-trust-broker",
+            iat: now, exp: now + 300, jti: randomJti(),
+        },
+    );
+}
+
+async function mintToken(state) {
+    const assertion = await clientAssertion(state);
+    let proof = await dpopProof(state, "POST", DEFAULT_HTU, null);
+    let resp = http.post(
+        `${BASE_URL}/v1/auth/token`,
+        JSON.stringify({ client_assertion: assertion }),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                "DPoP": proof,
+            },
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "auth_token" },
+        },
+    );
+
+    // Handle the server-nonce dance once. Mastio rotates the nonce every
+    // 5 min, accepts current+previous, and the proof signs the new
+    // value back into a follow-up request.
+    if (resp.status === 401
+        && resp.body
+        && resp.body.indexOf("use_dpop_nonce") >= 0) {
+        const nonce = resp.headers["Dpop-Nonce"] || resp.headers["dpop-nonce"];
+        if (nonce) state.dpopNonce = nonce;
+        dpopNonceRetry.add(1);
+        proof = await dpopProof(state, "POST", DEFAULT_HTU, null);
+        resp = http.post(
+            `${BASE_URL}/v1/auth/token`,
+            JSON.stringify({ client_assertion: assertion }),
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    "DPoP": proof,
+                },
+                timeout: REQ_TIMEOUT,
+                tags: { endpoint: "auth_token", nonce_retry: "1" },
+            },
+        );
+    }
+
+    mintLatency.add(resp.timings.duration);
+    const ok = resp.status === 200;
+    mintErrors.add(!ok);
+    if (!ok) {
+        return null;
+    }
+    tokenMint.add(1);
+    const body = resp.json();
+    state.token = body.access_token;
+    state.tokenExpiresAt = Date.now() + (body.expires_in * 1000) - TOKEN_REUSE_MARGIN_MS;
+    return state.token;
+}
+
+async function ensureToken(state) {
+    if (state.token && Date.now() < state.tokenExpiresAt) {
+        tokenReuse.add(1);
+        return state.token;
+    }
+    return await mintToken(state);
+}
+
+async function callTool(state, token) {
+    const proof = await dpopProof(
+        state, "POST", INGRESS_HTU, token,
+    );
+    // Deliberately unknown tool name: the executor still walks the auth
+    // dep + DPoP verify + JTI replay + log_audit path, but skips any
+    // real handler work. Same hot path as a real tool call would take
+    // for the parts we are measuring.
+    const body = JSON.stringify({
+        tool: "cullis_stress_probe",
+        parameters: {},
+        request_id: randomJti(),
+    });
+    const resp = http.post(
+        `${BASE_URL}/v1/ingress/execute`,
+        body,
+        {
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `DPoP ${token}`,
+                "DPoP": proof,
+            },
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "ingress_execute" },
+        },
+    );
+    ingressLatency.add(resp.timings.duration);
+    // 200-with-error-body (tool not found is a 2xx in the executor's
+    // contract) and 4xx both count as "request handled" from the
+    // stress perspective. We treat anything non-5xx as success.
+    const ok = resp.status < 500 && resp.status !== 0;
+    ingressErrors.add(!ok);
+    return ok;
+}
+
+
+// ── VU body ───────────────────────────────────────────────────────────
+
+export default async function () {
+    const state = await getAgentState();
+    const token = await ensureToken(state);
+    if (!token) {
+        // Mint failed: skip the tool call so we do not produce noise on
+        // the ingress metrics. The error rate already captured it.
+        return;
+    }
+    await callTool(state, token);
+    if (THINK_MS > 0) sleep(THINK_MS / 1000);
+}
+
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+    return {
+        stdout: textSummary(data),
+        "intra-org-summary.json": JSON.stringify(data, null, 2),
+    };
+}
+
+function textSummary(data) {
+    const m = data.metrics;
+    function pct(metric, key) {
+        return ((metric?.values?.[key]) || 0).toFixed(1);
+    }
+    const lines = [];
+    lines.push("");
+    lines.push("════ Cullis Mastio intra-org burst summary ════");
+    lines.push("");
+    lines.push(`  Base URL:           ${BASE_URL}`);
+    lines.push(`  Agents loaded:      ${AGENTS.length}`);
+    lines.push(`  Auth-token mints:   ${m.cullis_token_mint?.values?.count ?? 0}`);
+    lines.push(`  Auth-token reuse:   ${m.cullis_token_reuse?.values?.count ?? 0}`);
+    lines.push(`  DPoP nonce retries: ${m.cullis_dpop_nonce_retry?.values?.count ?? 0}`);
+    lines.push(`  Total requests:     ${m.http_reqs?.values?.count ?? 0}`);
+    lines.push(`  Requests per sec:   ${(m.http_reqs?.values?.rate ?? 0).toFixed(1)} RPS`);
+    lines.push("");
+    lines.push("  Mint /v1/auth/token:");
+    lines.push(`    error rate   ${((m.cullis_mint_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_mint_latency_ms, "avg")} / ${pct(m.cullis_mint_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_mint_latency_ms, "p(95)")} / ${pct(m.cullis_mint_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_mint_latency_ms, "max")} ms`);
+    lines.push("");
+    lines.push("  Ingress /v1/ingress/execute:");
+    lines.push(`    error rate   ${((m.cullis_ingress_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_ingress_latency_ms, "avg")} / ${pct(m.cullis_ingress_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_ingress_latency_ms, "p(95)")} / ${pct(m.cullis_ingress_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_ingress_latency_ms, "max")} ms`);
+    lines.push("");
+    return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Adds the C2.A.1 intra-org enterprise burst harness next to the existing `health-throughput.js` / `soak-stability.js` scenarios. Pure infra-test, no production code path touched.

- `bulk_enroll_agents.py` + `_bulk_inject.py`: SSHes into the Mastio container, reads Org CA from `proxy_config.org_ca_{key,cert}` directly, bulk-INSERTs N agents into `internal_agents` in one transaction. 5000 agents in ~4s wall clock; 50k extrapolates to ~25s.
- `_auth_smoke.py`: single-VU sanity for the full mint chain (POST `/v1/auth/token` + DPoP proof → 200 with `cnf.jkt` binding matching persistent `internal_agents.dpop_jkt`).
- `intra-org-mastio-burst.js`: k6 scenario ramping 50 → 500 → 2k → 5k VUs across 30 min. Mint + cache LOCAL_TOKEN, call `/v1/ingress/execute` with a deliberately-unknown tool name so the executor walks the full auth + DPoP + JTI + `log_audit` path without paying handler cost.
- `_analyze_burst.py`: streams the 9-10 GB k6 ndjson + docker-stats / audit-rate / mastio-errors monitor logs into a per-plateau markdown table.

README updated with the full setup → run → analyze flow plus the `Host: $host` nginx port-stripping trap for DPoP `htu`.

## Headline numbers (Mastio v0.4.3 bundle vs 4 vCPU VM, 5000 pre-enrolled agents)

| Plateau | VUs target | RPS utile (audit/s) | mint p99 ms | ingress p99 ms | mint err% | ingress err% | mcp CPU% | nginx CPU% |
|---|---|---|---|---|---|---|---|---|
| plateau_50  | 50   | 133  | 14    | 530   | 0  | 0  | 105 | 6   |
| plateau_500 | 500  | 116  | 14    | 4588  | 0  | 0  | 103 | 6   |
| plateau_2k  | 2000 | 49   | 7963  | 20599 | 94 | 96 | 114 | 27  |
| plateau_5k  | 5000 | 76   | 2962  | 18311 | 99 | 97 | 108 | 116 |

(audit/s column is the **useful** throughput — the http_reqs counter inflates RPS with fail-fast 502s once Mastio collapses.)

## Bottleneck ranking

1. **Single uvicorn worker** — bundle entrypoint runs `uvicorn ... --proxy-headers` without `--workers N`. GIL-bound at 1 core; mcp-proxy CPU pinned 103-114 % in every plateau, including 50 VUs. This is the dominant ceiling.
2. **Audit chain global `asyncio.Lock`** — `mcp_proxy/db.py:299` `_audit_chain_lock` serializes every `log_audit()` call. Combined with `SELECT MAX(chain_seq)` + SHA-256 + INSERT + SQLite WAL fsync (synchronous=FULL default) ≈ 5 ms/write → ~200/s theoretical, 133/s observed. **Per-process lock, so multi-worker uvicorn would not help across processes** without Postgres advisory lock or sequence-based chain_seq.
3. **nginx 4096 connection cap** — `worker_processes auto` × `worker_connections 1024`. nginx CPU climbs from 6 % to 116 % between plateau_50 and plateau_5k. Easy to lift, but only meaningful after #1 and #2.
4. **SQLite WAL fsync amplification** (not yet dominant) — 16 GB written for 168 k audit rows = ~100 KB/row amplification. Will become the next ceiling after #1 + #2 are removed.

Tier sizing read: **Tier 1 SMB verde, Tier 2 Mid rosso/giallo without tuning, Tier 3 Enterprise rosso strutturale** (1000 RPS sustained unreachable on commodity hardware without architectural change). Full report at `imp/c2-a1-intra-org-baseline-2026-05-16.md` (maintainer-local, gitignored — quote it from memory if a reviewer wants the deep dive).

## Next step (not this PR)

Fase A.1b re-runs this same scenario against a multi-worker uvicorn + Postgres-backed Mastio, gated **before** any Fase A.2 cross-org work — Court+federation overhead measurements on top of a saturated Mastio would be data of limited value. Three architectural changes on the path (multi-worker uvicorn, Postgres backend, Redis JTI store) are documented in the report.

## Forward reference

Baseline numbers in this PR are taken with the current identity model — agent = laptop (Connector device-code), no user/workload attribution distinction. The pending ADR-032 device attestation work will introduce attested workload identity as a separate principal type; throughput numbers should be re-taken after attestation lands because the auth dep path will gain an extra verification step.

## Test plan

- [x] `bulk_enroll_agents.py --n 50 --wipe` succeeds, agents visible in `internal_agents` via `docker exec sqlite3` count
- [x] `bulk_enroll_agents.py --n 5000 --wipe` succeeds in ~4s, `stress_agents.json` written ~8 MB, gitignored
- [x] `_auth_smoke.py` → `status=200`, `cnf.jkt` matches the agent's persistent `dpop_jkt`
- [x] `intra-org-mastio-burst.js` smoke (3 VUs, 10 s): 1543 iterations, 0 errors, 133 RPS, audit log delta matches iteration count exactly
- [x] Full 30-min run: 2.15M iterations, 168k new audit rows, no Mastio container WARN/ERROR/circuit/busy/deadlock entries, no `interrupted iterations` in k6
- [x] `_analyze_burst.py` against 9.9 GB ndjson: per-plateau markdown table emitted in ~5 min
- [x] DCO sign-off present on the commit, no Co-Authored-By trailer
- [x] No production code path touched (only `scripts/stress/` + `.gitignore`)