### PR TITLE
feat(stress): bulk_inject_pg helper for Postgres-backed Mastio benchmarks

### DIFF
--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -128,6 +128,54 @@ python scripts/stress/_auth_smoke.py
 (~8 MB at 5000 agents) — **gitignored**, carries per-agent PKCS8
 PEMs for the leaf cert + DPoP keypair. Never commit it.
 
+#### Postgres bulk inject helper
+
+`_bulk_inject_pg.py` is the Postgres counterpart of `_bulk_inject.py`
+for Mastio deployments where `MCP_PROXY_DATABASE_URL` points at
+Postgres (asyncpg DSN). Same in-container streaming pattern as
+the SQLite payload, but talks to the Mastio's Postgres backend via
+asyncpg (already pinned in the Mastio image — no extra deps).
+
+When to reach for it:
+
+- A Mastio bundle has been re-pointed at Postgres for an A.1b-style
+  multi-worker + Postgres backend benchmark.
+- Any future stress scenario that needs N pre-enrolled agents inside
+  a Postgres-backed Mastio without going through the device-code
+  enrollment HTTP path.
+
+Schema-aware differences from the SQLite payload: `federated_at` is
+`TIMESTAMPTZ` on Postgres (passes a Python `datetime`), `is_active`
+is `INTEGER`, `federated` is `BOOLEAN`. The payload uses
+`ON CONFLICT (agent_id) DO UPDATE` for idempotency, so re-runs
+overwrite `cert_pem` / `dpop_jkt` / `enrolled_at` while preserving
+admin-managed columns.
+
+Run it the same way as the SQLite variant — the orchestrator stays
+the SSH+docker-exec stream-via-stdin pattern:
+
+```bash
+# Assumes Postgres container is reachable from inside the Mastio
+# container at the hostname `postgres:5432` (set via docker
+# --network-alias postgres at deploy time).
+ssh cullis@192.168.122.170 'docker exec -i \
+    -e N_AGENTS=5000 -e PREFIX=stress -e WIPE_PREFIX=1 \
+    -e TRUST_DOMAIN=cullis.local -e AGENT_CAPABILITIES= \
+    cullis-mastio-mcp-proxy-1 python -' \
+        < scripts/stress/_bulk_inject_pg.py \
+        > scripts/stress/stress_agents.json
+```
+
+Override `DSN` env if the asyncpg connection string differs from the
+default `postgres://cullis_proxy:cullis_proxy_dev@postgres:5432/
+proxy_a` (e.g. a different superuser, or a Postgres on a non-default
+network alias).
+
+The harness keeps a single `stress_agents.json` shape across both
+helpers, so the k6 scenario and `_auth_smoke.py` work unchanged
+against a Postgres-backed Mastio. Only the bulk-inject payload
+differs.
+
 ### Run
 
 ```bash

--- a/scripts/stress/_bulk_inject_pg.py
+++ b/scripts/stress/_bulk_inject_pg.py
@@ -1,0 +1,185 @@
+"""Postgres variant of ``_bulk_inject.py`` for the A.1b Run 2 stress test.
+
+Streams via ``docker exec -i cullis-mastio-mcp-proxy-1 python -`` exactly
+like the SQLite payload, but talks to the Mastio's Postgres backend
+through asyncpg (already pinned in the Mastio image). Reads org CA from
+``proxy_config`` and writes per-agent rows into ``internal_agents``.
+
+ENV:
+  DSN              postgresql://user:pass@host:5432/db (defaults to the
+                   intra-cluster URL the Mastio container uses)
+  N_AGENTS         row count to seed
+  PREFIX           agent name prefix
+  TRUST_DOMAIN     spiffe trust domain (default cullis.local)
+  WIPE_PREFIX      1 to delete prior <prefix>-* rows first
+  AGENT_CAPABILITIES   comma-separated capability list
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sys
+
+import asyncpg
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+
+DSN = os.environ.get(
+    "DSN",
+    "postgres://cullis_proxy:cullis_proxy_dev@postgres:5432/proxy_a",
+)
+N = int(os.environ["N_AGENTS"])
+PREFIX = os.environ["PREFIX"]
+TRUST_DOMAIN = os.environ.get("TRUST_DOMAIN", "cullis.local")
+WIPE = os.environ.get("WIPE_PREFIX", "0") == "1"
+SET_CAPS = os.environ.get("AGENT_CAPABILITIES", "")
+
+
+def b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def jwk_for(pub):
+    nums = pub.public_numbers()
+    return {
+        "kty": "EC", "crv": "P-256",
+        "x": b64url(nums.x.to_bytes(32, "big")),
+        "y": b64url(nums.y.to_bytes(32, "big")),
+    }
+
+
+def rfc7638_thumbprint(jwk):
+    canonical = json.dumps(
+        {"crv": jwk["crv"], "kty": jwk["kty"],
+         "x": jwk["x"], "y": jwk["y"]},
+        separators=(",", ":"), sort_keys=True,
+    ).encode()
+    return b64url(hashlib.sha256(canonical).digest())
+
+
+async def main():
+    conn = await asyncpg.connect(DSN)
+    org_id = await conn.fetchval(
+        "SELECT value FROM proxy_config WHERE key = $1", "org_id",
+    )
+    org_ca_key_pem = await conn.fetchval(
+        "SELECT value FROM proxy_config WHERE key = $1", "org_ca_key",
+    )
+    org_ca_cert_pem = await conn.fetchval(
+        "SELECT value FROM proxy_config WHERE key = $1", "org_ca_cert",
+    )
+    if not (org_id and org_ca_key_pem and org_ca_cert_pem):
+        sys.exit("proxy_config missing org material")
+
+    ca_key = serialization.load_pem_private_key(
+        org_ca_key_pem.encode(), password=None,
+    )
+    ca_cert = x509.load_pem_x509_certificate(org_ca_cert_pem.encode())
+
+    if WIPE:
+        deleted = await conn.execute(
+            "DELETE FROM internal_agents WHERE agent_id LIKE $1",
+            f"{org_id}::{PREFIX}-%",
+        )
+        print(f"WIPE: {deleted}", file=sys.stderr)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    now_iso = now.isoformat(timespec="seconds")
+    caps_json = json.dumps([c for c in SET_CAPS.split(",") if c])
+
+    rows = []
+    agents_out = []
+    for i in range(N):
+        agent_name = f"{PREFIX}-{i:05d}"
+        agent_id = f"{org_id}::{agent_name}"
+        spiffe = f"spiffe://{TRUST_DOMAIN}/{org_id}/{agent_name}"
+
+        leaf_key = ec.generate_private_key(ec.SECP256R1())
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+            ]))
+            .issuer_name(ca_cert.subject)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=365))
+            .add_extension(
+                x509.SubjectAlternativeName([
+                    x509.UniformResourceIdentifier(spiffe),
+                ]),
+                critical=False,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        leaf_pkcs8 = leaf_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        dpop_key = ec.generate_private_key(ec.SECP256R1())
+        dpop_jwk_pub = jwk_for(dpop_key.public_key())
+        dpop_jkt = rfc7638_thumbprint(dpop_jwk_pub)
+        dpop_pkcs8 = dpop_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        # federated_at column is TIMESTAMPTZ in Postgres (TEXT in SQLite).
+        # is_active is INTEGER, federated is BOOLEAN. created_at and
+        # enrolled_at are TEXT in both backends.
+        rows.append((
+            agent_id, agent_name, caps_json, cert_pem, now_iso,
+            1, None, dpop_jkt, "stress", now_iso, spiffe,
+            True, now, "both", 1,
+        ))
+        agents_out.append({
+            "agent_id": agent_id, "agent_name": agent_name,
+            "leaf_priv_pkcs8_pem": leaf_pkcs8, "cert_pem": cert_pem,
+            "dpop_priv_pkcs8_pem": dpop_pkcs8,
+            "dpop_jwk_pub": dpop_jwk_pub, "dpop_jkt": dpop_jkt,
+        })
+
+    # Bulk INSERT — Postgres COPY would be faster but executemany via
+    # asyncpg is plenty quick for 5000 rows.
+    await conn.executemany(
+        """INSERT INTO internal_agents
+           (agent_id, display_name, capabilities, cert_pem, created_at,
+            is_active, device_info, dpop_jkt, enrollment_method, enrolled_at,
+            spiffe_id, federated, federated_at, reach, federation_revision)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+           ON CONFLICT (agent_id) DO UPDATE SET
+             cert_pem = EXCLUDED.cert_pem,
+             dpop_jkt = EXCLUDED.dpop_jkt,
+             enrolled_at = EXCLUDED.enrolled_at""",
+        rows,
+    )
+    count = await conn.fetchval(
+        "SELECT COUNT(*) FROM internal_agents WHERE agent_id LIKE $1",
+        f"{org_id}::{PREFIX}-%",
+    )
+
+    result = {
+        "org_id": org_id, "trust_domain": TRUST_DOMAIN,
+        "prefix": PREFIX, "requested": N, "after_count": count,
+        "agents": agents_out,
+    }
+    sys.stdout.write(json.dumps(result))
+    sys.stdout.flush()
+    print(f"OK: {count} {PREFIX}-* in postgres", file=sys.stderr)
+    await conn.close()
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds `_bulk_inject_pg.py` next to `_bulk_inject.py`: the asyncpg counterpart for stress runs where the Mastio bundle has been re-pointed at Postgres (A.1b architectural validation, or any future Tier 2/3 capacity benchmark on a Postgres-backed Mastio).

- Same in-container streaming pattern (`docker exec -i ... python -`) as the SQLite helper.
- Reads Org CA from `proxy_config` via asyncpg (already pinned in the Mastio image, no extra deps).
- `ON CONFLICT (agent_id) DO UPDATE` for idempotent re-runs.
- Schema-aware: `federated_at` TIMESTAMPTZ (passes `datetime`), `is_active` INTEGER, `federated` BOOLEAN.
- Output `stress_agents.json` shape identical to SQLite path, so `intra-org-mastio-burst.js` and `_auth_smoke.py` work unchanged against Postgres-backed Mastio.

README `scripts/stress/README.md` gains a "Postgres bulk inject helper" subsection documenting when to reach for it, schema differences vs SQLite helper, and the invocation shape.

## Why now

A.1b architectural validation (multi-worker uvicorn + Postgres backend) needed this helper to seed 5000 stress agents into a fresh Postgres-backed Mastio without going through the device-code enrollment HTTP path. Committing the helper makes that benchmark reproducible from main, and the same pattern will be reused for A.1c (Redis JTI cross-worker validation) and future capacity work that targets Postgres deployments.

## Test plan

- [x] `_bulk_inject_pg.py` seeds 5000 agents into a Postgres 16-alpine backend in ~1.6 s wall clock (vs ~1.8 s for SQLite — comparable).
- [x] Mastio sees the seeded agents (verified via `internal_agents.COUNT(*)` = 5000 immediately after run).
- [x] `_auth_smoke.py` succeeds against Postgres-backed Mastio using one of the seeded agents (`cnf.jkt` matches persistent `dpop_jkt`).
- [x] Full 30-min `intra-org-mastio-burst.js` run completes against Postgres-backed Mastio with 4 uvicorn workers — 314 877 audit rows written, zero IntegrityError / UNIQUE constraint failures in the Mastio error log.
- [x] DCO sign-off on the commit, no Co-Authored-By trailer.
- [x] No production code path touched (only `scripts/stress/`).