### PR TITLE
chore(release): Mastio v0.4.4 multi-worker uvicorn default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,52 @@
 # Changelog
 
-All notable changes to `cullis-connector` are documented in this file.
+Notable changes to the Cullis components released out of this
+monorepo. Each component has its own release cadence and tag prefix:
+`connector-vX.Y.Z` for the Connector, `mastio-vX.Y.Z` for the Mastio
+(both open-core and enterprise bundles), `court-vX.Y.Z` for the Court.
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-The connector follows its own release cadence, independent from the
-broker and proxy components of the Cullis monorepo. Connector releases
-are tagged `connector-vX.Y.Z`.
+The `release-*.yml` workflows extract the section for the released
+version from this file via `awk` matching `## [v<version>]`; bodies
+flow until the next `## ` heading.
+
+## [v0.4.4] — Mastio multi-worker default — 2026-05-16
+
+First Mastio release that uses this file for release notes (the
+component had no dedicated changelog before; release notes were
+generated from the boilerplate in `release-mastio.yml`).
+
+### Performance
+
+- **Multi-worker uvicorn enabled by default in both bundles** (`mastio-bundle`
+  and `mastio-enterprise-bundle`): the compose `command:` for the
+  `mcp-proxy` service now passes `--workers ${MASTIO_WORKERS:-4}` on
+  top of the existing `--proxy-headers --forwarded-allow-ips '*'`.
+  Operators override the count via `MASTIO_WORKERS` in `proxy.env`.
+- A.1b stress test (May 2026, internal) confirmed multi-worker
+  ship-safe on the default SQLite WAL: 0 audit-chain integrity
+  errors in 472k concurrent audit rows across 4 worker processes.
+  The `_AUDIT_CHAIN_MAX_RETRIES=5` path in `mcp_proxy/db.py` handles
+  cross-process concurrency transparently via the
+  `UNIQUE(chain_seq)` constraint + retry.
+- Throughput uplift +25–240% RPS on Tier 1 scenarios (50–500
+  concurrent agents). The mint endpoint p99 latency dropped ~100x
+  (3399ms → 25ms aggregate).
+
+### Notes
+
+- **DPoP replay protection** stays per-worker by default. For
+  cross-worker enforcement (recommended for any deploy that
+  publishes to the public internet), point the Mastio at Redis via
+  `MCP_PROXY_REDIS_URL`. Existing config, now relevant for
+  multi-worker deploys.
+- **Tier 2+ throughput** (sustained >500 RPS under p99 1s) requires
+  the batched audit chain landing in Mastio v0.5 (ADR-033, separate
+  roadmap). This release does not change the audit-chain shape.
+- **Helm chart and Dockerfile are unchanged.** The bundle compose
+  files are the only surface that ships a multi-worker default;
+  Helm operators who want the same behaviour set
+  `proxy.args[]` accordingly in their `values.yaml`.
 
 ## [v0.4.4] — 2026-05-12
 

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -68,6 +68,37 @@ CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh
 
 `latest` is fine for a quick try; pin to a specific tag in production.
 
+## Workers (uvicorn concurrency)
+
+Mastio v0.4.4 ships with multi-worker uvicorn enabled by default (4
+workers). For VMs with more or fewer logical cores, override the count
+via `proxy.env`:
+
+```bash
+echo 'MASTIO_WORKERS=8' >> proxy.env
+./deploy.sh --pull
+```
+
+A.1b stress test (May 2026) confirmed multi-worker ship-safe on the
+default SQLite WAL: 0 audit-chain integrity errors in 472k concurrent
+audit rows across 4 worker processes. Throughput uplift +25–240% on
+Tier 1 scenarios (50–500 concurrent agents) vs single-worker baseline;
+the mint endpoint p99 latency dropped ~100x.
+
+Replay protection: the DPoP JTI store is per-worker by default, so a
+replayed proof reaching a different worker is not detected within the
+1-minute TTL window. To enforce cross-worker replay protection, point
+the Mastio at Redis:
+
+```bash
+echo 'MCP_PROXY_REDIS_URL=redis://your-redis-host:6379/0' >> proxy.env
+./deploy.sh --pull
+```
+
+For sustained Tier 2 throughput (>500 RPS under p99 1s), additional
+architectural improvements (batched audit chain, ADR-033) are landing
+in Mastio v0.5 on a separate roadmap.
+
 ## Modes
 
 | Command | Effect |

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -53,6 +53,27 @@ services:
     # on proxy_net; the mastio-nginx sidecar below publishes 9443.
     expose:
       - "9100"
+    # v0.4.4 — multi-worker uvicorn default (4 workers). Re-declares the
+    # Dockerfile CMD because docker compose ``command:`` replaces, not
+    # appends. ``MASTIO_WORKERS`` overrides the worker count for VMs
+    # with more / fewer cores than the 4-CPU resource ceiling below.
+    # A.1b stress test confirmed multi-worker ship-safe on SQLite WAL:
+    # 0 IntegrityError in 472k concurrent audit rows, the per-worker
+    # JTI store keeps replay protection within each worker process.
+    # Cross-worker replay enforcement requires the Redis JTI store
+    # (set ``MCP_PROXY_REDIS_URL`` to enable).
+    command:
+      - uvicorn
+      - mcp_proxy.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9100"
+      - --proxy-headers
+      - --forwarded-allow-ips
+      - "*"
+      - --workers
+      - ${MASTIO_WORKERS:-4}
     environment:
       # The image tag this container was started with — read by the
       # dashboard's update banner so it can compare against the latest

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -81,6 +81,14 @@ MCP_PROXY_ALLOWED_ORIGINS=
 # to the host — all external traffic enters via the sidecar.
 MCP_PROXY_PORT=9443
 
+# Uvicorn worker count (v0.4.4+). Default 4 matches the 4-CPU resource
+# ceiling in docker-compose.yml. Raise on fatter VMs (rule of thumb:
+# ~1 worker per logical core, leave 1 free for nginx + the host).
+# A.1b stress test confirmed multi-worker ship-safe on SQLite WAL.
+# Set ``MCP_PROXY_REDIS_URL`` below to enforce DPoP replay protection
+# across workers (otherwise each worker has an independent JTI store).
+MASTIO_WORKERS=4
+
 # ─── ADR-030 — bind-mount data layout ────────────────────────────────────────
 #
 # Host directories bound into the mcp-proxy container. Default sits

--- a/packaging/mastio-enterprise-bundle/README.md
+++ b/packaging/mastio-enterprise-bundle/README.md
@@ -84,6 +84,29 @@ The first boot generates the Org CA and (if `MCP_PROXY_KMS_BACKEND` is
 not `local`) writes the Org CA private key to the configured KMS
 (Vault, AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager).
 
+## Workers (uvicorn concurrency)
+
+Enterprise v0.4.4 ships with multi-worker uvicorn enabled by default
+(4 workers). For VMs with more or fewer logical cores, override the
+count via `proxy.env`:
+
+```bash
+echo 'MASTIO_WORKERS=8' >> proxy.env
+./deploy.sh --pull
+```
+
+A.1b stress test (May 2026) confirmed multi-worker ship-safe on the
+default SQLite WAL: 0 audit-chain integrity errors in 472k concurrent
+audit rows across 4 worker processes. Throughput uplift +25–240% on
+Tier 1 scenarios (50–500 concurrent agents) vs single-worker baseline;
+the mint endpoint p99 latency dropped ~100x.
+
+Replay protection: the DPoP JTI store is per-worker by default. For
+cross-worker replay enforcement, point the Mastio at Redis via
+`MCP_PROXY_REDIS_URL` (existing config, now relevant for multi-worker
+deploys). For sustained Tier 2 throughput (>500 RPS under p99 1s),
+batched audit chain (ADR-033) lands in Mastio v0.5.
+
 ## Upgrading
 
 ```bash

--- a/packaging/mastio-enterprise-bundle/docker-compose.yml
+++ b/packaging/mastio-enterprise-bundle/docker-compose.yml
@@ -55,6 +55,27 @@ services:
         condition: service_completed_successfully
     expose:
       - "9100"
+    # v0.4.4 — multi-worker uvicorn default (4 workers). Re-declares the
+    # Dockerfile CMD because docker compose ``command:`` replaces, not
+    # appends. ``MASTIO_WORKERS`` overrides the worker count for VMs
+    # with more / fewer cores than the 4-CPU resource ceiling below.
+    # A.1b stress test confirmed multi-worker ship-safe on SQLite WAL:
+    # 0 IntegrityError in 472k concurrent audit rows, the per-worker
+    # JTI store keeps replay protection within each worker process.
+    # Cross-worker replay enforcement requires the Redis JTI store
+    # (set ``MCP_PROXY_REDIS_URL`` to enable).
+    command:
+      - uvicorn
+      - mcp_proxy.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9100"
+      - --proxy-headers
+      - --forwarded-allow-ips
+      - "*"
+      - --workers
+      - ${MASTIO_WORKERS:-4}
     environment:
       MCP_PROXY_VERSION:           ${CULLIS_MASTIO_VERSION:-unknown}
       MCP_PROXY_ENVIRONMENT:       ${MCP_PROXY_ENVIRONMENT:-development}

--- a/packaging/mastio-enterprise-bundle/proxy.env.example
+++ b/packaging/mastio-enterprise-bundle/proxy.env.example
@@ -47,6 +47,14 @@ MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.yourorg.example.com:9443
 # Public TLS port (host side; container always binds 9443).
 MCP_PROXY_PORT=9443
 
+# Uvicorn worker count (v0.4.4+). Default 4 matches the 4-CPU resource
+# ceiling in docker-compose.yml. Raise on fatter VMs (rule of thumb:
+# ~1 worker per logical core, leave 1 free for nginx + the host).
+# A.1b stress test confirmed multi-worker ship-safe on SQLite WAL.
+# Set ``MCP_PROXY_REDIS_URL`` to enforce DPoP replay protection across
+# workers (otherwise each worker has an independent JTI store).
+MASTIO_WORKERS=4
+
 # AI gateway: paste Anthropic API key to enable /v1/chat/completions.
 # Leave empty to disable the embedded LLM gateway cleanly.
 MCP_PROXY_ANTHROPIC_API_KEY=


### PR DESCRIPTION
## Summary

Config-only release enabling multi-worker uvicorn by default (4 workers) in both `mastio-bundle` and `mastio-enterprise-bundle`. Customer override via `MASTIO_WORKERS` env in `proxy.env`.

A.1b stress test (May 2026, internal report `imp/c2-a1b-arch-validation-2026-05-16.md`) validated:
- 0 audit-chain integrity errors in 472k concurrent audit rows (4 worker x SQLite WAL)
- +25-240% RPS uplift on Tier 1 scenarios (50-500 concurrent agents)
- Mint endpoint p99 latency ~100x improvement (3399ms -> 25ms aggregate)

`_AUDIT_CHAIN_MAX_RETRIES=5` in `mcp_proxy/db.py` already handles cross-process concurrency via UNIQUE(chain_seq) + retry. Zero code change, only:

- `packaging/mastio-bundle/docker-compose.yml`, `packaging/mastio-enterprise-bundle/docker-compose.yml`: `command:` override declaring uvicorn flags + `--workers ${MASTIO_WORKERS:-4}` (docker compose `command:` replaces the image CMD entirely, so the Dockerfile flags are restated here)
- `packaging/mastio-bundle/README.md`, `packaging/mastio-enterprise-bundle/README.md`: new "Workers (uvicorn concurrency)" section
- `packaging/mastio-bundle/proxy.env.example`, `packaging/mastio-enterprise-bundle/proxy.env.example`: `MASTIO_WORKERS=4` with rationale
- `CHANGELOG.md`: new `[v0.4.4] - Mastio multi-worker default - 2026-05-16` entry above the existing connector v0.4.4 (Mastio had no dedicated changelog before; the awk regex in `release-mastio.yml` will pick this up as release notes)

The Mastio image version derives from the git tag (release-mastio.yml extracts `${GITHUB_REF_NAME#mastio-v}` and passes as `--build-arg VERSION=`), so no version file to bump.

## Notes

- **DPoP replay protection** stays per-worker by default. Operators publishing to the public internet should point the Mastio at Redis (`MCP_PROXY_REDIS_URL`) to enforce cross-worker replay protection. Existing config, now more relevant.
- **Tier 2+ throughput** (sustained >500 RPS under p99 1s) requires the batched audit chain landing in Mastio v0.5 (ADR-033, separate roadmap).
- **Helm chart unchanged.** Bundle compose files are the only surface that ships a multi-worker default; Helm operators set `proxy.args[]` in `values.yaml`.

## Test plan

- [x] `docker compose config` renders `--workers "4"` in both bundles
- [x] `MASTIO_WORKERS=8` override interpolates correctly
- [x] `./demo_network/smoke.sh full` PASS (round-trip + signing key persist + hash chain integrity + MCP echo, ~50s)
- [x] `pytest tests/ -n auto --dist=loadfile` 3588 passed, 1 pre-existing failure on `test_badge_approvals_empty_when_plugin_unavailable` due to local `cullis_enterprise` editable install in venv (verified by `git stash` + re-run: fail identical without this PR's changes; CI runner is clean)
- [x] Manual bundle dogfood: `docker compose up -d --wait` brought all containers healthy on first boot; inspected `/proc/*/cmdline` inside `mcp-proxy` container and confirmed 1 uvicorn master + 4 multiprocessing-spawn worker processes (PIDs 1, 31, 54, 55, 56)
- [x] `curl -sk https://localhost:9443/health` returned `{"status":"ok","version":"0.4.2"}` (compose patch validates against the current `latest` image; v0.4.4 image will be built by the release workflow on tag push)

## Post-merge

1. Tag `mastio-v0.4.4` triggers `release-mastio.yml` + `release-mastio-enterprise-bundle.yml`: pulls release notes from the new `[v0.4.4]` section in CHANGELOG.md, builds + pushes the GHCR image, packages tar.gz + zip bundles, publishes the GitHub Release.
2. Verify `gh release view mastio-v0.4.4 --repo cullis-security/cullis` exists and `docker pull ghcr.io/cullis-security/cullis-mastio:0.4.4` resolves.