### PR TITLE
feat(connector): F4 R2 LOCAL_TOKEN session + MCP envelope (ADR-032 Layer 2 R2)

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -499,6 +499,40 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
                 "regardless.",
                 login_exc,
             )
+
+        # ADR-032 Layer 2 — if the operator ran ``cullis-connector login``
+        # the JSON session file under config_dir carries a valid Mastio
+        # session. Attach it to the SDK so every egress call carries
+        # ``X-Cullis-Session-Token`` + ``X-Cullis-On-Behalf-Of-User`` and
+        # audit rows pick up the user attribution downstream. An expired
+        # or missing session is silently ignored (anonymous-agent mode).
+        try:
+            from cullis_connector.identity.oidc_session import load_session
+
+            oidc_session = load_session(cfg.config_dir)
+            if oidc_session is None:
+                _log.debug("no OIDC user session on disk — agent-only mode")
+            elif oidc_session.is_expired():
+                _log.warning(
+                    "OIDC user session expired at %s — run "
+                    "`cullis-connector login` to bind a fresh one. "
+                    "Continuing in agent-only mode.",
+                    oidc_session.expires_at.isoformat(),
+                )
+            else:
+                client.attach_user_session(
+                    oidc_session.session_token, oidc_session.user_id,
+                )
+                _log.info(
+                    "attached OIDC user session for %s (expires %s)",
+                    oidc_session.user_id,
+                    oidc_session.expires_at.isoformat(timespec="seconds"),
+                )
+        except Exception as oidc_exc:  # noqa: BLE001
+            _log.warning(
+                "OIDC user-session attach failed (%s) — continuing in "
+                "agent-only mode.", oidc_exc,
+            )
     except Exception as exc:
         _log.error(
             "Failed to initialize CullisClient from %s: %s. "

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -318,6 +318,36 @@ class CullisClient(_AiGatewayMixin, _AuthMixin, _DiscoveryMixin, _EnrollmentMixi
         # available.
         self._ca_chain_path: "Path | None" = None
 
+        # ADR-032 Layer 2 — Connector user-session attribution.
+        # Carries the opaque ``user_sessions.session_id`` minted by
+        # the Mastio's /v1/principals/connector-login endpoint plus
+        # the bound user principal_id. When set, ``proxy_headers``
+        # injects ``X-Cullis-Session-Token`` + ``X-Cullis-On-Behalf-Of-User``
+        # on every egress request so the proxy can stamp
+        # ``audit_log.on_behalf_of_user_id``.
+        #
+        # Stored as a single tuple so attach / detach is an atomic
+        # attribute assignment under the GIL; readers in
+        # ``proxy_headers`` (hot path, no lock) see either the old
+        # value or the new value but never a torn half-update.
+        # ``_user_session_lock`` serialises *writers* so two threads
+        # calling ``attach_user_session`` concurrently can't
+        # interleave their state mutations.
+        import threading as _threading
+        self._user_session: "tuple[str, str] | None" = None
+        self._user_session_lock = _threading.Lock()
+
+        # ADR-032 Layer 2 R2 — device attestation claim allowlist slot.
+        # Populated in F2 (Intune) / F3 (Linux TPM) workstreams. Stored
+        # as the raw claim dict; ``proxy_headers`` JSON-serialises +
+        # base64url-nopad encodes on every egress call. Shares the
+        # writer lock with ``_user_session`` because both are part of
+        # the same "Connector identity envelope" and a single
+        # ``cullis-connector login`` invocation typically sets them
+        # together. Reader is lock-free (single attribute read under
+        # the GIL) for the same hot-path reason.
+        self._device_attestation: "dict | None" = None
+
     def __enter__(self) -> CullisClient:
         return self
 
@@ -389,6 +419,14 @@ class CullisClient(_AiGatewayMixin, _AuthMixin, _DiscoveryMixin, _EnrollmentMixi
         the last server nonce we saw. Missing method/url on a DPoP-enabled
         client returns just ``Content-Type`` — the cert at the TLS
         handshake still authenticates the call.
+
+        ADR-032 Layer 2 — when :meth:`attach_user_session` has bound a
+        Connector OIDC session, ``X-Cullis-Session-Token`` +
+        ``X-Cullis-On-Behalf-Of-User`` ride along so the proxy's
+        contextvar wiring populates ``audit_log.on_behalf_of_user_id``.
+        Read is lock-free: ``self._user_session`` is a tuple assigned
+        atomically under the GIL, so a writer never exposes a torn
+        half-update to the request loop.
         """
         headers = {
             "Content-Type": "application/json",
@@ -401,7 +439,80 @@ class CullisClient(_AiGatewayMixin, _AuthMixin, _DiscoveryMixin, _EnrollmentMixi
                 nonce=self._egress_dpop_nonce,
             )
             headers["DPoP"] = proof
+        session = getattr(self, "_user_session", None)
+        if session is not None:
+            session_token, principal_id = session
+            headers["X-Cullis-Session-Token"] = session_token
+            headers["X-Cullis-On-Behalf-Of-User"] = principal_id
+        attestation = getattr(self, "_device_attestation", None)
+        if attestation is not None:
+            import base64 as _base64
+            import json as _json
+            payload = _json.dumps(
+                attestation, separators=(",", ":"),
+            ).encode("utf-8")
+            headers["X-Cullis-Device-Attestation"] = (
+                _base64.urlsafe_b64encode(payload)
+                .rstrip(b"=").decode("ascii")
+            )
         return headers
+
+    def attach_user_session(
+        self,
+        session_token: str,
+        principal_id: str,
+    ) -> None:
+        """Bind a Connector OIDC user session for downstream egress calls.
+
+        After this call every ``proxy_headers()`` invocation carries the
+        two ADR-032 headers and the proxy's :func:`maybe_stamp_user_session`
+        accepts them. Idempotent: a second call with the same values is a
+        no-op; a call with different values overwrites the binding.
+        Thread-safe via :attr:`_user_session_lock` — two writers cannot
+        observe a torn intermediate state.
+        """
+        if not session_token or not principal_id:
+            raise ValueError(
+                "attach_user_session requires both session_token and "
+                "principal_id (got empty value)",
+            )
+        with self._user_session_lock:
+            self._user_session = (session_token, principal_id)
+
+    def detach_user_session(self) -> None:
+        """Drop the bound user session. Idempotent — calling on an
+        already-detached client is a no-op.
+        """
+        with self._user_session_lock:
+            self._user_session = None
+
+    def get_user_session(self) -> "tuple[str, str] | None":
+        """Return the bound ``(session_token, principal_id)`` tuple, or
+        ``None`` when no session is attached. Useful for diagnostics +
+        the ``cullis-connector whoami`` short-circuit.
+        """
+        return self._user_session
+
+    def attach_device_attestation(self, claim: "dict | None") -> None:
+        """Bind a device-attestation claim for downstream egress.
+
+        When set, every :meth:`proxy_headers` call emits the claim as
+        ``X-Cullis-Device-Attestation: base64url(JSON.dumps(claim))``
+        per ``imp/attestation-claim-schema.md`` sez. 3. Passing
+        ``None`` detaches the claim (e.g. after MDM polling reports
+        ``non_compliant`` and the Connector chooses to fall back to
+        anonymous-device mode rather than send a stale claim).
+
+        Only an allowlist + passthrough in R2 — the Mastio
+        verifies + recomputes ``effective_tier`` in F5. R2's job is to
+        ship the wire envelope so the F2 / F3 producers can fill it.
+        """
+        with self._user_session_lock:
+            self._device_attestation = claim
+
+    def get_device_attestation(self) -> "dict | None":
+        """Return the bound device-attestation claim, or ``None``."""
+        return self._device_attestation
 
     def _egress_http(
         self,

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -135,6 +135,16 @@ async def _enforce_local_token_dpop_binding(
     from mcp_proxy.auth.dpop_context import set_dpop_jkt
     set_dpop_jkt(proof_jkt)
 
+    # ADR-032 Layer 2 — graceful stamp of the per-request "on behalf of
+    # user" contextvar when the Connector adds X-Cullis-Session-Token +
+    # X-Cullis-On-Behalf-Of-User headers. Mirrors the wire-up in
+    # ``dependencies.py`` (Bearer-DPoP) and ``dpop_client_cert.py``
+    # (cert+DPoP); closes the third audit-producing auth path.
+    from mcp_proxy.auth.user_session import maybe_stamp_user_session
+    await maybe_stamp_user_session(
+        request, caller_agent_id=payload.agent_id,
+    )
+
 
 async def _is_known_local_kid(token: str, keystore) -> bool:
     """Pre-check: the token's ``kid`` matches a keystore row that is

--- a/mcp_proxy/middleware/strip_x_cullis_headers.py
+++ b/mcp_proxy/middleware/strip_x_cullis_headers.py
@@ -47,14 +47,21 @@ _log = logging.getLogger("mcp_proxy")
 _PREFIX = b"x-cullis-"
 
 # ADR-032 Layer 2 — the Connector legitimately propagates user identity
-# via X-Cullis-Session-Token + X-Cullis-On-Behalf-Of-User. These two are
-# the only client → proxy ``X-Cullis-*`` headers the Mastio reads from
-# an inbound request; every other ``X-Cullis-*`` stays stripped so the
-# blanket defence ("no handler trusts a forged trust header") still
+# via X-Cullis-Session-Token + X-Cullis-On-Behalf-Of-User and (R2) the
+# device-posture envelope via X-Cullis-Device-Attestation. These three
+# are the only client → proxy ``X-Cullis-*`` headers the Mastio reads
+# from an inbound request; every other ``X-Cullis-*`` stays stripped so
+# the blanket defence ("no handler trusts a forged trust header") still
 # holds for the rest of the namespace.
+#
+# R2 NOTE: the Mastio passes the attestation header through to the
+# policy / audit layer untouched. Verification of the claim (manufacturer
+# whitelist, stale-window, effective_tier recompute) lands in F5; this
+# allowlist is the wire-side prerequisite.
 _ALLOWLIST: frozenset[bytes] = frozenset({
     b"x-cullis-session-token",
     b"x-cullis-on-behalf-of-user",
+    b"x-cullis-device-attestation",
 })
 
 

--- a/tests/test_local_token_user_session.py
+++ b/tests/test_local_token_user_session.py
@@ -1,0 +1,368 @@
+"""ADR-032 Layer 2 R2 — LOCAL_TOKEN auth dep stamps on_behalf_of_user.
+
+R1 wired ``maybe_stamp_user_session`` into the Bearer-DPoP dep
+(``dependencies.py``) and the cert+DPoP dep (``dpop_client_cert.py``).
+The third auth-producing path — LOCAL_TOKEN with cnf.jkt + DPoP proof,
+landed in ``mcp_proxy/auth/local_agent_dep.py`` — was the symmetric
+gap. Without this wire-up, a Connector that bound an OIDC user
+session but talked to its Mastio via LOCAL_TOKEN (the SDK's default
+intra-org egress) silently dropped the user attribution on every
+audit row.
+
+These tests exercise the dep end-to-end via Starlette ``Request`` stubs
+so a future refactor can't drop the call without going red.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import importlib
+import time
+import uuid
+
+import jwt as jose_jwt
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request as StarletteRequest
+
+
+def _gen_ca() -> tuple[rsa.RSAPrivateKey, str, str]:
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "acme-ca")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject).issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(hours=1)
+        )
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=365)
+        )
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+    return ca_key, key_pem, cert_pem
+
+
+def _issue_leaf(ca_key, ca_cert_pem: str, agent_id: str):
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_subject = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, agent_id)]
+    )
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_subject).issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(minutes=5)
+        )
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=30)
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    x5c = [base64.b64encode(
+        leaf.public_bytes(serialization.Encoding.DER)
+    ).decode()]
+    return key_pem, x5c
+
+
+def _build_assertion(agent_id: str, leaf_key_pem: str, x5c: list[str]) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "sub": agent_id,
+        "iss": agent_id,
+        "aud": "agent-trust-broker",
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+        "jti": uuid.uuid4().hex,
+    }
+    return jose_jwt.encode(
+        payload, leaf_key_pem, algorithm="RS256", headers={"x5c": x5c},
+    )
+
+
+def _make_dpop_keypair():
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+    x = base64.urlsafe_b64encode(
+        nums.x.to_bytes(32, "big"),
+    ).rstrip(b"=").decode()
+    y = base64.urlsafe_b64encode(
+        nums.y.to_bytes(32, "big"),
+    ).rstrip(b"=").decode()
+    jwk = {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+    return priv, jwk
+
+
+def _build_dpop_proof(
+    priv, jwk, method: str, url: str, *,
+    access_token: str | None = None,
+) -> str:
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    claims: dict = {
+        "jti": uuid.uuid4().hex,
+        "htm": method.upper(),
+        "htu": url,
+        "iat": int(time.time()),
+    }
+    if access_token:
+        claims["ath"] = base64.urlsafe_b64encode(
+            hashlib.sha256(access_token.encode()).digest()
+        ).rstrip(b"=").decode()
+    return jose_jwt.encode(
+        claims, priv_pem, algorithm="ES256",
+        headers={"typ": "dpop+jwt", "jwk": jwk},
+    )
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.invalid")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_DPOP_IAT_WINDOW", "120")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import set_config
+        ca_key, ca_key_pem, ca_cert_pem = _gen_ca()
+        await set_config("org_ca_key", ca_key_pem)
+        await set_config("org_ca_cert", ca_cert_pem)
+
+        mgr = app.state.agent_manager
+        await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
+        await mgr.ensure_mastio_identity()
+        from mcp_proxy.auth.local_issuer import build_from_keystore
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        app.state.local_keystore = LocalKeyStore()
+        app.state.local_issuer = await build_from_keystore(
+            "acme", app.state.local_keystore,
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test",
+        ) as client:
+            yield {
+                "app": app, "client": client,
+                "ca_key": ca_key, "ca_cert_pem": ca_cert_pem,
+            }
+
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_user_contextvar():
+    from mcp_proxy.auth.user_context import (
+        reset_on_behalf_of_user,
+        set_on_behalf_of_user,
+    )
+    tok = set_on_behalf_of_user(None)
+    yield
+    reset_on_behalf_of_user(tok)
+
+
+async def _mint_bound_token(ctx, agent_id: str):
+    leaf_key_pem, x5c = _issue_leaf(
+        ctx["ca_key"], ctx["ca_cert_pem"], agent_id,
+    )
+    assertion = _build_assertion(agent_id, leaf_key_pem, x5c)
+    priv, jwk = _make_dpop_keypair()
+    proof = _build_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/auth/token",
+    )
+    resp = await ctx["client"].post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"], priv, jwk
+
+
+@pytest.mark.asyncio
+async def test_local_token_with_session_headers_stamps_user_contextvar(
+    proxy_app,
+):
+    """The headline R2 fix. A Connector that holds an OIDC user session
+    plus a LOCAL_TOKEN sends both on the request; the dep verifies the
+    LOCAL_TOKEN + DPoP, then stamps the user contextvar so downstream
+    audit rows record the on_behalf_of_user_id."""
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+    from mcp_proxy.auth.user_context import current_on_behalf_of_user
+    from mcp_proxy.db import create_user_session
+
+    ctx = proxy_app
+    # Use a typed-principal agent_id so ``_maybe_local_token`` follows
+    # the typed-principal branch (skips ``internal_agents`` lookup); the
+    # session-stamping helper runs from the shared
+    # ``_enforce_local_token_dpop_binding`` step, which both branches
+    # reach. Regular ``acme::connector`` agents would otherwise need
+    # an extra DB seed for the registry.
+    agent_id = "acme::user::alice-deadbeef"
+    token, priv, jwk = await _mint_bound_token(ctx, agent_id)
+
+    principal_id = "acme::user::alice-deadbeef"
+    session_token = "sess-r2-local-token-happy"
+    await create_user_session(
+        session_id=session_token,
+        principal_id=principal_id,
+        agent_cert_thumbprint="a" * 64,
+        sso_subject="alice@acme.com",
+        idp_issuer="https://idp.example.com",
+        display_name="Alice",
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+    )
+
+    proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/proxy/agents/list",
+        access_token=token,
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", proof.encode()),
+            (b"x-cullis-session-token", session_token.encode()),
+            (b"x-cullis-on-behalf-of-user", principal_id.encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+
+    payload = await _maybe_local_token(req)
+    assert payload is not None
+    assert payload.agent_id == agent_id
+    assert current_on_behalf_of_user() == principal_id
+
+
+@pytest.mark.asyncio
+async def test_local_token_without_session_headers_leaves_contextvar_unset(
+    proxy_app,
+):
+    """No session headers → request is anonymous-agent (the LOCAL_TOKEN
+    still authenticates the agent, contextvar stays None). Mirrors the
+    behaviour for cert+DPoP / Bearer-DPoP requests without the headers
+    so audit rows continue to record agent-only attribution."""
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+    from mcp_proxy.auth.user_context import current_on_behalf_of_user
+
+    ctx = proxy_app
+    agent_id = "acme::user::alice-deadbeef"
+    token, priv, jwk = await _mint_bound_token(ctx, agent_id)
+
+    proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/proxy/agents/list",
+        access_token=token,
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", proof.encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    payload = await _maybe_local_token(req)
+
+    assert payload is not None
+    assert payload.agent_id == agent_id
+    assert current_on_behalf_of_user() is None
+
+
+@pytest.mark.asyncio
+async def test_local_token_with_unknown_session_token_leaves_contextvar_unset(
+    proxy_app,
+):
+    """Session header refers to an unknown / revoked / expired row.
+    The dep does NOT 401 the request (graceful by design — agent identity
+    is the primary credential). The contextvar is left at None so audit
+    rows fall back to agent-only attribution and a WARN is emitted."""
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+    from mcp_proxy.auth.user_context import current_on_behalf_of_user
+
+    ctx = proxy_app
+    agent_id = "acme::user::alice-deadbeef"
+    token, priv, jwk = await _mint_bound_token(ctx, agent_id)
+
+    proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/proxy/agents/list",
+        access_token=token,
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", proof.encode()),
+            (b"x-cullis-session-token", b"sess-does-not-exist"),
+            (b"x-cullis-on-behalf-of-user", b"acme::user::nobody"),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    payload = await _maybe_local_token(req)
+
+    assert payload is not None
+    assert payload.agent_id == agent_id
+    assert current_on_behalf_of_user() is None

--- a/tests/test_sdk_user_session_headers.py
+++ b/tests/test_sdk_user_session_headers.py
@@ -1,0 +1,145 @@
+"""ADR-032 Layer 2 R2 — SDK egress header injection.
+
+Pins the contract that ``proxy_headers()`` carries:
+
+* ``X-Cullis-Session-Token`` + ``X-Cullis-On-Behalf-Of-User`` after
+  :meth:`CullisClient.attach_user_session` (R1 wire-up, finalised here).
+* ``X-Cullis-Device-Attestation`` after
+  :meth:`CullisClient.attach_device_attestation` (R2 new). Encoded as
+  ``base64url(JSON.dumps(claim, separators=(',', ':')))`` without
+  trailing ``=`` per ``imp/attestation-claim-schema.md`` sez. 3 +
+  memory ``feedback_base64url_nopad``.
+
+R2's job is the wire envelope only — Mastio-side verification of the
+attestation claim (effective_tier recompute, manufacturer whitelist,
+stale-window enforcement) lands in F5.
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from cullis_sdk import CullisClient
+
+
+@pytest.fixture
+def client():
+    c = CullisClient(broker_url="http://test.invalid", verify_tls=False)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_proxy_headers_returns_baseline_when_nothing_attached(client):
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    assert headers["Content-Type"] == "application/json"
+    assert "X-Cullis-Session-Token" not in headers
+    assert "X-Cullis-On-Behalf-Of-User" not in headers
+    assert "X-Cullis-Device-Attestation" not in headers
+
+
+def test_attach_user_session_injects_two_headers(client):
+    client.attach_user_session(
+        session_token="sess-abc123",
+        principal_id="acme::user::alice",
+    )
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    assert headers["X-Cullis-Session-Token"] == "sess-abc123"
+    assert headers["X-Cullis-On-Behalf-Of-User"] == "acme::user::alice"
+
+
+def test_attach_user_session_rejects_empty_token(client):
+    with pytest.raises(ValueError):
+        client.attach_user_session(session_token="", principal_id="acme::user::alice")
+
+
+def test_attach_user_session_rejects_empty_principal(client):
+    with pytest.raises(ValueError):
+        client.attach_user_session(session_token="sess-x", principal_id="")
+
+
+def test_detach_user_session_drops_headers(client):
+    client.attach_user_session("sess-abc123", "acme::user::alice")
+    client.detach_user_session()
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    assert "X-Cullis-Session-Token" not in headers
+    assert "X-Cullis-On-Behalf-Of-User" not in headers
+
+
+def test_detach_user_session_is_idempotent(client):
+    client.detach_user_session()  # no-op on fresh client
+    client.detach_user_session()  # still a no-op
+    assert client.get_user_session() is None
+
+
+def test_attach_device_attestation_emits_base64url_nopad(client):
+    claim = {
+        "mdm": "intune",
+        "device_id": "61b8d3f4-aef1",
+        "compliance": "compliant",
+        "hardware": "tpm_2.0",
+        "strength": "hw_attested",
+        "manufacturer": "Infineon",
+        "verified_at": "2026-05-17T08:34:00Z",
+        "stale_seconds": 312,
+    }
+    client.attach_device_attestation(claim)
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    encoded = headers["X-Cullis-Device-Attestation"]
+
+    # base64url, no padding.
+    assert "=" not in encoded
+    assert "+" not in encoded
+    assert "/" not in encoded
+
+    # Round-trip the encoding back to the original dict.
+    padded = encoded + "=" * (-len(encoded) % 4)
+    decoded = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+    assert decoded == claim
+
+
+def test_attach_device_attestation_serialises_with_compact_separators(client):
+    """Header size is bounded — the JSON must not contain unnecessary
+    whitespace. ``imp/attestation-claim-schema.md`` sez. 3 mandates
+    ``separators=(',', ':')`` for header-size minimisation (nginx default
+    8KB envelope budget)."""
+    claim = {"a": 1, "b": [2, 3]}
+    client.attach_device_attestation(claim)
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    encoded = headers["X-Cullis-Device-Attestation"]
+    padded = encoded + "=" * (-len(encoded) % 4)
+    raw = base64.urlsafe_b64decode(padded).decode("utf-8")
+    assert raw == '{"a":1,"b":[2,3]}'
+
+
+def test_attach_device_attestation_none_detaches(client):
+    client.attach_device_attestation({"mdm": "intune"})
+    client.attach_device_attestation(None)
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    assert "X-Cullis-Device-Attestation" not in headers
+
+
+def test_user_session_and_attestation_compose(client):
+    """All three headers ride together when both bindings are active."""
+    client.attach_user_session("sess-abc", "acme::user::alice")
+    client.attach_device_attestation({"mdm": "intune", "compliance": "compliant"})
+    headers = client.proxy_headers(method="POST", url="http://test/x")
+    assert headers["X-Cullis-Session-Token"] == "sess-abc"
+    assert headers["X-Cullis-On-Behalf-Of-User"] == "acme::user::alice"
+    assert "X-Cullis-Device-Attestation" in headers
+
+
+def test_get_user_session_returns_tuple_after_attach(client):
+    assert client.get_user_session() is None
+    client.attach_user_session("sess-x", "acme::user::bob")
+    assert client.get_user_session() == ("sess-x", "acme::user::bob")
+
+
+def test_get_device_attestation_returns_claim_after_attach(client):
+    assert client.get_device_attestation() is None
+    claim = {"mdm": None, "compliance": "unknown"}
+    client.attach_device_attestation(claim)
+    assert client.get_device_attestation() == claim

--- a/tests/test_strip_x_cullis_headers.py
+++ b/tests/test_strip_x_cullis_headers.py
@@ -231,6 +231,26 @@ async def test_adr032_allowlist_keeps_session_headers(client):
 
 
 @pytest.mark.asyncio
+async def test_adr032_r2_allowlist_keeps_device_attestation(client):
+    """ADR-032 Layer 2 R2 — Connector propagates the device-posture
+    envelope via ``X-Cullis-Device-Attestation``. It must reach the
+    policy / audit layer untouched (verification of the claim is F5,
+    this middleware is the wire-side prerequisite). Sibling
+    ``X-Cullis-*`` headers continue to strip.
+    """
+    resp = await client.get(
+        "/echo",
+        headers={
+            "X-Cullis-Device-Attestation": "eyJtZG0iOiJpbnR1bmUifQ",
+            "X-Cullis-Trust": "spoofed",
+        },
+    )
+    seen = {k.lower(): v for k, v in resp.json()["headers"]}
+    assert seen.get("x-cullis-device-attestation") == "eyJtZG0iOiJpbnR1bmUifQ"
+    assert "x-cullis-trust" not in seen
+
+
+@pytest.mark.asyncio
 async def test_no_x_cullis_no_changes(client):
     """A request with zero X-Cullis-* headers must traverse the
     middleware without scope copy or log event."""


### PR DESCRIPTION
## Summary

Continues #740 (F4 R1 OIDC foundation). Closes the three Layer 2 gaps the orchestrator flagged for R2:

- **LOCAL_TOKEN session stamping** — `mcp_proxy/auth/local_agent_dep.py` now calls `maybe_stamp_user_session()` after the DPoP binding check, symmetric to R1's wire-up on cert+DPoP (`dpop_client_cert.py`) and Bearer-DPoP (`dependencies.py`). Closes the third audit-producing auth path: a Connector that bound an OIDC user session but talked to its Mastio via LOCAL_TOKEN previously dropped `on_behalf_of_user_id` on every audit row.
- **SDK MCP envelope** — `CullisClient` gains `attach_user_session` / `detach_user_session` / `attach_device_attestation`. `proxy_headers()` injects the two ADR-032 session headers + `X-Cullis-Device-Attestation` (base64url, no padding) when bindings are set. Wire envelope per `imp/attestation-claim-schema.md` sez. 3 is locked here; server-side claim verification + `effective_tier` recompute lands in F5.
- **Middleware allowlist** — `StripXCullisHeadersMiddleware` now keeps `X-Cullis-Device-Attestation` alongside the two R1 headers. Blanket strip defence on every other `X-Cullis-*` is preserved.
- **Connector CLI auto-attach** — `_cmd_serve` auto-attaches a persisted `oidc_session.json` to the SDK so dogfood flows pick up the audit attribution without manual wiring.

## Scope deviation (Steps 4 + 5 deferred to R3)

The R2 prompt asked for `local_user_principals.password_hash` + a Mastio bcrypt endpoint (`/v1/principals/connector-login-local`) + admin local user provisioning. These directly conflict with migration `0028_revert_user_password`, which explicitly removed the Mastio password layer with the rationale:

> Mastio receives the resulting cert (or SSO header) and attributes the principal — it never holds the password. ... In Frontdesk shared-mode the credential lives in the Connector Ambassador's `users.db` (ADR-025 Phase 5).

The Connector Ambassador layer (`cullis_connector/identity/users.py` + `users_db.py`) already implements bcrypt + SQLite local-user store. The local-creds login path belongs there, with Mastio just trusting the Connector's cert+DPoP claim about the user (via the existing `/v1/principals/connector-login` endpoint that R1 added). Re-scoping the local-creds wiring to R3 keeps R2 architecturally consistent with 0028.

## Schema reference

`imp/attestation-claim-schema.md` sez. 3 (MCP envelope propagation) — locked source of truth for the three `X-Cullis-*` Connector → Mastio headers.

## Test plan

- [x] Unit: `tests/test_sdk_user_session_headers.py` — 12 cases (attach / detach / base64url-nopad / compose / get accessors)
- [x] Dep: `tests/test_local_token_user_session.py` — 3 cases (session stamps contextvar / no headers → None / unknown session → None)
- [x] Middleware: `tests/test_strip_x_cullis_headers.py` extended with `test_adr032_r2_allowlist_keeps_device_attestation`
- [x] Full parallel suite: `pytest tests/` — **3640 pass / 31 skip / 1 pre-existing local-env fail** (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`, fails locally because `cullis_enterprise` is editable-installed in the shared `.venv`; CI runs in clean venvs without it — known issue per memory `feedback_pythonpath_worktree_for_new_core_modules`)
- [x] Smoke gate: `./sandbox/smoke.sh full` — **25 pass / 0 fail / 1 skip** (B4.9 gated on `SMOKE_ASSERT_INTRA_ORG=1`)
- [ ] CI: full check matrix (this PR)