### PR TITLE
feat(connector): Linux TPM BYOD hw attestation Phase 1 (ADR-032 F3)

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -59,6 +59,7 @@ def enroll(
     request_timeout_s: float = 10.0,
     max_wait_s: int = 30 * 60,
     poll_sink=sys.stderr,
+    enable_hw_attestation: bool = True,
 ) -> IdentityBundle:
     """Full device-code enrollment, blocking until admin decides or TTL expires.
 
@@ -80,6 +81,19 @@ def enroll(
     private_key = generate_keypair()
     pubkey_pem = public_key_to_pem(private_key.public_key()).decode()
 
+    # ADR-032 F3: best-effort TPM 2.0 attestation. detect_best_keystore
+    # returns a soft keystore when the optional ``tpm2-pytss`` dep is
+    # absent or no TPM device is reachable; the enrollment then carries
+    # no attestation half and Mastio assigns the lower effective tier.
+    attestation = _maybe_collect_tpm_attestation(
+        site_url=site_url,
+        pubkey_pem=pubkey_pem,
+        verify_tls=verify_tls,
+        timeout_s=request_timeout_s,
+        enabled=enable_hw_attestation,
+        sink=poll_sink,
+    )
+
     # ADR-014 PR-C: the cert the Mastio signs at approval is the
     # agent's credential — no api_key is minted on either side.
 
@@ -100,6 +114,7 @@ def enroll(
         verify_tls=verify_tls,
         timeout_s=request_timeout_s,
         private_key=private_key,
+        attestation=attestation,
     )
     session_id = start_resp["session_id"]
     enroll_url = start_resp["enroll_url"]
@@ -222,8 +237,9 @@ def _start(
     timeout_s: float,
     dpop_jwk: dict | None = None,
     private_key=None,
+    attestation: "_AttestationBundle | None" = None,
 ) -> dict[str, Any]:
-    body = {
+    body: dict[str, Any] = {
         "pubkey_pem": pubkey_pem,
         "requester_name": requester.name,
         "requester_email": requester.email,
@@ -250,6 +266,13 @@ def _start(
         body["dpop_jwk"] = dpop_jwk
     if private_key is not None:
         body["pop_signature"] = _build_pop_signature(private_key, pubkey_pem)
+
+    if attestation is not None:
+        body["attestation_nonce_id"] = attestation.nonce_id
+        body["tpm_quote_b64"] = attestation.quote_b64
+        if attestation.manufacturer:
+            body["tpm_manufacturer"] = attestation.manufacturer
+        body["tpm_ek_cert_present"] = attestation.ek_cert_present
 
     try:
         response = httpx.post(
@@ -395,6 +418,106 @@ def cert_fingerprint(cert: x509.Certificate) -> str:
     """SHA-256 of the cert DER, 64-char hex. Used for operator verification."""
     import hashlib
     return hashlib.sha256(cert.public_bytes(encoding=_DER)).hexdigest()
+
+
+# ── ADR-032 F3: hardware attestation helpers ───────────────────────────
+
+
+@dataclass
+class _AttestationBundle:
+    nonce_id: str
+    quote_b64: str
+    manufacturer: str | None
+    ek_cert_present: bool
+
+
+def _maybe_collect_tpm_attestation(
+    *,
+    site_url: str,
+    pubkey_pem: str,
+    verify_tls: bool | str,
+    timeout_s: float,
+    enabled: bool,
+    sink,
+) -> _AttestationBundle | None:
+    """Best-effort: detect a hardware keystore, request a nonce, quote it.
+
+    Returns ``None`` on any failure; the enrollment then proceeds with
+    the soft path. This is intentionally NOT a fatal gate: Mastio refuses
+    ``_attested`` capability when the claim is absent, so the security
+    boundary lives server-side (memoria
+    ``feedback_h4_convergent_pattern_fallback_insecure_default``).
+    """
+    if not enabled:
+        return None
+
+    import base64 as _b64
+
+    try:
+        from cullis_connector.keystore import detect_best_keystore
+        keystore = detect_best_keystore(prefer_hardware=True)
+    except Exception as exc:
+        _log.info("keystore_detect_failed", extra={"err": str(exc)})
+        return None
+
+    claim = keystore.attestation_claim()
+    if claim is None:
+        # Soft keystore: nothing to attest.
+        return None
+
+    quote_fn = getattr(keystore, "generate_aik_quote", None)
+    if quote_fn is None:
+        return None
+
+    try:
+        nonce_resp = httpx.get(
+            f"{site_url}/v1/enrollment/attestation-nonce",
+            verify=verify_tls,
+            timeout=timeout_s,
+        )
+    except httpx.HTTPError as exc:
+        _log.info("attestation_nonce_unreachable", extra={"err": str(exc)})
+        return None
+    if nonce_resp.status_code != 200:
+        _log.info(
+            "attestation_nonce_status_not_ok",
+            extra={"status": nonce_resp.status_code},
+        )
+        return None
+
+    payload = nonce_resp.json()
+    nonce_id = payload.get("nonce_id")
+    nonce_b64 = payload.get("nonce_b64")
+    if not nonce_id or not nonce_b64:
+        return None
+    try:
+        nonce_bytes = _b64.urlsafe_b64decode(
+            nonce_b64 + "=" * (-len(nonce_b64) % 4),
+        )
+    except Exception:
+        return None
+
+    try:
+        quote_blob = quote_fn(nonce_bytes)
+    except Exception as exc:
+        _log.info("tpm_quote_failed", extra={"err": str(exc)})
+        return None
+
+    quote_b64 = _b64.urlsafe_b64encode(quote_blob).rstrip(b"=").decode()
+    ek_cert_present = claim.strength == "hw_attested"
+
+    print(
+        f"  ✓ TPM attestation bundled (strength={claim.strength}, "
+        f"manufacturer={claim.manufacturer or 'unknown'})",
+        file=sink,
+        flush=True,
+    )
+    return _AttestationBundle(
+        nonce_id=str(nonce_id),
+        quote_b64=quote_b64,
+        manufacturer=claim.manufacturer,
+        ek_cert_present=ek_cert_present,
+    )
 
 
 # local alias to avoid a circular-looking import in the helper above

--- a/cullis_connector/keystore/__init__.py
+++ b/cullis_connector/keystore/__init__.py
@@ -1,0 +1,53 @@
+"""Key backends for the Connector identity material (ADR-032 F3).
+
+The :class:`KeyStore` abstraction lets the enrollment flow swap between
+software-only keys (existing default), Linux TPM 2.0 hardware-bound keys,
+and (future) macOS Secure Enclave / Windows TPM backends without rewriting
+the call sites. Only the TPM backend can produce an attestation claim with
+``strength="hw_attested"``; the soft backend reports ``None`` and the
+server downgrades the effective tier accordingly.
+"""
+from cullis_connector.keystore.base import (
+    AttestationClaim,
+    KeyStore,
+    KeyStoreUnavailable,
+)
+from cullis_connector.keystore.soft import SoftKeyStore
+
+__all__ = [
+    "AttestationClaim",
+    "KeyStore",
+    "KeyStoreUnavailable",
+    "SoftKeyStore",
+    "detect_best_keystore",
+]
+
+
+def detect_best_keystore(
+    *,
+    soft_key_path=None,
+    tpm_persistent_handle: int = 0x81010001,
+    prefer_hardware: bool = True,
+):
+    """Return the strongest available :class:`KeyStore` for this host.
+
+    Phase 1 attempts Linux TPM 2.0 first when ``prefer_hardware`` is set,
+    falling back to a soft keystore on any import / device / permission
+    error. The fallback is intentional; a Connector without a TPM should
+    still enroll, just at a lower effective tier (see ADR-032 Decision K).
+    """
+    if prefer_hardware:
+        try:
+            from cullis_connector.keystore.tpm_linux import LinuxTpmKeyStore
+
+            return LinuxTpmKeyStore(persistent_handle=tpm_persistent_handle)
+        except KeyStoreUnavailable:
+            pass
+        except Exception:
+            # Defensive: any TPM hiccup falls back rather than hard-failing
+            # the enrollment flow. Mastio refuses ``_attested`` capability
+            # without a verified claim, so this is a UX choice not a
+            # security one (memoria
+            # feedback_h4_convergent_pattern_fallback_insecure_default).
+            pass
+    return SoftKeyStore(private_key_path=soft_key_path)

--- a/cullis_connector/keystore/base.py
+++ b/cullis_connector/keystore/base.py
@@ -1,0 +1,104 @@
+"""Abstract :class:`KeyStore` and the on-the-wire attestation claim shape.
+
+The claim mirrors ``imp/attestation-claim-schema.md`` sez. 1. Only the
+hardware-related subset is owned by the keystore; the MDM/compliance half
+is filled in by F2 (Intune polling). The Mastio enrollment endpoint merges
+the two halves before persisting ``device_attestation``.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Literal
+
+HardwareKind = Literal["tpm_2.0", "secure_enclave", "soft"]
+AttestationStrength = Literal["hw_attested", "hw_isolated", "soft_only"]
+
+
+class KeyStoreUnavailable(Exception):
+    """Raised when a hardware backend cannot be initialised.
+
+    Callers (notably :func:`detect_best_keystore`) catch this to fall back
+    to the soft keystore. A bare ``ImportError`` from the optional
+    ``tpm2-pytss`` dependency, a missing ``/dev/tpmrm0`` device node, or
+    an EACCES on the TCTI socket all surface as this exception so the
+    enrollment flow sees a single, semantically meaningful failure type.
+    """
+
+
+@dataclass(frozen=True)
+class AttestationClaim:
+    """Hardware-side half of the device attestation claim.
+
+    Field names + value vocabularies match the lock in
+    ``imp/attestation-claim-schema.md`` sez. 1. ``hardware`` and
+    ``strength`` are required; ``manufacturer`` may be ``None`` when the
+    TPM advertises a vendor outside the Phase 1 whitelist or when no EK
+    cert was parsed.
+    """
+
+    hardware: HardwareKind
+    strength: AttestationStrength
+    manufacturer: str | None = None
+    # Free-form telemetry consumed by audit (not by the schema contract).
+    extras: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        out: dict[str, object] = {
+            "hardware": self.hardware,
+            "strength": self.strength,
+        }
+        if self.manufacturer is not None:
+            out["manufacturer"] = self.manufacturer
+        return out
+
+
+class KeyStore(ABC):
+    """DPoP / CSR key backend.
+
+    Implementations must produce a stable public key across calls (the
+    enrollment flow submits the PEM once at ``/v1/enrollment/start`` and
+    later DPoP proofs must verify against it) and must guarantee that
+    :meth:`sign` cannot be forged without on-device material. The soft
+    backend stores a PKCS#8 PEM under ``chmod 600``; the TPM backend
+    keeps the private half inside the chip and only exposes signatures.
+    """
+
+    @abstractmethod
+    def sign(self, message: bytes) -> bytes:
+        """Return a signature over ``message``.
+
+        Signature encoding is keystore-defined but must verify against the
+        algorithm implied by :meth:`public_key_pem` (ECDSA-SHA256 for the
+        EC P-256 backends used in Phase 1, DER-encoded ``r,s``).
+        """
+
+    @abstractmethod
+    def public_key_pem(self) -> str:
+        """Return the SubjectPublicKeyInfo PEM of the stored key."""
+
+    @abstractmethod
+    def attestation_strength(self) -> AttestationStrength:
+        """Return ``hw_attested`` / ``hw_isolated`` / ``soft_only``.
+
+        ``hw_attested`` requires that the backend can produce a quote the
+        server can verify (TPM AIK quote + EK chain or manufacturer match
+        Phase 1). ``hw_isolated`` means the key lives in hardware but the
+        attestation surface is unavailable (no EK cert, vTPM, etc).
+        ``soft_only`` is the file-on-disk backend.
+        """
+
+    @abstractmethod
+    def attestation_claim(self) -> AttestationClaim | None:
+        """Return the hardware-side claim, or ``None`` for soft backends."""
+
+    def generate_aik_quote(self, nonce: bytes) -> bytes | None:
+        """Produce an AIK quote bound to ``nonce``.
+
+        Default implementation returns ``None``; only hardware backends
+        that own an Attestation Identity Key override this. The enrollment
+        flow uses ``hasattr(self, "generate_aik_quote")``-style branching
+        with the return value: ``None`` means "no quote to ship", a bytes
+        blob is forwarded server-side for verification.
+        """
+        return None

--- a/cullis_connector/keystore/soft.py
+++ b/cullis_connector/keystore/soft.py
@@ -1,0 +1,107 @@
+"""Soft (file-on-disk) :class:`KeyStore`; existing default.
+
+Wraps an in-memory ``cryptography`` EC P-256 private key so the enrollment
+flow can treat soft and TPM backends uniformly. No attestation claim is
+emitted: the server resolves ``effective_tier`` to ``untrusted`` /
+``byod_isolated`` depending on what the rest of the envelope ships.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+
+from cullis_connector.identity.keypair import (
+    generate_keypair,
+    public_key_to_pem,
+)
+from cullis_connector.keystore.base import (
+    AttestationClaim,
+    AttestationStrength,
+    KeyStore,
+)
+
+
+class SoftKeyStore(KeyStore):
+    """In-process EC P-256 key, optionally persisted to a PKCS#8 PEM file.
+
+    Three modes:
+
+    * ``private_key_path`` is ``None`` → generate ephemeral key (tests, dev)
+    * ``private_key_path`` exists       → load from disk
+    * ``private_key_path`` missing      → generate and persist (chmod 600)
+    """
+
+    def __init__(
+        self,
+        *,
+        private_key_path: Path | str | None = None,
+        private_key: PrivateKeyTypes | None = None,
+    ) -> None:
+        if private_key is not None:
+            self._key = private_key
+            self._path: Path | None = (
+                Path(private_key_path) if private_key_path else None
+            )
+            return
+
+        if private_key_path is None:
+            self._key = generate_keypair()
+            self._path = None
+            return
+
+        path = Path(private_key_path)
+        self._path = path
+        if path.exists():
+            self._key = serialization.load_pem_private_key(
+                path.read_bytes(), password=None,
+            )
+            return
+
+        self._key = generate_keypair()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        pem = self._key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        path.write_bytes(pem)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            # Best-effort; POSIX-only, Windows is out of scope for Phase 1.
+            pass
+
+    # ── KeyStore interface ───────────────────────────────────────────────
+
+    def sign(self, message: bytes) -> bytes:
+        if isinstance(self._key, ec.EllipticCurvePrivateKey):
+            return self._key.sign(message, ec.ECDSA(hashes.SHA256()))
+        raise NotImplementedError(
+            f"SoftKeyStore.sign does not support {type(self._key).__name__}"
+            "; Phase 1 uses EC P-256 only",
+        )
+
+    def public_key_pem(self) -> str:
+        return public_key_to_pem(self._key.public_key()).decode()
+
+    def attestation_strength(self) -> AttestationStrength:
+        return "soft_only"
+
+    def attestation_claim(self) -> AttestationClaim | None:
+        return None
+
+    # ── Soft-only helpers (used by tests + legacy callers) ──────────────
+
+    @property
+    def private_key(self) -> PrivateKeyTypes:
+        """Escape hatch for code paths that still need the raw key.
+
+        New code should use :meth:`sign` instead so it stays portable to
+        the TPM backend. Kept available because the enrollment + DPoP key
+        material currently lives in two separate stores (cert key vs DPoP
+        JWK) and refactoring both is out of scope for F3 Phase 1.
+        """
+        return self._key

--- a/cullis_connector/keystore/tpm_linux.py
+++ b/cullis_connector/keystore/tpm_linux.py
@@ -1,0 +1,497 @@
+"""Linux TPM 2.0 :class:`KeyStore` via ``tpm2-pytss`` (ADR-032 F3 Phase 1).
+
+Generates a non-extractable ECC P-256 key (``fixedTPM | fixedParent |
+sensitiveDataOrigin``) inside the TPM, makes it persistent at a configurable
+NV handle (default 0x81010001), and exposes it through the
+:class:`~cullis_connector.keystore.base.KeyStore` interface. The private
+half never leaves the chip; signatures, public-key reads, and the AIK
+quote all round-trip through the TPM driver.
+
+The optional dependency lives in ``[project.optional-dependencies] tpm``;
+when missing, :class:`LinuxTpmKeyStore` raises :class:`KeyStoreUnavailable`
+and :func:`detect_best_keystore` falls back to the soft backend.
+
+Phase 1 limitations explicit in the prompt:
+
+* EK CA chain verification is deferred (ADR-032 Decision Q8). Strength
+  is ``hw_attested`` only when the EK certificate is present AND the
+  manufacturer is in the Phase 1 whitelist; otherwise ``hw_isolated``.
+* No PCR policy binding; Phase 1 reads PCR 0..7 into the quote but
+  does not enforce a measured-boot allowlist.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from cullis_connector.keystore.base import (
+    AttestationClaim,
+    AttestationStrength,
+    KeyStore,
+    KeyStoreUnavailable,
+)
+
+_log = logging.getLogger("cullis_connector.keystore.tpm_linux")
+
+# ADR-032 Decision Q8; Phase 1 manufacturer whitelist. Mirrors the value
+# in ``mcp_proxy/attestation/tpm_verify.py``. A future ADR will move this
+# to a refreshable remote bundle; for now both ends hard-code the same set
+# so a customer-supplied chip outside the list still enrolls (downgraded
+# to ``hw_isolated``) without a Mastio config bump.
+TPM_MANUFACTURER_WHITELIST: frozenset[str] = frozenset(
+    {"Infineon", "Microsoft", "ST", "Nuvoton", "Intel"},
+)
+
+
+class LinuxTpmKeyStore(KeyStore):
+    """TPM 2.0-backed EC P-256 keystore (Linux, ``tpm2-pytss`` ≥ 2.0)."""
+
+    def __init__(self, persistent_handle: int = 0x81010001) -> None:
+        try:
+            import tpm2_pytss  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise KeyStoreUnavailable(
+                "tpm2-pytss is not installed; `pip install"
+                " 'cullis-connector[tpm]'` to enable Linux TPM attestation",
+            ) from exc
+
+        try:
+            self._esapi = tpm2_pytss.ESAPI()  # type: ignore[attr-defined]
+        except Exception as exc:
+            # Common causes: /dev/tpmrm0 missing, EACCES on tcti socket,
+            # swtpm not running. The fallback path in detect_best_keystore
+            # catches this and continues with the soft backend.
+            raise KeyStoreUnavailable(
+                f"TPM 2.0 device not reachable: {exc}",
+            ) from exc
+
+        self._tss = tpm2_pytss
+        self._handle = persistent_handle
+        self._ek_cert_present = False
+        self._cached_pub_pem: str | None = None
+        self._cached_manufacturer: str | None = None
+        self._ensure_key()
+
+    # ── Lifecycle ────────────────────────────────────────────────────────
+
+    def _ensure_key(self) -> None:
+        """Idempotent persistent-key provisioning.
+
+        Reads the persistent handle; if absent, creates an ECC P-256
+        primary under the Endorsement hierarchy and evicts it to the
+        handle. Subsequent process restarts hit the read path and reuse
+        the chip-resident key.
+        """
+        try:
+            self._read_existing_public()
+            return
+        except _PersistentHandleMissing:
+            pass
+
+        self._create_and_persist()
+        self._read_existing_public()
+
+    def _read_existing_public(self) -> None:
+        tss = self._tss
+        try:
+            # TPM2_ReadPublic on the persistent handle. tpm2-pytss exposes
+            # this as ``ESAPI.tr_from_tpmpublic`` + ``read_public``.
+            obj_handle = self._esapi.tr_from_tpmpublic(self._handle)
+            public, _name, _qname = self._esapi.read_public(obj_handle)
+        except Exception as exc:
+            # Discriminate "no such handle" from real errors. tpm2-pytss
+            # raises ``TSS2_Exception`` with rc_handle / rc_value subcodes
+            # but the import surface varies between releases; match on
+            # the well-known TPM_RC_HANDLE bit instead of class.
+            msg = str(exc).lower()
+            if "handle" in msg and ("0x18b" in msg or "value" in msg or "not found" in msg):
+                raise _PersistentHandleMissing(self._handle) from exc
+            raise
+
+        self._cached_pub_pem = _ecc_public_to_pem(public, tss)
+
+    def _create_and_persist(self) -> None:
+        tss = self._tss
+
+        ek_template = _ek_template(tss)
+        primary, _outp, _name, _qname = self._esapi.create_primary(
+            in_sensitive=tss.TPM2B_SENSITIVE_CREATE(),
+            in_public=ek_template,
+            primary_handle=tss.ESYS_TR.ENDORSEMENT,
+            outside_info=tss.TPM2B_DATA(),
+            creation_pcr=tss.TPML_PCR_SELECTION(),
+        )
+
+        try:
+            ecc_template = _ecc_signing_template(tss)
+            child, _cpub, _cname, _cqname, _ck = self._esapi.create(
+                parent_handle=primary,
+                in_sensitive=tss.TPM2B_SENSITIVE_CREATE(),
+                in_public=ecc_template,
+                outside_info=tss.TPM2B_DATA(),
+                creation_pcr=tss.TPML_PCR_SELECTION(),
+            )
+
+            loaded = self._esapi.load(
+                parent_handle=primary,
+                in_private=child,
+                in_public=_cpub,
+            )
+
+            self._esapi.evict_control(
+                auth=tss.ESYS_TR.OWNER,
+                object_handle=loaded,
+                persistent_handle=self._handle,
+            )
+        finally:
+            try:
+                self._esapi.flush_context(primary)
+            except Exception:
+                pass
+
+        # Phase 1 best-effort EK cert read. NV index 0x01C00002 is the
+        # canonical low-range RSA EK cert location per TCG EK Credential
+        # Profile §2.2. A missing index just means the chip ships without
+        # a manufacturer cert (common on vTPM / swtpm); strength drops to
+        # hw_isolated and enrollment continues.
+        self._probe_ek_certificate()
+
+    def _probe_ek_certificate(self) -> None:
+        tss = self._tss
+        ek_nv = 0x01C00002  # TCG EK Credential Profile, low-range RSA
+        try:
+            handle = self._esapi.tr_from_tpmpublic(ek_nv)
+            nv_pub, _name = self._esapi.nv_read_public(handle)
+            size = int(nv_pub.nvPublic.dataSize)
+            if size <= 0:
+                return
+            data = self._esapi.nv_read(
+                auth_handle=tss.ESYS_TR.OWNER,
+                nv_index=handle,
+                size=size,
+                offset=0,
+            )
+            self._ek_cert_present = True
+            self._cached_manufacturer = _ek_cert_manufacturer(bytes(data))
+        except Exception:
+            # vTPM / swtpm / locked-down chip; degrade silently to
+            # hw_isolated. Mastio refuses ``_attested`` capability so
+            # the absence of the cert never grants extra trust.
+            self._ek_cert_present = False
+            self._cached_manufacturer = None
+
+    # ── KeyStore interface ──────────────────────────────────────────────
+
+    def sign(self, message: bytes) -> bytes:
+        tss = self._tss
+        digest = _sha256(message)
+        obj_handle = self._esapi.tr_from_tpmpublic(self._handle)
+        scheme = tss.TPMT_SIG_SCHEME(
+            scheme=tss.TPM2_ALG.ECDSA,
+            details=tss.TPMU_SIG_SCHEME(ecdsa=tss.TPMS_SCHEME_HASH(hashAlg=tss.TPM2_ALG.SHA256)),
+        )
+        validation = tss.TPMT_TK_HASHCHECK(
+            tag=tss.TPM2_ST.HASHCHECK,
+            hierarchy=tss.ESYS_TR.OWNER,
+            digest=tss.TPM2B_DIGEST(),
+        )
+        signature = self._esapi.sign(
+            key_handle=obj_handle,
+            digest=tss.TPM2B_DIGEST(digest),
+            in_scheme=scheme,
+            validation=validation,
+        )
+        return _ecdsa_sig_to_der(signature)
+
+    def public_key_pem(self) -> str:
+        if self._cached_pub_pem is None:
+            self._read_existing_public()
+        assert self._cached_pub_pem is not None
+        return self._cached_pub_pem
+
+    def attestation_strength(self) -> AttestationStrength:
+        if self._ek_cert_present and self._cached_manufacturer in TPM_MANUFACTURER_WHITELIST:
+            return "hw_attested"
+        return "hw_isolated"
+
+    def attestation_claim(self) -> AttestationClaim:
+        return AttestationClaim(
+            hardware="tpm_2.0",
+            strength=self.attestation_strength(),
+            manufacturer=self._cached_manufacturer,
+        )
+
+    def generate_aik_quote(self, nonce: bytes) -> bytes:
+        """Produce an AIK-signed quote over PCR 0..7 + ``nonce``.
+
+        Phase 1 reuses the persistent signing key as the AIK. A proper
+        restricted attestation key per TCG AIK Credential Profile is on
+        the Phase 2 roadmap once EK CA chain verify ships.
+        """
+        tss = self._tss
+        obj_handle = self._esapi.tr_from_tpmpublic(self._handle)
+        pcr_selection = _pcr_selection_sha256(tss, pcrs=range(0, 8))
+
+        scheme = tss.TPMT_SIG_SCHEME(
+            scheme=tss.TPM2_ALG.ECDSA,
+            details=tss.TPMU_SIG_SCHEME(ecdsa=tss.TPMS_SCHEME_HASH(hashAlg=tss.TPM2_ALG.SHA256)),
+        )
+        quote, signature = self._esapi.quote(
+            sign_handle=obj_handle,
+            pcr_select=pcr_selection,
+            qualifying_data=tss.TPM2B_DATA(nonce),
+            in_scheme=scheme,
+        )
+        # Serialize quote + signature as a length-prefixed pair so the
+        # verifier can split them deterministically without re-asking
+        # tpm2-pytss for parser internals.
+        quote_bytes = bytes(quote)
+        sig_bytes = _ecdsa_sig_to_der(signature)
+        return _pack_quote_envelope(quote_bytes, sig_bytes, nonce)
+
+
+# ── Module-private helpers ───────────────────────────────────────────────
+
+
+class _PersistentHandleMissing(Exception):
+    """Raised when the persistent NV handle is empty (first-run path)."""
+
+    def __init__(self, handle: int) -> None:
+        super().__init__(f"persistent handle 0x{handle:08X} not provisioned")
+        self.handle = handle
+
+
+def _sha256(data: bytes) -> bytes:
+    import hashlib
+
+    return hashlib.sha256(data).digest()
+
+
+def _ek_template(tss: Any) -> Any:
+    """Minimal EK ECC P-256 template suitable for create_primary."""
+    return tss.TPM2B_PUBLIC(
+        publicArea=tss.TPMT_PUBLIC(
+            type=tss.TPM2_ALG.ECC,
+            nameAlg=tss.TPM2_ALG.SHA256,
+            objectAttributes=(
+                tss.TPMA_OBJECT.FIXEDTPM
+                | tss.TPMA_OBJECT.FIXEDPARENT
+                | tss.TPMA_OBJECT.SENSITIVEDATAORIGIN
+                | tss.TPMA_OBJECT.USERWITHAUTH
+                | tss.TPMA_OBJECT.RESTRICTED
+                | tss.TPMA_OBJECT.DECRYPT
+            ),
+            parameters=tss.TPMU_PUBLIC_PARMS(
+                eccDetail=tss.TPMS_ECC_PARMS(
+                    symmetric=tss.TPMT_SYM_DEF_OBJECT(
+                        algorithm=tss.TPM2_ALG.AES,
+                        keyBits=tss.TPMU_SYM_KEY_BITS(aes=128),
+                        mode=tss.TPMU_SYM_MODE(aes=tss.TPM2_ALG.CFB),
+                    ),
+                    scheme=tss.TPMT_ECC_SCHEME(scheme=tss.TPM2_ALG.NULL),
+                    curveID=tss.TPM2_ECC.NIST_P256,
+                    kdf=tss.TPMT_KDF_SCHEME(scheme=tss.TPM2_ALG.NULL),
+                ),
+            ),
+            unique=tss.TPMU_PUBLIC_ID(ecc=tss.TPMS_ECC_POINT()),
+        ),
+    )
+
+
+def _ecc_signing_template(tss: Any) -> Any:
+    """ECC P-256 signing-only template (fixedTPM, fixedParent, sign)."""
+    return tss.TPM2B_PUBLIC(
+        publicArea=tss.TPMT_PUBLIC(
+            type=tss.TPM2_ALG.ECC,
+            nameAlg=tss.TPM2_ALG.SHA256,
+            objectAttributes=(
+                tss.TPMA_OBJECT.FIXEDTPM
+                | tss.TPMA_OBJECT.FIXEDPARENT
+                | tss.TPMA_OBJECT.SENSITIVEDATAORIGIN
+                | tss.TPMA_OBJECT.USERWITHAUTH
+                | tss.TPMA_OBJECT.SIGN_ENCRYPT
+            ),
+            parameters=tss.TPMU_PUBLIC_PARMS(
+                eccDetail=tss.TPMS_ECC_PARMS(
+                    symmetric=tss.TPMT_SYM_DEF_OBJECT(algorithm=tss.TPM2_ALG.NULL),
+                    scheme=tss.TPMT_ECC_SCHEME(
+                        scheme=tss.TPM2_ALG.ECDSA,
+                        details=tss.TPMU_ASYM_SCHEME(
+                            ecdsa=tss.TPMS_SCHEME_HASH(hashAlg=tss.TPM2_ALG.SHA256),
+                        ),
+                    ),
+                    curveID=tss.TPM2_ECC.NIST_P256,
+                    kdf=tss.TPMT_KDF_SCHEME(scheme=tss.TPM2_ALG.NULL),
+                ),
+            ),
+            unique=tss.TPMU_PUBLIC_ID(ecc=tss.TPMS_ECC_POINT()),
+        ),
+    )
+
+
+def _ecc_public_to_pem(public: Any, tss: Any) -> str:
+    """Lift a TPM2B_PUBLIC into a portable PEM SubjectPublicKeyInfo."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    pub_area = public.publicArea
+    x = bytes(pub_area.unique.ecc.x.buffer)
+    y = bytes(pub_area.unique.ecc.y.buffer)
+    # SECP256R1 = NIST P-256. Phase 1 emits only this curve so the assert
+    # is a tripwire for future curve additions; callers don't catch it.
+    assert int(pub_area.parameters.eccDetail.curveID) == int(tss.TPM2_ECC.NIST_P256), (
+        "Phase 1 expects NIST P-256; rebuild templates if widening"
+    )
+
+    public_numbers = ec.EllipticCurvePublicNumbers(
+        x=int.from_bytes(x, "big"),
+        y=int.from_bytes(y, "big"),
+        curve=ec.SECP256R1(),
+    )
+    cryptography_pub = public_numbers.public_key()
+    return cryptography_pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _ecdsa_sig_to_der(signature: Any) -> bytes:
+    """Convert a TPMT_SIGNATURE (ECDSA-SHA256) into the standard ASN.1 DER form."""
+    from cryptography.hazmat.primitives.asymmetric.utils import (
+        encode_dss_signature,
+    )
+
+    r_buf = bytes(signature.signature.ecdsa.signatureR.buffer)
+    s_buf = bytes(signature.signature.ecdsa.signatureS.buffer)
+    return encode_dss_signature(
+        int.from_bytes(r_buf, "big"),
+        int.from_bytes(s_buf, "big"),
+    )
+
+
+def _pcr_selection_sha256(tss: Any, *, pcrs: Any) -> Any:
+    """Build a TPML_PCR_SELECTION over SHA-256 bank for the given PCR indices."""
+    bitmap = bytearray(3)  # 24 PCRs default → 3 bytes mask
+    for pcr in pcrs:
+        bitmap[pcr // 8] |= 1 << (pcr % 8)
+    return tss.TPML_PCR_SELECTION(
+        pcrSelections=[
+            tss.TPMS_PCR_SELECTION(
+                hash=tss.TPM2_ALG.SHA256,
+                sizeofSelect=len(bitmap),
+                pcrSelect=bytes(bitmap),
+            ),
+        ],
+    )
+
+
+# Envelope format for the AIK quote:
+#
+#   magic         : b"CULLIS-Q1"
+#   nonce_len     : uint16 BE
+#   nonce
+#   quote_len     : uint32 BE
+#   quote bytes (TPMS_ATTEST marshalled form)
+#   sig_len       : uint32 BE
+#   signature DER (ECDSA-SHA256)
+#
+# Kept simple on purpose: the verifier in ``mcp_proxy/attestation/tpm_verify``
+# unpacks it without depending on tpm2-pytss being installed server-side.
+
+_QUOTE_MAGIC = b"CULLIS-Q1"
+
+
+def _pack_quote_envelope(quote: bytes, sig: bytes, nonce: bytes) -> bytes:
+    if len(nonce) > 0xFFFF:
+        raise ValueError("nonce too long for envelope (max 65535 bytes)")
+    out = bytearray()
+    out += _QUOTE_MAGIC
+    out += len(nonce).to_bytes(2, "big")
+    out += nonce
+    out += len(quote).to_bytes(4, "big")
+    out += quote
+    out += len(sig).to_bytes(4, "big")
+    out += sig
+    return bytes(out)
+
+
+def unpack_quote_envelope(blob: bytes) -> tuple[bytes, bytes, bytes]:
+    """Reverse of :func:`_pack_quote_envelope`. Exported for the verifier."""
+    if len(blob) < len(_QUOTE_MAGIC) + 2 + 4 + 4:
+        raise ValueError("quote envelope truncated")
+    if blob[: len(_QUOTE_MAGIC)] != _QUOTE_MAGIC:
+        raise ValueError("quote envelope magic mismatch")
+    pos = len(_QUOTE_MAGIC)
+    nonce_len = int.from_bytes(blob[pos : pos + 2], "big")
+    pos += 2
+    nonce = blob[pos : pos + nonce_len]
+    pos += nonce_len
+    quote_len = int.from_bytes(blob[pos : pos + 4], "big")
+    pos += 4
+    quote = blob[pos : pos + quote_len]
+    pos += quote_len
+    sig_len = int.from_bytes(blob[pos : pos + 4], "big")
+    pos += 4
+    sig = blob[pos : pos + sig_len]
+    if len(sig) != sig_len:
+        raise ValueError("quote envelope signature truncated")
+    return nonce, quote, sig
+
+
+def _ek_cert_manufacturer(der: bytes) -> str | None:
+    """Best-effort manufacturer string extracted from an EK certificate.
+
+    Looks at the Subject DN's OU + the Subject Alternative Name's
+    DirectoryName, where TPM EK certs typically embed
+    ``TPMManufacturer=...`` / ``OU=Infineon Technologies AG``.
+    """
+    try:
+        from cryptography import x509
+        from cryptography.x509 import NameOID
+    except Exception:
+        return None
+
+    try:
+        cert = x509.load_der_x509_certificate(der)
+    except Exception:
+        return None
+
+    candidates: list[str] = []
+    try:
+        for attr in cert.subject.get_attributes_for_oid(NameOID.ORGANIZATIONAL_UNIT_NAME):
+            candidates.append(str(attr.value))
+    except Exception:
+        pass
+    try:
+        for attr in cert.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME):
+            candidates.append(str(attr.value))
+    except Exception:
+        pass
+
+    for candidate in candidates:
+        normalised = _normalise_manufacturer(candidate)
+        if normalised is not None:
+            return normalised
+    return None
+
+
+def _normalise_manufacturer(raw: str) -> str | None:
+    """Map a free-form vendor string onto the Phase 1 whitelist label."""
+    lowered = raw.lower()
+    table = {
+        "infineon": "Infineon",
+        "ifx": "Infineon",
+        "microsoft": "Microsoft",
+        "mscm": "Microsoft",
+        "stmicro": "ST",
+        "st micro": "ST",
+        " st ": "ST",
+        "nuvoton": "Nuvoton",
+        "ntc": "Nuvoton",
+        "intel": "Intel",
+        "intc": "Intel",
+    }
+    for needle, label in table.items():
+        if needle in lowered:
+            return label
+    return None

--- a/mcp_proxy/alembic/versions/0036_pending_attestation.py
+++ b/mcp_proxy/alembic/versions/0036_pending_attestation.py
@@ -1,0 +1,57 @@
+"""ADR-032 F3: pending_enrollments.device_attestation_json.
+
+Revision ID: 0036_pending_attestation
+Revises: 0035_mdm_device_state
+Create Date: 2026-05-17 09:00:00.000000
+
+F3 Phase 1 (Linux TPM BYOD) extends the enrollment flow with an optional
+``tpm_quote`` field. When the Connector ships one, the server verifies it
+against the public key in the CSR + the server-issued nonce, derives the
+hardware-side attestation claim (``hardware=tpm_2.0`` +
+``strength=hw_attested``/``hw_isolated`` + ``manufacturer=<vendor>``) and
+persists the JSON-serialised claim on the pending row. Approval copies
+the claim onto ``internal_agents.last_attestation`` (added by
+``0035_mdm_device_state`` for the F2 Intune path; F3 reuses the same
+column so the agent row has one canonical place for the merged claim).
+
+NOT touched here:
+
+* ``internal_agents.last_attestation`` (owned by F2 migration
+  ``0035_mdm_device_state``).
+* ``audit_log.device_attestation`` + ``audit_log.effective_tier`` (owned
+  by the future F6 audit migration).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0036_pending_attestation"
+down_revision: Union[str, Sequence[str], None] = "0035_mdm_device_state"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_PENDING = "pending_enrollments"
+_COL = "device_attestation_json"
+
+
+def _has_column(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if table not in set(insp.get_table_names()):
+        return False
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def upgrade() -> None:
+    if not _has_column(_PENDING, _COL):
+        with op.batch_alter_table(_PENDING) as batch_op:
+            batch_op.add_column(sa.Column(_COL, sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if _has_column(_PENDING, _COL):
+        with op.batch_alter_table(_PENDING) as batch_op:
+            batch_op.drop_column(_COL)

--- a/mcp_proxy/attestation/__init__.py
+++ b/mcp_proxy/attestation/__init__.py
@@ -1,27 +1,51 @@
-"""Device attestation claim — server-side authoritative compute.
+"""Device attestation: server-side authoritative compute + TPM verify.
 
-See ``imp/attestation-claim-schema.md`` v1.0 for the canonical claim
-shape, tier algorithm, and stale-window policy. This package is the
-implementation of sections 1 + 2 + 5 of that doc on the Mastio side.
+Two halves of the ADR-032 claim live here:
+
+* F2 (Layer 1, MDM): tier algorithm, claim builder, stale-window helper.
+  Locked against ``imp/attestation-claim-schema.md`` v1.0 sez. 1 + 2 + 5.
+* F3 (Phase 1, hardware): TPM 2.0 quote verifier + single-use nonce store
+  used by ``POST /v1/enrollment/start``.
 
 Exports:
 
-* :func:`compute_effective_tier` — pure function over the four input
-  fields the schema names. Used by the enrollment hook to stamp the
-  initial tier, and (later, F5) by the policy decision point.
-* :func:`is_stale` — true when ``stale_seconds`` exceeds the
-  configured threshold; callers must downgrade ``compliance`` to
-  ``unknown`` before re-evaluating the tier.
-* :func:`build_attestation_claim` — assembles the JSON shape sez. 1.
-  Convenience wrapper; the enrollment hook composes the dict
-  directly with the device row, this helper exists so future call
-  sites (admin re-attestation endpoint, dashboard preview) get the
-  same canonical shape without duplication.
+* :func:`compute_effective_tier`, :func:`is_stale`,
+  :func:`build_attestation_claim` (from :mod:`.tier`).
+* :func:`verify_tpm_quote`, :exc:`TpmQuoteVerificationError`,
+  :data:`TPM_MANUFACTURER_WHITELIST` (from :mod:`.tpm_verify`).
+* :func:`issue_nonce`, :func:`consume_nonce`,
+  :func:`set_attestation_nonce_redis_pool`,
+  :func:`reset_memory_store_for_tests`, :class:`IssuedNonce`
+  (from :mod:`.nonce_store`).
 """
+from mcp_proxy.attestation.nonce_store import (
+    IssuedNonce,
+    consume_nonce,
+    issue_nonce,
+    reset_memory_store_for_tests,
+    set_attestation_nonce_redis_pool,
+)
 from mcp_proxy.attestation.tier import (
     build_attestation_claim,
     compute_effective_tier,
     is_stale,
 )
+from mcp_proxy.attestation.tpm_verify import (
+    TPM_MANUFACTURER_WHITELIST,
+    TpmQuoteVerificationError,
+    verify_tpm_quote,
+)
 
-__all__ = ["build_attestation_claim", "compute_effective_tier", "is_stale"]
+__all__ = [
+    "IssuedNonce",
+    "TPM_MANUFACTURER_WHITELIST",
+    "TpmQuoteVerificationError",
+    "build_attestation_claim",
+    "compute_effective_tier",
+    "consume_nonce",
+    "is_stale",
+    "issue_nonce",
+    "reset_memory_store_for_tests",
+    "set_attestation_nonce_redis_pool",
+    "verify_tpm_quote",
+]

--- a/mcp_proxy/attestation/nonce_store.py
+++ b/mcp_proxy/attestation/nonce_store.py
@@ -1,0 +1,155 @@
+"""Single-use server-issued nonces for the TPM attestation flow.
+
+Each ``GET /v1/enrollment/attestation-nonce`` mints a 32-byte random nonce,
+returns the base64url encoding + an opaque ``nonce_id``, and records the
+pair in an in-process store with a short TTL (default 60s, configurable
+via ``MCP_PROXY_ATTESTATION_NONCE_TTL_SECONDS``).
+
+Redis is preferred when the proxy is configured for it; the
+``set_attestation_nonce_redis_pool`` hook lets the lifespan wire it in
+without circular imports. When Redis is unavailable the fallback is a
+``dict`` guarded by an ``asyncio.Lock``; that keeps the spike usable on
+laptops and in CI without standing up a broker. Multi-worker uvicorn
+deployments must enable Redis (see memoria
+``feedback_mastio_multiworker_audit_chain_retry_ship_safe`` for the
+analogous shared-state caveat).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+_log = logging.getLogger("mcp_proxy.attestation.nonce_store")
+
+
+_DEFAULT_TTL_SECONDS = 60
+_NONCE_BYTES = 32  # 256-bit, well past TPM quote replay surface
+
+
+def _ttl_seconds() -> int:
+    try:
+        return max(5, int(os.environ.get(
+            "MCP_PROXY_ATTESTATION_NONCE_TTL_SECONDS",
+            str(_DEFAULT_TTL_SECONDS),
+        )))
+    except ValueError:
+        return _DEFAULT_TTL_SECONDS
+
+
+def _b64url_nopad(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+@dataclass(frozen=True)
+class IssuedNonce:
+    nonce_id: str
+    nonce_b64: str
+    nonce_bytes: bytes
+    expires_at_epoch: int
+
+
+class _RedisLike(Protocol):
+    async def set(self, *args: object, **kwargs: object) -> object: ...
+    async def get(self, *args: object, **kwargs: object) -> object: ...
+    async def delete(self, *args: object, **kwargs: object) -> object: ...
+
+
+_REDIS_POOL: _RedisLike | None = None
+
+
+def set_attestation_nonce_redis_pool(pool: _RedisLike | None) -> None:
+    """Lifespan hook; wire the redis client if attestation needs it."""
+    global _REDIS_POOL
+    _REDIS_POOL = pool
+
+
+# In-memory fallback. Keys are nonce_id, values are (nonce_b64, expires_at).
+_MEMORY: dict[str, tuple[str, int]] = {}
+_MEMORY_LOCK = asyncio.Lock()
+
+
+def _redis_key(nonce_id: str) -> str:
+    return f"cullis:attest:nonce:{nonce_id}"
+
+
+async def issue_nonce() -> IssuedNonce:
+    """Mint a fresh single-use nonce. TTL clamps storage on either backend."""
+    raw = secrets.token_bytes(_NONCE_BYTES)
+    nonce_id = secrets.token_urlsafe(16)
+    nonce_b64 = _b64url_nopad(raw)
+    ttl = _ttl_seconds()
+    expires_at = int(time.time()) + ttl
+
+    if _REDIS_POOL is not None:
+        try:
+            await _REDIS_POOL.set(_redis_key(nonce_id), nonce_b64, ex=ttl)
+            return IssuedNonce(
+                nonce_id=nonce_id,
+                nonce_b64=nonce_b64,
+                nonce_bytes=raw,
+                expires_at_epoch=expires_at,
+            )
+        except Exception as exc:
+            # Redis hiccup; fall through to memory backend so the spike
+            # path stays usable. Single-process Mastio deployments are
+            # safe; multi-worker users hit the gotcha above.
+            _log.warning("attestation_nonce_redis_set_failed", extra={"err": str(exc)})
+
+    async with _MEMORY_LOCK:
+        _prune_locked()
+        _MEMORY[nonce_id] = (nonce_b64, expires_at)
+    return IssuedNonce(
+        nonce_id=nonce_id,
+        nonce_b64=nonce_b64,
+        nonce_bytes=raw,
+        expires_at_epoch=expires_at,
+    )
+
+
+async def consume_nonce(nonce_id: str) -> bytes | None:
+    """Single-use lookup. Returns the raw 32-byte nonce or ``None``."""
+    if not nonce_id:
+        return None
+    if _REDIS_POOL is not None:
+        try:
+            value = await _REDIS_POOL.get(_redis_key(nonce_id))
+            if value is None:
+                # Fall through to memory in case the issue path landed there.
+                pass
+            else:
+                await _REDIS_POOL.delete(_redis_key(nonce_id))
+                decoded = value.decode() if isinstance(value, (bytes, bytearray)) else str(value)
+                return _b64url_decode(decoded)
+        except Exception as exc:
+            _log.warning("attestation_nonce_redis_get_failed", extra={"err": str(exc)})
+
+    async with _MEMORY_LOCK:
+        _prune_locked()
+        entry = _MEMORY.pop(nonce_id, None)
+    if entry is None:
+        return None
+    nonce_b64, _expires_at = entry
+    return _b64url_decode(nonce_b64)
+
+
+def _prune_locked() -> None:
+    now = int(time.time())
+    stale = [k for k, (_b, exp) in _MEMORY.items() if exp < now]
+    for key in stale:
+        _MEMORY.pop(key, None)
+
+
+def reset_memory_store_for_tests() -> None:
+    """Test helper; wipe the in-memory backend between cases."""
+    _MEMORY.clear()

--- a/mcp_proxy/attestation/tpm_verify.py
+++ b/mcp_proxy/attestation/tpm_verify.py
@@ -1,0 +1,170 @@
+"""Server-side TPM 2.0 quote verifier (ADR-032 F3 Phase 1).
+
+Pure-Python: imports only ``cryptography``. The Connector ships a quote
+envelope packed by ``cullis_connector.keystore.tpm_linux._pack_quote_envelope``
+which we unpack and verify against the PEM public key submitted in the
+same enrollment request.
+
+Phase 1 limits (explicit in ``imp/c2-f3-linux-tpm-spike-prompt.md``):
+
+* EK CA chain verify DEFERRED (Decision Q8). Manufacturer trust is by
+  literal whitelist; an unknown vendor downgrades strength to
+  ``hw_isolated`` rather than refusing the claim.
+* No PCR allowlist; the quote attests to PCR 0..7 (the static-root
+  measured-boot range) but we do not pin a known-good digest. The
+  ``policy.tier_evaluated`` audit row preserves the digest so a future
+  F5 release can compare.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
+
+_log = logging.getLogger("mcp_proxy.attestation.tpm_verify")
+
+# Mirrors the Connector-side set in
+# ``cullis_connector/keystore/tpm_linux.py``. The two must stay in sync;
+# a future ADR will move both to a refreshable remote bundle. Order is
+# alphabetical to make diffs reviewer-friendly.
+TPM_MANUFACTURER_WHITELIST: frozenset[str] = frozenset(
+    {"Infineon", "Intel", "Microsoft", "Nuvoton", "ST"},
+)
+
+class TpmQuoteVerificationError(Exception):
+    """Raised when the quote envelope is malformed, the signature fails,
+    or the embedded nonce does not match the server-issued challenge."""
+
+
+_QUOTE_MAGIC = b"CULLIS-Q1"
+
+
+def _unpack_envelope(blob: bytes) -> tuple[bytes, bytes, bytes]:
+    """Inverse of the Connector packer. Server-local copy so this module
+    does not depend on ``tpm2-pytss`` being installed on the Mastio host."""
+    if len(blob) < len(_QUOTE_MAGIC) + 2 + 4 + 4:
+        raise TpmQuoteVerificationError("quote envelope truncated")
+    if blob[: len(_QUOTE_MAGIC)] != _QUOTE_MAGIC:
+        raise TpmQuoteVerificationError("quote envelope magic mismatch")
+    pos = len(_QUOTE_MAGIC)
+    nonce_len = int.from_bytes(blob[pos : pos + 2], "big")
+    pos += 2
+    nonce = blob[pos : pos + nonce_len]
+    pos += nonce_len
+    quote_len = int.from_bytes(blob[pos : pos + 4], "big")
+    pos += 4
+    quote = blob[pos : pos + quote_len]
+    pos += quote_len
+    if len(quote) != quote_len:
+        raise TpmQuoteVerificationError("quote body truncated")
+    sig_len = int.from_bytes(blob[pos : pos + 4], "big")
+    pos += 4
+    sig = blob[pos : pos + sig_len]
+    if len(sig) != sig_len:
+        raise TpmQuoteVerificationError("quote signature truncated")
+    return nonce, quote, sig
+
+
+def _load_pub(public_key_pem: str) -> PublicKeyTypes:
+    try:
+        return serialization.load_pem_public_key(public_key_pem.encode())
+    except Exception as exc:
+        raise TpmQuoteVerificationError(f"invalid public key PEM: {exc}") from exc
+
+
+def verify_tpm_quote(
+    quote_blob: bytes,
+    public_key_pem: str,
+    expected_nonce: bytes,
+    *,
+    manufacturer: str | None = None,
+    manufacturer_whitelist: frozenset[str] | None = None,
+    ek_cert_present: bool = False,
+) -> tuple[bool, dict[str, object]]:
+    """Verify ``quote_blob`` and derive the hardware-side attestation claim.
+
+    Returns ``(valid, claim_partial)``. ``valid`` is ``False`` only when
+    cryptographic verification fails or the nonce is wrong; an unknown
+    manufacturer still counts as ``valid`` but downgrades ``strength`` to
+    ``hw_isolated`` (Phase 1 EK CA gap, ADR-032 Q8).
+
+    ``claim_partial`` has the shape locked in
+    ``imp/attestation-claim-schema.md`` sez. 1 for the hardware fields:
+
+    * ``hardware`` ; always ``"tpm_2.0"`` (Phase 1 owns no other backend)
+    * ``strength`` ; ``hw_attested`` / ``hw_isolated`` / ``soft_only``
+    * ``manufacturer``; passthrough or ``None``
+    * ``pcr_digest_sha256``; hex of the quote digest, for audit replay
+    """
+    whitelist = manufacturer_whitelist or TPM_MANUFACTURER_WHITELIST
+    try:
+        nonce, quote_bytes, sig_bytes = _unpack_envelope(quote_blob)
+    except TpmQuoteVerificationError as exc:
+        _log.warning("tpm_quote_envelope_error", extra={"err": str(exc)})
+        return False, _claim_soft_only()
+
+    if nonce != expected_nonce:
+        _log.warning(
+            "tpm_quote_nonce_mismatch",
+            extra={
+                "expected_sha256": hashlib.sha256(expected_nonce).hexdigest(),
+                "got_sha256": hashlib.sha256(nonce).hexdigest(),
+            },
+        )
+        return False, _claim_soft_only()
+
+    pub = _load_pub(public_key_pem)
+    if not isinstance(pub, ec.EllipticCurvePublicKey):
+        _log.warning(
+            "tpm_quote_unsupported_key",
+            extra={"key_type": type(pub).__name__},
+        )
+        return False, _claim_soft_only()
+
+    digest = hashlib.sha256(quote_bytes).digest()
+    try:
+        # tpm2-pytss exports an ECDSA-SHA256 signature; we verify the
+        # signature over the quote bytes the TPM signed (the TPMS_ATTEST
+        # marshalled form). Verifying with ``ec.ECDSA(Prehashed)`` lets
+        # us pass the SHA-256 digest we already computed.
+        from cryptography.hazmat.primitives.asymmetric.utils import (
+            Prehashed,
+        )
+
+        pub.verify(sig_bytes, digest, ec.ECDSA(Prehashed(hashes.SHA256())))
+    except InvalidSignature:
+        _log.warning("tpm_quote_invalid_signature")
+        return False, _claim_soft_only()
+
+    # Quote is valid. Derive strength from manufacturer/EK posture.
+    strength: Literal["hw_attested", "hw_isolated"]
+    if ek_cert_present and manufacturer in whitelist:
+        strength = "hw_attested"
+    else:
+        strength = "hw_isolated"
+
+    claim: dict[str, object] = {
+        "hardware": "tpm_2.0",
+        "strength": strength,
+        "manufacturer": manufacturer,
+        "pcr_digest_sha256": digest.hex(),
+    }
+    return True, claim
+
+
+def _claim_soft_only() -> dict[str, object]:
+    return {
+        "hardware": "soft",
+        "strength": "soft_only",
+        "manufacturer": None,
+    }
+
+
+# Tier algorithm lives in :mod:`mcp_proxy.attestation.tier` (F2). The
+# F3 verifier returns the hardware-side fields; the enrollment hook
+# combines them with the MDM half and calls :func:`tier.compute_effective_tier`.

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -76,6 +76,11 @@ class InternalAgent(Base):
     # Nullable=False + default ``both`` keeps the permissive shape for
     # rows written during the grace period before enforcement lands.
     reach = Column(String, nullable=False, server_default="both")
+    # ADR-032 attestation column ``last_attestation`` is added by
+    # migration 0035_mdm_device_state (F2 Intune spike). The F3 hardware
+    # claim is merged with the F2 MDM half by the enrollment hook and
+    # written there too; not declared on the ORM model because the
+    # writers use raw SQL via ``conn.execute(text(...))``.
 
 
 class AuditLogEntry(Base):
@@ -192,6 +197,11 @@ class PendingEnrollment(Base):
 
     # Rejected
     rejection_reason = Column(Text, nullable=True)
+
+    # ADR-032 F3: hardware attestation claim (JSON). Populated when the
+    # Connector ships a verified ``tpm_quote`` at start_enrollment time;
+    # carried to ``internal_agents.device_attestation_json`` on approve.
+    device_attestation_json = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("idx_pending_enrollments_status", "status"),

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -24,6 +24,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 
+from mcp_proxy.attestation import issue_nonce
 from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
@@ -125,6 +126,13 @@ async def start_enrollment(
                 device_info=payload.device_info,
                 dpop_jwk=payload.dpop_jwk,
                 pop_signature=payload.pop_signature,
+                # ADR-032 F3: optional TPM attestation half. When the
+                # Connector omits these the service path is identical to
+                # the pre-F3 behaviour (soft keystore, no claim).
+                attestation_nonce_id=payload.attestation_nonce_id,
+                tpm_quote_b64=payload.tpm_quote_b64,
+                tpm_manufacturer=payload.tpm_manufacturer,
+                tpm_ek_cert_present=payload.tpm_ek_cert_present,
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
@@ -204,6 +212,32 @@ def _verify_enrollment_proof(
         return False
     except Exception:
         return False
+
+
+# ADR-032 F3: attestation nonce mint endpoint (anonymous, rate-limited).
+# Issued before ``POST /v1/enrollment/start`` so the Connector can bind a
+# fresh TPM quote to a server-controlled challenge. The pair (nonce_id,
+# nonce_b64) is consumed when start_enrollment verifies the quote.
+_ATTESTATION_NONCE_PER_MINUTE = 30
+
+
+@router.get("/v1/enrollment/attestation-nonce")
+async def attestation_nonce(request: Request) -> dict[str, object]:
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}:enroll.attestation_nonce",
+        _ATTESTATION_NONCE_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="attestation nonce rate limit exceeded",
+        )
+    issued = await issue_nonce()
+    return {
+        "nonce_id": issued.nonce_id,
+        "nonce_b64": issued.nonce_b64,
+        "expires_at_epoch": issued.expires_at_epoch,
+    }
 
 
 @router.get(

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -67,6 +67,50 @@ class EnrollmentStartRequest(BaseModel):
             " a follow-up release."
         ),
     )
+    # ── ADR-032 F3: TPM attestation (optional) ────────────────────────
+    attestation_nonce_id: str | None = Field(
+        None,
+        max_length=128,
+        description=(
+            "Opaque identifier of the server-issued nonce the Connector"
+            " consumed when generating ``tpm_quote_b64``. Returned by"
+            " ``GET /v1/enrollment/attestation-nonce``. Required iff"
+            " ``tpm_quote_b64`` is set."
+        ),
+    )
+    tpm_quote_b64: str | None = Field(
+        None,
+        max_length=16384,
+        description=(
+            "ADR-032 F3 Phase 1: base64url AIK quote envelope produced"
+            " by the Linux TPM keystore (see"
+            " ``cullis_connector.keystore.tpm_linux``). Optional. When"
+            " present, the server verifies the quote against"
+            " ``pubkey_pem`` + the nonce identified by"
+            " ``attestation_nonce_id`` and, on success, persists the"
+            " hardware-side claim ({hardware, strength, manufacturer})"
+            " for the eventual ``effective_tier`` recomputation."
+        ),
+    )
+    tpm_manufacturer: str | None = Field(
+        None,
+        max_length=64,
+        description=(
+            "Self-declared TPM EK manufacturer (Infineon / ST / etc)."
+            " Cross-checked against ``TPM_MANUFACTURER_WHITELIST`` on"
+            " the server; an unknown vendor downgrades ``strength`` to"
+            " ``hw_isolated`` (Phase 1 EK CA chain deferred per Q8)."
+        ),
+    )
+    tpm_ek_cert_present: bool = Field(
+        False,
+        description=(
+            "Whether the Connector found an EK certificate in NV index"
+            " 0x01C00002. Used together with ``tpm_manufacturer`` to"
+            " gate ``hw_attested`` strength. swtpm / vTPM environments"
+            " typically report ``False`` and stay at ``hw_isolated``."
+        ),
+    )
 
 
 class EnrollmentStartResponse(BaseModel):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -226,6 +226,10 @@ async def start_enrollment(
     device_info: str | None,
     dpop_jwk: dict | None = None,
     pop_signature: str | None = None,
+    attestation_nonce_id: str | None = None,
+    tpm_quote_b64: str | None = None,
+    tpm_manufacturer: str | None = None,
+    tpm_ek_cert_present: bool = False,
 ) -> StartedEnrollment:
     """Create a new pending enrollment.
 
@@ -274,6 +278,17 @@ async def start_enrollment(
             fingerprint,
         )
 
+    # ADR-032 F3 Phase 1: verify the optional TPM attestation half.
+    # Failures here are user-facing 400s; absence is silent (Connector
+    # without a TPM keeps enrolling at the lower effective tier).
+    attestation_json = await _verify_tpm_attestation(
+        pubkey_pem=pubkey_pem,
+        attestation_nonce_id=attestation_nonce_id,
+        tpm_quote_b64=tpm_quote_b64,
+        manufacturer=tpm_manufacturer,
+        ek_cert_present=tpm_ek_cert_present,
+    )
+
     session_id = secrets.token_urlsafe(24)
     now = _now()
     expires_at = now + ENROLLMENT_TTL
@@ -283,11 +298,13 @@ async def start_enrollment(
             """INSERT INTO pending_enrollments (
                 session_id, pubkey_pem, pubkey_fingerprint,
                 requester_name, requester_email, reason, device_info,
-                status, created_at, expires_at, dpop_jkt
+                status, created_at, expires_at, dpop_jkt,
+                device_attestation_json
             ) VALUES (
                 :sid, :pk, :fp,
                 :name, :email, :reason, :device,
-                'pending', :created, :expires, :dpop_jkt
+                'pending', :created, :expires, :dpop_jkt,
+                :dev_attest
             )"""
         ),
         {
@@ -301,9 +318,100 @@ async def start_enrollment(
             "created": _iso(now),
             "expires": _iso(expires_at),
             "dpop_jkt": dpop_jkt,
+            "dev_attest": attestation_json,
         },
     )
+
+    if attestation_json:
+        # Audit the verified hardware claim at enrollment time; the F6
+        # audit migration will extend ``audit_log`` with first-class
+        # columns; until then the JSON detail captures the same payload.
+        await conn.execute(
+            text(
+                """INSERT INTO audit_log
+                   (timestamp, agent_id, action, status, detail)
+                   VALUES (:ts, :aid, 'device_attestation.verified', 'success', :detail)"""
+            ),
+            {
+                "ts": _iso(now),
+                "aid": f"pending::{session_id}",
+                "detail": attestation_json,
+            },
+        )
+
     return StartedEnrollment(session_id=session_id, expires_at=expires_at)
+
+
+async def _verify_tpm_attestation(
+    *,
+    pubkey_pem: str,
+    attestation_nonce_id: str | None,
+    tpm_quote_b64: str | None,
+    manufacturer: str | None,
+    ek_cert_present: bool,
+) -> str | None:
+    """Verify the TPM quote and return the claim JSON, or ``None`` if no
+    quote was submitted.
+
+    Raises :class:`EnrollmentError` (400) when the Connector ships a
+    quote without a nonce id, when the nonce has already been consumed
+    or expired, or when the cryptographic verification fails. A missing
+    quote is silent: the agent enrolls at the lower effective tier.
+    """
+    if not tpm_quote_b64 and not attestation_nonce_id:
+        return None
+    if bool(tpm_quote_b64) ^ bool(attestation_nonce_id):
+        raise EnrollmentError(
+            "tpm_quote_b64 and attestation_nonce_id must both be supplied"
+            " (or both omitted)",
+            http_status=400,
+        )
+
+    import base64 as _b64
+    import json as _json
+
+    from mcp_proxy.attestation import (
+        TpmQuoteVerificationError,
+        consume_nonce,
+        verify_tpm_quote,
+    )
+
+    nonce_bytes = await consume_nonce(attestation_nonce_id or "")
+    if nonce_bytes is None:
+        raise EnrollmentError(
+            "attestation nonce expired or already consumed", http_status=400,
+        )
+
+    try:
+        quote_blob = _b64.urlsafe_b64decode(
+            (tpm_quote_b64 or "") + "=" * (-len(tpm_quote_b64 or "") % 4),
+        )
+    except Exception as exc:
+        raise EnrollmentError(
+            f"tpm_quote_b64 is not valid base64url: {exc}", http_status=400,
+        ) from exc
+
+    try:
+        valid, claim = verify_tpm_quote(
+            quote_blob,
+            pubkey_pem,
+            nonce_bytes,
+            manufacturer=manufacturer,
+            ek_cert_present=ek_cert_present,
+        )
+    except TpmQuoteVerificationError as exc:
+        raise EnrollmentError(
+            f"tpm_quote verification failed: {exc}", http_status=400,
+        ) from exc
+
+    if not valid:
+        raise EnrollmentError(
+            "tpm_quote signature or nonce verification failed",
+            http_status=400,
+        )
+
+    claim["verified_at"] = _iso(_now())
+    return _json.dumps(claim, separators=(",", ":"), sort_keys=True)
 
 
 async def approve(
@@ -397,6 +505,12 @@ async def approve(
         f"{agent_manager.org_id}/{name_part}"
     )
 
+    # ADR-032 F3: the verified hardware claim from start_enrollment lives
+    # on ``pending_enrollments.device_attestation_json``. F2's
+    # ``stamp_attestation_on_enrollment`` (below) is the writer for
+    # ``internal_agents.last_attestation`` and will pick up the hardware
+    # half once F5 merges the two halves. Keeping the claim only on the
+    # pending row for the F3 spike avoids fighting F2 over the agent row.
     if existing.first() is None:
         # ADR-010 D1 left ``federated`` opt-in (admin flips manually) so
         # an org could onboard local-only agents without leaking them

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -110,6 +110,14 @@ dev = [
     "ruff>=0.4",
     "build>=1.0",
 ]
+# ADR-032 F3 Phase 1: Linux TPM 2.0 hardware attestation. Optional so a
+# Connector install on Windows / macOS / a vTPM-less Linux box keeps
+# working with the soft keystore fallback. Requires kernel resource
+# manager at /dev/tpmrm0 (provided by Linux >= 4.12) or a swtpm socket
+# pointed at by TCTI env vars; see imp/c2-f3-linux-tpm-spike-prompt.md.
+tpm = [
+    "tpm2-pytss>=2.0",
+]
 
 [project.urls]
 Homepage = "https://cullis.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,13 @@ desktop = [
 spiffe = [
     "spiffe>=0.2.0",
 ]
+# ADR-032 F3 Phase 1: Linux TPM 2.0 hardware attestation. Optional so
+# core test runs and Connector installs without a TPM keep using the soft
+# keystore fallback. Requires kernel resource manager at /dev/tpmrm0
+# (Linux >= 4.12) or a swtpm socket pointed at by TCTI env vars.
+tpm = [
+    "tpm2-pytss>=2.0",
+]
 
 [project.scripts]
 cullis-connector = "cullis_connector.cli:main"

--- a/tests/test_attestation_tier_mapping_hw.py
+++ b/tests/test_attestation_tier_mapping_hw.py
@@ -1,0 +1,88 @@
+"""Tier mapping with the hardware half of the device attestation claim.
+
+Exercises ``compute_effective_tier`` from the server-authoritative side
+and the schema field constraints. Mirrors the matrix locked in
+``imp/attestation-claim-schema.md`` sez. 2.
+
+The function ships in :mod:`mcp_proxy.attestation.tier` (owned by F2 Intune
+spike); F3 adds the hardware-side coverage exercised below.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.attestation import compute_effective_tier
+
+
+def _hardware_for(strength: str | None) -> str | None:
+    if strength in ("hw_attested", "hw_isolated"):
+        return "tpm_2.0"
+    if strength == "soft_only":
+        return "soft"
+    return None
+
+
+@pytest.mark.parametrize(
+    ("mdm", "compliance", "strength", "expected"),
+    [
+        # Managed + hw_attested → top tier
+        ("intune", "compliant", "hw_attested", "managed_attested"),
+        # Managed only; hardware silent
+        ("intune", "compliant", "soft_only", "managed"),
+        ("intune", "compliant", None, "managed"),
+        ("intune", "compliant", "hw_isolated", "managed"),
+        # MDM present but non-compliant → BYOD ladder
+        ("intune", "non_compliant", "hw_attested", "byod_attested"),
+        ("intune", "non_compliant", "hw_isolated", "byod_isolated"),
+        ("intune", "non_compliant", "soft_only", "untrusted"),
+        # No MDM; pure BYOD
+        (None, None, "hw_attested", "byod_attested"),
+        (None, None, "hw_isolated", "byod_isolated"),
+        (None, None, "soft_only", "untrusted"),
+        # Defensive: missing fields are treated as the most permissive
+        # downgrade (untrusted), never as silent grants.
+        (None, None, None, "untrusted"),
+        ("intune", None, "hw_attested", "byod_attested"),  # compliance=None != compliant
+        ("intune", "unknown", "hw_attested", "byod_attested"),
+    ],
+)
+def test_effective_tier_matrix(mdm, compliance, strength, expected):
+    assert (
+        compute_effective_tier(
+            mdm=mdm,
+            compliance=compliance,
+            hardware=_hardware_for(strength),
+            strength=strength,
+        )
+        == expected
+    )
+
+
+def test_hw_attested_alone_does_not_imply_managed():
+    """Pure BYOD with TPM ``hw_attested`` MUST remain at ``byod_attested``
+    until the F2 MDM half lands. Doc gap explicit in the F3 spike prompt:
+    ``managed_attested`` is not reachable without an MDM device id +
+    compliance=compliant.
+    """
+    assert (
+        compute_effective_tier(
+            mdm=None,
+            compliance=None,
+            hardware="tpm_2.0",
+            strength="hw_attested",
+        )
+        != "managed_attested"
+    )
+
+
+def test_managed_attested_requires_both_halves():
+    # Sanity guard against the schema drifting.
+    assert (
+        compute_effective_tier(
+            mdm="intune",
+            compliance="compliant",
+            hardware="tpm_2.0",
+            strength="hw_attested",
+        )
+        == "managed_attested"
+    )

--- a/tests/test_enrollment_tpm_flow.py
+++ b/tests/test_enrollment_tpm_flow.py
@@ -1,0 +1,246 @@
+"""End-to-end enrollment with the TPM attestation half (F3 Phase 1).
+
+Software-mocked: the test drives the real service.start_enrollment path
+but signs the "quote" with an in-process EC P-256 key in place of the
+TPM. This exercises the full server pipeline; nonce mint, quote verify,
+pending_enrollments.device_attestation_json persistence, audit event; on
+hosts without a TPM (which is the default in CI).
+
+A separate test exercises the soft-fallback path: omitting the TPM
+fields must keep the enrollment running without an attestation row.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from sqlalchemy import text
+
+from mcp_proxy.attestation import nonce_store
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment import service
+from mcp_proxy.enrollment.service import EnrollmentError
+
+
+_QUOTE_MAGIC = b"CULLIS-Q1"
+
+
+def _pack(quote: bytes, sig: bytes, nonce: bytes) -> bytes:
+    out = bytearray()
+    out += _QUOTE_MAGIC
+    out += len(nonce).to_bytes(2, "big")
+    out += nonce
+    out += len(quote).to_bytes(4, "big")
+    out += quote
+    out += len(sig).to_bytes(4, "big")
+    out += sig
+    return bytes(out)
+
+
+def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return key, pem
+
+
+def _build_quote_b64(nonce: bytes, key: ec.EllipticCurvePrivateKey) -> str:
+    body = b"mocked-TPMS_ATTEST||" + nonce
+    digest = hashlib.sha256(body).digest()
+    sig = key.sign(digest, ec.ECDSA(Prehashed(hashes.SHA256())))
+    blob = _pack(body, sig, nonce)
+    return base64.urlsafe_b64encode(blob).rstrip(b"=").decode()
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "tpm_flow.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    await init_db(url)
+    nonce_store.reset_memory_store_for_tests()
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_with_valid_tpm_quote_persists_claim(db_engine):
+    key, pem = _ec_keypair()
+    issued = await nonce_store.issue_nonce()
+    quote_b64 = _build_quote_b64(issued.nonce_bytes, key)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pem,
+            requester_name="Hardware Hannah",
+            requester_email="hh@acme.com",
+            reason="tpm-pilot",
+            device_info=None,
+            attestation_nonce_id=issued.nonce_id,
+            tpm_quote_b64=quote_b64,
+            tpm_manufacturer="Infineon",
+            tpm_ek_cert_present=True,
+        )
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT device_attestation_json FROM pending_enrollments "
+                "WHERE session_id = :sid"
+            ),
+            {"sid": started.session_id},
+        )
+        row = result.first()
+    assert row is not None
+    claim_json = row[0]
+    assert claim_json
+    claim = json.loads(claim_json)
+    assert claim["hardware"] == "tpm_2.0"
+    assert claim["strength"] == "hw_attested"
+    assert claim["manufacturer"] == "Infineon"
+    assert "verified_at" in claim
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_audit_row_written_on_verified_quote(db_engine):
+    key, pem = _ec_keypair()
+    issued = await nonce_store.issue_nonce()
+    quote_b64 = _build_quote_b64(issued.nonce_bytes, key)
+
+    async with get_db() as conn:
+        await service.start_enrollment(
+            conn,
+            pubkey_pem=pem,
+            requester_name="Hannah",
+            requester_email="h@acme.com",
+            reason=None,
+            device_info=None,
+            attestation_nonce_id=issued.nonce_id,
+            tpm_quote_b64=quote_b64,
+            tpm_manufacturer="Infineon",
+            tpm_ek_cert_present=True,
+        )
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT action FROM audit_log WHERE action = "
+                "'device_attestation.verified'"
+            )
+        )
+        actions = [r[0] for r in result.all()]
+    assert actions == ["device_attestation.verified"]
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_without_tpm_fields_skips_attestation(db_engine):
+    _, pem = _ec_keypair()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pem,
+            requester_name="Soft Sam",
+            requester_email="s@acme.com",
+            reason=None,
+            device_info=None,
+        )
+        result = await conn.execute(
+            text(
+                "SELECT device_attestation_json FROM pending_enrollments "
+                "WHERE session_id = :sid"
+            ),
+            {"sid": started.session_id},
+        )
+        row = result.first()
+    assert row is not None
+    assert row[0] is None
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_rejects_quote_without_nonce_id(db_engine):
+    key, pem = _ec_keypair()
+    issued = await nonce_store.issue_nonce()
+    quote_b64 = _build_quote_b64(issued.nonce_bytes, key)
+
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=pem,
+                requester_name="Half",
+                requester_email="h@acme.com",
+                reason=None,
+                device_info=None,
+                attestation_nonce_id=None,
+                tpm_quote_b64=quote_b64,
+            )
+    assert exc.value.http_status == 400
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_rejects_expired_or_unknown_nonce(db_engine):
+    key, pem = _ec_keypair()
+    bogus_nonce = secrets.token_bytes(32)
+    body = b"mocked-TPMS_ATTEST||" + bogus_nonce
+    digest = hashlib.sha256(body).digest()
+    sig = key.sign(digest, ec.ECDSA(Prehashed(hashes.SHA256())))
+    blob = _pack(body, sig, bogus_nonce)
+    quote_b64 = base64.urlsafe_b64encode(blob).rstrip(b"=").decode()
+
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=pem,
+                requester_name="Stale",
+                requester_email="x@acme.com",
+                reason=None,
+                device_info=None,
+                attestation_nonce_id="never-issued",
+                tpm_quote_b64=quote_b64,
+            )
+    assert exc.value.http_status == 400
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_rejects_tampered_quote(db_engine):
+    key, pem = _ec_keypair()
+    issued = await nonce_store.issue_nonce()
+    quote_b64 = _build_quote_b64(issued.nonce_bytes, key)
+    # Flip a byte deep inside the base64url payload; corrupts the
+    # signature DER and must fail crypto verification.
+    raw = bytearray(base64.urlsafe_b64decode(quote_b64 + "=" * (-len(quote_b64) % 4)))
+    raw[-1] ^= 0x80
+    tampered_b64 = base64.urlsafe_b64encode(bytes(raw)).rstrip(b"=").decode()
+
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=pem,
+                requester_name="Tampered",
+                requester_email="t@acme.com",
+                reason=None,
+                device_info=None,
+                attestation_nonce_id=issued.nonce_id,
+                tpm_quote_b64=tampered_b64,
+                tpm_manufacturer="Infineon",
+                tpm_ek_cert_present=True,
+            )
+    assert exc.value.http_status == 400

--- a/tests/test_keystore_soft.py
+++ b/tests/test_keystore_soft.py
@@ -1,0 +1,60 @@
+"""Smoke tests for the soft :class:`KeyStore` (ADR-032 F3).
+
+Covers the three constructor paths (in-memory ephemeral, persist-on-disk,
+load-from-disk), the signature round-trip with the EC P-256 public key,
+and the contract that the soft backend never emits an attestation claim.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from cullis_connector.keystore.base import KeyStoreUnavailable
+from cullis_connector.keystore.soft import SoftKeyStore
+
+
+def test_ephemeral_keystore_signs_verifiably():
+    ks = SoftKeyStore()
+    msg = b"cullis-attestation-test"
+    sig = ks.sign(msg)
+
+    pub = serialization.load_pem_public_key(ks.public_key_pem().encode())
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+    # Round-trip; raises if the signature does not verify.
+    pub.verify(sig, msg, ec.ECDSA(hashes.SHA256()))
+
+
+def test_persist_then_reload_yields_same_pubkey(tmp_path):
+    path = tmp_path / "soft.key.pem"
+    ks1 = SoftKeyStore(private_key_path=path)
+    pem1 = ks1.public_key_pem()
+    assert path.exists()
+    if path.stat().st_mode & 0o777 not in (0o600, 0o400):
+        # ``chmod 600`` is best-effort on POSIX, but on Windows the bits
+        # vary. Don't fail the test on non-POSIX hosts.
+        import os
+
+        if os.name == "posix":
+            pytest.fail(f"expected 0o600 on POSIX, got {oct(path.stat().st_mode & 0o777)}")
+
+    ks2 = SoftKeyStore(private_key_path=path)
+    assert ks2.public_key_pem() == pem1
+
+
+def test_attestation_claim_is_none_for_soft():
+    ks = SoftKeyStore()
+    assert ks.attestation_claim() is None
+    assert ks.attestation_strength() == "soft_only"
+
+
+def test_generate_aik_quote_default_returns_none():
+    ks = SoftKeyStore()
+    # Soft backend never owns an AIK; calling the helper must yield
+    # ``None`` so the enrollment flow can treat it uniformly.
+    assert ks.generate_aik_quote(b"nonce") is None
+
+
+def test_keystore_unavailable_is_an_exception():
+    # Sanity; KeyStoreUnavailable is importable and is a real Exception.
+    assert issubclass(KeyStoreUnavailable, Exception)

--- a/tests/test_keystore_tpm_linux.py
+++ b/tests/test_keystore_tpm_linux.py
@@ -1,0 +1,91 @@
+"""Linux TPM keystore; exercises the import-gated paths.
+
+The bulk of the TPM behaviour needs a real (or vTPM/swtpm-backed) device
+and is skipped by default; CI / NixOS / laptops without ``tpm2-pytss`` go
+through the import-failure path which is the most exercised branch in
+production today. The full hardware run is gated on:
+
+* ``tpm2-pytss`` installed (optional extra ``[tpm]``)
+* ``CULLIS_TPM_TEST_TCTI`` env (e.g. ``swtpm:port=2321``) pointing at
+  a swtpm or kernel resource manager
+
+When both are present the test provisions the persistent handle, signs a
+canonical buffer, and round-trips the signature through ``cryptography``
+so we get a real ECDSA-SHA256 verify rather than a tpm2-pytss self-check.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from cullis_connector.keystore.base import KeyStoreUnavailable
+from cullis_connector.keystore.soft import SoftKeyStore
+
+
+_TPM_PYTSS_AVAILABLE = False
+try:  # pragma: no cover; environment-dependent
+    import tpm2_pytss  # noqa: F401
+
+    _TPM_PYTSS_AVAILABLE = True
+except Exception:
+    pass
+
+
+_HARDWARE_GATE = bool(os.environ.get("CULLIS_TPM_TEST_TCTI"))
+
+
+def test_detect_best_keystore_falls_back_to_soft_when_tpm_unavailable(monkeypatch):
+    """When the optional TPM dep is absent or the device is unreachable,
+    the public detector returns a :class:`SoftKeyStore` instead of
+    raising. This is the production path on Windows / macOS / vTPM-less
+    Linux hosts and the most important invariant for the spike.
+    """
+
+    # Force LinuxTpmKeyStore to raise KeyStoreUnavailable regardless of the
+    # actual host (some CI runners do have a TPM). We patch the import
+    # surface used by detect_best_keystore.
+    from cullis_connector import keystore as ks_pkg
+
+    class _Boom:
+        def __init__(self, *_a, **_kw):
+            raise KeyStoreUnavailable("forced by test")
+
+    monkeypatch.setattr(
+        "cullis_connector.keystore.tpm_linux.LinuxTpmKeyStore",
+        _Boom,
+        raising=True,
+    )
+    # Re-import path also has to see the patched class; detect_best_keystore
+    # does ``from cullis_connector.keystore.tpm_linux import LinuxTpmKeyStore``
+    # at call time so the monkeypatch takes effect.
+    chosen = ks_pkg.detect_best_keystore(prefer_hardware=True)
+    assert isinstance(chosen, SoftKeyStore)
+    assert chosen.attestation_claim() is None
+
+
+@pytest.mark.skipif(not _TPM_PYTSS_AVAILABLE, reason="tpm2-pytss not installed")
+@pytest.mark.skipif(not _HARDWARE_GATE, reason="CULLIS_TPM_TEST_TCTI not set")
+def test_linux_tpm_keystore_signs_with_real_device():  # pragma: no cover
+    """Real-device path. Gated on CULLIS_TPM_TEST_TCTI so CI stays green
+    on hosts without a vTPM/swtpm available.
+    """
+    from cullis_connector.keystore.tpm_linux import LinuxTpmKeyStore
+
+    ks = LinuxTpmKeyStore(persistent_handle=0x81010099)
+    pem = ks.public_key_pem()
+    pub = serialization.load_pem_public_key(pem.encode())
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+
+    sig = ks.sign(b"hello-tpm")
+    pub.verify(sig, b"hello-tpm", ec.ECDSA(hashes.SHA256()))
+
+    claim = ks.attestation_claim()
+    assert claim is not None
+    assert claim.hardware == "tpm_2.0"
+    assert claim.strength in {"hw_attested", "hw_isolated"}
+
+    quote = ks.generate_aik_quote(b"\x01" * 32)
+    assert quote.startswith(b"CULLIS-Q1")

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0035_mdm_device_state",)]
+    assert rows == [("0036_pending_attestation",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0035_mdm_device_state",)]
+    assert version == [("0036_pending_attestation",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0035_mdm_device_state"
+HEAD_REVISION = "0036_pending_attestation"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0035_mdm_device_state"
+HEAD_REVISION = "0036_pending_attestation"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0035_mdm_device_state"
+HEAD_REVISION = "0036_pending_attestation"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 

--- a/tests/test_tpm_verify.py
+++ b/tests/test_tpm_verify.py
@@ -1,0 +1,157 @@
+"""Mastio-side TPM quote verifier (mcp_proxy.attestation.tpm_verify).
+
+The unit suite stays pure-Python: the envelope packer mirrors the one in
+``cullis_connector.keystore.tpm_linux`` but uses a software EC P-256 key
+in place of the chip so we can exercise the verifier end-to-end without
+a TPM.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+
+from mcp_proxy.attestation import compute_effective_tier
+from mcp_proxy.attestation.tpm_verify import (
+    TPM_MANUFACTURER_WHITELIST,
+    verify_tpm_quote,
+)
+
+
+_QUOTE_MAGIC = b"CULLIS-Q1"
+
+
+def _pack(quote: bytes, sig: bytes, nonce: bytes) -> bytes:
+    out = bytearray()
+    out += _QUOTE_MAGIC
+    out += len(nonce).to_bytes(2, "big")
+    out += nonce
+    out += len(quote).to_bytes(4, "big")
+    out += quote
+    out += len(sig).to_bytes(4, "big")
+    out += sig
+    return bytes(out)
+
+
+def _fake_quote(nonce: bytes, private_key: ec.EllipticCurvePrivateKey) -> tuple[bytes, str]:
+    """Build a software-signed envelope shaped like the TPM packer."""
+    quote_body = b"mocked-TPMS_ATTEST||" + nonce
+    digest = hashlib.sha256(quote_body).digest()
+    sig = private_key.sign(digest, ec.ECDSA(Prehashed(hashes.SHA256())))
+    pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return _pack(quote_body, sig, nonce), pem
+
+
+def test_verify_valid_quote_with_whitelisted_manufacturer_marks_hw_attested():
+    nonce = secrets.token_bytes(32)
+    key = ec.generate_private_key(ec.SECP256R1())
+    envelope, pem = _fake_quote(nonce, key)
+
+    valid, claim = verify_tpm_quote(
+        envelope,
+        pem,
+        nonce,
+        manufacturer="Infineon",
+        ek_cert_present=True,
+    )
+    assert valid is True
+    assert claim["hardware"] == "tpm_2.0"
+    assert claim["strength"] == "hw_attested"
+    assert claim["manufacturer"] == "Infineon"
+    assert "pcr_digest_sha256" in claim
+
+
+def test_unknown_manufacturer_downgrades_to_hw_isolated():
+    nonce = secrets.token_bytes(32)
+    key = ec.generate_private_key(ec.SECP256R1())
+    envelope, pem = _fake_quote(nonce, key)
+
+    valid, claim = verify_tpm_quote(
+        envelope, pem, nonce, manufacturer="OffBrand", ek_cert_present=True,
+    )
+    assert valid is True
+    assert claim["strength"] == "hw_isolated"
+
+
+def test_no_ek_cert_downgrades_to_hw_isolated():
+    nonce = secrets.token_bytes(32)
+    key = ec.generate_private_key(ec.SECP256R1())
+    envelope, pem = _fake_quote(nonce, key)
+
+    valid, claim = verify_tpm_quote(
+        envelope, pem, nonce, manufacturer="Infineon", ek_cert_present=False,
+    )
+    assert valid is True
+    assert claim["strength"] == "hw_isolated"
+
+
+def test_nonce_mismatch_fails_verification():
+    nonce = secrets.token_bytes(32)
+    bad_nonce = secrets.token_bytes(32)
+    key = ec.generate_private_key(ec.SECP256R1())
+    envelope, pem = _fake_quote(nonce, key)
+
+    valid, claim = verify_tpm_quote(envelope, pem, bad_nonce)
+    assert valid is False
+    assert claim["strength"] == "soft_only"
+
+
+def test_tampered_signature_fails_verification():
+    nonce = secrets.token_bytes(32)
+    key = ec.generate_private_key(ec.SECP256R1())
+    envelope, pem = _fake_quote(nonce, key)
+    tampered = bytearray(envelope)
+    tampered[-1] ^= 0xFF  # flip a bit in the signature DER
+
+    valid, _claim = verify_tpm_quote(bytes(tampered), pem, nonce)
+    assert valid is False
+
+
+def test_truncated_envelope_returns_soft_only():
+    valid, claim = verify_tpm_quote(b"too-short", "ignored-pem", b"")
+    assert valid is False
+    assert claim["strength"] == "soft_only"
+
+
+def test_phase1_whitelist_contains_expected_vendors():
+    # If a customer reports a Phase 1 vendor that isn't here, ADR-032
+    # Q8 says the bundle needs a refresh; not a silent server upgrade.
+    assert {"Infineon", "Microsoft", "ST", "Nuvoton", "Intel"}.issubset(
+        TPM_MANUFACTURER_WHITELIST,
+    )
+
+
+def test_effective_tier_algorithm_matches_schema():
+    # Locked algorithm from imp/attestation-claim-schema.md sez. 2.
+    cases = [
+        # (mdm, compliance, strength, expected)
+        ("intune", "compliant", "hw_attested", "managed_attested"),
+        ("intune", "compliant", "hw_isolated", "managed"),
+        ("intune", "compliant", "soft_only", "managed"),
+        ("intune", "non_compliant", "hw_attested", "byod_attested"),
+        (None, None, "hw_attested", "byod_attested"),
+        (None, None, "hw_isolated", "byod_isolated"),
+        (None, None, "soft_only", "untrusted"),
+        (None, None, None, "untrusted"),
+    ]
+    def _hardware(strength):
+        if strength in ("hw_attested", "hw_isolated"):
+            return "tpm_2.0"
+        if strength == "soft_only":
+            return "soft"
+        return None
+
+    for mdm, compliance, strength, expected in cases:
+        got = compute_effective_tier(
+            mdm=mdm,
+            compliance=compliance,
+            hardware=_hardware(strength),
+            strength=strength,
+        )
+        assert got == expected, (mdm, compliance, strength, expected, got)


### PR DESCRIPTION
## Summary

ADR-032 F3 Phase 1: hardware-side device attestation via Linux TPM 2.0. Connector ships an AIK-style quote at enrollment; Mastio verifies it against a server-issued nonce and persists the JSON claim shape locked in `imp/attestation-claim-schema.md`.

- New `cullis_connector.keystore` package (abstract base, soft fallback, Linux TPM via optional `tpm2-pytss` extra)
- New `mcp_proxy.attestation` module (quote verifier + nonce store, pure-Python so the Mastio host needs no TPM deps)
- New `GET /v1/enrollment/attestation-nonce` (rate-limited, single-use, 60s TTL)
- `POST /v1/enrollment/start` grew optional `tpm_quote_b64` + `attestation_nonce_id` + `tpm_manufacturer` + `tpm_ek_cert_present`
- Alembic 0035 adds `device_attestation_json TEXT NULL` on `pending_enrollments` + `internal_agents`; HEAD pin bumped in the four migration regression tests

## Doc gap

Pure-BYOD `managed_attested` is NOT reachable in Phase 1 because the EK CA chain verify is deferred (ADR-032 Q8 pre-revenue decision) and the MDM half lives in F2. A Connector with a Phase-1-whitelisted TPM + verified quote tops out at `byod_attested`. Customers accept this for the pilot per memoria `feedback_adr_internal_vs_public_ratification`.

## Test plan

- [x] `pytest tests/test_keystore_soft.py tests/test_keystore_tpm_linux.py tests/test_tpm_verify.py tests/test_attestation_tier_mapping_hw.py tests/test_enrollment_tpm_flow.py` (28 + 7 + skips)
- [x] `pytest tests/test_enrollment.py tests/test_enrollment_dpop_jkt.py tests/test_h_csr_pop.py tests/test_m_onb_status_pop.py tests/test_enrollment_dashboard.py` regression
- [x] `pytest tests/test_proxy_migrations*.py` after bumping HEAD pin from `0034_user_sessions_obo` to `0035_pending_attestation`
- [x] `./demo_network/smoke.sh full` (cross-org E2E round-trip + hash chain + MCP forwarder)
- [x] Full `pytest tests/ -n auto --dist=loadfile` parallel: 3654 passed, one pre-existing failure unrelated to F3 (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable` trips on the local dev venv having `cullis_enterprise` installed)
- [ ] vTPM dogfood: not run on this branch (the executor host has no swtpm available); the gated `test_linux_tpm_keystore_signs_with_real_device` test SKIPS until `CULLIS_TPM_TEST_TCTI` is set and `tpm2-pytss` is installed