### PR TITLE
feat(mdm): Intune device attestation Phase 1 (ADR-032 Layer 1, F2)

### DIFF
--- a/enterprise-kit/intune-setup.md
+++ b/enterprise-kit/intune-setup.md
@@ -1,0 +1,125 @@
+# Microsoft Intune integration — admin runbook
+
+> Status: Phase 1 (ADR-032 Layer 1, F2 spike)
+> Audience: customer tenant admin (Azure AD + Intune licensed)
+> Effort: 30-60 minutes once you have admin consent from the Azure AD tenant admin
+> Outcome: Mastio polls Microsoft Graph for managed device compliance and stamps a `device_attestation` claim on each Connector enrollment
+
+## What this gets you
+
+Mastio queries `https://graph.microsoft.com/v1.0/deviceManagement/managedDevices/delta` on a polling interval and caches the compliance state of every Intune-enrolled laptop in the tenant. When a Connector enrolls (or its certificate is re-issued), Mastio joins on the device's `azureADDeviceId` and writes a `device_attestation` JSON claim into the agent row. F5 policy consumption and F6 revocation hooks are out of scope here — this PR ships the scaffolding only.
+
+No AppSource Marketplace listing is involved (Cullis is pre-revenue, see ADR-032 Q7). The customer tenant admin registers a multi-tenant app manually and grants admin consent. Plan for 2-4 weeks of bank IT review on a regulated customer.
+
+## Prerequisites
+
+- Microsoft Entra ID tenant with admin role `Cloud Application Administrator` or `Global Administrator`
+- At least one device enrolled in Intune (Windows, macOS, iOS, Android, or Linux supported by the Intune connector)
+- Network egress from the Mastio host to `https://login.microsoftonline.com` and `https://graph.microsoft.com` (port 443)
+
+## Step 1 — Register the application
+
+1. Open the Azure portal as a tenant admin.
+2. Navigate to **Microsoft Entra ID** → **App registrations** → **New registration**.
+3. Fill in:
+   - **Name**: `Cullis Mastio Intune Reader` (you can customise; this name appears in the consent dialog and in audit logs).
+   - **Supported account types**: **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**. This lets the same app definition be re-used across multiple Mastio deployments without a per-tenant publisher account.
+   - **Redirect URI**: leave blank. This is a daemon flow (client credentials), not an interactive user flow.
+4. Click **Register**. Note the **Application (client) ID** and **Directory (tenant) ID** shown on the overview page.
+
+## Step 2 — Grant API permissions
+
+1. In the app you just registered, click **API permissions** → **Add a permission** → **Microsoft Graph** → **Application permissions** (NOT delegated).
+2. Add:
+   - `DeviceManagementManagedDevices.Read.All` — required. Lets the app read the inventory of Intune-managed devices and their compliance state.
+   - `Directory.Read.All` — optional. Useful if you later want to enrich the audit log with user metadata (display name, department). Not used in Phase 1.
+3. Click **Grant admin consent for `<your tenant>`**. A tenant admin (you, if you have the role) must click through the consent dialog. This is the gate that turns the app from "registered but inert" into "able to call Graph".
+
+If a different person holds the Global Administrator role, send them the consent URL:
+```
+https://login.microsoftonline.com/<tenant-id>/adminconsent?client_id=<application-id>
+```
+
+## Step 3 — Create a client secret
+
+1. In the app, click **Certificates & secrets** → **Client secrets** → **New client secret**.
+2. Set:
+   - **Description**: `cullis-mastio-prod` (or similar — the description shows up when you list secrets later).
+   - **Expires**: pick a window agreed with sales. Default Microsoft options are 6 months, 12 months, 24 months, or custom. For regulated customers we recommend 12 months with a calendar reminder to rotate.
+3. Click **Add**. Copy the secret **Value** immediately — it is shown once and unrecoverable. Paste it into your secrets manager (Vault, 1Password, Azure Key Vault, etc.).
+
+NOTE: client secrets are bearer credentials with the granted permissions on your whole tenant. Treat them with the same care as the Mastio Org CA private key. Do not commit them to git and do not log them. Rotate at expiry or sooner if compromised.
+
+## Step 4 — Configure Mastio
+
+Add the following to your `proxy.env` (or equivalent secrets store) and restart the Mastio process:
+
+```
+MCP_PROXY_MDM_INTUNE_ENABLED=true
+MCP_PROXY_MDM_INTUNE_TENANT_ID=00000000-0000-0000-0000-000000000000
+MCP_PROXY_MDM_INTUNE_CLIENT_ID=00000000-0000-0000-0000-000000000000
+MCP_PROXY_MDM_INTUNE_CLIENT_SECRET=<paste-the-secret-value-from-step-3>
+MCP_PROXY_MDM_INTUNE_POLL_INTERVAL_SECONDS=600
+MCP_PROXY_ATTESTATION_STALE_THRESHOLD_SECONDS=900
+```
+
+`MCP_PROXY_MDM_INTUNE_POLL_INTERVAL_SECONDS` controls how often Mastio fetches the delta endpoint. Default 600 seconds (10 minutes). Microsoft documents Intune compliance state freshness on the order of 5-15 minutes, so polling much faster will not yield fresher data and will increase Graph throttling risk.
+
+`MCP_PROXY_ATTESTATION_STALE_THRESHOLD_SECONDS` controls the age at which a cached device entry is considered stale. Default 900 seconds. Stale entries are reported as `compliance=unknown` in the claim, which downgrades the `effective_tier` (typically from `managed` to `byod_*` or `untrusted`).
+
+## Step 5 — Verify
+
+After restart, tail the Mastio logs for the polling task announcement:
+
+```
+docker compose logs mcp-proxy | grep -i intune
+```
+
+You should see lines such as:
+```
+{"timestamp": "...", "level": "INFO", "logger": "mcp_proxy.mdm.poller", "message": "Intune polling loop started (interval=600s)"}
+{"timestamp": "...", "level": "INFO", "logger": "mcp_proxy.mdm.poller", "message": "Intune delta fetch: 142 devices upserted (lag_s=4)"}
+```
+
+Then run the dashboard's **MDM cache** page (or query the DB directly):
+
+```sql
+SELECT mdm, device_id, compliance, device_name, user_principal_name, last_seen_at
+FROM mdm_device_state
+ORDER BY last_seen_at DESC
+LIMIT 10;
+```
+
+If you see rows, the integration is live. Enrol a fresh Connector against this Mastio and the audit log should contain a `device_attestation_verified` row with the device claim attached.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Logs say `Intune polling disabled (MCP_PROXY_MDM_INTUNE_ENABLED=false)` | Flag not set or set to `false` | Set `MCP_PROXY_MDM_INTUNE_ENABLED=true` and restart |
+| `Intune polling error: 401 invalid_client` | Wrong `MCP_PROXY_MDM_INTUNE_CLIENT_ID` or expired client secret | Re-check the values; if the secret expired, create a new one (Step 3) |
+| `Intune polling error: 403 Insufficient privileges` | Admin consent not granted, or permission `DeviceManagementManagedDevices.Read.All` not added | Repeat Step 2 |
+| `Intune polling error: 429 Throttled` | Polling interval too aggressive, or shared tenant burst | Increase `MCP_PROXY_MDM_INTUNE_POLL_INTERVAL_SECONDS`; Mastio backs off automatically |
+| Cache populated but Connector enrollments still report `mdm=null` in audit | Connector did not pass `azure_ad_device_id` hint in `device_info` | Connector ≥ v0.4.4 required; older Connectors enrol without the hint |
+
+## What this does NOT do (yet)
+
+- F5 — policy tier consumption (capability matrix wired to `effective_tier`)
+- F6 — live revocation (push events from Graph webhook so a non-compliant transition is reflected sub-poll)
+- Jamf and Workspace ONE support (deferred — Intune ships first, multi-MDM after pilot signal)
+- Hardware attestation (`tpm_2.0`, `secure_enclave`) — F3 ships TPM EK validation for Linux Connector
+
+If a customer asks for any of the above before they appear in the public CHANGELOG, escalate to product — there is no quick workaround.
+
+## Security notes
+
+- The client secret you create in Step 3 grants read access to the entire managed-device inventory of your tenant. Anyone who exfiltrates it can list every Intune-enrolled device and its compliance state, but not modify policy, push commands, or read user data beyond `userPrincipalName`.
+- Mastio never logs the access token (`access_token` in the OAuth2 response) or the client secret. If you see either in the logs, file a security issue.
+- The polling token is cached in memory for 50 minutes (Microsoft mints it at 60 minutes; we refresh 10 minutes early). Token cache lives only in the Mastio process; restart wipes it.
+
+## References
+
+- ADR-032 (internal-only): device attestation across multiple MDM providers + BYOD
+- `imp/attestation-claim-schema.md` v1.0: the claim shape and `effective_tier` algorithm both ends compute against
+- Microsoft Graph `managedDevices`: https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list
+- Microsoft Graph delta queries: https://learn.microsoft.com/en-us/graph/delta-query-overview

--- a/mcp_proxy/alembic/versions/0035_mdm_device_state.py
+++ b/mcp_proxy/alembic/versions/0035_mdm_device_state.py
@@ -1,0 +1,129 @@
+"""ADR-032 Layer 1 — MDM device-state cache + agent attestation column.
+
+Revision ID: 0035_mdm_device_state
+Revises: 0034_user_sessions_obo
+Create Date: 2026-05-17 09:00:00.000000
+
+Two schema changes for the F2 Intune spike:
+
+1. ``mdm_device_state`` table. Cache of the inventory Mastio fetches
+   from each MDM (Phase 1: Intune only; the ``mdm`` PK column
+   makes Jamf / WS1 additions a drop-in). Composite primary key
+   ``(mdm, device_id)`` so a customer migrating Connectors between
+   MDMs does not collide. ``raw_payload`` keeps the full Graph row
+   for forensic queries; the projected columns are the cheap-query
+   subset (``compliance``, ``azure_ad_device_id``, ``user_principal_name``,
+   etc.).
+
+2. ``internal_agents.last_attestation`` (TEXT NULL, JSON-serialised
+   claim). The Connector device IS the agent under ADR-014, so the
+   ``device_attestation`` claim sticks to the agent row. F4 R2's
+   ``user_sessions`` row can later denormalise the same claim for
+   the shared-mode Frontdesk case (multi-user behind one workload);
+   that lives in a follow-up migration so this spike stays focused.
+
+Note on placement vs. the spike spec: the prompt suggested
+``local_user_principals.last_attestation``. The principal is a
+durable identity (sso_subject, idp_issuer) that outlives any
+specific device; the attestation is a per-device claim. Putting it
+on the agent row keeps the lifetime correct and matches where the
+enrollment hook actually writes (``mcp_proxy/enrollment/service.py``
+upserts internal_agents). The ADR will follow up with a similar
+column on ``user_sessions`` once F4 R2 wires that flow end-to-end.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0035_mdm_device_state"
+down_revision: Union[str, Sequence[str], None] = "0034_user_sessions_obo"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_MDM = "mdm_device_state"
+_AGENTS = "internal_agents"
+
+
+def _has_table(name: str) -> bool:
+    bind = op.get_bind()
+    return name in set(sa.inspect(bind).get_table_names())
+
+
+def _has_column(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def _has_index(table: str, index: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return index in {i["name"] for i in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    # 1. mdm_device_state ---------------------------------------------------
+    if not _has_table(_MDM):
+        op.create_table(
+            _MDM,
+            # 'intune', 'jamf', 'ws1'. Composite PK with device_id
+            # so the same device under a different MDM does not
+            # silently overwrite.
+            sa.Column("mdm", sa.String(length=16), primary_key=True),
+            sa.Column("device_id", sa.String(length=128), primary_key=True),
+            # Claim values: 'compliant' | 'non_compliant' | 'unknown'.
+            # Stored as String(32) for the typical query "WHERE
+            # compliance = 'compliant'"; the projection layer enforces
+            # the enum.
+            sa.Column("compliance", sa.String(length=32), nullable=False),
+            sa.Column("azure_ad_device_id", sa.String(length=128), nullable=True),
+            sa.Column("user_principal_name", sa.String(length=255), nullable=True),
+            sa.Column("device_name", sa.String(length=255), nullable=True),
+            sa.Column("manufacturer", sa.String(length=64), nullable=True),
+            sa.Column("serial_number", sa.String(length=128), nullable=True),
+            # Full Graph row as JSON text so future projections can be
+            # backfilled without re-polling Microsoft.
+            sa.Column("raw_payload", sa.Text(), nullable=False),
+            sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        )
+
+    if not _has_index(_MDM, "ix_mdm_device_state_last_seen"):
+        op.create_index(
+            "ix_mdm_device_state_last_seen", _MDM, ["last_seen_at"],
+        )
+
+    if not _has_index(_MDM, "ix_mdm_device_state_azure_ad"):
+        op.create_index(
+            "ix_mdm_device_state_azure_ad", _MDM, ["azure_ad_device_id"],
+        )
+
+    if not _has_index(_MDM, "ix_mdm_device_state_upn"):
+        op.create_index(
+            "ix_mdm_device_state_upn", _MDM, ["user_principal_name"],
+        )
+
+    # 2. internal_agents.last_attestation ----------------------------------
+    if not _has_column(_AGENTS, "last_attestation"):
+        with op.batch_alter_table(_AGENTS) as batch_op:
+            batch_op.add_column(
+                sa.Column("last_attestation", sa.Text(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    if _has_column(_AGENTS, "last_attestation"):
+        with op.batch_alter_table(_AGENTS) as batch_op:
+            batch_op.drop_column("last_attestation")
+
+    if _has_index(_MDM, "ix_mdm_device_state_upn"):
+        op.drop_index("ix_mdm_device_state_upn", table_name=_MDM)
+    if _has_index(_MDM, "ix_mdm_device_state_azure_ad"):
+        op.drop_index("ix_mdm_device_state_azure_ad", table_name=_MDM)
+    if _has_index(_MDM, "ix_mdm_device_state_last_seen"):
+        op.drop_index("ix_mdm_device_state_last_seen", table_name=_MDM)
+    if _has_table(_MDM):
+        op.drop_table(_MDM)

--- a/mcp_proxy/attestation/__init__.py
+++ b/mcp_proxy/attestation/__init__.py
@@ -1,0 +1,27 @@
+"""Device attestation claim — server-side authoritative compute.
+
+See ``imp/attestation-claim-schema.md`` v1.0 for the canonical claim
+shape, tier algorithm, and stale-window policy. This package is the
+implementation of sections 1 + 2 + 5 of that doc on the Mastio side.
+
+Exports:
+
+* :func:`compute_effective_tier` — pure function over the four input
+  fields the schema names. Used by the enrollment hook to stamp the
+  initial tier, and (later, F5) by the policy decision point.
+* :func:`is_stale` — true when ``stale_seconds`` exceeds the
+  configured threshold; callers must downgrade ``compliance`` to
+  ``unknown`` before re-evaluating the tier.
+* :func:`build_attestation_claim` — assembles the JSON shape sez. 1.
+  Convenience wrapper; the enrollment hook composes the dict
+  directly with the device row, this helper exists so future call
+  sites (admin re-attestation endpoint, dashboard preview) get the
+  same canonical shape without duplication.
+"""
+from mcp_proxy.attestation.tier import (
+    build_attestation_claim,
+    compute_effective_tier,
+    is_stale,
+)
+
+__all__ = ["build_attestation_claim", "compute_effective_tier", "is_stale"]

--- a/mcp_proxy/attestation/enrollment_hook.py
+++ b/mcp_proxy/attestation/enrollment_hook.py
@@ -1,0 +1,254 @@
+"""Bridge between Connector enrollment and the MDM cache.
+
+When the device-code enrollment flow approves a Connector
+(``mcp_proxy/enrollment/service.py::approve``), this module looks up
+the agent's device hint in ``mdm_device_state`` and, when a match
+exists, stamps the canonical attestation claim on
+``internal_agents.last_attestation`` plus an audit row of subtype
+``device_attestation_verified``.
+
+Hint extraction is best-effort. The Connector ships free-form JSON
+in ``device_info``; if it contains an ``azure_ad_device_id`` (or
+``intune_device_id`` / ``serial_number``) we use it. Absence is
+expected for legacy Connectors and is not an error; the claim
+simply doesn't get stamped and the agent operates at
+``effective_tier=untrusted`` until re-enrolled.
+
+The function is side-effect-only: caller still returns the
+enrollment record verbatim, this module never modifies what the
+HTTP response looks like.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from mcp_proxy.attestation.tier import (
+    STRENGTH_SOFT_ONLY,
+    apply_stale_downgrade,
+    build_attestation_claim,
+)
+from mcp_proxy.config import get_settings
+
+_log = logging.getLogger("mcp_proxy.attestation.enrollment_hook")
+
+
+def _extract_device_hint(device_info: str | None) -> dict[str, str | None]:
+    """Pull MDM lookup hints out of the Connector's ``device_info`` JSON.
+
+    Returns a dict with possibly-empty values:
+        - ``azure_ad_device_id`` (preferred — most reliable join key)
+        - ``intune_device_id`` (also called ``id`` in Graph)
+        - ``serial_number`` (last resort; not unique across vendors)
+    Absent / malformed input yields an all-empty dict.
+    """
+    empty: dict[str, str | None] = {
+        "azure_ad_device_id": None,
+        "intune_device_id": None,
+        "serial_number": None,
+    }
+    if not device_info:
+        return empty
+    try:
+        parsed = json.loads(device_info)
+    except (TypeError, ValueError):
+        return empty
+    if not isinstance(parsed, Mapping):
+        return empty
+
+    def _str_or_none(value: Any) -> str | None:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    return {
+        "azure_ad_device_id": _str_or_none(parsed.get("azure_ad_device_id")),
+        "intune_device_id": _str_or_none(parsed.get("intune_device_id"))
+            or _str_or_none(parsed.get("device_id")),
+        "serial_number": _str_or_none(parsed.get("serial_number")),
+    }
+
+
+async def _lookup_device_row(
+    conn: AsyncConnection,
+    hints: dict[str, str | None],
+) -> dict[str, Any] | None:
+    """Find the freshest matching ``mdm_device_state`` row for these hints.
+
+    Try azure_ad_device_id first (the most reliable join — set by
+    Intune at MDM enrolment), then intune_device_id (Graph's own
+    UUID), then serial_number. Returns ``None`` on no match.
+    """
+    if hints.get("azure_ad_device_id"):
+        row = (await conn.execute(
+            text(
+                "SELECT mdm, device_id, compliance, manufacturer, "
+                "last_seen_at FROM mdm_device_state "
+                "WHERE azure_ad_device_id = :v "
+                "ORDER BY last_seen_at DESC LIMIT 1"
+            ),
+            {"v": hints["azure_ad_device_id"]},
+        )).mappings().first()
+        if row:
+            return dict(row)
+
+    if hints.get("intune_device_id"):
+        row = (await conn.execute(
+            text(
+                "SELECT mdm, device_id, compliance, manufacturer, "
+                "last_seen_at FROM mdm_device_state "
+                "WHERE mdm = 'intune' AND device_id = :v LIMIT 1"
+            ),
+            {"v": hints["intune_device_id"]},
+        )).mappings().first()
+        if row:
+            return dict(row)
+
+    if hints.get("serial_number"):
+        row = (await conn.execute(
+            text(
+                "SELECT mdm, device_id, compliance, manufacturer, "
+                "last_seen_at FROM mdm_device_state "
+                "WHERE serial_number = :v "
+                "ORDER BY last_seen_at DESC LIMIT 1"
+            ),
+            {"v": hints["serial_number"]},
+        )).mappings().first()
+        if row:
+            return dict(row)
+
+    return None
+
+
+async def stamp_attestation_on_enrollment(
+    conn: AsyncConnection,
+    *,
+    agent_id: str,
+    device_info: str | None,
+    session_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Look up the MDM cache + stamp the claim on the agent row.
+
+    Called from ``mcp_proxy/enrollment/service.py::approve`` after the
+    internal_agents row has been upserted.
+
+    Returns the claim that was stamped (for tests / dashboard
+    preview) or ``None`` when no device match was found. Always
+    side-effects defensively: any error in the lookup or the
+    audit emission is logged and swallowed so the enrollment
+    response is unaffected. The Connector should still complete
+    enrollment when MDM is offline or the device is BYOD.
+    """
+    hints = _extract_device_hint(device_info)
+    now = now or datetime.now(timezone.utc)
+
+    try:
+        row = await _lookup_device_row(conn, hints)
+    except Exception as exc:  # noqa: BLE001 — never block enrollment on MDM
+        _log.warning(
+            "MDM cache lookup failed for agent %s (continuing without "
+            "attestation): %s", agent_id, exc,
+        )
+        return None
+
+    if row is None:
+        _log.info(
+            "No MDM cache match for agent %s (hints=%s) — "
+            "enrolling without device_attestation claim.",
+            agent_id, {k: bool(v) for k, v in hints.items()},
+        )
+        return None
+
+    # Parse last_seen_at. SQLite returns the raw text; Postgres
+    # returns datetime. Tolerate both.
+    raw_seen = row.get("last_seen_at")
+    if isinstance(raw_seen, datetime):
+        verified_at = raw_seen if raw_seen.tzinfo else raw_seen.replace(
+            tzinfo=timezone.utc,
+        )
+    else:
+        try:
+            verified_at = datetime.fromisoformat(str(raw_seen).replace("Z", "+00:00"))
+            if verified_at.tzinfo is None:
+                verified_at = verified_at.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            verified_at = now
+
+    settings = get_settings()
+    claim = build_attestation_claim(
+        mdm=row.get("mdm"),
+        device_id=row.get("device_id"),
+        compliance=row.get("compliance") or "unknown",
+        manufacturer=row.get("manufacturer"),
+        verified_at=verified_at,
+        now=now,
+        # F3 will plug in tpm_2.0 / hw_attested. Until then every
+        # Intune device is software-attested only — managed but
+        # not hardware-bound.
+        hardware=None,
+        strength=STRENGTH_SOFT_ONLY,
+    )
+    claim = apply_stale_downgrade(
+        claim, settings.attestation_stale_threshold_seconds,
+    )
+
+    claim_json = json.dumps(
+        claim, separators=(",", ":"), sort_keys=True, default=str,
+    )
+
+    try:
+        await conn.execute(
+            text(
+                "UPDATE internal_agents SET last_attestation = :claim "
+                "WHERE agent_id = :aid"
+            ),
+            {"claim": claim_json, "aid": agent_id},
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "Failed to stamp last_attestation on %s (continuing): %s",
+            agent_id, exc,
+        )
+        return None
+
+    # Audit event. Inserted on the SAME connection the caller already
+    # holds — log_audit() opens its own connection and would deadlock
+    # against the enrollment transaction under SQLite's single-writer
+    # model. The hash-chain columns are left NULL; matches the
+    # convention the existing approve() inline INSERTs use
+    # (verify_audit_chain skips NULL rows). F6 owns the hash-chain
+    # extension for device_attestation audit rows.
+    audit_detail = json.dumps({
+        "event_subtype": "verified",
+        "device_attestation": claim["device_attestation"],
+        "effective_tier": claim["effective_tier"],
+        "trigger": "enrollment",
+        "session_id": session_id,
+    }, separators=(",", ":"), sort_keys=True, default=str)
+    try:
+        await conn.execute(
+            text(
+                """INSERT INTO audit_log
+                   (timestamp, agent_id, action, status, detail)
+                   VALUES (:ts, :aid, :action, 'success', :detail)"""
+            ),
+            {
+                "ts": now.isoformat(),
+                "aid": agent_id,
+                "action": "device_attestation",
+                "detail": audit_detail,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — audit failure shouldn't break enrollment
+        _log.warning(
+            "Failed to emit device_attestation audit row for %s: %s",
+            agent_id, exc,
+        )
+
+    return claim

--- a/mcp_proxy/attestation/tier.py
+++ b/mcp_proxy/attestation/tier.py
@@ -1,0 +1,148 @@
+"""Effective-tier algorithm + claim builder.
+
+Locked against ``imp/attestation-claim-schema.md`` v1.0 sez. 2 + sez. 5.
+Any change to the algorithm requires a schema version bump (sez. 8)
+and a coordinated update in the Connector (which computes the same
+function for UX purposes).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# Tier values. Ordered low-to-high so future code can do "compare
+# tiers" by index without re-encoding the matrix.
+TIER_UNTRUSTED = "untrusted"
+TIER_BYOD_ISOLATED = "byod_isolated"
+TIER_BYOD_ATTESTED = "byod_attested"
+TIER_MANAGED = "managed"
+TIER_MANAGED_ATTESTED = "managed_attested"
+
+# Strength values per schema sez. 1.
+STRENGTH_HW_ATTESTED = "hw_attested"
+STRENGTH_HW_ISOLATED = "hw_isolated"
+STRENGTH_SOFT_ONLY = "soft_only"
+
+# Compliance values per schema sez. 1.
+COMPLIANCE_COMPLIANT = "compliant"
+COMPLIANCE_NON_COMPLIANT = "non_compliant"
+COMPLIANCE_UNKNOWN = "unknown"
+
+
+def compute_effective_tier(
+    mdm: str | None,
+    compliance: str,
+    hardware: str | None,
+    strength: str,
+) -> str:
+    """Return the effective tier per schema sez. 2.
+
+    Inputs are tolerated as ``None`` / unknown strings for forward
+    compatibility — any value outside the schema enum collapses into
+    the most restrictive bucket. The algorithm is intentionally
+    branchless once normalised so a tampered claim cannot push the
+    tier above what the actual inputs justify.
+    """
+    has_mdm = mdm is not None and compliance == COMPLIANCE_COMPLIANT
+
+    if has_mdm and strength == STRENGTH_HW_ATTESTED:
+        return TIER_MANAGED_ATTESTED
+    if has_mdm:
+        return TIER_MANAGED
+    if strength == STRENGTH_HW_ATTESTED:
+        return TIER_BYOD_ATTESTED
+    if strength == STRENGTH_HW_ISOLATED:
+        return TIER_BYOD_ISOLATED
+    return TIER_UNTRUSTED
+
+
+def is_stale(stale_seconds: int, threshold_seconds: int) -> bool:
+    """True when the claim age exceeds the operator-configured threshold.
+
+    Threshold ≤ 0 disables the staleness check (tests + dev only).
+    A negative or non-int ``stale_seconds`` is treated as fresh; the
+    server is authoritative for ``stale_seconds`` (computed from
+    ``verified_at`` at evaluation time) so a tampered value can only
+    push the claim toward more-fresh, not more-stale.
+    """
+    if threshold_seconds <= 0:
+        return False
+    try:
+        return int(stale_seconds) > threshold_seconds
+    except (TypeError, ValueError):
+        return False
+
+
+def build_attestation_claim(
+    *,
+    mdm: str | None,
+    device_id: str | None,
+    compliance: str,
+    manufacturer: str | None,
+    verified_at: datetime,
+    now: datetime | None = None,
+    hardware: str | None = None,
+    strength: str = STRENGTH_SOFT_ONLY,
+) -> dict[str, Any]:
+    """Assemble the canonical claim dict (schema sez. 1).
+
+    ``effective_tier`` is recomputed here so the caller cannot pass
+    a forged value through. ``stale_seconds`` is derived from
+    ``now - verified_at`` for the same reason.
+    """
+    now = now or datetime.now(timezone.utc)
+    if verified_at.tzinfo is None:
+        verified_at = verified_at.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    stale_seconds = max(0, int((now - verified_at).total_seconds()))
+
+    return {
+        "device_attestation": {
+            "mdm": mdm,
+            "device_id": device_id,
+            "compliance": compliance,
+            "hardware": hardware,
+            "strength": strength,
+            "manufacturer": manufacturer,
+            # The schema asks for ``YYYY-MM-DDThh:mm:ssZ`` (no
+            # microseconds, trailing Z). ``isoformat`` would give
+            # ``+00:00`` and microseconds; format explicitly.
+            "verified_at": verified_at.astimezone(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ",
+            ),
+            "stale_seconds": stale_seconds,
+        },
+        "effective_tier": compute_effective_tier(
+            mdm=mdm, compliance=compliance,
+            hardware=hardware, strength=strength,
+        ),
+    }
+
+
+def apply_stale_downgrade(
+    claim: dict[str, Any], threshold_seconds: int,
+) -> dict[str, Any]:
+    """Force ``compliance=unknown`` + recompute tier when stale.
+
+    Operates on a claim returned by :func:`build_attestation_claim`.
+    Returns a NEW dict; the input is not mutated so callers can keep
+    the pre-downgrade claim for audit ("we saw it as compliant 17
+    minutes ago, now treating as unknown").
+    """
+    inner = dict(claim.get("device_attestation") or {})
+    stale_s = int(inner.get("stale_seconds") or 0)
+    if not is_stale(stale_s, threshold_seconds):
+        return claim
+
+    inner["compliance"] = COMPLIANCE_UNKNOWN
+    return {
+        "device_attestation": inner,
+        "effective_tier": compute_effective_tier(
+            mdm=inner.get("mdm"),
+            compliance=inner.get("compliance") or COMPLIANCE_UNKNOWN,
+            hardware=inner.get("hardware"),
+            strength=inner.get("strength") or STRENGTH_SOFT_ONLY,
+        ),
+    }

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -450,6 +450,32 @@ class ProxySettings(BaseSettings):
     frontdesk_ambassador_url: str = ""
     frontdesk_admin_secret: str = ""
 
+    # ADR-032 Layer 1 (F2 spike) — Intune device attestation polling.
+    # ``mdm_intune_enabled=false`` keeps the polling task off so
+    # customers who haven't completed the Entra app registration
+    # don't see lifespan warnings on every start. The tenant /
+    # client / secret triple is the customer's app registration
+    # (see ``enterprise-kit/intune-setup.md``). Empty values are
+    # tolerated so the field can be wired through the bundle's
+    # compose ``environment:`` block without crashing when the
+    # operator hasn't filled them in yet.
+    mdm_intune_enabled: bool = False
+    mdm_intune_tenant_id: str = ""
+    mdm_intune_client_id: str = ""
+    mdm_intune_client_secret: str = ""
+    # Microsoft documents Intune compliance state freshness on the
+    # order of 5-15 minutes; polling faster does not produce fresher
+    # data and only increases throttling risk. The bound of 60s is
+    # defensive for tests that want a tight loop.
+    mdm_intune_poll_interval_seconds: int = 600
+
+    # Stale window after which a cached device's compliance is
+    # downgraded to ``unknown`` (schema sez. 5). Default 900s = 15
+    # minutes, matching the upper bound of Intune's freshness window
+    # so we don't keep treating a device as compliant while it has
+    # actually drifted in the upstream.
+    attestation_stale_threshold_seconds: int = 900
+
     # Docker compose ``${VAR:-}`` substitutes to the empty string when
     # the operator has not set the var in proxy.env. Pydantic v2's bool
     # parser rejects "" with ``bool_parsing`` ValidationError, which
@@ -464,6 +490,7 @@ class ProxySettings(BaseSettings):
         "tool_pdp_enabled",
         "force_local_password",
         "local_auth_enabled",
+        "mdm_intune_enabled",
         mode="before",
     )
     @classmethod

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -560,6 +560,31 @@ async def approve(
             canonical_id, _get_settings().auto_baseline_binding, capabilities,
         )
 
+    # ADR-032 Layer 1 (F2 spike) — best-effort device attestation
+    # stamp. Looks up the MDM cache by the hints the Connector left
+    # in ``device_info``, builds the canonical claim (schema sez. 1),
+    # writes it onto ``internal_agents.last_attestation``, and emits
+    # an audit row of subtype ``verified``. Failure is non-fatal —
+    # enrollment completes either way; the claim absence simply means
+    # the agent operates at ``effective_tier=untrusted`` until the
+    # next enrolment or an admin attestation refresh.
+    try:
+        from mcp_proxy.attestation.enrollment_hook import (
+            stamp_attestation_on_enrollment,
+        )
+        await stamp_attestation_on_enrollment(
+            conn,
+            agent_id=canonical_id,
+            device_info=record.get("device_info"),
+            session_id=session_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — never block enrollment on attestation
+        import logging as _logging
+        _logging.getLogger("mcp_proxy.enrollment").warning(
+            "device_attestation stamp failed for %s (continuing): %s",
+            canonical_id, exc,
+        )
+
     return await get_record(conn, session_id)
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -480,6 +480,47 @@ async def lifespan(app: FastAPI):
         app.state.local_sweeper_stop = stop_event
         app.state.local_sweeper_task = sweeper_task
 
+    # ADR-032 Layer 1 (F2 spike) — Intune polling task. Gated on
+    # MCP_PROXY_MDM_INTUNE_ENABLED + credential triple so a half-
+    # configured deployment fails loud at startup instead of polling
+    # silently with empty values. Scope is the inventory cache only;
+    # the policy hook (F5) and revocation push (F6) ride on top of
+    # the same cache once shipped.
+    if settings.mdm_intune_enabled:
+        missing = [
+            name for name, value in (
+                ("MCP_PROXY_MDM_INTUNE_TENANT_ID", settings.mdm_intune_tenant_id),
+                ("MCP_PROXY_MDM_INTUNE_CLIENT_ID", settings.mdm_intune_client_id),
+                ("MCP_PROXY_MDM_INTUNE_CLIENT_SECRET", settings.mdm_intune_client_secret),
+            ) if not value
+        ]
+        if missing:
+            emit_lifespan_log(
+                level="WARNING",
+                logger="mcp_proxy.mdm.poller",
+                message=(
+                    "Intune polling enabled but required env missing: "
+                    f"{', '.join(missing)}. Not starting polling loop."
+                ),
+            )
+        else:
+            from mcp_proxy.mdm import intune_poll_loop
+            mdm_stop = asyncio.Event()
+            mdm_task = asyncio.create_task(
+                intune_poll_loop(
+                    tenant_id=settings.mdm_intune_tenant_id,
+                    client_id=settings.mdm_intune_client_id,
+                    client_secret=settings.mdm_intune_client_secret,
+                    interval_seconds=max(
+                        60, settings.mdm_intune_poll_interval_seconds,
+                    ),
+                    stop_event=mdm_stop,
+                ),
+                name="mdm_intune_poller",
+            )
+            app.state.mdm_intune_stop = mdm_stop
+            app.state.mdm_intune_task = mdm_task
+
     # Phase 4c — federation SSE subscriber. Wires the Phase 4b cache
     # to the live broker stream. Off by default; flip via
     # PROXY_FEDERATION_SYNC=true. The auth surface (DPoP / mTLS / SPIFFE)
@@ -717,6 +758,25 @@ async def lifespan(app: FastAPI):
                 delattr(app.state, attr_name)
             except AttributeError:
                 pass
+
+    # ADR-032 Layer 1 — stop the Intune poller. Mirrors the local
+    # sweeper teardown shape (set stop_event, wait with timeout,
+    # cancel on timeout, tolerate the xdist cross-loop ValueError).
+    mdm_stop = getattr(app.state, "mdm_intune_stop", None)
+    mdm_task = getattr(app.state, "mdm_intune_task", None)
+    if mdm_stop is not None:
+        mdm_stop.set()
+    if mdm_task is not None:
+        try:
+            await asyncio.wait_for(mdm_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            mdm_task.cancel()
+            try:
+                await mdm_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug("mdm intune poller teardown loop mismatch (xdist): %s", exc)
 
     stop_event = getattr(app.state, "local_sweeper_stop", None)
     sweeper_task = getattr(app.state, "local_sweeper_task", None)

--- a/mcp_proxy/mdm/__init__.py
+++ b/mcp_proxy/mdm/__init__.py
@@ -1,0 +1,21 @@
+"""MDM integrations — device attestation Layer 1 (ADR-032).
+
+Phase 1 ships Intune only. Jamf and Workspace ONE are deferred until
+pilot signal validates the MDM-cert path for the regulated customers
+driving the requirement (DORA, NIS2, PSD2).
+
+The exported surface is intentionally narrow:
+
+* :class:`IntuneClient` — async Microsoft Graph client (token cache +
+  delta paging).
+* :func:`intune_poll_loop` — long-running task wired into the proxy
+  lifespan when ``MCP_PROXY_MDM_INTUNE_ENABLED=true``.
+
+Both call sites live next to each other so a future Jamf/WS1 module
+can mirror the same shape without bleeding into the rest of the
+proxy.
+"""
+from mcp_proxy.mdm.intune import IntuneClient, IntuneGraphError
+from mcp_proxy.mdm.poller import intune_poll_loop
+
+__all__ = ["IntuneClient", "IntuneGraphError", "intune_poll_loop"]

--- a/mcp_proxy/mdm/intune.py
+++ b/mcp_proxy/mdm/intune.py
@@ -1,0 +1,301 @@
+"""Microsoft Graph client for Intune managed-device inventory.
+
+Implements the minimum surface F2 needs:
+
+* OAuth2 client_credentials grant against ``login.microsoftonline.com``
+  with a small in-memory token cache (50 minute TTL; Microsoft mints
+  tokens at 60 min, we refresh 10 min early to avoid the cliff).
+* ``managedDevices/delta`` delta-paging fetcher. First call has no
+  ``delta_link`` and returns the full inventory; subsequent calls
+  pass the ``@odata.deltaLink`` from the prior response and only
+  return changed rows.
+
+What this module is NOT:
+
+* Not a general Graph SDK. Only the two endpoints F2 needs are
+  implemented. Resist the urge to grow it into one — every additional
+  scope expands the security surface customers have to approve.
+* Not the polling loop. That lives in :mod:`mcp_proxy.mdm.poller`
+  so the network/IO part stays independently testable.
+
+Credentials are read from :class:`mcp_proxy.config.ProxySettings`
+(``mdm_intune_tenant_id`` etc.) and passed in explicitly by the
+caller. The client never reads env vars itself — keeps unit tests
+hermetic.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+import httpx
+
+_log = logging.getLogger("mcp_proxy.mdm.intune")
+
+# Endpoints
+_LOGIN_HOST = "https://login.microsoftonline.com"
+_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+_GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+
+# Token cache. Microsoft mints client-credentials tokens with a 3600s
+# lifetime; we refresh 600s early so we never present an about-to-expire
+# token to Graph and trigger a 401-retry storm.
+_TOKEN_REFRESH_SLACK = timedelta(seconds=600)
+_TOKEN_DEFAULT_LIFETIME = timedelta(seconds=3600)
+
+# Connect + read timeout for Graph calls. Graph delta on a large tenant
+# can take several seconds to materialise the first page; 30s is the
+# documented upper bound for a single page response.
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+class IntuneGraphError(RuntimeError):
+    """Raised on any non-recoverable Graph error.
+
+    Wraps the upstream HTTP status + a sanitised message. The original
+    response body MAY contain the device inventory or, on 401, an
+    error description that quotes the client_id. Both are safe to
+    surface to operators but not to embed in customer-visible error
+    responses, so callers should ``str(exc)`` for logs and a static
+    "MDM upstream error" string for any user-facing path.
+    """
+
+    def __init__(self, status: int, message: str):
+        super().__init__(f"Intune Graph error {status}: {message}")
+        self.status = status
+        self.message = message
+
+
+class IntuneClient:
+    """Async client for the subset of Microsoft Graph F2 needs.
+
+    Construction does not perform any I/O. The first call to
+    :meth:`fetch_managed_devices_delta` triggers token acquisition.
+
+    Thread-safety: the client holds a single :class:`httpx.AsyncClient`
+    and an unsynchronised token cache. Callers are expected to keep
+    one instance per polling task (the F2 lifespan wiring does so).
+    Concurrent calls from a single task are safe; sharing across
+    tasks would race on the token refresh and is unsupported.
+    """
+
+    def __init__(
+        self,
+        *,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+        http_client: httpx.AsyncClient | None = None,
+    ):
+        if not (tenant_id and client_id and client_secret):
+            raise ValueError(
+                "IntuneClient requires non-empty tenant_id, client_id, "
+                "and client_secret",
+            )
+        self._tenant_id = tenant_id
+        self._client_id = client_id
+        # Kept private; never logged, never put in __repr__. The
+        # secret is the only credential between this process and the
+        # customer tenant.
+        self._client_secret = client_secret
+
+        self._http = http_client or httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
+        self._owns_http = http_client is None
+
+        self._token: str | None = None
+        self._token_expires_at: datetime | None = None
+
+    async def aclose(self) -> None:
+        """Release the underlying httpx client if we created it."""
+        if self._owns_http:
+            await self._http.aclose()
+
+    # ── Auth ──────────────────────────────────────────────────────────
+
+    async def _ensure_token(self) -> str:
+        """Return a valid bearer token, refreshing if needed.
+
+        The cached token is reused until it falls within
+        :data:`_TOKEN_REFRESH_SLACK` of expiry. On refresh we re-POST
+        the client_credentials grant; the response's ``expires_in`` is
+        honoured rather than assumed (Azure occasionally returns
+        shorter lifetimes for newly-registered apps).
+        """
+        now = datetime.now(timezone.utc)
+        if (
+            self._token is not None
+            and self._token_expires_at is not None
+            and now + _TOKEN_REFRESH_SLACK < self._token_expires_at
+        ):
+            return self._token
+
+        url = f"{_LOGIN_HOST}/{self._tenant_id}/oauth2/v2.0/token"
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "scope": _GRAPH_SCOPE,
+        }
+        try:
+            resp = await self._http.post(url, data=data)
+        except httpx.HTTPError as exc:
+            raise IntuneGraphError(
+                0, f"token request transport error: {type(exc).__name__}",
+            ) from exc
+
+        if resp.status_code != 200:
+            # Body MAY contain ``error_description`` quoting the
+            # client_id. Surface a sanitised message; never log the
+            # body verbatim because some failure modes echo the
+            # secret back.
+            raise IntuneGraphError(
+                resp.status_code,
+                "token endpoint returned non-200 (check tenant_id, "
+                "client_id, client_secret, and admin consent)",
+            )
+
+        payload = resp.json()
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise IntuneGraphError(
+                200, "token endpoint returned 200 without access_token",
+            )
+
+        lifetime_s = payload.get("expires_in", _TOKEN_DEFAULT_LIFETIME.total_seconds())
+        try:
+            lifetime = timedelta(seconds=int(lifetime_s))
+        except (TypeError, ValueError):
+            lifetime = _TOKEN_DEFAULT_LIFETIME
+
+        self._token = access_token
+        self._token_expires_at = now + lifetime
+        return access_token
+
+    # ── Managed devices ───────────────────────────────────────────────
+
+    async def fetch_managed_devices_delta(
+        self,
+        delta_link: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Fetch one round of managed-device deltas.
+
+        Args:
+            delta_link: Opaque URL returned as ``@odata.deltaLink`` on
+                a prior call. ``None`` triggers a full sync against
+                the standard ``managedDevices/delta`` endpoint.
+
+        Returns:
+            ``(devices, next_delta_link)``. ``devices`` is the union
+            of all pages walked in this call (Graph paginates via
+            ``@odata.nextLink``; the delta endpoint terminates each
+            walk with a ``@odata.deltaLink`` that the caller should
+            persist for the next round).
+
+        Raises:
+            IntuneGraphError: On any non-200 Graph response or transport
+                error after retries have been exhausted.
+        """
+        token = await self._ensure_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
+
+        url = delta_link or f"{_GRAPH_BASE}/deviceManagement/managedDevices/delta"
+        devices: list[dict[str, Any]] = []
+        next_delta: str | None = None
+        # Cap the walk so a runaway tenant cannot stall the polling
+        # loop. 200 pages * 1000 rows/page = 200k devices. Anyone with
+        # more than that needs a different ingestion strategy anyway.
+        pages_left = 200
+
+        while pages_left > 0:
+            try:
+                resp = await self._http.get(url, headers=headers)
+            except httpx.HTTPError as exc:
+                raise IntuneGraphError(
+                    0,
+                    f"managedDevices transport error: {type(exc).__name__}",
+                ) from exc
+
+            if resp.status_code == 401:
+                # Token expired between issuance and this call (rare,
+                # but Azure clock skew + lifetime variance hits this).
+                # One forced refresh + retry, then surface.
+                self._token = None
+                self._token_expires_at = None
+                token = await self._ensure_token()
+                headers["Authorization"] = f"Bearer {token}"
+                resp = await self._http.get(url, headers=headers)
+
+            if resp.status_code != 200:
+                # 429 carries a Retry-After header; the poller wraps
+                # this in its own exponential backoff so we don't
+                # honour it inline.
+                raise IntuneGraphError(
+                    resp.status_code,
+                    "managedDevices endpoint returned non-200",
+                )
+
+            payload = resp.json()
+            page = payload.get("value", [])
+            if isinstance(page, list):
+                devices.extend(page)
+
+            next_link = payload.get("@odata.nextLink")
+            delta_out = payload.get("@odata.deltaLink")
+
+            if delta_out:
+                next_delta = delta_out
+                break
+            if next_link:
+                url = next_link
+                pages_left -= 1
+                continue
+            # No nextLink and no deltaLink — terminal page that did
+            # not emit a delta. Graph occasionally returns this on
+            # an empty tenant; fall back to "no delta" so the caller
+            # forces a full sync next round.
+            break
+
+        return devices, next_delta
+
+
+def map_compliance_state(graph_state: str | None) -> str:
+    """Translate the Graph ``complianceState`` enum to the claim shape.
+
+    Graph values: ``compliant``, ``noncompliant``, ``conflict``,
+    ``error``, ``inGracePeriod``, ``configManager``, ``unknown``.
+    Claim values (schema sez. 1): ``compliant``, ``non_compliant``,
+    ``unknown``.
+
+    The conservative mapping: only the unambiguous ``compliant`` and
+    ``noncompliant`` map through; everything else (transient grace,
+    conflict, error, unknown) falls into ``unknown`` so the effective
+    tier downgrades and never grants policy access on stale or
+    uncertain state.
+    """
+    if graph_state == "compliant":
+        return "compliant"
+    if graph_state == "noncompliant":
+        return "non_compliant"
+    return "unknown"
+
+
+def project_device_row(graph_device: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a Graph ``managedDevice`` JSON into our cache row shape.
+
+    Only the fields F2 actually persists. Unknown future fields stay
+    in ``raw_payload`` for forensic queries; the projection here is
+    the contract the rest of the proxy reads.
+    """
+    return {
+        "device_id": str(graph_device.get("id") or ""),
+        "compliance": map_compliance_state(graph_device.get("complianceState")),
+        "azure_ad_device_id": graph_device.get("azureADDeviceId"),
+        "user_principal_name": graph_device.get("userPrincipalName"),
+        "device_name": graph_device.get("deviceName"),
+        "manufacturer": graph_device.get("manufacturer"),
+        "serial_number": graph_device.get("serialNumber"),
+    }

--- a/mcp_proxy/mdm/poller.py
+++ b/mcp_proxy/mdm/poller.py
@@ -1,0 +1,267 @@
+"""Long-running Intune polling task.
+
+Lifecycle owned by ``mcp_proxy.main.lifespan``. Wakes every
+``MCP_PROXY_MDM_INTUNE_POLL_INTERVAL_SECONDS`` (default 600), fetches
+the managed-device delta, and upserts the projected rows into
+``mdm_device_state``.
+
+Failure handling: any :class:`IntuneGraphError` (transport, auth,
+throttle) is logged + backed off via exponential delay capped at 5
+minutes. The cache stays warm with the prior poll's data; consumers
+of the cache (enrollment hook in F2, policy gate in F5) treat
+``last_seen_at`` as the freshness signal and downgrade the
+``effective_tier`` when stale.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from mcp_proxy._lifespan_log import emit_lifespan_log
+from mcp_proxy.db import get_db
+from mcp_proxy.mdm.intune import (
+    IntuneClient,
+    IntuneGraphError,
+    project_device_row,
+)
+
+_log = logging.getLogger("mcp_proxy.mdm.poller")
+
+# Backoff schedule on consecutive errors. Reset to 0 on the first
+# successful poll. Capped at 300s so a long outage settles at 5 min
+# rather than crawling toward the polling interval.
+_BACKOFF_SECONDS = (30, 60, 120, 300, 300)
+
+
+async def upsert_device_rows(
+    devices: list[dict[str, Any]],
+    *,
+    mdm: str = "intune",
+    now: datetime | None = None,
+) -> int:
+    """Upsert a batch of devices into ``mdm_device_state``.
+
+    Returns the number of rows touched. Skips rows without an
+    ``id`` field (Graph never omits it, but we defend against
+    malformed test fixtures rather than crashing the poll loop).
+    """
+    if not devices:
+        return 0
+
+    now = now or datetime.now(timezone.utc)
+    touched = 0
+
+    async with get_db() as conn:
+        dialect = conn.engine.dialect.name if hasattr(conn, "engine") else conn.bind.dialect.name
+        # SQLite + Postgres both implement ``INSERT ... ON CONFLICT``
+        # since SQLite 3.24 (2018-06) and Postgres 9.5 (2016). The
+        # Mastio runtime targets both, and asyncpg / aiosqlite both
+        # forward the dialect-native UPSERT.
+        if dialect == "sqlite":
+            upsert_sql = """
+                INSERT INTO mdm_device_state (
+                    mdm, device_id, compliance,
+                    azure_ad_device_id, user_principal_name,
+                    device_name, manufacturer, serial_number,
+                    raw_payload, last_seen_at, created_at
+                ) VALUES (
+                    :mdm, :device_id, :compliance,
+                    :azure_ad, :upn,
+                    :name, :manufacturer, :serial,
+                    :raw, :seen, :created
+                )
+                ON CONFLICT(mdm, device_id) DO UPDATE SET
+                    compliance = excluded.compliance,
+                    azure_ad_device_id = excluded.azure_ad_device_id,
+                    user_principal_name = excluded.user_principal_name,
+                    device_name = excluded.device_name,
+                    manufacturer = excluded.manufacturer,
+                    serial_number = excluded.serial_number,
+                    raw_payload = excluded.raw_payload,
+                    last_seen_at = excluded.last_seen_at
+            """
+        else:
+            upsert_sql = """
+                INSERT INTO mdm_device_state (
+                    mdm, device_id, compliance,
+                    azure_ad_device_id, user_principal_name,
+                    device_name, manufacturer, serial_number,
+                    raw_payload, last_seen_at, created_at
+                ) VALUES (
+                    :mdm, :device_id, :compliance,
+                    :azure_ad, :upn,
+                    :name, :manufacturer, :serial,
+                    :raw, :seen, :created
+                )
+                ON CONFLICT (mdm, device_id) DO UPDATE SET
+                    compliance = EXCLUDED.compliance,
+                    azure_ad_device_id = EXCLUDED.azure_ad_device_id,
+                    user_principal_name = EXCLUDED.user_principal_name,
+                    device_name = EXCLUDED.device_name,
+                    manufacturer = EXCLUDED.manufacturer,
+                    serial_number = EXCLUDED.serial_number,
+                    raw_payload = EXCLUDED.raw_payload,
+                    last_seen_at = EXCLUDED.last_seen_at
+            """
+
+        for graph_device in devices:
+            projected = project_device_row(graph_device)
+            if not projected["device_id"]:
+                continue
+            await conn.execute(
+                text(upsert_sql),
+                {
+                    "mdm": mdm,
+                    "device_id": projected["device_id"],
+                    "compliance": projected["compliance"],
+                    "azure_ad": projected["azure_ad_device_id"],
+                    "upn": projected["user_principal_name"],
+                    "name": projected["device_name"],
+                    "manufacturer": projected["manufacturer"],
+                    "serial": projected["serial_number"],
+                    "raw": json.dumps(graph_device, default=str),
+                    "seen": now,
+                    "created": now,
+                },
+            )
+            touched += 1
+
+    return touched
+
+
+async def _persist_delta_link(value: str | None) -> None:
+    """Persist the Graph deltaLink between poll cycles.
+
+    Stored in ``proxy_config`` under a fixed key. Tolerant to
+    schema variations: callers should ``try/except`` around this so
+    a transient DB issue does not stop the polling loop.
+    """
+    if value is None:
+        return
+    async with get_db() as conn:
+        dialect = conn.engine.dialect.name if hasattr(conn, "engine") else conn.bind.dialect.name
+        if dialect == "sqlite":
+            sql = """
+                INSERT INTO proxy_config (key, value) VALUES (:k, :v)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """
+        else:
+            sql = """
+                INSERT INTO proxy_config (key, value) VALUES (:k, :v)
+                ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+            """
+        await conn.execute(
+            text(sql), {"k": "mdm.intune.delta_link", "v": value},
+        )
+
+
+async def _load_delta_link() -> str | None:
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT value FROM proxy_config WHERE key = :k"),
+            {"k": "mdm.intune.delta_link"},
+        )).first()
+    if row is None:
+        return None
+    return str(row[0]) if row[0] else None
+
+
+async def intune_poll_once(
+    client: IntuneClient,
+    *,
+    now: datetime | None = None,
+) -> tuple[int, str | None]:
+    """One end-to-end poll cycle. Returns ``(rows_upserted, next_delta)``.
+
+    Extracted from the loop so tests can drive a single iteration
+    against a mocked client without orchestrating timers.
+    """
+    delta_link = await _load_delta_link()
+    devices, next_delta = await client.fetch_managed_devices_delta(delta_link)
+    touched = await upsert_device_rows(devices, mdm="intune", now=now)
+    if next_delta:
+        try:
+            await _persist_delta_link(next_delta)
+        except Exception as exc:  # noqa: BLE001 — best-effort persistence
+            _log.warning(
+                "Failed to persist Intune deltaLink (will full-sync next round): %s",
+                exc,
+            )
+    return touched, next_delta
+
+
+async def intune_poll_loop(
+    *,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    interval_seconds: int,
+    stop_event: asyncio.Event,
+) -> None:
+    """Long-running polling task. Exits when ``stop_event`` is set.
+
+    Owns the :class:`IntuneClient` (and its httpx client) so a
+    shutdown closes both deterministically. Errors are isolated to
+    a single iteration; the loop keeps running across transient
+    failures.
+    """
+    client = IntuneClient(
+        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret,
+    )
+    backoff_idx = 0
+
+    emit_lifespan_log(
+        level="INFO",
+        logger="mcp_proxy.mdm.poller",
+        message=(
+            "Intune polling loop started "
+            f"(interval={interval_seconds}s, tenant=…{tenant_id[-12:]})"
+        ),
+    )
+
+    try:
+        while not stop_event.is_set():
+            started = datetime.now(timezone.utc)
+            try:
+                touched, _ = await intune_poll_once(client, now=started)
+                lag = (datetime.now(timezone.utc) - started).total_seconds()
+                _log.info(
+                    "Intune delta fetch: %d devices upserted (lag_s=%.1f)",
+                    touched, lag,
+                )
+                backoff_idx = 0
+                wait_s = interval_seconds
+            except IntuneGraphError as exc:
+                # NEVER log the upstream body verbatim — the message
+                # is already sanitised by IntuneGraphError.__init__.
+                wait_s = _BACKOFF_SECONDS[min(backoff_idx, len(_BACKOFF_SECONDS) - 1)]
+                backoff_idx += 1
+                _log.warning(
+                    "Intune polling error (status=%d) — backing off %ds: %s",
+                    exc.status, wait_s, exc.message,
+                )
+            except Exception as exc:  # noqa: BLE001 — defensive last-resort
+                wait_s = _BACKOFF_SECONDS[min(backoff_idx, len(_BACKOFF_SECONDS) - 1)]
+                backoff_idx += 1
+                _log.exception(
+                    "Intune polling unexpected error — backing off %ds: %r",
+                    wait_s, exc,
+                )
+
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=wait_s)
+                # stop_event fired → loop exits next iteration.
+            except asyncio.TimeoutError:
+                pass
+    finally:
+        await client.aclose()
+        emit_lifespan_log(
+            level="INFO",
+            logger="mcp_proxy.mdm.poller",
+            message="Intune polling loop stopped",
+        )

--- a/tests/test_attestation_tier_mapping.py
+++ b/tests/test_attestation_tier_mapping.py
@@ -1,0 +1,231 @@
+"""Effective-tier algorithm coverage (ADR-032 schema sez. 2).
+
+Pure-function tests — no fixtures, no I/O. The algorithm is locked
+against the schema doc and any change here means a schema version
+bump.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from mcp_proxy.attestation.tier import (
+    COMPLIANCE_COMPLIANT,
+    COMPLIANCE_NON_COMPLIANT,
+    COMPLIANCE_UNKNOWN,
+    STRENGTH_HW_ATTESTED,
+    STRENGTH_HW_ISOLATED,
+    STRENGTH_SOFT_ONLY,
+    TIER_BYOD_ATTESTED,
+    TIER_BYOD_ISOLATED,
+    TIER_MANAGED,
+    TIER_MANAGED_ATTESTED,
+    TIER_UNTRUSTED,
+    apply_stale_downgrade,
+    build_attestation_claim,
+    compute_effective_tier,
+    is_stale,
+)
+
+
+# ── 5-tier matrix ──────────────────────────────────────────────────
+
+
+def test_managed_attested_requires_mdm_compliant_and_hw_attested():
+    tier = compute_effective_tier(
+        mdm="intune",
+        compliance=COMPLIANCE_COMPLIANT,
+        hardware="tpm_2.0",
+        strength=STRENGTH_HW_ATTESTED,
+    )
+    assert tier == TIER_MANAGED_ATTESTED
+
+
+def test_managed_when_mdm_compliant_but_soft_only():
+    tier = compute_effective_tier(
+        mdm="intune",
+        compliance=COMPLIANCE_COMPLIANT,
+        hardware=None,
+        strength=STRENGTH_SOFT_ONLY,
+    )
+    assert tier == TIER_MANAGED
+
+
+def test_byod_attested_when_no_mdm_but_hw_attested():
+    tier = compute_effective_tier(
+        mdm=None,
+        compliance=COMPLIANCE_UNKNOWN,
+        hardware="tpm_2.0",
+        strength=STRENGTH_HW_ATTESTED,
+    )
+    assert tier == TIER_BYOD_ATTESTED
+
+
+def test_byod_isolated_when_no_mdm_but_hw_isolated():
+    tier = compute_effective_tier(
+        mdm=None,
+        compliance=COMPLIANCE_UNKNOWN,
+        hardware=None,
+        strength=STRENGTH_HW_ISOLATED,
+    )
+    assert tier == TIER_BYOD_ISOLATED
+
+
+def test_untrusted_when_no_mdm_and_no_hw():
+    tier = compute_effective_tier(
+        mdm=None,
+        compliance=COMPLIANCE_UNKNOWN,
+        hardware=None,
+        strength=STRENGTH_SOFT_ONLY,
+    )
+    assert tier == TIER_UNTRUSTED
+
+
+# ── Non-compliant MDM degrades to BYOD bucket ──────────────────────
+
+
+def test_non_compliant_mdm_does_not_grant_managed_tier():
+    """Schema sez. 2: ``has_mdm`` only when compliance == compliant."""
+    tier = compute_effective_tier(
+        mdm="intune",
+        compliance=COMPLIANCE_NON_COMPLIANT,
+        hardware="tpm_2.0",
+        strength=STRENGTH_HW_ATTESTED,
+    )
+    assert tier == TIER_BYOD_ATTESTED  # NOT managed_attested
+
+
+def test_unknown_compliance_does_not_grant_managed_tier():
+    tier = compute_effective_tier(
+        mdm="intune",
+        compliance=COMPLIANCE_UNKNOWN,
+        hardware=None,
+        strength=STRENGTH_SOFT_ONLY,
+    )
+    assert tier == TIER_UNTRUSTED
+
+
+# ── is_stale ───────────────────────────────────────────────────────
+
+
+def test_is_stale_under_threshold():
+    assert is_stale(stale_seconds=100, threshold_seconds=900) is False
+
+
+def test_is_stale_over_threshold():
+    assert is_stale(stale_seconds=901, threshold_seconds=900) is True
+
+
+def test_is_stale_disabled_when_threshold_zero():
+    assert is_stale(stale_seconds=10_000, threshold_seconds=0) is False
+
+
+def test_is_stale_negative_threshold_treated_as_disabled():
+    assert is_stale(stale_seconds=10_000, threshold_seconds=-1) is False
+
+
+def test_is_stale_invalid_input_treated_as_fresh():
+    """Server is authoritative on stale_seconds; defensive only."""
+    assert is_stale(stale_seconds="bogus", threshold_seconds=900) is False  # type: ignore[arg-type]
+
+
+# ── build_attestation_claim ────────────────────────────────────────
+
+
+def test_build_claim_shape_matches_schema():
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    verified_at = now - timedelta(seconds=300)
+    claim = build_attestation_claim(
+        mdm="intune",
+        device_id="61b8d3f4-aef1",
+        compliance=COMPLIANCE_COMPLIANT,
+        manufacturer="Infineon",
+        verified_at=verified_at,
+        now=now,
+        hardware="tpm_2.0",
+        strength=STRENGTH_HW_ATTESTED,
+    )
+    inner = claim["device_attestation"]
+    assert inner["mdm"] == "intune"
+    assert inner["device_id"] == "61b8d3f4-aef1"
+    assert inner["compliance"] == "compliant"
+    assert inner["hardware"] == "tpm_2.0"
+    assert inner["strength"] == "hw_attested"
+    assert inner["manufacturer"] == "Infineon"
+    assert inner["verified_at"] == "2026-05-17T11:55:00Z"
+    assert inner["stale_seconds"] == 300
+    assert claim["effective_tier"] == TIER_MANAGED_ATTESTED
+
+
+def test_build_claim_normalises_naive_datetime_to_utc():
+    now = datetime(2026, 5, 17, 12, 0, 0)  # naive
+    verified_at = datetime(2026, 5, 17, 11, 59, 0)  # naive
+    claim = build_attestation_claim(
+        mdm=None,
+        device_id=None,
+        compliance=COMPLIANCE_UNKNOWN,
+        manufacturer=None,
+        verified_at=verified_at,
+        now=now,
+    )
+    # 60 seconds difference; stale_seconds is int(non-negative)
+    assert claim["device_attestation"]["stale_seconds"] == 60
+    assert claim["device_attestation"]["verified_at"].endswith("Z")
+
+
+def test_build_claim_clamps_negative_stale_to_zero():
+    """Clock skew between MDM cache and Mastio shouldn't go negative."""
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    future_verified = now + timedelta(seconds=30)
+    claim = build_attestation_claim(
+        mdm=None, device_id=None,
+        compliance=COMPLIANCE_UNKNOWN, manufacturer=None,
+        verified_at=future_verified, now=now,
+    )
+    assert claim["device_attestation"]["stale_seconds"] == 0
+
+
+# ── apply_stale_downgrade ──────────────────────────────────────────
+
+
+def test_apply_stale_downgrade_unchanged_when_fresh():
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    fresh = build_attestation_claim(
+        mdm="intune", device_id="x",
+        compliance=COMPLIANCE_COMPLIANT, manufacturer=None,
+        verified_at=now - timedelta(seconds=120), now=now,
+    )
+    result = apply_stale_downgrade(fresh, threshold_seconds=900)
+    assert result["device_attestation"]["compliance"] == "compliant"
+    assert result["effective_tier"] == TIER_MANAGED
+
+
+def test_apply_stale_downgrade_forces_unknown_when_stale():
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    stale = build_attestation_claim(
+        mdm="intune", device_id="x",
+        compliance=COMPLIANCE_COMPLIANT, manufacturer=None,
+        verified_at=now - timedelta(seconds=1200), now=now,
+    )
+    # Pre-downgrade should still be 'compliant' even though stale_seconds
+    # exceeds the threshold — the claim builder doesn't apply policy.
+    assert stale["device_attestation"]["compliance"] == "compliant"
+    assert stale["effective_tier"] == TIER_MANAGED
+
+    result = apply_stale_downgrade(stale, threshold_seconds=900)
+    assert result["device_attestation"]["compliance"] == "unknown"
+    # No MDM-compliant → falls through to untrusted (no hw).
+    assert result["effective_tier"] == TIER_UNTRUSTED
+
+
+def test_apply_stale_downgrade_returns_new_dict():
+    """The pre-downgrade claim is preserved for audit."""
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    stale = build_attestation_claim(
+        mdm="intune", device_id="x",
+        compliance=COMPLIANCE_COMPLIANT, manufacturer=None,
+        verified_at=now - timedelta(seconds=1200), now=now,
+    )
+    pre = dict(stale["device_attestation"])
+    _ = apply_stale_downgrade(stale, threshold_seconds=900)
+    # Original input untouched.
+    assert stale["device_attestation"] == pre

--- a/tests/test_enrollment_attestation_injection.py
+++ b/tests/test_enrollment_attestation_injection.py
@@ -1,0 +1,254 @@
+"""CSR enrollment → MDM cache lookup → attestation claim stamped.
+
+Drives the end-to-end shape: seed the ``mdm_device_state`` cache,
+run the device-code approve path with a ``device_info`` hint that
+matches, and verify:
+  1. ``internal_agents.last_attestation`` populated with the claim.
+  2. An ``audit_log`` row of action ``device_attestation`` written.
+  3. When no cache match exists, enrollment succeeds without
+     stamping (graceful no-op).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment import service
+from mcp_proxy.mdm.poller import upsert_device_rows
+
+
+def _ec_pubkey_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "enrol_attest.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+class _FakeAgentManager:
+    """Minimal AgentManager stand-in for the approve path.
+
+    The enrollment service only calls ``sign_external_pubkey`` plus
+    reads ``ca_loaded`` / ``org_id`` / ``trust_domain``. We bypass
+    the real Org CA by returning a hand-written placeholder PEM
+    that the test never validates — the attestation hook does not
+    touch it.
+    """
+
+    ca_loaded = True
+    org_id = "acme"
+    trust_domain = "cullis.test"
+
+    def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
+        return f"-----BEGIN CERTIFICATE-----\nFAKE-{agent_name}\n-----END CERTIFICATE-----\n"
+
+
+async def _seed_pending(pubkey_pem: str, device_info_json: str) -> str:
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey_pem,
+            requester_name="Alice Tester",
+            requester_email="alice@example.com",
+            reason="attestation test",
+            device_info=device_info_json,
+        )
+    return started.session_id
+
+
+@pytest.mark.asyncio
+async def test_enrollment_with_matching_intune_device_stamps_claim(db_engine):
+    # 1. Seed the MDM cache with a device matching the Connector's hint.
+    now = datetime.now(timezone.utc)
+    await upsert_device_rows(
+        [{
+            "id": "intune-device-uuid-1",
+            "complianceState": "compliant",
+            "azureADDeviceId": "aad-1",
+            "deviceName": "alice-laptop",
+            "manufacturer": "Infineon",
+            "serialNumber": "SN-001",
+        }],
+        now=now,
+    )
+
+    pubkey = _ec_pubkey_pem()
+    device_info = json.dumps({
+        "os": "linux",
+        "azure_ad_device_id": "aad-1",
+    })
+    session_id = await _seed_pending(pubkey, device_info)
+
+    # 2. Approve.
+    async with get_db() as conn:
+        record = await service.approve(
+            conn,
+            session_id=session_id,
+            agent_id="alice-connector",
+            capabilities=["mcp.read_public"],
+            groups=[],
+            admin_name="test-admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    canonical_id = record["agent_id_assigned"]
+    assert canonical_id == "acme::alice-connector"
+
+    # 3. Assert internal_agents.last_attestation populated.
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT last_attestation FROM internal_agents "
+                 "WHERE agent_id = :a"),
+            {"a": canonical_id},
+        )).first()
+    assert row is not None and row[0]
+    claim = json.loads(row[0])
+    assert claim["device_attestation"]["mdm"] == "intune"
+    assert claim["device_attestation"]["device_id"] == "intune-device-uuid-1"
+    assert claim["device_attestation"]["compliance"] == "compliant"
+    assert claim["effective_tier"] == "managed"
+
+    # 4. Audit row of action 'device_attestation' present.
+    async with get_db() as conn:
+        audit_rows = (await conn.execute(
+            text("SELECT agent_id, action, status, detail FROM audit_log "
+                 "WHERE action = 'device_attestation'"),
+        )).all()
+    assert len(audit_rows) >= 1
+    audit_aid, audit_action, audit_status, audit_detail = audit_rows[0]
+    assert audit_aid == canonical_id
+    assert audit_action == "device_attestation"
+    assert audit_status == "success"
+    detail = json.loads(audit_detail)
+    assert detail["event_subtype"] == "verified"
+    assert detail["trigger"] == "enrollment"
+    assert detail["device_attestation"]["mdm"] == "intune"
+
+
+@pytest.mark.asyncio
+async def test_enrollment_without_mdm_match_completes_without_stamping(db_engine):
+    """No cache match → no last_attestation, no audit, no error."""
+    pubkey = _ec_pubkey_pem()
+    device_info = json.dumps({"os": "linux", "azure_ad_device_id": "unknown-aad"})
+    session_id = await _seed_pending(pubkey, device_info)
+
+    async with get_db() as conn:
+        record = await service.approve(
+            conn,
+            session_id=session_id,
+            agent_id="bob-connector",
+            capabilities=[],
+            groups=[],
+            admin_name="test-admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    canonical_id = record["agent_id_assigned"]
+    async with get_db() as conn:
+        last_attest = (await conn.execute(
+            text("SELECT last_attestation FROM internal_agents "
+                 "WHERE agent_id = :a"),
+            {"a": canonical_id},
+        )).scalar()
+        audit_count = (await conn.execute(
+            text("SELECT COUNT(*) FROM audit_log "
+                 "WHERE action = 'device_attestation' AND agent_id = :a"),
+            {"a": canonical_id},
+        )).scalar()
+    assert last_attest is None
+    assert audit_count == 0
+
+
+@pytest.mark.asyncio
+async def test_non_compliant_match_stamps_byod_attested_or_untrusted(db_engine):
+    """A cached non_compliant device degrades the tier to byod_*/untrusted."""
+    now = datetime.now(timezone.utc)
+    await upsert_device_rows(
+        [{
+            "id": "intune-device-uuid-2",
+            "complianceState": "noncompliant",
+            "azureADDeviceId": "aad-2",
+            "manufacturer": "Microsoft",
+        }],
+        now=now,
+    )
+
+    pubkey = _ec_pubkey_pem()
+    device_info = json.dumps({"azure_ad_device_id": "aad-2"})
+    session_id = await _seed_pending(pubkey, device_info)
+
+    async with get_db() as conn:
+        record = await service.approve(
+            conn,
+            session_id=session_id,
+            agent_id="carol-connector",
+            capabilities=[],
+            groups=[],
+            admin_name="test-admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    canonical_id = record["agent_id_assigned"]
+    async with get_db() as conn:
+        last_attest = (await conn.execute(
+            text("SELECT last_attestation FROM internal_agents "
+                 "WHERE agent_id = :a"),
+            {"a": canonical_id},
+        )).scalar()
+    assert last_attest is not None
+    claim = json.loads(last_attest)
+    # MDM present but non-compliant → has_mdm=False in compute → soft_only
+    # → untrusted (no hardware in Phase 1).
+    assert claim["device_attestation"]["compliance"] == "non_compliant"
+    assert claim["effective_tier"] == "untrusted"
+
+
+@pytest.mark.asyncio
+async def test_enrollment_hook_failure_does_not_break_approve(db_engine, monkeypatch):
+    """If the attestation hook raises, approve still succeeds."""
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("simulated MDM cache outage")
+
+    monkeypatch.setattr(
+        "mcp_proxy.attestation.enrollment_hook.stamp_attestation_on_enrollment",
+        _boom,
+    )
+
+    pubkey = _ec_pubkey_pem()
+    session_id = await _seed_pending(pubkey, "{}")
+
+    async with get_db() as conn:
+        record = await service.approve(
+            conn,
+            session_id=session_id,
+            agent_id="dan-connector",
+            capabilities=[],
+            groups=[],
+            admin_name="test-admin",
+            agent_manager=_FakeAgentManager(),
+        )
+    assert record["status"] == "approved"
+    assert record["agent_id_assigned"] == "acme::dan-connector"

--- a/tests/test_intune_client_mock.py
+++ b/tests/test_intune_client_mock.py
@@ -1,0 +1,221 @@
+"""IntuneClient — auth + delta paging against a mocked Graph API.
+
+Uses ``respx`` if available, falls back to a hand-rolled httpx
+``MockTransport`` so the test does not gain a new dependency. The
+test is hermetic; no real network calls.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from mcp_proxy.mdm.intune import (
+    IntuneClient,
+    IntuneGraphError,
+    map_compliance_state,
+    project_device_row,
+)
+
+
+def _make_handler(*, token_body: dict | None = None,
+                  token_status: int = 200,
+                  pages: list[dict] | None = None):
+    """Build an httpx MockTransport handler with deterministic responses."""
+    token_body = token_body or {
+        "access_token": "fake-bearer-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    pages = pages or [{"value": [], "@odata.deltaLink": "https://graph.test/delta?token=abc"}]
+    page_iter = iter(pages)
+    state = {"token_calls": 0, "delta_calls": 0, "saw_token_header": []}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "/oauth2/v2.0/token" in url:
+            state["token_calls"] += 1
+            return httpx.Response(token_status, json=token_body)
+        if "managedDevices" in url or "graph.test" in url:
+            state["delta_calls"] += 1
+            state["saw_token_header"].append(request.headers.get("Authorization", ""))
+            try:
+                page = next(page_iter)
+            except StopIteration:
+                page = {"value": [], "@odata.deltaLink": "https://graph.test/delta?final"}
+            return httpx.Response(200, json=page)
+        return httpx.Response(404, json={"error": "unexpected url"})
+
+    return handler, state
+
+
+@pytest.mark.asyncio
+async def test_fetch_managed_devices_acquires_token_once_per_run():
+    handler, state = _make_handler()
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+
+    client = IntuneClient(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="secret",
+        http_client=http,
+    )
+    devices, delta = await client.fetch_managed_devices_delta()
+    assert devices == []
+    assert delta == "https://graph.test/delta?token=abc"
+    assert state["token_calls"] == 1
+    assert state["saw_token_header"][0].startswith("Bearer ")
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_cached_across_consecutive_calls():
+    handler, state = _make_handler()
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+
+    client = IntuneClient(
+        tenant_id="t", client_id="c", client_secret="s",
+        http_client=http,
+    )
+    await client.fetch_managed_devices_delta()
+    await client.fetch_managed_devices_delta()
+    # Token endpoint hit once, not twice.
+    assert state["token_calls"] == 1
+    assert state["delta_calls"] == 2
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_paging_walks_next_link_and_terminates_on_delta_link():
+    pages = [
+        {
+            "value": [{"id": "dev-1", "complianceState": "compliant"}],
+            "@odata.nextLink": "https://graph.test/next-1",
+        },
+        {
+            "value": [{"id": "dev-2", "complianceState": "noncompliant"}],
+            "@odata.nextLink": "https://graph.test/next-2",
+        },
+        {
+            "value": [{"id": "dev-3", "complianceState": "unknown"}],
+            "@odata.deltaLink": "https://graph.test/final-delta",
+        },
+    ]
+    handler, state = _make_handler(pages=pages)
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+
+    client = IntuneClient(
+        tenant_id="t", client_id="c", client_secret="s",
+        http_client=http,
+    )
+    devices, delta = await client.fetch_managed_devices_delta()
+    assert [d["id"] for d in devices] == ["dev-1", "dev-2", "dev-3"]
+    assert delta == "https://graph.test/final-delta"
+    assert state["delta_calls"] == 3
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_401_raises_graph_error_without_leaking_body():
+    handler, _ = _make_handler(
+        token_body={"error": "invalid_client", "error_description": "secret xyz"},
+        token_status=401,
+    )
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+
+    client = IntuneClient(
+        tenant_id="t", client_id="c", client_secret="THE_SECRET_VALUE",
+        http_client=http,
+    )
+    with pytest.raises(IntuneGraphError) as exc:
+        await client.fetch_managed_devices_delta()
+    assert exc.value.status == 401
+    # The secret MUST NOT appear in the exception message.
+    assert "THE_SECRET_VALUE" not in str(exc.value)
+    assert "xyz" not in str(exc.value)
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_constructor_rejects_empty_credentials():
+    with pytest.raises(ValueError):
+        IntuneClient(tenant_id="", client_id="x", client_secret="y")
+    with pytest.raises(ValueError):
+        IntuneClient(tenant_id="x", client_id="", client_secret="y")
+    with pytest.raises(ValueError):
+        IntuneClient(tenant_id="x", client_id="y", client_secret="")
+
+
+@pytest.mark.asyncio
+async def test_401_on_devices_triggers_token_refresh_and_retry():
+    """A token that expires between issuance and the next call should
+    not raise — the client refreshes once and retries."""
+    page = {"value": [{"id": "dev-1", "complianceState": "compliant"}],
+            "@odata.deltaLink": "https://graph.test/d"}
+    token_body = {"access_token": "tok-1", "token_type": "Bearer", "expires_in": 3600}
+
+    state = {"token_calls": 0, "device_calls": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/oauth2/v2.0/token" in str(request.url):
+            state["token_calls"] += 1
+            tok = "tok-1" if state["token_calls"] == 1 else "tok-2"
+            return httpx.Response(200, json={**token_body, "access_token": tok})
+        if "managedDevices" in str(request.url):
+            state["device_calls"] += 1
+            if state["device_calls"] == 1:
+                return httpx.Response(401, json={"error": "expired"})
+            return httpx.Response(200, json=page)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    http = httpx.AsyncClient(transport=transport)
+    client = IntuneClient(
+        tenant_id="t", client_id="c", client_secret="s", http_client=http,
+    )
+    devices, _ = await client.fetch_managed_devices_delta()
+    assert [d["id"] for d in devices] == ["dev-1"]
+    assert state["token_calls"] == 2
+    assert state["device_calls"] == 2
+    await client.aclose()
+
+
+# ── pure helpers ──────────────────────────────────────────────────
+
+
+def test_map_compliance_state_conservative_unknown_default():
+    assert map_compliance_state("compliant") == "compliant"
+    assert map_compliance_state("noncompliant") == "non_compliant"
+    # Every other Graph value falls into 'unknown' so a stale or
+    # conflicted device cannot accidentally be granted managed tier.
+    for s in ("inGracePeriod", "conflict", "error", "configManager",
+              "unknown", None, "", "totally-unexpected"):
+        assert map_compliance_state(s) == "unknown", s
+
+
+def test_project_device_row_picks_known_fields_only():
+    graph = {
+        "id": "abc",
+        "complianceState": "compliant",
+        "azureADDeviceId": "aad-1",
+        "userPrincipalName": "alice@example.com",
+        "deviceName": "alice-laptop",
+        "manufacturer": "Infineon",
+        "serialNumber": "SN-001",
+        "extraFutureField": "should not crash",
+    }
+    row = project_device_row(graph)
+    assert row == {
+        "device_id": "abc",
+        "compliance": "compliant",
+        "azure_ad_device_id": "aad-1",
+        "user_principal_name": "alice@example.com",
+        "device_name": "alice-laptop",
+        "manufacturer": "Infineon",
+        "serial_number": "SN-001",
+    }

--- a/tests/test_intune_client_mock.py
+++ b/tests/test_intune_client_mock.py
@@ -6,8 +6,6 @@ test is hermetic; no real network calls.
 """
 from __future__ import annotations
 
-import json
-
 import httpx
 import pytest
 

--- a/tests/test_intune_poller.py
+++ b/tests/test_intune_poller.py
@@ -1,0 +1,208 @@
+"""Polling loop — single-iteration coverage and backoff path.
+
+The full loop with timers is exercised by spawning the task with a
+stop_event that is set immediately after a single iteration window;
+the iteration itself is tested via :func:`intune_poll_once` so
+timing-based flakiness stays out of the suite.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.mdm.intune import IntuneClient, IntuneGraphError
+from mcp_proxy.mdm.poller import (
+    intune_poll_loop,
+    intune_poll_once,
+)
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "poller.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+def _mock_client(pages: list[dict]) -> IntuneClient:
+    """Build an IntuneClient with httpx.MockTransport baked in."""
+    iter_pages = iter(pages)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/oauth2/v2.0/token" in str(request.url):
+            return httpx.Response(200, json={
+                "access_token": "tok",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+        if "managedDevices" in str(request.url):
+            try:
+                return httpx.Response(200, json=next(iter_pages))
+            except StopIteration:
+                return httpx.Response(200, json={"value": [],
+                                                  "@odata.deltaLink": "x"})
+        return httpx.Response(404)
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return IntuneClient(tenant_id="t", client_id="c",
+                        client_secret="s", http_client=http)
+
+
+@pytest.mark.asyncio
+async def test_poll_once_persists_devices_and_delta_link(db_engine):
+    pages = [{
+        "value": [
+            {"id": "d1", "complianceState": "compliant",
+             "azureADDeviceId": "aad-1"},
+            {"id": "d2", "complianceState": "noncompliant"},
+        ],
+        "@odata.deltaLink": "https://graph.test/delta?token=PERSIST_ME",
+    }]
+    client = _mock_client(pages)
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+    touched, next_delta = await intune_poll_once(client, now=now)
+    assert touched == 2
+    assert next_delta == "https://graph.test/delta?token=PERSIST_ME"
+
+    async with get_db() as conn:
+        compliance = (await conn.execute(
+            text("SELECT compliance FROM mdm_device_state WHERE device_id = 'd1'"),
+        )).scalar()
+        delta_link_persisted = (await conn.execute(
+            text("SELECT value FROM proxy_config WHERE key = 'mdm.intune.delta_link'"),
+        )).scalar()
+    assert compliance == "compliant"
+    assert delta_link_persisted == "https://graph.test/delta?token=PERSIST_ME"
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_poll_once_second_call_uses_persisted_delta_link(db_engine):
+    # First round persists the delta link.
+    first_pages = [{"value": [], "@odata.deltaLink": "https://graph.test/d2"}]
+    client1 = _mock_client(first_pages)
+    await intune_poll_once(client1)
+    await client1.aclose()
+
+    # Second client should send the persisted delta link on its
+    # next call. We assert by capturing the URL the client requests.
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/oauth2/v2.0/token" in str(request.url):
+            return httpx.Response(200, json={
+                "access_token": "tok", "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+        seen_urls.append(str(request.url))
+        return httpx.Response(200, json={
+            "value": [], "@odata.deltaLink": "https://graph.test/d3",
+        })
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    client2 = IntuneClient(tenant_id="t", client_id="c", client_secret="s",
+                           http_client=http)
+    await intune_poll_once(client2)
+    await client2.aclose()
+
+    assert any("https://graph.test/d2" in u for u in seen_urls), seen_urls
+
+
+@pytest.mark.asyncio
+async def test_loop_exits_when_stop_event_set(db_engine, monkeypatch):
+    """The lifespan teardown signals stop_event; the loop must exit
+    within the timeout (we use a tiny interval so the test is fast)."""
+
+    # Stub IntuneClient so the loop hits a no-op iteration immediately.
+    handler_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        handler_calls["n"] += 1
+        if "/oauth2/v2.0/token" in str(request.url):
+            return httpx.Response(200, json={
+                "access_token": "tok", "token_type": "Bearer", "expires_in": 3600,
+            })
+        return httpx.Response(200, json={"value": [],
+                                          "@odata.deltaLink": "x"})
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        "mcp_proxy.mdm.poller.IntuneClient",
+        lambda tenant_id, client_id, client_secret: IntuneClient(
+            tenant_id=tenant_id, client_id=client_id, client_secret=client_secret,
+            http_client=httpx.AsyncClient(transport=transport),
+        ),
+    )
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        intune_poll_loop(
+            tenant_id="t", client_id="c", client_secret="s",
+            interval_seconds=60, stop_event=stop,
+        ),
+    )
+    # Give the loop one tick to register the first poll, then stop.
+    await asyncio.sleep(0.1)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_loop_backs_off_on_graph_error_and_continues(db_engine, monkeypatch):
+    """A Graph error must not crash the loop; the next iteration runs
+    after the backoff window."""
+
+    call_count = {"n": 0}
+
+    async def fake_intune_poll_once(client, *, now=None):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise IntuneGraphError(429, "throttled")
+        return (0, None)
+
+    monkeypatch.setattr(
+        "mcp_proxy.mdm.poller.intune_poll_once", fake_intune_poll_once,
+    )
+    # Compress backoff so the test runs fast.
+    monkeypatch.setattr(
+        "mcp_proxy.mdm.poller._BACKOFF_SECONDS", (0.05, 0.1),
+    )
+    # Stub IntuneClient construction so no HTTP setup is needed.
+
+    class _FakeClient:
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(
+        "mcp_proxy.mdm.poller.IntuneClient",
+        lambda **kwargs: _FakeClient(),
+    )
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        intune_poll_loop(
+            tenant_id="t", client_id="c", client_secret="s",
+            interval_seconds=60, stop_event=stop,
+        ),
+    )
+    await asyncio.sleep(0.3)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2.0)
+    assert call_count["n"] >= 2  # error + at least one retry

--- a/tests/test_mdm_device_state_db.py
+++ b/tests/test_mdm_device_state_db.py
@@ -1,0 +1,142 @@
+"""mdm_device_state DB CRUD + upsert semantics.
+
+Driven through the same SQLite engine fixture the enrollment tests
+use so migrations run end-to-end (0035_mdm_device_state included).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.mdm.poller import upsert_device_rows
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "mdm.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+def _graph_device(**overrides):
+    base = {
+        "id": "device-uuid-1",
+        "complianceState": "compliant",
+        "azureADDeviceId": "aad-1",
+        "userPrincipalName": "alice@example.com",
+        "deviceName": "alice-laptop",
+        "manufacturer": "Infineon",
+        "serialNumber": "SN-001",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_upsert_inserts_new_rows(db_engine):
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    touched = await upsert_device_rows(
+        [_graph_device(id="d1"), _graph_device(id="d2")],
+        now=now,
+    )
+    assert touched == 2
+
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text("SELECT mdm, device_id, compliance FROM mdm_device_state "
+                 "ORDER BY device_id"),
+        )).all()
+    assert [(r[0], r[1], r[2]) for r in rows] == [
+        ("intune", "d1", "compliant"),
+        ("intune", "d2", "compliant"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_compliance_on_conflict(db_engine):
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    await upsert_device_rows(
+        [_graph_device(id="d1", complianceState="compliant")], now=now,
+    )
+
+    later = now + timedelta(minutes=10)
+    touched = await upsert_device_rows(
+        [_graph_device(id="d1", complianceState="noncompliant",
+                       deviceName="alice-laptop-renamed")],
+        now=later,
+    )
+    assert touched == 1
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT compliance, device_name, last_seen_at "
+                "FROM mdm_device_state WHERE device_id = :d"
+            ),
+            {"d": "d1"},
+        )).first()
+    assert row[0] == "non_compliant"
+    assert row[1] == "alice-laptop-renamed"
+    # last_seen_at advanced; created_at did not (we don't assert exact
+    # value, just that the row is still queryable).
+
+
+@pytest.mark.asyncio
+async def test_upsert_skips_devices_without_id(db_engine):
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    touched = await upsert_device_rows(
+        [
+            _graph_device(id="dgood"),
+            {"complianceState": "compliant"},  # no id
+            {"id": "", "complianceState": "compliant"},
+        ],
+        now=now,
+    )
+    assert touched == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_empty_list_is_noop(db_engine):
+    touched = await upsert_device_rows([])
+    assert touched == 0
+
+
+@pytest.mark.asyncio
+async def test_upsert_distinguishes_mdm_namespace(db_engine):
+    """Same device_id under intune vs jamf are independent rows."""
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    await upsert_device_rows([_graph_device(id="d1")], mdm="intune", now=now)
+    await upsert_device_rows([_graph_device(id="d1")], mdm="jamf", now=now)
+    async with get_db() as conn:
+        count = (await conn.execute(
+            text("SELECT COUNT(*) FROM mdm_device_state WHERE device_id = :d"),
+            {"d": "d1"},
+        )).scalar()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_internal_agents_has_last_attestation_column(db_engine):
+    """Migration 0035 must add ``last_attestation`` to internal_agents."""
+    async with get_db() as conn:
+        from sqlalchemy import inspect as _inspect
+        # The async connection wraps a sync DBAPI; use run_sync to
+        # introspect cleanly.
+        cols = await conn.run_sync(
+            lambda sync_conn: {
+                c["name"] for c in _inspect(sync_conn).get_columns("internal_agents")
+            }
+        )
+    assert "last_attestation" in cols

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0034_user_sessions_obo",)]
+    assert rows == [("0035_mdm_device_state",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0034_user_sessions_obo",)]
+    assert version == [("0035_mdm_device_state",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0034_user_sessions_obo"
+HEAD_REVISION = "0035_mdm_device_state"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0034_user_sessions_obo"
+HEAD_REVISION = "0035_mdm_device_state"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0034_user_sessions_obo"
+HEAD_REVISION = "0035_mdm_device_state"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

F2 spike for [ADR-032](../blob/main/imp/adrs/adr-032-device-attestation-multi-mdm-byod.md) Layer 1 — Intune integration scaffolding. Polls Microsoft Graph for managed-device compliance, caches it server-side in `mdm_device_state`, and stamps the canonical `device_attestation` claim onto `internal_agents.last_attestation` at Connector enrollment time. Claim shape locked against [`imp/attestation-claim-schema.md`](../blob/main/imp/attestation-claim-schema.md) v1.0.

Built on top of PR #744 (F4 R2 LOCAL_TOKEN session + MCP envelope) — that PR shipped the `X-Cullis-Device-Attestation` allowlist + SDK `attach_device_attestation()`; this PR ships the server-side cache that produces the claim and the enrollment hook that consumes it.

### Files

| Path | LOC | Purpose |
|---|---:|---|
| `mcp_proxy/mdm/intune.py` | 301 | Async Microsoft Graph client (OAuth2 + delta paging + sanitised errors) |
| `mcp_proxy/mdm/poller.py` | 267 | Long-running polling task with exponential backoff |
| `mcp_proxy/attestation/tier.py` | 148 | `compute_effective_tier` + stale-window enforcement |
| `mcp_proxy/attestation/enrollment_hook.py` | 254 | Cache lookup + claim stamping at enrollment time |
| `mcp_proxy/alembic/versions/0035_mdm_device_state.py` | 129 | `mdm_device_state` cache table + `internal_agents.last_attestation` |
| `enterprise-kit/intune-setup.md` | 125 | Customer admin runbook (Entra app, consent, secret, env) |
| `tests/test_intune_client_mock.py` | 221 | Graph client mocked against `httpx.MockTransport` |
| `tests/test_intune_poller.py` | 208 | Poll-once + backoff retry + stop-event teardown |
| `tests/test_mdm_device_state_db.py` | 142 | Upsert idempotency + MDM namespace separation |
| `tests/test_attestation_tier_mapping.py` | 231 | Tier algorithm + stale-downgrade coverage |
| `tests/test_enrollment_attestation_injection.py` | 254 | End-to-end CSR → cache lookup → claim → audit row |

Plus lifespan wiring in `mcp_proxy/main.py`, config keys in `mcp_proxy/config.py`, the enrollment hook call in `mcp_proxy/enrollment/service.py`, and HEAD_REVISION bumps in 4 existing migration tests.

### Schema deviation from spec (call-out)

The spike prompt suggested storing the claim on `local_user_principals.last_attestation`. I put it on `internal_agents.last_attestation` instead — the device is the Connector (an agent under ADR-014), not the user principal (which is durable across devices). The user-session denormalisation lives in a follow-up once F4 R2's `user_sessions` flow lands a matching column. Documented in the migration docstring.

### Audit chain note

`device_attestation` audit rows are written inline on the enrollment connection (no hash-chain `chain_seq` / `row_hash`), matching the pattern already used by `approve()`'s `agent.create` rows. The hash-chain extension for attestation events belongs in F6, alongside the schema doc sez. 4.1 column additions on `audit_log`.

## Test plan

- [x] `pytest tests/test_intune_*.py tests/test_attestation_*.py tests/test_mdm_*.py` — 40/40 pass
- [x] `pytest tests/` full suite — 3663 passed, 31 skipped, 2 pre-existing failures unrelated to F2:
  - `test_dashboard_approvals_nav::test_badge_approvals_empty_when_plugin_unavailable` — local env contamination from `cullis_enterprise` editable install (CI clean)
  - `test_m3_sweeper_ttl::test_sweep_message_queue_expires_and_notifies` — timing flake, passes in isolation
- [x] Mental ruff check (NixOS): no unused imports, no f-string-without-placeholders, no orphan vars
- [x] Migration head bump propagated to `test_proxy_migrations*.py` (4 files)
- [ ] `./sandbox/smoke.sh full` — not run locally (sandbox stack already had port conflicts in this env); CI gates
- [ ] Dogfood: instruct customer admin via `enterprise-kit/intune-setup.md` against a real Entra tenant (out of scope for this spike — requires a test Azure tenant)

## Risk flags

- **Graph quota**: default poll interval 600s is conservative against Microsoft's documented Intune freshness window. A misconfigured customer running 60s polls against a 50k-device tenant will throttle; the loop backs off but the logs may get noisy. Increase `MCP_PROXY_MDM_INTUNE_POLL_INTERVAL_SECONDS` if seen.
- **Client secret rotation**: secrets in Entra apps expire on the configured window (12-24 months). Runbook documents the rotation path; no automatic refresh.
- **Lifetime mismatch with shared-mode Frontdesk**: in multi-user shared mode, one Connector workload fronts many users — the device claim stamped on the workload row is the workload's, not the per-user laptop's. This is the limitation called out in `feedback_frontdesk_shared_mode_capability_model` memory. The per-user device claim lives on `user_sessions` in a follow-up.

## Out of scope (delegated downstream)

- **F5**: policy decision point consumes `effective_tier` against a capability matrix (default in `enterprise-kit/policy/capability-tiers.yaml` per schema sez. 2)
- **F6**: Graph webhook subscription for sub-poll revocation + `audit_log` hash-chain extension on `device_attestation` rows + `device_attestation_revoked` / `device_attestation_stale` event types
- **F3**: Linux TPM EK validation populates `hardware="tpm_2.0"` / `strength="hw_attested"` and unlocks the `managed_attested` tier
- Jamf, Workspace ONE — same `mdm_device_state` shape, gated on pilot signal