### PR TITLE
feat(connector): F4 R3 local-credentials login + first-run wizard (ADR-025 Phase 5)

### DIFF
--- a/cullis_connector/ambassador/shared/provisioning.py
+++ b/cullis_connector/ambassador/shared/provisioning.py
@@ -231,6 +231,94 @@ class SdkMastioCsrTransport:
             ) from exc
         return _parse_csr_response(body)
 
+    def _post_local_attribution_sync(
+        self,
+        *,
+        local_subject: str,
+        display_name: str | None,
+        device_cert_thumbprint: str,
+    ) -> dict:
+        client = self._get()
+        body = {
+            "local_subject": local_subject,
+            "display_name": display_name,
+            "device_cert_thumbprint": device_cert_thumbprint,
+            "auth_mode": "local",
+        }
+        resp = client._authed_request(
+            "POST",
+            "/v1/principals/connector-login-local-attribution",
+            json=body,
+        )
+        if resp.status_code == 401:
+            self._invalidate()
+            client = self._get()
+            resp = client._authed_request(
+                "POST",
+                "/v1/principals/connector-login-local-attribution",
+                json=body,
+            )
+        if resp.status_code != 201:
+            raise MastioCsrError(
+                f"Mastio /v1/principals/connector-login-local-attribution "
+                f"returned {resp.status_code}: {resp.text[:512]}",
+            )
+        return resp.json()
+
+    async def attribute_local_login(
+        self,
+        *,
+        local_subject: str,
+        display_name: str | None,
+        device_cert_thumbprint: str,
+    ) -> tuple[str, str, datetime]:
+        """Bind a local-auth user identity to the calling Connector.
+
+        ADR-025 Phase 5 / F4 R3 — companion to :meth:`sign_csr`. The
+        Connector has already verified bcrypt against its local
+        ``users.db``; this call asks the Mastio to mint a
+        ``user_sessions`` row pinned to the calling device cert so
+        downstream audit rows pick up ``on_behalf_of_user_id`` for the
+        user.
+
+        Returns ``(user_id, session_token, expires_at)``. Raises
+        :class:`MastioCsrError` on failure so the caller can collapse
+        a transient outage into a "deferred attribution" banner rather
+        than rolling back the password verification.
+        """
+        try:
+            body = await asyncio.to_thread(
+                self._post_local_attribution_sync,
+                local_subject=local_subject,
+                display_name=display_name,
+                device_cert_thumbprint=device_cert_thumbprint,
+            )
+        except MastioCsrError:
+            raise
+        except Exception as exc:
+            raise MastioCsrError(
+                f"transport failure calling Mastio "
+                f"/v1/principals/connector-login-local-attribution: {exc}",
+            ) from exc
+        try:
+            user_id = str(body["user_id"])
+            session_token = str(body["session_token"])
+            expires_at_iso = body["expires_at"]
+        except (KeyError, TypeError) as exc:
+            raise MastioCsrError(
+                f"Mastio attribution response missing fields: {body!r}",
+            ) from exc
+        try:
+            expires_at = datetime.fromisoformat(
+                expires_at_iso.replace("Z", "+00:00"),
+            )
+        except (AttributeError, ValueError) as exc:
+            raise MastioCsrError(
+                f"Mastio attribution response invalid expires_at: "
+                f"{expires_at_iso!r}",
+            ) from exc
+        return user_id, session_token, expires_at
+
 
 def _parse_csr_response(body: dict) -> tuple[str, datetime]:
     """Decode the JSON body of /v1/principals/csr into (cert_pem, not_after)."""

--- a/cullis_connector/auth/local_router.py
+++ b/cullis_connector/auth/local_router.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import logging
 import os
+import time
+
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
@@ -34,10 +36,16 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from cullis_connector.ambassador.shared.wire import bootstrap_cookie_secret
+from cullis_connector.identity.oidc_session import OidcSession, save_session
 from cullis_connector.identity.cert_session_map import (
     delete_binding,
     derive_session_id,
     record_binding,
+)
+from cullis_connector.identity.audit import (
+    log_lockout_trigger,
+    log_login_attempt,
+    log_password_change,
 )
 from cullis_connector.identity.csr_flow import (
     LocalProvisioningError,
@@ -51,8 +59,15 @@ from cullis_connector.identity.local_session import (
     issue_local_cookie,
     parse_local_cookie,
 )
+from cullis_connector.identity.lockout import (
+    is_locked,
+    record_failure,
+    record_success,
+)
 from cullis_connector.identity.users import (
     MIN_PASSWORD_LENGTH,
+    count_users,
+    create_user,
     get_user_by_name,
     mark_password_changed,
     set_password_hash,
@@ -70,39 +85,91 @@ _templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 router = APIRouter(tags=["auth", "local"])
 
 
-# ── Phase 4 stubs ────────────────────────────────────────────────────────
+# ── Phase 4 wire-up (ADR-025 Phase 5, F4 R3) ─────────────────────────────
 #
-# Wired to the real lockout + audit modules in a follow-up PR after
-# Phase 4 (cullis_connector/identity/lockout.py + audit.py) lands. For
-# Phase 2 these are intentional no-ops that emit a single warning so
-# the call-sites stay shaped correctly and follow-up only edits the
-# helper bodies.
+# Replaces the Phase-2 stubs that no-op'd lockout + audit accounting.
+# Both helpers live in ``cullis_connector.identity`` and share state
+# with the rest of the local-auth stack (admin disable, audit query,
+# Frontdesk dashboard).
+#
+# The helpers below intentionally collapse every failure path to a log
+# breadcrumb rather than re-raising. A login flow that 500s because the
+# audit DB hiccupped is worse than a login flow that succeeds but
+# leaves a faint trace — the audit log is observability, not a gate.
 
 
-def _check_lockout(ip: str, user_name: str) -> bool:
-    """Return ``True`` if the (ip, user_name) pair is currently locked.
+def _now_epoch() -> float:
+    """Wall-clock epoch seconds. Wrapped so tests can monkey-patch."""
+    return time.time()
 
-    Phase-2 stub — never locked. Wired to lockout/audit in follow-up PR
-    after Phase 4 lands.
+
+async def _check_lockout(ip: str) -> float | None:
+    """Return the unlock-time epoch when ``ip`` is locked, else ``None``.
+
+    Wraps :func:`cullis_connector.identity.lockout.is_locked` so the
+    call site stays terse and the stub-shape (`async` with a single ip
+    arg) is unchanged from the Phase-2 placeholder.
     """
-    return False
+    try:
+        return await is_locked(ip)
+    except Exception as exc:  # noqa: BLE001 — fail-open on lockout I/O
+        _log.warning("lockout probe failed for ip=%s: %s", ip, exc)
+        return None
 
 
-def _record_login_attempt(
-    ip: str, user_name: str, success: bool,
+async def _record_login_attempt(
+    config_dir: Path,
+    *,
+    ip: str,
+    user_name: str | None,
+    success: bool,
+    reason: str = "",
 ) -> None:
-    """Record a login attempt for lockout + audit accounting.
+    """Audit one login attempt + update the lockout counter.
 
-    Phase-2 stub — no-op. Wired to lockout/audit in follow-up PR after
-    Phase 4 lands.
+    On success: ``log_login_attempt(status='ok')`` + ``record_success``
+    so the IP's failure run resets. On failure: ``log_login_attempt(
+    status='fail')`` + ``record_failure``; when the lockout threshold
+    trips we also emit ``log_lockout_trigger`` so a reviewer can
+    correlate the 429 wave back to the offending IP.
     """
-    # Single debug line only — never log the password and never log a
-    # full audit event from the stub (so the follow-up PR's audit
-    # writer is the only place rows are emitted).
-    _log.debug(
-        "login attempt (stub) ip=%s user_name=%s success=%s",
-        ip, user_name, success,
-    )
+    status_str = "ok" if success else "fail"
+    try:
+        await log_login_attempt(
+            config_dir,
+            ip=ip,
+            user_name=user_name,
+            status=status_str,
+            reason=reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — audit best-effort
+        _log.warning(
+            "audit write failed user_name=%s ip=%s success=%s: %s",
+            user_name, ip, success, exc,
+        )
+
+    try:
+        if success:
+            await record_success(ip)
+        else:
+            _count, unlock_at = await record_failure(ip, user_name)
+            if unlock_at is not None:
+                try:
+                    await log_lockout_trigger(
+                        config_dir,
+                        ip=ip,
+                        locked_until=unlock_at,
+                        user_name=user_name,
+                    )
+                except Exception as exc:  # noqa: BLE001 — audit best-effort
+                    _log.warning(
+                        "lockout audit write failed ip=%s: %s", ip, exc,
+                    )
+    except Exception as exc:  # noqa: BLE001 — lockout state I/O failure
+        _log.warning(
+            "lockout counter update failed ip=%s success=%s: %s",
+            ip, success, exc,
+        )
 
 
 # ── Request / response models ────────────────────────────────────────────
@@ -132,6 +199,14 @@ class LoginResponse(BaseModel):
     #                local-mode boot bailed out). Login still works,
     #                /v1/* is gated upstream.
     provisioning: str = "skipped"
+    # ADR-025 Phase 5 / F4 R3 — Mastio attribution call result for the
+    # user_sessions row that lets downstream audit pick up
+    # ``on_behalf_of_user_id``. Same three states as ``provisioning``;
+    # the two calls are independent because the cert + the session row
+    # serve different layers (transport vs audit), and one can succeed
+    # while the other fails (e.g. cert cache hit + Mastio attribution
+    # endpoint hiccup).
+    attribution: str = "skipped"
 
 
 class ChangePasswordRequest(BaseModel):
@@ -157,6 +232,25 @@ class RuntimeInfoResponse(BaseModel):
     auth_mode: str
     login_url: str
     require_change_password_url: str
+    # ADR-025 Phase 5 / F4 R3 — flips to True when ``users.db`` is empty
+    # on a Connector desktop install so the SPA renders the owner-setup
+    # form instead of the login form. Probe is intentionally on the
+    # public ``/api/auth/runtime-info`` endpoint so the bootstrap can
+    # decide before it has any cookie.
+    setup_required: bool = False
+    setup_url: str = "/api/auth/first-run-setup"
+
+
+class FirstRunSetupRequest(BaseModel):
+    """Body for ``POST /api/auth/first-run-setup``.
+
+    Same validation envelope as ``LoginRequest`` so the SPA can reuse
+    its existing field-error renderer. ``display_name`` is optional.
+    """
+
+    user_name: str = Field(..., min_length=1, max_length=64)
+    password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=4096)
+    display_name: str = Field(default="", max_length=255)
 
 
 class ReprovisionResponse(BaseModel):
@@ -382,6 +476,76 @@ async def _bind_login_cert(
     return "ok", None
 
 
+async def _bind_mastio_user_session(
+    request: Request,
+    *,
+    user_name: str,
+    display_name: str | None,
+    device_thumbprint: str,
+) -> tuple[str, str | None]:
+    """Call the Mastio attribution endpoint and persist the returned session.
+
+    ADR-025 Phase 5 / F4 R3. Returns ``(status, detail)`` where status
+    is one of:
+
+      - ``"ok"``       — session minted + persisted under
+                         ``<config_dir>/oidc_session.json`` so the
+                         downstream MCP envelope layer (R2) picks up
+                         ``X-Cullis-Session-Token`` automatically.
+      - ``"deferred"`` — Mastio refused / unreachable. The user login
+                         is still considered successful; subsequent
+                         MCP traffic falls back to agent-only audit
+                         attribution until the next login retry.
+      - ``"skipped"``  — no Mastio CSR transport on this app (pre-
+                         enrollment dashboard, dev mode).
+
+    All exceptions collapse to ``deferred`` so a Mastio outage cannot
+    take down the dashboard login.
+    """
+    transport = getattr(request.app.state, "local_csr_transport", None)
+    if transport is None or not device_thumbprint:
+        return "skipped", None
+
+    try:
+        user_id, session_token, expires_at = await transport.attribute_local_login(
+            local_subject=user_name,
+            display_name=display_name,
+            device_cert_thumbprint=device_thumbprint,
+        )
+    except Exception as exc:  # noqa: BLE001 — degrade, don't crash login
+        _log.warning(
+            "Mastio local-login attribution failed user_name=%s: %s",
+            user_name, exc,
+        )
+        return "deferred", str(exc)
+
+    try:
+        save_session(
+            _config_dir(request),
+            OidcSession(
+                user_id=user_id,
+                session_token=session_token,
+                sso_subject=f"local:{user_name}",
+                idp_issuer="local",
+                display_name=display_name,
+                expires_at=expires_at,
+                device_thumbprint=device_thumbprint,
+                source="local",
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 — persistence best-effort
+        _log.warning(
+            "Mastio attribution session persist failed user_name=%s: %s",
+            user_name, exc,
+        )
+        # The session is still valid in-memory on the Mastio; we just
+        # won't auto-attach on Connector restart. Treat as ok for the
+        # current process so the user isn't bounced.
+        return "ok", None
+
+    return "ok", None
+
+
 def _cert_thumbprint(cert_pem: str) -> str:
     """SHA-256 hex of the cert DER. Lazily import cryptography so a
     test that monkey-patches the provisioner does not pull
@@ -438,27 +602,48 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
     user_names off the response code or message.
     """
     ip = _client_ip(request)
-    if _check_lockout(ip, body.user_name):
-        # Phase-4 stub — never returns True today. Real implementation
-        # surfaces 429 with a Retry-After header.
-        _record_login_attempt(ip, body.user_name, success=False)
+    config_dir = _config_dir(request)
+    locked_until = await _check_lockout(ip)
+    if locked_until is not None:
+        # 429 with Retry-After lets a well-behaved client back off
+        # without re-probing the password endpoint on a tight loop.
+        retry_after = max(1, int(locked_until - _now_epoch()))
+        await _record_login_attempt(
+            config_dir,
+            ip=ip,
+            user_name=body.user_name,
+            success=False,
+            reason="locked",
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="too many login attempts",
+            headers={"Retry-After": str(retry_after)},
         )
 
-    config_dir = _config_dir(request)
     async with get_users_session(config_dir) as session:
         user = await get_user_by_name(session, body.user_name)
         if user is None or user.disabled:
-            _record_login_attempt(ip, body.user_name, success=False)
+            await _record_login_attempt(
+                config_dir,
+                ip=ip,
+                user_name=body.user_name,
+                success=False,
+                reason="unknown_or_disabled",
+            )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="invalid credentials",
             )
         ok = await verify_password(session, body.user_name, body.password)
     if not ok:
-        _record_login_attempt(ip, body.user_name, success=False)
+        await _record_login_attempt(
+            config_dir,
+            ip=ip,
+            user_name=body.user_name,
+            success=False,
+            reason="bad_password",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid credentials",
@@ -483,9 +668,32 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
         # that's about to be replaced.
         provisioning = "skipped"
         provisioning_detail: str | None = None
+        attribution_status: str = "skipped"
     else:
         provisioning, provisioning_detail = await _bind_login_cert(
             request, payload,
+        )
+        # ADR-025 Phase 5 / F4 R3 — alongside the CSR, ask Mastio to
+        # mint a ``user_sessions`` row attributing future MCP calls
+        # from this Connector to the user_name we just authenticated.
+        # Best-effort: a Mastio outage degrades to "deferred" and the
+        # cert middleware can still serve ``/v1/*`` (the audit row
+        # just won't carry ``on_behalf_of_user_id`` until next login).
+        device_thumbprint = ""
+        try:
+            from cullis_connector.identity.store import load_identity
+            bundle = load_identity(_config_dir(request))
+            if bundle.cert_pem:
+                device_thumbprint = _cert_thumbprint(bundle.cert_pem)
+        except Exception as exc:  # noqa: BLE001 — pre-enrollment ok
+            _log.debug(
+                "F4 R3: no device cert thumbprint resolvable yet: %s", exc,
+            )
+        attribution_status, _attribution_detail = await _bind_mastio_user_session(
+            request,
+            user_name=payload.user_name,
+            display_name=user.display_name,
+            device_thumbprint=device_thumbprint,
         )
 
     body_out = LoginResponse(
@@ -494,6 +702,7 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
         principal_name=payload.principal_name,
         exp=payload.exp,
         provisioning=provisioning,
+        attribution=attribution_status,
     )
     response = JSONResponse(body_out.model_dump())
     if provisioning == "deferred":
@@ -506,7 +715,13 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
                 _sanitize_header_value(provisioning_detail)
             )
     _set_cookie(response, cookie_value)
-    _record_login_attempt(ip, body.user_name, success=True)
+    await _record_login_attempt(
+        config_dir,
+        ip=ip,
+        user_name=body.user_name,
+        success=True,
+        reason=provisioning,
+    )
     # Never log the password — only the username + result.
     _log.info(
         "local login ok user_name=%s must_change=%s provisioning=%s",
@@ -590,6 +805,18 @@ async def change_password(
         # ``set_password_hash`` semantics drift in future. Currently
         # already cleared via ``must_change=False``.
         await mark_password_changed(session, payload.user_name)
+
+    # F4 R3 — emit a pw.change audit row. Never carries the password
+    # value (only the user_name); a Connector compromise that gains
+    # SQL write still cannot rewrite it because the audit table has
+    # a RAISE FAIL trigger on UPDATE/DELETE.
+    try:
+        await log_password_change(config_dir, user_name=payload.user_name)
+    except Exception as exc:  # noqa: BLE001 — audit best-effort
+        _log.warning(
+            "pw.change audit write failed user_name=%s: %s",
+            payload.user_name, exc,
+        )
 
     new_payload = build_payload(
         user_name=payload.user_name,
@@ -701,21 +928,109 @@ async def whoami_local(request: Request) -> WhoamiLocalResponse:
 
 
 @router.get("/api/auth/runtime-info", response_model=RuntimeInfoResponse)
-async def runtime_info() -> RuntimeInfoResponse:
+async def runtime_info(request: Request) -> RuntimeInfoResponse:
     """Public hint for the SPA bootstrap: which login flow to render.
 
     Intentionally no-auth so the SPA can fetch this before it has any
-    cookie. Returns only public-safe metadata (URL paths, mode name).
+    cookie. Returns only public-safe metadata (URL paths, mode name,
+    setup state).
+
+    ``setup_required`` is a public boolean — knowing whether a fresh
+    Connector install has zero users does not leak anything an attacker
+    couldn't infer from observing 401-on-every-login. Treating the DB
+    probe as a hard failure would force the SPA to render an unusable
+    page, so a probe error falls back to ``False`` and the SPA shows
+    the regular login (a missing user surfaces as the usual 401).
     """
     # Hardcoded "local" because this router is only mounted in
     # local mode by ``build_app``. Callers in shared/oidc mode get
     # 404 from FastAPI (no router mounted) — the SPA detects this and
     # falls back to the SSO bootstrap path.
+    setup_required = False
+    try:
+        config_dir = _config_dir(request)
+        async with get_users_session(config_dir) as session:
+            setup_required = await count_users(session) == 0
+    except Exception as exc:  # noqa: BLE001 — probe must not 500
+        _log.warning("runtime-info: users.db probe failed: %s", exc)
     return RuntimeInfoResponse(
         auth_mode="local",
         login_url="/login",
         require_change_password_url="/change-password",
+        setup_required=setup_required,
     )
+
+
+@router.post("/api/auth/first-run-setup", response_model=LoginResponse)
+async def first_run_setup(
+    body: FirstRunSetupRequest, request: Request,
+) -> JSONResponse:
+    """ADR-025 Phase 5 / F4 R3 — create the owner user on a fresh install.
+
+    Only succeeds when ``users.db`` is empty. The new account is
+    created with ``must_change_password=False`` because the operator
+    just picked the password interactively — forcing them through a
+    second change form on the next request would be hostile UX. The
+    response shape mirrors :class:`LoginResponse` so the SPA can reuse
+    its post-login handler.
+
+    Refuses with 409 once any user exists. That keeps the endpoint
+    safe to leave mounted in production: a leaked URL cannot be used
+    to mint an admin on a long-running Connector.
+
+    No lockout / audit on the setup path itself — there is no prior
+    state to brute-force against, and the audit table is created on
+    the first login attempt downstream.
+    """
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        if await count_users(session) != 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="setup already completed",
+            )
+        try:
+            user = await create_user(
+                session,
+                name=body.user_name,
+                password=body.password,
+                must_change=False,
+                display_name=body.display_name,
+            )
+        except ValueError as exc:
+            # password/username rule failure — surface verbatim so the
+            # SPA can render a useful field error.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            )
+
+    payload = build_payload(
+        user_name=user.user_name,
+        must_change_password=False,
+    )
+    secret = _cookie_secret(request)
+    cookie_value = issue_local_cookie(payload, secret)
+
+    body_out = LoginResponse(
+        ok=True,
+        must_change_password=False,
+        principal_name=payload.principal_name,
+        exp=payload.exp,
+        # Setup deliberately does NOT mint a CSR or attribute the
+        # session on Mastio: the Connector may not yet have its agent
+        # cert when the wizard runs, and even when it does, deferring
+        # provisioning to the next user-initiated request keeps the
+        # blast radius of a Mastio outage contained to the next
+        # request rather than the setup itself.
+        provisioning="skipped",
+    )
+    response = JSONResponse(body_out.model_dump(), status_code=201)
+    _set_cookie(response, cookie_value)
+    _log.info(
+        "first-run setup completed user_name=%s", user.user_name,
+    )
+    return response
 
 
 __all__ = [

--- a/cullis_connector/identity/oidc_session.py
+++ b/cullis_connector/identity/oidc_session.py
@@ -1,10 +1,16 @@
-"""Local persistence of the Connector's OIDC user session (ADR-032 Layer 2).
+"""Local persistence of the Connector's user session (ADR-032 Layer 2).
 
-After a successful ``cullis-connector login`` the Mastio mints a session
-token bound to the Connector's enrolled agent identity + the OIDC user
-identity. The Connector keeps a single JSON row per profile under:
+After a successful ``cullis-connector login`` (SSO path) OR a successful
+local-auth login through the Connector's dashboard (ADR-025 Phase 5 /
+F4 R3 path), the Mastio mints a session token bound to the Connector's
+enrolled agent identity + the user identity. The Connector keeps a
+single JSON row per profile under:
 
     ~/.cullis/<profile>/oidc_session.json   (chmod 600)
+
+The filename is kept as ``oidc_session.json`` for backward compat with
+R1 deployments; the file now carries a ``source`` field so both SSO
+and local-auth sessions share the same persistence + load path.
 
 The MCP envelope propagation layer reads this file on every outbound
 call to add ``X-Cullis-Session-Token`` + ``X-Cullis-On-Behalf-Of-User``
@@ -22,15 +28,27 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 _log = logging.getLogger("cullis_connector.identity.oidc_session")
 
 OIDC_SESSION_FILENAME = "oidc_session.json"
 
 
+SessionSource = Literal["sso", "local"]
+
+
 @dataclass(frozen=True)
 class OidcSession:
-    """In-memory view of the persisted Connector OIDC session."""
+    """In-memory view of the persisted Connector user session.
+
+    The dataclass name is kept as ``OidcSession`` for backward compat
+    with R1 import sites; the ``source`` field distinguishes SSO and
+    local-auth sessions. When ``source == "local"`` the
+    ``sso_subject`` field carries the local username (prefixed
+    ``local:<user_name>`` by the Mastio attribution endpoint) and
+    ``idp_issuer`` is the literal ``"local"``.
+    """
 
     user_id: str
     session_token: str
@@ -39,6 +57,7 @@ class OidcSession:
     display_name: str | None
     expires_at: datetime
     device_thumbprint: str
+    source: SessionSource = "sso"
 
     def is_expired(self, *, now: datetime | None = None) -> bool:
         now = now or datetime.now(timezone.utc)
@@ -53,6 +72,7 @@ class OidcSession:
             "display_name": self.display_name,
             "expires_at": self.expires_at.astimezone(timezone.utc).isoformat(),
             "device_thumbprint": self.device_thumbprint,
+            "source": self.source,
         }
 
     @classmethod
@@ -61,6 +81,10 @@ class OidcSession:
         exp = datetime.fromisoformat(raw_exp)
         if exp.tzinfo is None:
             exp = exp.replace(tzinfo=timezone.utc)
+        # Backward compat: R1 files don't carry ``source``. Default to
+        # ``"sso"`` so a legacy oidc_session.json still loads.
+        raw_source = data.get("source", "sso")
+        source: SessionSource = "local" if raw_source == "local" else "sso"
         return cls(
             user_id=str(data["user_id"]),
             session_token=str(data["session_token"]),
@@ -69,6 +93,7 @@ class OidcSession:
             display_name=data.get("display_name"),
             expires_at=exp,
             device_thumbprint=str(data["device_thumbprint"]),
+            source=source,
         )
 
 

--- a/cullis_connector/identity/users.py
+++ b/cullis_connector/identity/users.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import bcrypt
-from sqlalchemy import Index, Integer, String, select
+from sqlalchemy import Index, Integer, String, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -307,3 +307,18 @@ async def reset_password(
     return await set_password_hash(
         session, name, new_password, must_change=True,
     )
+
+
+async def count_users(session: AsyncSession) -> int:
+    """Return the total number of rows in ``local_users``.
+
+    Used by the ADR-025 Phase 5 first-run wizard (F4 R3): a fresh
+    Connector desktop install has an empty ``users.db`` and the SPA
+    needs a zero-cost probe to decide between rendering the login
+    form and the owner-setup form. Counts both enabled and disabled
+    rows so a disabled-out-of-band first user does not accidentally
+    re-trigger the wizard.
+    """
+    stmt = select(func.count()).select_from(LocalUser)
+    result = await session.execute(stmt)
+    return int(result.scalar_one() or 0)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -2045,6 +2045,71 @@ async def revoke_user_session(session_id: str) -> bool:
     return (result.rowcount or 0) > 0
 
 
+async def upsert_local_user_principal_local(
+    *,
+    principal_id: str,
+    user_name: str,
+    display_name: str | None,
+) -> None:
+    """Insert or update a local-auth user principal (ADR-025 Phase 5 / F4 R3).
+
+    Counterpart to :func:`upsert_local_user_principal_sso` for users
+    that authenticate against the Connector's local ``users.db`` rather
+    than via an external IdP. The two columns ``sso_subject`` and
+    ``idp_issuer`` are intentionally left at NULL — that absence is the
+    on-row marker that says "this principal was provisioned via the
+    local-auth path". Pre-existing rows (e.g. a principal that was
+    first seen via SSO and is now also reachable via local-auth on the
+    same Connector) keep their SSO metadata untouched; only the
+    display_name + last_active_at refresh.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id FROM local_user_principals "
+                "WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )).first()
+        if existing is None:
+            await conn.execute(
+                text(
+                    """INSERT INTO local_user_principals (
+                           principal_id, user_name, display_name,
+                           reach, surface, cert_thumbprint,
+                           created_at, last_active_at,
+                           sso_subject, idp_issuer
+                       ) VALUES (
+                           :pid, :user_name, :display_name,
+                           'intra', 'connector', NULL,
+                           :ts, :ts,
+                           NULL, NULL
+                       )"""
+                ),
+                {
+                    "pid": principal_id,
+                    "user_name": user_name,
+                    "display_name": display_name,
+                    "ts": ts,
+                },
+            )
+        else:
+            await conn.execute(
+                text(
+                    """UPDATE local_user_principals
+                          SET display_name = COALESCE(:display_name, display_name),
+                              last_active_at = :ts
+                        WHERE principal_id = :pid"""
+                ),
+                {
+                    "pid": principal_id,
+                    "display_name": display_name,
+                    "ts": ts,
+                },
+            )
+
+
 async def upsert_local_user_principal_sso(
     *,
     principal_id: str,

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1414,6 +1414,16 @@ app.include_router(principals_router)
 from mcp_proxy.registry.connector_login_router import router as connector_login_router
 app.include_router(connector_login_router)
 
+# ADR-025 Phase 5 / F4 R3 — local-auth attribution sibling of
+# /v1/principals/connector-login. The Connector posts here after
+# verifying bcrypt against its local users.db; this endpoint mints
+# the user_sessions row without touching a password (per migration
+# 0028_revert_user_password: Mastio is not the password store).
+from mcp_proxy.registry.connector_login_local_attribution_router import (
+    router as connector_login_local_attribution_router,
+)
+app.include_router(connector_login_local_attribution_router)
+
 # ADR-004 PR A — reverse-proxy router for /v1/broker/*, /v1/auth/*,
 # /v1/registry/*. Registered before local handlers so the proxy owns these
 # paths by default; local endpoints live under /v1/egress/* and /v1/ingress/*.

--- a/mcp_proxy/registry/connector_login_local_attribution_router.py
+++ b/mcp_proxy/registry/connector_login_local_attribution_router.py
@@ -1,0 +1,263 @@
+"""ADR-025 Phase 5 / F4 R3 — Connector local-auth → user-bound session.
+
+Companion to ``connector_login_router.py``. The two share the
+``user_sessions`` row format (R1's migration 0034) and the
+``maybe_stamp_user_session`` downstream pinning (R2). They diverge on
+the trust model:
+
+* OIDC path (``connector_login_router.py``): the Connector replays a
+  fresh IdP id_token; Mastio derives the user from ``sub`` + ``iss``.
+* Local-auth path (this file): the Connector has already verified
+  bcrypt against ``cullis_connector/identity/users.py`` (ADR-025
+  Phase 1) and declares ``"user X just logged in"``. Mastio trusts
+  the declaration because:
+
+    1. cert+DPoP authenticates the calling Connector device.
+    2. The device cert is org-CA issued + thumbprint-pinned, so a
+       compromised Connector can be revoked centrally.
+    3. The threat-model parity with OIDC: an attacker who compromises
+       the IdP token store can mint arbitrary ``sub`` claims; an
+       attacker who compromises a Connector can declare arbitrary
+       local_subject claims. Both paths fall back to cert revocation
+       + audit forensics. Acceptable for pilot pre-revenue per
+       ADR-032 + ADR-025 threat model.
+
+NO password verify here. NO password column. Migration 0028
+explicitly removed ``local_user_principals.password_hash`` with the
+rationale "Mastio is not the password store". The credential lives in
+the Connector's ``users.db``; Mastio just mints + tracks the session.
+
+Endpoint:
+
+    POST /v1/principals/connector-login-local-attribution
+
+Request body:
+
+    {
+      "local_subject": "alice",
+      "display_name": "Alice Smith",
+      "device_cert_thumbprint": "<sha256-hex>",
+      "auth_mode": "local"
+    }
+
+Response: same shape as the SSO sibling.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import (
+    create_user_session,
+    upsert_local_user_principal_local,
+)
+from mcp_proxy.models import TokenPayload
+
+_log = logging.getLogger("mcp_proxy.registry.connector_login_local_attribution")
+
+router = APIRouter(prefix="/v1/principals", tags=["principals"])
+
+
+_DEFAULT_TTL_SECONDS = 3600
+
+# Username convention shared with ``mcp_proxy/admin/users.py`` +
+# ``cullis_connector/identity/users.py``: 1-64 chars, alphanumerics +
+# ``._-``. Constrains the body so a malformed Connector can't smuggle a
+# control byte through to ``local_user_principals.user_name`` (which we
+# splice into the SPIFFE-shaped principal_id below).
+_LOCAL_SUBJECT_RE = re.compile(r"^[a-zA-Z0-9._-]{1,64}$")
+
+
+class ConnectorLoginLocalAttributionRequest(BaseModel):
+    """Body for ``POST /v1/principals/connector-login-local-attribution``."""
+
+    local_subject: str = Field(..., min_length=1, max_length=64)
+    display_name: str | None = Field(default=None, max_length=255)
+    device_cert_thumbprint: str = Field(
+        ..., min_length=32, max_length=128,
+        description="SHA-256 hex digest of the calling Connector's "
+                    "agent cert (DER).",
+    )
+    auth_mode: Literal["local"] = "local"
+
+
+class ConnectorLoginLocalAttributionResponse(BaseModel):
+    """Body returned by ``POST /v1/principals/connector-login-local-attribution``."""
+
+    user_id: str
+    session_token: str
+    expires_at: datetime
+
+
+def _derive_caller_cert_thumbprint(request: Request) -> str | None:
+    """SHA-256 hex of the caller's TLS client cert, or None.
+
+    Mirrors :func:`mcp_proxy.registry.connector_login_router._derive_caller_cert_thumbprint`
+    so the local-auth flow gets the same MEDIUM C2 guarantee: the body
+    thumbprint cannot disagree with the cert nginx accepted.
+    """
+    from mcp_proxy.auth.client_cert import _decode_escaped_pem
+
+    if request.headers.get("X-SSL-Client-Verify") != "SUCCESS":
+        return None
+    escaped_pem = request.headers.get("X-SSL-Client-Cert") or ""
+    if not escaped_pem:
+        return None
+    try:
+        pem = _decode_escaped_pem(escaped_pem)
+        cert = x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    except (ValueError, AttributeError):
+        return None
+    return hashlib.sha256(
+        cert.public_bytes(serialization.Encoding.DER),
+    ).hexdigest()
+
+
+def _resolve_ttl_seconds() -> int:
+    """Read the configurable session TTL, fall back to 1h."""
+    settings = get_settings()
+    raw = getattr(settings, "user_session_ttl_seconds", None)
+    if raw is None:
+        return _DEFAULT_TTL_SECONDS
+    try:
+        ttl = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_TTL_SECONDS
+    if ttl <= 0:
+        return _DEFAULT_TTL_SECONDS
+    return ttl
+
+
+@router.post(
+    "/connector-login-local-attribution",
+    response_model=ConnectorLoginLocalAttributionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def connector_login_local_attribution(
+    body: ConnectorLoginLocalAttributionRequest,
+    request: Request,
+    token: TokenPayload = Depends(get_authenticated_agent),
+) -> ConnectorLoginLocalAttributionResponse:
+    """Bind a local-auth user identity to the calling Connector.
+
+    The Connector attests it verified bcrypt against its local
+    ``users.db`` for ``body.local_subject``; Mastio mints a
+    ``user_sessions`` row pinned to the calling Connector's cert
+    thumbprint so the resulting session_token only attributes audit
+    rows when re-presented from the same device.
+    """
+    if not _LOCAL_SUBJECT_RE.match(body.local_subject):
+        # Pydantic max_length already capped at 64, but the regex closes
+        # the SQL/SPIFFE injection vector on the *content* of the value.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "local_subject must match the local-user_name convention "
+                "(alphanumerics + ._- only, 1-64 chars)"
+            ),
+        )
+
+    # Same MEDIUM C2 guarantee as the SSO sibling: refuse a body
+    # thumbprint that disagrees with the nginx-forwarded cert.
+    server_thumbprint = _derive_caller_cert_thumbprint(request)
+    if server_thumbprint is not None:
+        if not hmac.compare_digest(
+            server_thumbprint.lower(), body.device_cert_thumbprint.lower(),
+        ):
+            _log.warning(
+                "connector-login-local-attribution: device_cert_thumbprint "
+                "mismatch (agent=%s body_prefix=%s server_prefix=%s)",
+                token.agent_id,
+                body.device_cert_thumbprint[:16],
+                server_thumbprint[:16],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "device_cert_thumbprint does not match the TLS "
+                    "client cert presented at the handshake"
+                ),
+            )
+        bound_thumbprint = server_thumbprint
+    else:
+        bound_thumbprint = body.device_cert_thumbprint
+
+    # principal_id mirrors the SSO sibling's shape so downstream policy /
+    # audit code does not need a special-case for local-auth. The
+    # uniqueness invariant is preserved: ``users.db`` enforces UNIQUE
+    # on ``user_name`` within a Connector deployment, and each
+    # deployment is bound to one Mastio org.
+    user_name = body.local_subject.lower()
+    principal_id = f"{token.org}::user::{user_name}"
+
+    try:
+        await upsert_local_user_principal_local(
+            principal_id=principal_id,
+            user_name=user_name,
+            display_name=body.display_name,
+        )
+    except Exception:  # noqa: BLE001
+        _log.exception(
+            "connector-login-local-attribution: upsert failed for %s",
+            principal_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="user-principal store temporarily unavailable",
+        )
+
+    ttl = _resolve_ttl_seconds()
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=ttl)
+    session_id = secrets.token_urlsafe(32)
+
+    # The SSO sibling carries the real ``sso_subject`` / ``idp_issuer``
+    # for the audit row; local-auth has neither, so we stuff a constant
+    # marker into ``sso_subject`` so a downstream SQL "where did this
+    # session come from" query can still cluster local vs SSO without a
+    # schema migration. ``idp_issuer`` mirrors the same marker.
+    try:
+        await create_user_session(
+            session_id=session_id,
+            principal_id=principal_id,
+            agent_cert_thumbprint=bound_thumbprint,
+            sso_subject=f"local:{user_name}",
+            idp_issuer="local",
+            display_name=body.display_name,
+            expires_at=expires_at,
+        )
+    except Exception:  # noqa: BLE001
+        _log.exception(
+            "connector-login-local-attribution: create_user_session failed "
+            "for %s",
+            principal_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="session store temporarily unavailable",
+        )
+
+    _log.info(
+        "connector-login-local-attribution: agent=%s bound user=%s "
+        "auth_mode=local session_ttl=%ds",
+        token.agent_id, principal_id, ttl,
+    )
+
+    return ConnectorLoginLocalAttributionResponse(
+        user_id=principal_id,
+        session_token=session_id,
+        expires_at=expires_at,
+    )

--- a/tests/connector/test_auth_local_router.py
+++ b/tests/connector/test_auth_local_router.py
@@ -482,3 +482,167 @@ def test_login_deferred_provisioning_header_does_not_crash_uvicorn(
     assert "\r" not in raw_detail
     # Truncation honoured to keep header well under 2 KB
     assert len(raw_detail) <= 256
+
+
+# ── ADR-025 Phase 5 / F4 R3 — first-run wizard ──────────────────────────
+
+
+def test_runtime_info_setup_required_true_when_users_empty(client):
+    """A fresh Connector with no users.db rows surfaces setup_required."""
+    r = client.get("/api/auth/runtime-info")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["setup_required"] is True
+    assert body["setup_url"] == "/api/auth/first-run-setup"
+
+
+def test_runtime_info_setup_required_false_after_first_user(client):
+    """As soon as any user exists the wizard is no longer needed."""
+    _create_user(
+        client, user_name="alice", password="longpassword", must_change=False,
+    )
+    r = client.get("/api/auth/runtime-info")
+    assert r.status_code == 200, r.text
+    assert r.json()["setup_required"] is False
+
+
+def test_first_run_setup_creates_owner_user_and_issues_cookie(client):
+    r = client.post(
+        "/api/auth/first-run-setup",
+        json={
+            "user_name": "owner",
+            "password": "longpassword",
+            "display_name": "Owner User",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["must_change_password"] is False
+    assert body["provisioning"] == "skipped"
+    # Cookie was issued so the operator lands on the dashboard right
+    # after setup without a second password prompt.
+    cookie_names = {c.name for c in client.cookies.jar}
+    assert LOCAL_SESSION_COOKIE_NAME in cookie_names
+    secret = _cookie_secret(client)
+    raw_cookie = client.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+    payload = parse_local_cookie(raw_cookie, secret)
+    assert payload is not None
+    assert payload.user_name == "owner"
+    assert payload.must_change_password is False
+
+
+def test_first_run_setup_refused_with_409_when_user_already_exists(client):
+    _create_user(
+        client, user_name="alice", password="longpassword", must_change=False,
+    )
+    r = client.post(
+        "/api/auth/first-run-setup",
+        json={"user_name": "second", "password": "longpassword"},
+    )
+    assert r.status_code == 409, r.text
+    assert "setup already completed" in r.text
+
+
+def test_first_run_setup_password_too_short_returns_400_or_422(client):
+    r = client.post(
+        "/api/auth/first-run-setup",
+        json={"user_name": "owner", "password": "short"},
+    )
+    # Pydantic min_length=8 raises 422 before the handler runs.
+    assert r.status_code in {400, 422}, r.text
+
+
+def test_first_run_setup_invalid_username_rejected(client):
+    """user_name regex rejects spaces / control bytes via create_user."""
+    r = client.post(
+        "/api/auth/first-run-setup",
+        json={
+            "user_name": "bad user!",
+            "password": "longpassword",
+        },
+    )
+    assert r.status_code in {400, 422}, r.text
+
+
+def test_first_run_setup_then_login_succeeds(client):
+    """End-to-end: setup → cookie → logout → login with same creds."""
+    r = client.post(
+        "/api/auth/first-run-setup",
+        json={"user_name": "owner", "password": "longpassword"},
+    )
+    assert r.status_code == 201, r.text
+    # Drop the cookie so we exercise the real login path next.
+    client.post("/api/auth/logout")
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "owner", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["must_change_password"] is False
+
+
+# ── ADR-025 Phase 5 / F4 R3 — login → Mastio attribution chain ─────────
+
+
+def test_login_invokes_mastio_attribution_helper(client, monkeypatch):
+    """Login success path calls ``_bind_mastio_user_session`` so the
+    Connector posts a user_login_attribution to Mastio after bcrypt
+    verify. Helper is monkey-patched to avoid spinning a real Mastio.
+    """
+    from cullis_connector.auth import local_router as _lr
+
+    seen: dict[str, object] = {}
+
+    async def fake_bind_login_cert(request, payload):  # noqa: ARG001
+        return "skipped", None
+
+    async def fake_bind_mastio(
+        request, *, user_name, display_name, device_thumbprint,
+    ):  # noqa: ARG001
+        seen["user_name"] = user_name
+        seen["display_name"] = display_name
+        seen["device_thumbprint"] = device_thumbprint
+        return "ok", None
+
+    monkeypatch.setattr(_lr, "_bind_login_cert", fake_bind_login_cert)
+    monkeypatch.setattr(_lr, "_bind_mastio_user_session", fake_bind_mastio)
+
+    _create_user(
+        client, user_name="alice", password="longpassword", must_change=False,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "alice", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    assert seen.get("user_name") == "alice"
+    # No enrolled cert in this test fixture, so the helper gets the
+    # empty thumbprint and (in the real helper) returns "skipped".
+    assert "device_thumbprint" in seen
+
+
+def test_login_skips_attribution_when_must_change(client, monkeypatch):
+    """First-login (must_change=True) skips both CSR + attribution so
+    the cert + user session are bound to the post-change state.
+    """
+    from cullis_connector.auth import local_router as _lr
+
+    invoked: list[str] = []
+
+    async def fake_bind_mastio(request, **kwargs):  # noqa: ARG001
+        invoked.append("called")
+        return "ok", None
+
+    monkeypatch.setattr(_lr, "_bind_mastio_user_session", fake_bind_mastio)
+
+    _create_user(
+        client, user_name="bob", password="longpassword", must_change=True,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "bob", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    assert invoked == [], "attribution must not run while must_change=True"
+    assert r.json()["must_change_password"] is True

--- a/tests/test_connector_login_local_attribution_router.py
+++ b/tests/test_connector_login_local_attribution_router.py
@@ -1,0 +1,227 @@
+"""ADR-025 Phase 5 / F4 R3 — ``POST /v1/principals/connector-login-local-attribution``.
+
+Companion to ``test_connector_login_endpoint.py``: same fixtures, same
+schema invariants, but the local-auth attribution path. The Connector
+has already verified bcrypt against ``cullis_connector/identity/users.py``
+and the Mastio mints the user_sessions row without touching a password
+(per migration 0028_revert_user_password).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.models import TokenPayload
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_agent(
+    *, org: str = "acme", agent_id: str = "acme::connector",
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}",
+        scope=[],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "attribution.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def app_client(proxy_db):
+    from mcp_proxy.main import app
+
+    app.dependency_overrides[get_authenticated_agent] = lambda: _fake_agent()
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.pop(get_authenticated_agent, None)
+
+
+def _body(**overrides):
+    base = {
+        "local_subject": "alice",
+        "display_name": "Alice Smith",
+        "device_cert_thumbprint": "a" * 64,
+        "auth_mode": "local",
+    }
+    base.update(overrides)
+    return base
+
+
+async def test_attribution_creates_session_and_local_principal(app_client):
+    resp = app_client.post(
+        "/v1/principals/connector-login-local-attribution", json=_body(),
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+
+    user_id = data["user_id"]
+    assert user_id == "acme::user::alice"
+    assert isinstance(data["session_token"], str) and len(data["session_token"]) > 16
+    assert data["expires_at"]
+
+    async with get_db() as conn:
+        sess = (await conn.execute(
+            text("SELECT * FROM user_sessions WHERE session_id = :sid"),
+            {"sid": data["session_token"]},
+        )).mappings().first()
+        assert sess is not None
+        assert sess["principal_id"] == user_id
+        # Local-auth marker: idp_issuer == "local", sso_subject is
+        # synthesised so a SQL "cluster by source" query still works.
+        assert sess["idp_issuer"] == "local"
+        assert sess["sso_subject"] == "local:alice"
+        assert sess["agent_cert_thumbprint"] == "a" * 64
+        assert sess["revoked_at"] is None
+
+        principal = (await conn.execute(
+            text(
+                "SELECT principal_id, user_name, sso_subject, idp_issuer "
+                "FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": user_id},
+        )).mappings().first()
+        assert principal is not None
+        assert principal["user_name"] == "alice"
+        # Local-auth rows leave sso_subject/idp_issuer NULL — the
+        # presence of those NULLs is itself the "this principal came
+        # from the local-auth path" marker on disk.
+        assert principal["sso_subject"] is None
+        assert principal["idp_issuer"] is None
+
+
+async def test_attribution_idempotent_same_subject(app_client):
+    r1 = app_client.post(
+        "/v1/principals/connector-login-local-attribution", json=_body(),
+    )
+    r2 = app_client.post(
+        "/v1/principals/connector-login-local-attribution", json=_body(),
+    )
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    # Re-login mints a fresh session.
+    assert r1.json()["session_token"] != r2.json()["session_token"]
+    # Stable principal_id across re-logins (no nonce/timing in the slug).
+    assert r1.json()["user_id"] == r2.json()["user_id"]
+
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT principal_id FROM local_user_principals "
+                "WHERE principal_id = :pid"
+            ),
+            {"pid": r1.json()["user_id"]},
+        )).all()
+        assert len(rows) == 1
+
+
+async def test_attribution_rejects_invalid_local_subject(app_client):
+    """Username regex closes the SQL/SPIFFE-injection vector."""
+    resp = app_client.post(
+        "/v1/principals/connector-login-local-attribution",
+        json=_body(local_subject="bob;DROP TABLE users"),
+    )
+    # Either pydantic max_length or the inner regex catches it.
+    assert resp.status_code in {400, 422}, resp.text
+
+
+async def test_attribution_rejects_too_long_local_subject(app_client):
+    resp = app_client.post(
+        "/v1/principals/connector-login-local-attribution",
+        json=_body(local_subject="a" * 65),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_attribution_principal_id_lowercased(app_client):
+    """user_name is lowercased so case-variant logins collapse to one row."""
+    r1 = app_client.post(
+        "/v1/principals/connector-login-local-attribution",
+        json=_body(local_subject="Alice"),
+    )
+    r2 = app_client.post(
+        "/v1/principals/connector-login-local-attribution",
+        json=_body(local_subject="alice"),
+    )
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    assert r1.json()["user_id"] == r2.json()["user_id"] == "acme::user::alice"
+
+
+async def test_attribution_does_not_share_principal_with_sso_login(app_client):
+    """Local-auth and SSO logins land on distinct principals even when
+    the local_subject matches the SSO email's local-part. The SSO
+    sibling appends a stable hash suffix; local-auth does not. Both
+    paths are safe because the principal_id prefix is the only thing
+    routed by policy.
+    """
+    local = app_client.post(
+        "/v1/principals/connector-login-local-attribution",
+        json=_body(local_subject="alice"),
+    )
+    sso = app_client.post(
+        "/v1/principals/connector-login",
+        json={
+            "user_subject_sso": "alice@acme.com",
+            "display_name": "Alice Smith",
+            "idp_issuer": "https://idp.example.com",
+            "device_cert_thumbprint": "a" * 64,
+        },
+    )
+    assert local.status_code == 201
+    assert sso.status_code == 201
+    assert local.json()["user_id"] != sso.json()["user_id"]
+    # SSO carries the hash suffix; local-auth does not.
+    assert local.json()["user_id"] == "acme::user::alice"
+    assert sso.json()["user_id"].startswith("acme::user::alice-")
+
+
+async def test_attribution_persists_session_ttl(app_client):
+    """expires_at honours the configured TTL (~1h default)."""
+    from datetime import datetime, timezone
+    resp = app_client.post(
+        "/v1/principals/connector-login-local-attribution", json=_body(),
+    )
+    assert resp.status_code == 201
+    expires_at = datetime.fromisoformat(
+        resp.json()["expires_at"].replace("Z", "+00:00"),
+    )
+    now = datetime.now(timezone.utc)
+    delta = (expires_at - now).total_seconds()
+    # Allow generous slack so a slow CI doesn't flap the assertion.
+    assert 60 <= delta <= 3 * 3600

--- a/tests/test_connector_oidc_session_storage.py
+++ b/tests/test_connector_oidc_session_storage.py
@@ -86,3 +86,71 @@ def test_is_expired_past_expiry():
 def test_is_expired_far_future():
     s = _session(expires_at=datetime.now(timezone.utc) + timedelta(hours=1))
     assert s.is_expired() is False
+
+
+# ── ADR-025 Phase 5 / F4 R3: source field ────────────────────────────────
+
+
+def test_source_defaults_to_sso_for_backward_compat():
+    """R1 callers construct OidcSession without ``source`` — the
+    default must keep them on the SSO path so existing call-sites
+    don't silently flip behaviour."""
+    s = _session()
+    assert s.source == "sso"
+
+
+def test_save_and_load_round_trip_with_local_source(tmp_path):
+    save_session(tmp_path, _session(source="local"))
+    loaded = load_session(tmp_path)
+    assert loaded is not None
+    assert loaded.source == "local"
+
+
+def test_load_legacy_file_without_source_field(tmp_path):
+    """A R1 oidc_session.json on disk (pre-source-field) must still
+    load — that's the upgrade path for a Connector that was logged in
+    via SSO before the upgrade and continues to use the same session."""
+    import json
+    path = tmp_path / "oidc_session.json"
+    legacy_payload = {
+        "user_id": "acme::user::alice",
+        "session_token": "legacy-token",
+        "sso_subject": "alice@acme.com",
+        "idp_issuer": "https://idp.example.com",
+        "display_name": "Alice",
+        "expires_at": (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).isoformat(),
+        "device_thumbprint": "a" * 64,
+        # no "source" key — pre-R3 file.
+    }
+    path.write_text(json.dumps(legacy_payload))
+    loaded = load_session(tmp_path)
+    assert loaded is not None
+    assert loaded.source == "sso"
+
+
+def test_load_rejects_unknown_source_value_safely(tmp_path):
+    """Defence-in-depth: a tampered file with ``source: "admin"``
+    must NOT silently grant any new privileges. The dataclass restricts
+    to ``Literal["sso", "local"]`` — anything else falls back to sso so
+    a forged file cannot opt into a future "trusted" tier without an
+    explicit code change."""
+    import json
+    path = tmp_path / "oidc_session.json"
+    tampered = {
+        "user_id": "acme::user::alice",
+        "session_token": "x",
+        "sso_subject": "alice@acme.com",
+        "idp_issuer": "https://idp.example.com",
+        "display_name": None,
+        "expires_at": (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).isoformat(),
+        "device_thumbprint": "a" * 64,
+        "source": "admin-omg",
+    }
+    path.write_text(json.dumps(tampered))
+    loaded = load_session(tmp_path)
+    assert loaded is not None
+    assert loaded.source == "sso"


### PR DESCRIPTION
## Summary

Continues #740 (R1 OIDC) + #744 (R2 MCP envelope). Closes the local-auth side of the canonical UX flow: customers without a corporate IdP can sign in to a Connector with admin-managed local credentials, and the resulting session attributes downstream MCP audit rows the same way an SSO session does.

### Trust model

Mastio is **not** the password store — migration `0028_revert_user_password` (2026-05-10) explicitly removed `local_user_principals.password_hash` with the rationale "Mastio is not the password store". The credential lives in the Connector Ambassador's `users.db` (ADR-025 Phase 1). bcrypt verify happens on the Connector; Mastio trusts the cert+DPoP-authenticated Connector device to declare the user via a new attribution endpoint, mints a `user_sessions` row pinned to the device thumbprint, and returns an opaque `session_token`.

Compromise parity with OIDC:
- compromised IdP token store → attacker mints arbitrary `sub` claims
- compromised Connector device → attacker mints arbitrary `local_subject` claims

Both paths fall back to cert revocation + audit forensics — acceptable for pilot pre-revenue per ADR-025 + ADR-032.

### Shipped

- **Mastio attribution endpoint** `POST /v1/principals/connector-login-local-attribution` parallel `connector_login_router.py`. cert+DPoP auth, body `local_subject + display_name + device_cert_thumbprint`. Mints `user_sessions` with marker `sso_subject="local:<name>"` + `idp_issuer="local"` so SQL "where did this come from" still clusters without a schema migration. MEDIUM C2 server-side thumbprint check is preserved (refuses a body thumbprint that disagrees with the nginx-forwarded cert).
- **`upsert_local_user_principal_local`** helper in `mcp_proxy/db.py`. NULL `sso_subject` / `idp_issuer` is the on-row marker for the local-auth path; pre-existing SSO rows keep their columns untouched.
- **`SdkMastioCsrTransport.attribute_local_login`** uses the same cached device-bound `CullisClient` as the CSR path so one login round-trip serves both calls.
- **Connector local_router `/api/auth/login`** now calls `_bind_mastio_user_session` after `_bind_login_cert` succeeds; result surfaces in `LoginResponse.attribution` (`ok` / `deferred` / `skipped`) so a Mastio outage degrades gracefully without rolling back password verification.
- **Phase-4 lockout + audit wired up** — the local-router stubs are replaced by real calls into `cullis_connector.identity.lockout` + `audit`. `/api/auth/login` emits a `log_login_attempt` + `record_failure` / `record_success` per attempt; lockout trigger fires `log_lockout_trigger`; pw.change emits a `log_password_change` row.
- **`OidcSession` dataclass** gains a `source: Literal["sso", "local"]` field. Backward-compat: R1 files missing the field default to `"sso"`; a tampered file with an unknown `source` value falls back to `"sso"` rather than silently opting into a future tier.
- **First-run wizard**: `GET /api/auth/runtime-info` now returns `setup_required` + `setup_url`; `POST /api/auth/first-run-setup` creates the owner user (`count_users == 0` gate) + issues the local session cookie so the operator lands on the dashboard. 409 on any subsequent call so a leaked URL cannot mint a second admin.

### Out of scope (R4)

- Frontdesk SPA `AdminUsers.tsx` wire-up against the new Connector admin endpoints (UI already exists; backend wiring punted).
- Rolling session TTL knob (default stays hard 1h banking-grade per ADR-032 decision D).

## Test plan

- [x] **Unit + integration**: 74 tests pass across `tests/connector/test_auth_local_router.py` (lockout wire-up + audit + first-run wizard), `tests/test_connector_login_local_attribution_router.py` (Mastio endpoint), `tests/test_connector_oidc_session_storage.py` (source field round-trip + legacy load).
- [x] **Full suite**: `pytest tests/` — 3648 pass, 31 skip, 1 pre-existing local-env fail (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`, caused by `cullis_enterprise` editable-installed in the shared `.venv`; CI runs clean per memory `feedback_pythonpath_worktree_for_new_core_modules`), 3 flaky-isolation errors in `test_audit_race_safety.py` that pass when re-run in isolation.
- [x] **Smoke**: `./sandbox/smoke.sh full` — 25 pass, 0 fail, 1 skip (B4.9 gated on `SMOKE_ASSERT_INTRA_ORG=1`).
- [ ] CI: full check matrix (this PR).
- [ ] Dogfood VM Frontdesk: admin creates user, browser login local, audit row carries `on_behalf_of_user_id` + marker `idp_issuer="local"` (deferred to post-merge).