### PR TITLE
feat(policy): 5-tier capability gating (ADR-032 Decision E F5)

### DIFF
--- a/app/policy/engine.py
+++ b/app/policy/engine.py
@@ -21,6 +21,23 @@ class PolicyDecision:
     allowed: bool
     reason: str
     policy_id: str | None = None
+    # ADR-032 Decision E / F5 — device-attestation tier metadata.
+    # All three default to ``None`` so existing call sites that don't
+    # set them keep their wire format unchanged. The fields surface
+    # via the audit row + the API response so a CISO running a forensic
+    # query can answer "which device tier was authoritative at the
+    # moment of this deny?" without re-resolving the claim later.
+    effective_tier: str | None = None
+    required_tier: str | None = None
+    # Short stable token for downstream UX / metrics labelling. The
+    # canonical values:
+    #   * ``insufficient_tier``       — device tier below capability requirement
+    #   * ``capability_not_granted``  — principal lacks the capability scope
+    #   * ``binding_missing``         — typed principal without MCP-resource binding
+    #   * ``policy_match_deny``       — explicit deny rule fired
+    # Future denies adding a new bucket should extend this list and the
+    # dashboard's filter dropdown together.
+    denied_reason_code: str | None = None
 
 
 class PolicyEngine:

--- a/enterprise-kit/policy/capability-tiers.yaml
+++ b/enterprise-kit/policy/capability-tiers.yaml
@@ -1,0 +1,83 @@
+# ADR-032 Decision E / F5 — capability → minimum tier matrix.
+#
+# Each entry maps a capability name (or wildcard) to the lowest
+# device-attestation tier that's allowed to invoke it. The Mastio
+# proxy recomputes the principal's effective tier server-side from
+# ``internal_agents.last_attestation`` on every call (the Connector's
+# claim is advisory; tampering can only lower the value, never raise
+# it) and refuses the call with ``denied_reason_code=insufficient_tier``
+# when the principal's tier ranks below the capability's minimum.
+#
+# Tier ordering (low → high, schema-doc sez. 2):
+#   untrusted < byod_isolated < byod_attested < managed < managed_attested
+#
+# Wildcard match: a capability name ending in ``.*`` matches any
+# capability with that prefix (one-level glob). More specific
+# entries always win — ``admin.read`` overrides ``admin.*``. Exact
+# names are looked up first.
+#
+# Migration path: capabilities not listed default to
+# ``default_min_tier`` below. Customers can roll out tier enforcement
+# gradually by leaving the default at ``untrusted`` until every
+# fleet device emits a claim, then raising the default to
+# ``byod_isolated`` once the long tail of legacy clients has been
+# replaced.
+#
+# Schema reference: imp/attestation-claim-schema.md sez. 2.
+
+version: "1.0"
+
+# Default minimum tier for capabilities not listed below.
+# Pilot deployments keep this at ``untrusted`` to avoid surprising
+# legacy fleets; raise it once the device-attestation rollout is
+# complete.
+default_min_tier: untrusted
+
+capabilities:
+  # ── untrusted (max permissive) ─────────────────────────────────
+  # Diagnostic / health surfaces that customer support tooling
+  # exercises before a device has any claim attached. Keeping these
+  # at ``untrusted`` lets a fresh-out-of-the-box device probe
+  # connectivity without false-positive denials.
+  mcp.read_public:
+    min_tier: untrusted
+    description: "Public information, no sensitive data"
+  mcp.echo:
+    min_tier: untrusted
+    description: "Diagnostic / health"
+
+  # ── byod_attested (hardware proof, BYOD) ───────────────────────
+  # Internal-only data: source code, design docs, internal
+  # wikis. Requires hardware-backed strength (TPM 2.0 / Secure
+  # Enclave) so a soft-only laptop cannot exfiltrate via a stolen
+  # session token.
+  mcp.read_internal_docs:
+    min_tier: byod_attested
+    description: "Internal company documentation"
+  mcp.code_review:
+    min_tier: byod_attested
+    description: "Source code access"
+
+  # ── managed (MDM-managed compliant) ────────────────────────────
+  # Customer data + financial reads. Requires MDM enrollment +
+  # compliant posture so a remote-wipe path exists if the device
+  # is lost. Hardware attestation is not yet required at this
+  # tier (some legacy fleets predate TPM 2.0).
+  mcp.read_customer_db:
+    min_tier: managed
+    description: "Customer database read"
+  mcp.financial_read:
+    min_tier: managed
+    description: "Financial data read"
+
+  # ── managed_attested (MDM + hardware) ──────────────────────────
+  # Writable financial + administrative operations. The "money
+  # moves" tier — both the central-IT posture (MDM compliant)
+  # AND the hardware proof (TPM-attested) need to line up before
+  # we honour the call.
+  mcp.transfer_money:
+    min_tier: managed_attested
+    description: "Outbound financial transaction"
+  "admin.*":
+    min_tier: managed_attested
+    description: "Admin operations (wildcard match)"

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1471,6 +1471,12 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
     # Migration 0014 (F-B-11 Phase 2) — same permissiveness.
     if "dpop_jkt" in row.keys():
         out["dpop_jkt"] = row["dpop_jkt"]
+    # F2 #746 migration 0035 — device-attestation claim JSON. Surfaces
+    # for the F5 tier-gate path (``mcp_proxy/policy/tier_eval.py``).
+    # NULL when no claim recorded yet; the tier resolver treats that
+    # as "untrusted".
+    if "last_attestation" in row.keys():
+        out["last_attestation"] = row["last_attestation"]
     return out
 
 

--- a/mcp_proxy/policy/tier_eval.py
+++ b/mcp_proxy/policy/tier_eval.py
@@ -1,0 +1,148 @@
+"""Server-authoritative effective-tier resolution for a principal.
+
+ADR-032 Decision E / F5. The Connector emits an attestation claim on
+every MCP envelope (R2 wire-up), but that claim is advisory — the
+Mastio is the authoritative source for ``effective_tier`` because
+*it* enforces the capability gate. This module owns the read path:
+
+* Look up ``internal_agents.last_attestation`` (TEXT NULL, JSON-
+  serialised claim, populated by F2 enrollment hook).
+* Parse the JSON; bail to ``untrusted`` on any decode failure.
+* Apply the stale-window downgrade per schema sez. 5 so a fresh
+  customer-incompliance signal forces the tier to drop without
+  waiting for the next Intune polling cycle.
+* Return the recomputed ``effective_tier`` (not the claim's stored
+  value — schema sez. 7: server recomputes from inputs so a
+  tampered claim can only lower, never raise).
+
+The helper is intentionally synchronous in spirit (no DB session
+needed beyond ``get_agent``) and async in shape so callers can
+``await`` without restructuring.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from mcp_proxy.attestation.tier import (
+    TIER_UNTRUSTED,
+    apply_stale_downgrade,
+    compute_effective_tier,
+)
+from mcp_proxy.db import get_agent
+
+_log = logging.getLogger("mcp_proxy.policy.tier_eval")
+
+# Stale threshold in seconds. Default 15 min per schema-doc sez. 5
+# (Intune polling cycle). Configurable via env so an operator can
+# tighten the window for a high-trust deployment without rebuilding
+# the bundle.
+ENV_STALE_THRESHOLD = "MCP_PROXY_ATTESTATION_STALE_THRESHOLD_SECONDS"
+DEFAULT_STALE_THRESHOLD_SECONDS = 900
+
+
+def _resolve_stale_threshold() -> int:
+    """Read the configured stale threshold. Falls back to the default
+    when the env var is missing or malformed."""
+    raw = os.environ.get(ENV_STALE_THRESHOLD)
+    if not raw:
+        return DEFAULT_STALE_THRESHOLD_SECONDS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        _log.warning(
+            "%s=%s is not an int — using default %ds",
+            ENV_STALE_THRESHOLD, raw, DEFAULT_STALE_THRESHOLD_SECONDS,
+        )
+        return DEFAULT_STALE_THRESHOLD_SECONDS
+    if value < 0:
+        _log.warning(
+            "%s=%d is negative — using default %ds",
+            ENV_STALE_THRESHOLD, value, DEFAULT_STALE_THRESHOLD_SECONDS,
+        )
+        return DEFAULT_STALE_THRESHOLD_SECONDS
+    return value
+
+
+def _safe_parse_attestation(raw: Any) -> dict | None:
+    """JSON-decode ``raw`` into a dict; return ``None`` on any failure.
+
+    Tolerates ``None`` (no claim recorded yet) + ``""`` (empty TEXT
+    column) + malformed JSON without raising. The caller treats a
+    ``None`` return as "no claim, default to untrusted".
+    """
+    if not raw:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _recompute_tier_from_claim(claim: dict) -> str:
+    """Run the server-side tier function over the claim's inner block.
+
+    Schema sez. 7: the server NEVER trusts the claim's stored
+    ``effective_tier`` value. We pull the input fields out and
+    recompute, so a forged claim that claims ``managed_attested``
+    while carrying ``strength=soft_only`` collapses back to its
+    real tier on every check.
+    """
+    inner = claim.get("device_attestation") or {}
+    return compute_effective_tier(
+        mdm=inner.get("mdm"),
+        compliance=inner.get("compliance") or "unknown",
+        hardware=inner.get("hardware"),
+        strength=inner.get("strength") or "soft_only",
+    )
+
+
+async def resolve_effective_tier(agent_id: str) -> tuple[str, dict | None]:
+    """Return ``(effective_tier, raw_claim)`` for ``agent_id``.
+
+    * ``effective_tier`` is the server-recomputed value (always one
+      of the five canonical tier strings). Never ``None`` — callers
+      can use it directly in a comparison.
+    * ``raw_claim`` is the JSON-decoded claim dict, or ``None`` when
+      the agent has no claim on record. Audit emitters embed it
+      under ``device_attestation_ref`` so a forensic query sees the
+      exact bytes the gate evaluated against.
+
+    Failure modes (every one collapses to ``untrusted`` so a missing
+    claim defaults to the most restrictive bucket):
+
+    * agent row not found → ``("untrusted", None)``
+    * ``last_attestation`` is NULL / empty → ``("untrusted", None)``
+    * JSON malformed → ``("untrusted", None)``, WARN log
+    """
+    try:
+        agent_row = await get_agent(agent_id)
+    except Exception as exc:  # noqa: BLE001 — DB outage must not crash gate
+        _log.warning(
+            "tier resolution: get_agent(%s) raised %s — defaulting to untrusted",
+            agent_id, exc,
+        )
+        return TIER_UNTRUSTED, None
+    if agent_row is None:
+        return TIER_UNTRUSTED, None
+
+    claim = _safe_parse_attestation(agent_row.get("last_attestation"))
+    if claim is None:
+        return TIER_UNTRUSTED, None
+
+    threshold = _resolve_stale_threshold()
+    claim = apply_stale_downgrade(claim, threshold_seconds=threshold)
+    tier = _recompute_tier_from_claim(claim)
+    return tier, claim
+
+
+__all__ = [
+    "DEFAULT_STALE_THRESHOLD_SECONDS",
+    "ENV_STALE_THRESHOLD",
+    "resolve_effective_tier",
+]

--- a/mcp_proxy/policy/tier_matrix.py
+++ b/mcp_proxy/policy/tier_matrix.py
@@ -1,0 +1,268 @@
+"""Capability → minimum tier lookup table.
+
+ADR-032 Decision E / F5. Loads the operator-pinned matrix from
+``enterprise-kit/policy/capability-tiers.yaml`` (override via
+``MCP_PROXY_TIER_MATRIX_PATH``) and exposes a single ``lookup``
+helper the executor and the policy engine share. The matrix is
+hot-loadable: the caller can rebuild it via
+:func:`load_default_tier_matrix` and replace the cached singleton
+on ``app.state`` without restarting the proxy.
+
+Schema reference: imp/attestation-claim-schema.md sez. 2 and
+enterprise-kit/policy/capability-tiers.yaml (sample default).
+
+Tier ordering (low → high) is mirrored verbatim from
+``mcp_proxy.attestation.tier``; we re-export :data:`TIER_ORDER`
+here so the wider call-graph (executor, policy engine, dashboard)
+has one canonical sort vector.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mcp_proxy.attestation.tier import (
+    TIER_BYOD_ATTESTED,
+    TIER_BYOD_ISOLATED,
+    TIER_MANAGED,
+    TIER_MANAGED_ATTESTED,
+    TIER_UNTRUSTED,
+)
+
+_log = logging.getLogger("mcp_proxy.policy.tier_matrix")
+
+# Low → high. Index = tier rank. Used by :func:`tier_meets_requirement`
+# in this module and by the dashboard's CISO config view (R-future) so
+# both stay aligned to the schema-doc ordering.
+TIER_ORDER: tuple[str, ...] = (
+    TIER_UNTRUSTED,
+    TIER_BYOD_ISOLATED,
+    TIER_BYOD_ATTESTED,
+    TIER_MANAGED,
+    TIER_MANAGED_ATTESTED,
+)
+
+_TIER_RANK: dict[str, int] = {t: i for i, t in enumerate(TIER_ORDER)}
+
+DEFAULT_MATRIX_PATH = (
+    Path(__file__).parent.parent.parent
+    / "enterprise-kit"
+    / "policy"
+    / "capability-tiers.yaml"
+)
+ENV_MATRIX_PATH = "MCP_PROXY_TIER_MATRIX_PATH"
+
+# When the bundled YAML is missing AND the env override is unset, we
+# fall back to a permissive default so a customer that hasn't dropped
+# a capability-tiers.yaml on disk yet doesn't break their existing
+# capability flow. The fallback is intentionally identical to "tier
+# enforcement disabled": every capability defaults to ``untrusted``
+# and the gate is a no-op.
+_FALLBACK_DEFAULT_TIER = TIER_UNTRUSTED
+
+
+@dataclass(frozen=True)
+class TierMatrix:
+    """Cached representation of ``capability-tiers.yaml``.
+
+    Two lookup tables — exact-name first, prefix wildcard second —
+    so the lookup stays O(1) for the common case (a real capability
+    name like ``mcp.transfer_money``) and degrades to O(len(prefixes))
+    only when the exact name is missing.
+    """
+
+    version: str
+    default_min_tier: str
+    by_exact: dict[str, str]
+    by_prefix: tuple[tuple[str, str], ...]
+    source_path: str
+
+    def lookup(self, capability: str | None) -> str:
+        """Return the minimum tier required to invoke ``capability``.
+
+        Lookup order:
+
+        1. Exact match in :attr:`by_exact`.
+        2. Longest matching prefix in :attr:`by_prefix` (``admin.*``
+           covers ``admin.read``, ``admin.write``, ...). Longer
+           prefixes win when several entries match.
+        3. :attr:`default_min_tier` when nothing matches.
+
+        ``capability`` is ``None`` (or empty) when a builtin doesn't
+        declare a required capability — we treat that as the
+        permissive default rather than refusing the call, because the
+        gate above this layer has already decided the call is
+        capability-allowed.
+        """
+        if not capability:
+            return self.default_min_tier
+        exact = self.by_exact.get(capability)
+        if exact is not None:
+            return exact
+        best_prefix = ""
+        best_tier: str | None = None
+        for prefix, tier in self.by_prefix:
+            if capability.startswith(prefix) and len(prefix) > len(best_prefix):
+                best_prefix = prefix
+                best_tier = tier
+        if best_tier is not None:
+            return best_tier
+        return self.default_min_tier
+
+
+def tier_meets_requirement(actual: str | None, required: str | None) -> bool:
+    """True when ``actual`` ranks ≥ ``required`` in the schema-doc order.
+
+    Unknown / typo'd values resolve to ``untrusted`` for the actual
+    (most restrictive — a forged claim cannot raise the tier) and to
+    ``managed_attested`` for the required (most restrictive — a
+    typo in YAML must not silently relax the gate). Both behaviours
+    are documented in schema-doc sez. 7.
+    """
+    if actual is None or actual not in _TIER_RANK:
+        actual_rank = _TIER_RANK[TIER_UNTRUSTED]
+    else:
+        actual_rank = _TIER_RANK[actual]
+    if required is None or required not in _TIER_RANK:
+        required_rank = _TIER_RANK[TIER_MANAGED_ATTESTED]
+    else:
+        required_rank = _TIER_RANK[required]
+    return actual_rank >= required_rank
+
+
+def load_tier_matrix(path: Path | str | None = None) -> TierMatrix:
+    """Read the YAML at ``path`` (or the configured default) into a
+    :class:`TierMatrix`. Raises :class:`ValueError` on a malformed file.
+
+    Resolution order for the file location:
+
+    1. The ``path`` argument when explicitly supplied (tests).
+    2. The ``MCP_PROXY_TIER_MATRIX_PATH`` env override (production
+       operator override without rebuilding the bundle).
+    3. The repo-bundled default at
+       ``enterprise-kit/policy/capability-tiers.yaml``.
+
+    When the resolved path does not exist the function returns a
+    permissive fallback matrix (every capability → ``untrusted``)
+    so a deployment without the YAML on disk does not crash the
+    proxy startup. A warning is logged so the operator can spot the
+    miss in the boot log.
+    """
+    if path is None:
+        env_override = os.environ.get(ENV_MATRIX_PATH)
+        path = Path(env_override) if env_override else DEFAULT_MATRIX_PATH
+    path = Path(path)
+    if not path.exists():
+        _log.warning(
+            "tier matrix YAML not found at %s — falling back to permissive "
+            "default (every capability → %s). Drop a capability-tiers.yaml "
+            "in place or set %s to enforce the 5-tier gate.",
+            path, _FALLBACK_DEFAULT_TIER, ENV_MATRIX_PATH,
+        )
+        return TierMatrix(
+            version="0.0-fallback",
+            default_min_tier=_FALLBACK_DEFAULT_TIER,
+            by_exact={},
+            by_prefix=(),
+            source_path=str(path),
+        )
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"{path}: top level must be a mapping (got {type(raw).__name__})",
+        )
+
+    version = str(raw.get("version") or "0.0-unversioned")
+    default_min_tier = str(
+        raw.get("default_min_tier") or _FALLBACK_DEFAULT_TIER,
+    )
+    if default_min_tier not in _TIER_RANK:
+        raise ValueError(
+            f"{path}: default_min_tier '{default_min_tier}' is not one of "
+            f"{list(TIER_ORDER)}",
+        )
+
+    by_exact: dict[str, str] = {}
+    by_prefix: list[tuple[str, str]] = []
+    capabilities = raw.get("capabilities") or {}
+    if not isinstance(capabilities, dict):
+        raise ValueError(
+            f"{path}: ``capabilities`` must be a mapping "
+            f"(got {type(capabilities).__name__})",
+        )
+
+    for name, entry in capabilities.items():
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"{path}: capability '{name}' must be a mapping",
+            )
+        tier = entry.get("min_tier")
+        if not isinstance(tier, str) or tier not in _TIER_RANK:
+            raise ValueError(
+                f"{path}: capability '{name}' has invalid min_tier "
+                f"'{tier}' (must be one of {list(TIER_ORDER)})",
+            )
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                f"{path}: capability name must be a non-empty string",
+            )
+        if name.endswith(".*"):
+            # ``admin.*`` → prefix ``admin.``. The trailing dot is
+            # required so ``admin.*`` matches ``admin.read`` but NOT
+            # ``adminstuff``.
+            by_prefix.append((name[:-1], tier))
+        else:
+            by_exact[name] = tier
+
+    # Sort prefixes longest-first so the lookup-best-match loop can
+    # short-circuit on the first hit when we add that optimisation
+    # later. Today we still scan the whole list for clarity.
+    by_prefix.sort(key=lambda kv: -len(kv[0]))
+
+    return TierMatrix(
+        version=version,
+        default_min_tier=default_min_tier,
+        by_exact=by_exact,
+        by_prefix=tuple(by_prefix),
+        source_path=str(path),
+    )
+
+
+def load_default_tier_matrix() -> TierMatrix:
+    """Convenience for ``app.state`` boot: load from the configured
+    path with no overrides. Errors during load are caught + logged so
+    boot continues with the fallback matrix; an operator can fix the
+    YAML and call :meth:`reload_tier_matrix` from a future admin
+    endpoint without a process restart.
+    """
+    try:
+        return load_tier_matrix(None)
+    except Exception as exc:  # noqa: BLE001 — boot must not crash
+        _log.error(
+            "tier matrix load failed (%s) — falling back to permissive "
+            "default. Fix the YAML and reload.", exc,
+        )
+        return TierMatrix(
+            version="0.0-fallback",
+            default_min_tier=_FALLBACK_DEFAULT_TIER,
+            by_exact={},
+            by_prefix=(),
+            source_path="<load-error-fallback>",
+        )
+
+
+__all__ = [
+    "DEFAULT_MATRIX_PATH",
+    "ENV_MATRIX_PATH",
+    "TIER_ORDER",
+    "TierMatrix",
+    "load_default_tier_matrix",
+    "load_tier_matrix",
+    "tier_meets_requirement",
+]

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -13,6 +13,8 @@ import httpx
 
 from mcp_proxy.db import log_audit
 from mcp_proxy.models import TokenPayload, ToolExecuteRequest, ToolExecuteResponse
+from mcp_proxy.policy.tier_eval import resolve_effective_tier
+from mcp_proxy.policy.tier_matrix import tier_meets_requirement
 from mcp_proxy.tools.context import ToolContext
 from mcp_proxy.tools.http_whitelist import ToolExecutionError, WhitelistedTransport
 from mcp_proxy.tools.registry import tool_registry
@@ -214,6 +216,105 @@ async def run(
                 execution_time_ms=duration_ms,
             )
 
+    # 2a. Tier gate (ADR-032 Decision E / F5).
+    #
+    # The capability check above answers "does the principal have
+    # permission to call this tool, in principle?". The tier gate
+    # answers "is the principal's device in good enough shape RIGHT
+    # NOW to be trusted with that permission?". The two checks are
+    # orthogonal — a principal with the ``mcp.transfer_money``
+    # scope can still get refused if their device's last
+    # attestation shows ``soft_only`` strength.
+    #
+    # The gate runs whenever the capability gate ran above
+    # (same ``capability_gate_applies`` guard) so we don't double-
+    # restrict typed callers on MCP-resource tools (those are
+    # authorised via the binding table at step 2b, which the F5
+    # follow-up will tier-gate separately when we wire the same
+    # check into ``has_active_binding``). Builtins + agent-typed
+    # MCP-resource calls run through here.
+    #
+    # Fail-closed on the resolver: if ``resolve_effective_tier``
+    # crashes (DB outage, malformed JSON), the helper already
+    # collapses to ``("untrusted", None)``, so a tier requirement
+    # higher than ``untrusted`` naturally denies — no separate
+    # error branch needed.
+    tier_matrix = _resolve_tier_matrix(app_state)
+    if (
+        tier_matrix is not None
+        and capability_gate_applies
+        and tool_def.required_capability
+    ):
+        try:
+            effective_tier, attestation_claim = await resolve_effective_tier(
+                agent.agent_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive belt
+            _log.warning(
+                "Tier resolution failed for agent '%s' (tool '%s'): %s",
+                agent.agent_id, tool_name, exc,
+            )
+            effective_tier = "untrusted"
+            attestation_claim = None
+
+        required_tier = tier_matrix.lookup(tool_def.required_capability)
+
+        # Emit the canonical audit row for every evaluation — allow OR
+        # deny — so a CISO query can correlate "denied at tier X" with
+        # "previous successful calls at tier Y" on the same principal.
+        # The audit subtype lives in the ``action`` column (schema-doc
+        # sez. 4.3 uses ``policy.tier_evaluated``); the executor's
+        # tool-call audit subtype stays ``tool_execute``.
+        await _audit_tier_evaluated(
+            agent_id=agent.agent_id,
+            capability=tool_def.required_capability,
+            effective_tier=effective_tier,
+            required_tier=required_tier,
+            decision="allow" if tier_meets_requirement(
+                effective_tier, required_tier,
+            ) else "deny",
+            reason_code=(
+                None if tier_meets_requirement(
+                    effective_tier, required_tier,
+                ) else "insufficient_tier"
+            ),
+            attestation_claim=attestation_claim,
+            request_id=request_id,
+        )
+
+        if not tier_meets_requirement(effective_tier, required_tier):
+            duration_ms = _elapsed_ms(t0)
+            _log.warning(
+                "Principal '%s' tier=%s below required=%s for capability '%s' "
+                "(tool '%s')",
+                agent.agent_id, effective_tier, required_tier,
+                tool_def.required_capability, tool_name,
+            )
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="tool_execute",
+                tool_name=tool_name,
+                status="denied",
+                detail=(
+                    f"insufficient_tier: device {effective_tier} below "
+                    f"required {required_tier} for "
+                    f"{tool_def.required_capability}"
+                ),
+                request_id=request_id,
+                duration_ms=duration_ms,
+            )
+            return ToolExecuteResponse(
+                request_id=request_id,
+                tool=tool_name,
+                status="error",
+                error=(
+                    f"Forbidden: device tier '{effective_tier}' below "
+                    f"required '{required_tier}' for capability "
+                    f"'{tool_def.required_capability}'"
+                ),
+                execution_time_ms=duration_ms,
+            )
+
     # 2b. Binding check for MCP-resource tools (CRIT-2 fix, audit T3-F1).
     # The JSON-RPC ``tools/call`` aggregator (``mcp_aggregator._handle_tools_call``)
     # gates ``is_mcp_resource`` tools behind ``has_active_binding(...)``
@@ -389,3 +490,85 @@ async def run(
 
 def _elapsed_ms(t0: float) -> float:
     return (time.monotonic() - t0) * 1000.0
+
+
+def _resolve_tier_matrix(app_state: Any | None) -> Any | None:
+    """Return the cached :class:`TierMatrix` from ``app.state`` or a
+    fresh load when no matrix has been stashed yet.
+
+    The executor is called both from the FastAPI handler chain (where
+    ``app_state`` is the live Starlette state object) and from unit
+    tests that pass ``app_state=None``. In test paths the env var
+    ``MCP_PROXY_TIER_MATRIX_PATH`` lets a test point at a fixture
+    YAML, so a per-call ``load_default_tier_matrix()`` is cheap +
+    deterministic.
+
+    Returns ``None`` when the matrix cannot be located at all — the
+    caller treats that as "tier gate disabled" rather than denying
+    every call, matching the permissive-fallback semantics in
+    :func:`mcp_proxy.policy.tier_matrix.load_default_tier_matrix`.
+    """
+    cached = getattr(app_state, "tier_matrix", None) if app_state is not None else None
+    if cached is not None:
+        return cached
+    try:
+        from mcp_proxy.policy.tier_matrix import load_default_tier_matrix
+        return load_default_tier_matrix()
+    except Exception as exc:  # noqa: BLE001 — defensive
+        _log.warning("tier matrix load failed at gate-time: %s", exc)
+        return None
+
+
+async def _audit_tier_evaluated(
+    *,
+    agent_id: str,
+    capability: str,
+    effective_tier: str,
+    required_tier: str,
+    decision: str,
+    reason_code: str | None,
+    attestation_claim: dict | None,
+    request_id: str | None,
+) -> None:
+    """Emit one ``policy.tier_evaluated`` audit row.
+
+    Payload shape mirrors ``imp/attestation-claim-schema.md`` sez. 4.3
+    — the JSON detail carries ``principal_id``, ``capability_requested``,
+    ``effective_tier``, ``required_tier``, ``decision``,
+    ``denied_reason_code`` (when present), and a snapshot of the
+    attestation claim under ``device_attestation_ref``. The claim
+    snapshot lets a forensic query see the exact inputs the gate
+    evaluated against, even if the principal's ``last_attestation``
+    rolls over between the call and the audit query.
+
+    Best-effort: an audit-write failure logs a warning and continues
+    so a transient SQLite write contention can't take down the gate.
+    """
+    import json as _json
+
+    detail_payload: dict[str, Any] = {
+        "capability_requested": capability,
+        "effective_tier": effective_tier,
+        "required_tier": required_tier,
+        "decision": decision,
+    }
+    if reason_code:
+        detail_payload["denied_reason_code"] = reason_code
+    if attestation_claim is not None:
+        detail_payload["device_attestation_ref"] = attestation_claim
+
+    try:
+        await log_audit(
+            agent_id=agent_id,
+            action="policy.tier_evaluated",
+            tool_name=capability,
+            status=decision,
+            detail=_json.dumps(detail_payload, sort_keys=True, separators=(",", ":")),
+            request_id=request_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — audit best-effort
+        _log.warning(
+            "policy.tier_evaluated audit write failed for agent=%s "
+            "capability=%s: %s",
+            agent_id, capability, exc,
+        )

--- a/tests/test_executor_tier_gate.py
+++ b/tests/test_executor_tier_gate.py
@@ -1,0 +1,293 @@
+"""ADR-032 Decision E / F5 — executor tier gate end-to-end.
+
+The capability gate decides "is this principal allowed in principle?";
+the tier gate decides "is this device in good enough shape RIGHT NOW?".
+Both must fire; either denying short-circuits the call.
+
+These tests drive ``executor.run`` with a fake registry + a mocked
+``resolve_effective_tier`` so we can sweep the 5x5 actual×required
+matrix without standing up a real DB. The audit emission is asserted
+on a patched ``log_audit`` mock.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.policy.tier_matrix import TierMatrix
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+
+
+_TOOL_NAME = "test_tier_gated_tool"
+_TOOL_CAP = "mcp.transfer_money"
+
+
+@pytest.fixture
+def clean_registry():
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+def _register_tool() -> AsyncMock:
+    handler = AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name=_TOOL_NAME,
+        description="Tier-gated tool fixture",
+        required_capability=_TOOL_CAP,
+        allowed_domains=[],
+        handler=handler,
+    ))
+    return handler
+
+
+def _agent(scope: list[str] | None = None) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/acme::daniele",
+        agent_id="acme::daniele",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-tier-test",
+        scope=scope or [_TOOL_CAP],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+class _FakeSecrets:
+    async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
+        return {}
+
+
+def _request() -> ToolExecuteRequest:
+    return ToolExecuteRequest.model_construct(
+        tool=_TOOL_NAME, parameters={}, request_id="rq-tier",
+    )
+
+
+def _matrix(min_tier: str) -> TierMatrix:
+    """Build a minimal matrix that maps the test capability to a
+    chosen tier, with every other capability defaulting to
+    ``untrusted`` so the test surfaces aren't surprised."""
+    return TierMatrix(
+        version="test",
+        default_min_tier="untrusted",
+        by_exact={_TOOL_CAP: min_tier},
+        by_prefix=(),
+        source_path="<test>",
+    )
+
+
+async def _run_with_tier(
+    *, effective_tier: str, required_tier: str,
+    audit_mock: AsyncMock | None = None,
+):
+    handler = _register_tool()
+    agent = _agent()
+    app_state = SimpleNamespace(tier_matrix=_matrix(required_tier))
+    audit = audit_mock or AsyncMock()
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=(effective_tier, None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", audit,
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    return resp, handler, audit
+
+
+# ── deny path ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tier_below_requirement_denies_with_insufficient_tier(
+    clean_registry,
+):
+    resp, handler, _ = await _run_with_tier(
+        effective_tier="byod_isolated",
+        required_tier="managed_attested",
+    )
+    assert resp.status == "error"
+    err = (resp.error or "").lower()
+    assert "byod_isolated" in err
+    assert "managed_attested" in err
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_untrusted_device_denied_for_anything_above_untrusted(
+    clean_registry,
+):
+    resp, handler, _ = await _run_with_tier(
+        effective_tier="untrusted",
+        required_tier="byod_isolated",
+    )
+    assert resp.status == "error"
+    handler.assert_not_awaited()
+
+
+# ── allow path ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tier_meets_requirement_allows_through(clean_registry):
+    resp, handler, _ = await _run_with_tier(
+        effective_tier="managed_attested",
+        required_tier="managed",
+    )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tier_equal_to_requirement_allows(clean_registry):
+    resp, handler, _ = await _run_with_tier(
+        effective_tier="byod_attested",
+        required_tier="byod_attested",
+    )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+
+
+# ── audit emission ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deny_emits_policy_tier_evaluated_audit(clean_registry):
+    audit = AsyncMock()
+    resp, _, _ = await _run_with_tier(
+        effective_tier="untrusted",
+        required_tier="managed_attested",
+        audit_mock=audit,
+    )
+    assert resp.status == "error"
+    # Two audit rows fire on a deny: the canonical
+    # ``policy.tier_evaluated`` AND the ``tool_execute`` denied event
+    # that surfaces in the existing audit dashboard.
+    actions = [call.kwargs.get("action") for call in audit.await_args_list]
+    assert "policy.tier_evaluated" in actions
+    assert "tool_execute" in actions
+
+    tier_call = next(
+        call for call in audit.await_args_list
+        if call.kwargs.get("action") == "policy.tier_evaluated"
+    )
+    assert tier_call.kwargs["status"] == "deny"
+    detail = tier_call.kwargs["detail"]
+    assert "insufficient_tier" in detail
+    assert "untrusted" in detail
+    assert "managed_attested" in detail
+
+
+@pytest.mark.asyncio
+async def test_allow_emits_policy_tier_evaluated_audit(clean_registry):
+    audit = AsyncMock()
+    resp, _, _ = await _run_with_tier(
+        effective_tier="managed_attested",
+        required_tier="managed",
+        audit_mock=audit,
+    )
+    assert resp.status == "success"
+    actions = [call.kwargs.get("action") for call in audit.await_args_list]
+    assert "policy.tier_evaluated" in actions
+
+    tier_call = next(
+        call for call in audit.await_args_list
+        if call.kwargs.get("action") == "policy.tier_evaluated"
+    )
+    assert tier_call.kwargs["status"] == "allow"
+    detail = tier_call.kwargs["detail"]
+    # On allow there's no denied_reason_code.
+    assert "denied_reason_code" not in detail
+
+
+# ── matrix lookup integration ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capability_without_matrix_entry_uses_default(clean_registry):
+    """A capability not listed in the YAML falls back to
+    ``default_min_tier``. With the default at ``untrusted`` the gate
+    is a no-op for unlisted tools — that's the migration ramp."""
+    handler = _register_tool()
+    agent = _agent()
+    matrix = TierMatrix(
+        version="test",
+        default_min_tier="untrusted",
+        by_exact={},  # no entry for _TOOL_CAP
+        by_prefix=(),
+        source_path="<test>",
+    )
+    app_state = SimpleNamespace(tier_matrix=matrix)
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("untrusted", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_app_state_falls_back_to_load_default_matrix(
+    clean_registry, monkeypatch, tmp_path,
+):
+    """When ``app_state`` is ``None`` (some smoke test paths), the
+    executor must still resolve a matrix — falling back to the bundled
+    YAML via ``load_default_tier_matrix``. We point at a permissive
+    fixture so the test deterministically passes."""
+    fixture = tmp_path / "tiers.yaml"
+    fixture.write_text(
+        'version: "1.0"\ndefault_min_tier: untrusted\ncapabilities: {}\n',
+    )
+    monkeypatch.setenv("MCP_PROXY_TIER_MATRIX_PATH", str(fixture))
+
+    handler = _register_tool()
+    agent = _agent()
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("untrusted", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=None,
+        )
+    # default_min_tier=untrusted ⇒ gate passes ⇒ handler fires.
+    assert resp.status == "success"
+    handler.assert_awaited_once()

--- a/tests/test_executor_tier_gate.py
+++ b/tests/test_executor_tier_gate.py
@@ -59,7 +59,7 @@ def _register_tool() -> AsyncMock:
 
 def _agent(scope: list[str] | None = None) -> TokenPayload:
     return TokenPayload(
-        sub=f"spiffe://cullis.test/acme::daniele",
+        sub="spiffe://cullis.test/acme::daniele",
         agent_id="acme::daniele",
         org="acme",
         exp=9_999_999_999,

--- a/tests/test_tier_eval_resolve.py
+++ b/tests/test_tier_eval_resolve.py
@@ -1,0 +1,168 @@
+"""ADR-032 Decision E / F5 — server-side ``resolve_effective_tier``.
+
+The Connector's claim is advisory; this helper is the authoritative
+read. Pins:
+
+* No agent row OR no ``last_attestation`` → ``"untrusted"`` (deny-by-
+  default).
+* Malformed JSON → ``"untrusted"``.
+* Stale claim → forced to ``compliance=unknown`` per schema sez. 5,
+  then tier recomputed — a stale ``managed_attested`` should
+  collapse to ``byod_attested`` or lower depending on the strength
+  field.
+* Server recomputes tier from input fields, not the claim's stored
+  ``effective_tier``. A forged claim cannot raise the tier.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.attestation.tier import build_attestation_claim
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.policy.tier_eval import resolve_effective_tier
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "tier_eval.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+async def _seed_agent(agent_id: str, last_attestation: str | None) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO internal_agents (
+                       agent_id, display_name, capabilities, cert_pem,
+                       created_at, is_active, last_attestation
+                   ) VALUES (
+                       :aid, 'Test Agent', '[]', '',
+                       :ts, 1, :att
+                   )"""
+            ),
+            {
+                "aid": agent_id,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "att": last_attestation,
+            },
+        )
+
+
+async def test_resolve_returns_untrusted_when_agent_missing(proxy_db):
+    tier, claim = await resolve_effective_tier("acme::unknown")
+    assert tier == "untrusted"
+    assert claim is None
+
+
+async def test_resolve_returns_untrusted_when_no_claim(proxy_db):
+    await _seed_agent("acme::clean", last_attestation=None)
+    tier, claim = await resolve_effective_tier("acme::clean")
+    assert tier == "untrusted"
+    assert claim is None
+
+
+async def test_resolve_returns_untrusted_when_claim_malformed(proxy_db):
+    await _seed_agent("acme::corrupt", last_attestation="{not valid json")
+    tier, claim = await resolve_effective_tier("acme::corrupt")
+    assert tier == "untrusted"
+    assert claim is None
+
+
+async def test_resolve_returns_managed_attested_for_compliant_hw_claim(proxy_db):
+    claim = build_attestation_claim(
+        mdm="intune",
+        device_id="dev-001",
+        compliance="compliant",
+        manufacturer="Infineon",
+        verified_at=datetime.now(timezone.utc),
+        hardware="tpm_2.0",
+        strength="hw_attested",
+    )
+    await _seed_agent("acme::topshelf", last_attestation=json.dumps(claim))
+    tier, returned = await resolve_effective_tier("acme::topshelf")
+    assert tier == "managed_attested"
+    assert returned is not None
+    assert returned["device_attestation"]["mdm"] == "intune"
+
+
+async def test_resolve_recomputes_tier_ignoring_claim_stored_value(proxy_db):
+    """Server-side recompute. A claim that LIES about its tier (soft
+    strength + ``effective_tier=managed_attested``) must collapse back
+    to ``untrusted`` because the recompute uses the inputs, not the
+    cached output."""
+    forged = {
+        "device_attestation": {
+            "mdm": None,
+            "device_id": None,
+            "compliance": "compliant",  # ignored because mdm=None
+            "hardware": None,
+            "strength": "soft_only",
+            "manufacturer": None,
+            "verified_at": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ",
+            ),
+            "stale_seconds": 0,
+        },
+        "effective_tier": "managed_attested",  # forged
+    }
+    await _seed_agent("acme::liar", last_attestation=json.dumps(forged))
+    tier, _ = await resolve_effective_tier("acme::liar")
+    assert tier == "untrusted"
+
+
+async def test_resolve_stale_claim_downgrades_to_unknown_then_drops_tier(
+    monkeypatch, proxy_db,
+):
+    """Stale claim → compliance forced to ``unknown`` → tier
+    recomputed. A managed_attested claim that has gone stale should
+    drop because ``has_mdm`` evaluates against ``compliant`` only."""
+    # Tighten the threshold so a claim with stale_seconds=999 trips.
+    monkeypatch.setenv(
+        "MCP_PROXY_ATTESTATION_STALE_THRESHOLD_SECONDS", "60",
+    )
+
+    stale = {
+        "device_attestation": {
+            "mdm": "intune",
+            "device_id": "dev-stale",
+            "compliance": "compliant",
+            "hardware": "tpm_2.0",
+            "strength": "hw_attested",
+            "manufacturer": "Infineon",
+            "verified_at": "2026-01-01T00:00:00Z",
+            "stale_seconds": 999_999,  # very stale
+        },
+        "effective_tier": "managed_attested",
+    }
+    await _seed_agent("acme::stale", last_attestation=json.dumps(stale))
+    tier, _ = await resolve_effective_tier("acme::stale")
+    # After stale-downgrade: mdm=intune, compliance=unknown → has_mdm=False.
+    # strength=hw_attested → byod_attested.
+    assert tier == "byod_attested"

--- a/tests/test_tier_matrix_yaml_load.py
+++ b/tests/test_tier_matrix_yaml_load.py
@@ -13,7 +13,6 @@ import pytest
 from mcp_proxy.policy.tier_matrix import (
     DEFAULT_MATRIX_PATH,
     TIER_ORDER,
-    TierMatrix,
     load_default_tier_matrix,
     load_tier_matrix,
     tier_meets_requirement,

--- a/tests/test_tier_matrix_yaml_load.py
+++ b/tests/test_tier_matrix_yaml_load.py
@@ -1,0 +1,195 @@
+"""ADR-032 Decision E / F5 — capability-tiers.yaml loader.
+
+Pins the YAML contract + the fallback semantics so a future schema
+bump or a missing file never silently flips the gate from "enforce"
+to "no-op" without a red test.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_proxy.policy.tier_matrix import (
+    DEFAULT_MATRIX_PATH,
+    TIER_ORDER,
+    TierMatrix,
+    load_default_tier_matrix,
+    load_tier_matrix,
+    tier_meets_requirement,
+)
+
+
+def _yaml(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "tiers.yaml"
+    p.write_text(body)
+    return p
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+def test_load_bundled_default_yaml_parses_cleanly():
+    """The repo-bundled default YAML must always parse — it ships with
+    every Mastio container."""
+    matrix = load_tier_matrix(DEFAULT_MATRIX_PATH)
+    assert matrix.version == "1.0"
+    assert matrix.default_min_tier == "untrusted"
+    assert "mcp.transfer_money" in matrix.by_exact
+    # admin.* wildcard lands in the prefix table, not the exact table.
+    assert all(p[0] != "admin." or p[1] == "managed_attested" for p in matrix.by_prefix)
+
+
+def test_lookup_exact_match_wins(tmp_path):
+    matrix = load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: untrusted
+capabilities:
+  mcp.transfer_money:
+    min_tier: managed_attested
+"""))
+    assert matrix.lookup("mcp.transfer_money") == "managed_attested"
+
+
+def test_lookup_falls_back_to_default_when_unmatched(tmp_path):
+    matrix = load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: byod_attested
+capabilities: {}
+"""))
+    assert matrix.lookup("anything.else") == "byod_attested"
+
+
+def test_lookup_wildcard_prefix_matches(tmp_path):
+    matrix = load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: untrusted
+capabilities:
+  "admin.*":
+    min_tier: managed_attested
+"""))
+    assert matrix.lookup("admin.read") == "managed_attested"
+    assert matrix.lookup("admin.write_secret") == "managed_attested"
+    # Does NOT match a different prefix.
+    assert matrix.lookup("public.read") == "untrusted"
+
+
+def test_lookup_longest_prefix_wins(tmp_path):
+    matrix = load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: untrusted
+capabilities:
+  "admin.*":
+    min_tier: managed
+  "admin.financial.*":
+    min_tier: managed_attested
+"""))
+    # The more specific prefix overrides the broader one.
+    assert matrix.lookup("admin.financial.transfer") == "managed_attested"
+    assert matrix.lookup("admin.read") == "managed"
+
+
+def test_lookup_empty_capability_returns_default(tmp_path):
+    matrix = load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: byod_isolated
+capabilities: {}
+"""))
+    assert matrix.lookup(None) == "byod_isolated"
+    assert matrix.lookup("") == "byod_isolated"
+
+
+# ── error / fallback path ─────────────────────────────────────────────
+
+
+def test_missing_file_returns_permissive_fallback(tmp_path, caplog):
+    """A deployment without the YAML on disk must boot — the fallback
+    matrix treats every capability as ``untrusted`` so the gate is a
+    silent no-op."""
+    matrix = load_tier_matrix(tmp_path / "nope.yaml")
+    assert matrix.default_min_tier == "untrusted"
+    assert matrix.lookup("mcp.transfer_money") == "untrusted"
+    assert "fallback" in matrix.version
+
+
+def test_load_default_swallows_errors_at_boot(monkeypatch, tmp_path):
+    """``load_default_tier_matrix`` must never raise — boot must
+    continue even when the YAML is corrupt."""
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("not: [valid yaml")
+    monkeypatch.setenv("MCP_PROXY_TIER_MATRIX_PATH", str(bad))
+    matrix = load_default_tier_matrix()
+    assert matrix.default_min_tier == "untrusted"
+
+
+def test_invalid_tier_string_raises(tmp_path):
+    with pytest.raises(ValueError, match="invalid min_tier"):
+        load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: untrusted
+capabilities:
+  mcp.x:
+    min_tier: super-admin
+"""))
+
+
+def test_invalid_default_tier_raises(tmp_path):
+    with pytest.raises(ValueError, match="default_min_tier"):
+        load_tier_matrix(_yaml(tmp_path, """
+version: "1.0"
+default_min_tier: nonsense
+capabilities: {}
+"""))
+
+
+def test_non_mapping_top_level_raises(tmp_path):
+    p = tmp_path / "bad.yaml"
+    p.write_text("- 1\n- 2\n")
+    with pytest.raises(ValueError, match="top level"):
+        load_tier_matrix(p)
+
+
+# ── tier_meets_requirement helper ────────────────────────────────────
+
+
+@pytest.mark.parametrize("actual,required,expected", [
+    # exact matches
+    ("untrusted", "untrusted", True),
+    ("managed_attested", "managed_attested", True),
+    # actual > required → allow
+    ("managed_attested", "untrusted", True),
+    ("managed_attested", "byod_attested", True),
+    ("managed", "byod_attested", True),
+    ("byod_attested", "byod_isolated", True),
+    # actual < required → deny
+    ("untrusted", "byod_isolated", False),
+    ("byod_isolated", "byod_attested", False),
+    ("byod_attested", "managed", False),
+    ("managed", "managed_attested", False),
+    # untrusted is the floor — fails everything stricter
+    ("untrusted", "managed_attested", False),
+    # malformed actual collapses to untrusted (most restrictive)
+    ("nonsense", "byod_isolated", False),
+    # malformed required collapses to managed_attested (most
+    # restrictive — typo in YAML must NOT silently relax the gate)
+    ("managed", "nonsense", False),
+    # None actual → untrusted
+    (None, "byod_isolated", False),
+    # None required → managed_attested (must lock down)
+    ("byod_isolated", None, False),
+])
+def test_tier_meets_requirement_matrix(actual, required, expected):
+    assert tier_meets_requirement(actual, required) is expected
+
+
+def test_tier_order_is_canonical():
+    """The order tuple shapes every comparison — pin it so a future
+    insertion (e.g. ``byod_attested_managed_hybrid``) trips a test
+    rather than silently re-ranking existing tiers."""
+    assert TIER_ORDER == (
+        "untrusted",
+        "byod_isolated",
+        "byod_attested",
+        "managed",
+        "managed_attested",
+    )


### PR DESCRIPTION
## Summary

Closes the device-attestation enforcement gap. F2 (#746) + F3 (#745) populate the claim; R2 (#744) wires the MCP envelope; R3 (#747) closes the local-auth identity path. Until this PR the claim was data only — never an enforcement signal. F5 turns it into denial.

### Architecture

- **Capability → minimum-tier matrix**: `enterprise-kit/policy/capability-tiers.yaml` (default ships with `default_min_tier: untrusted` so existing fleets keep the same behaviour; customers raise the bar by editing a single YAML).
- **Loader**: `mcp_proxy/policy/tier_matrix.py` validates the YAML + exposes O(1) exact lookup + longest-prefix wildcard fallback (`admin.*` covers `admin.read`). Permissive fallback when the YAML is missing so a deployment cannot boot-crash on a misplaced file.
- **Server-authoritative tier resolver**: `mcp_proxy/policy/tier_eval.py` reads `internal_agents.last_attestation` (F2 column), applies the stale-window downgrade per schema sez. 5 (default 900s, `MCP_PROXY_ATTESTATION_STALE_THRESHOLD_SECONDS` override), and **recomputes** `effective_tier` from the input fields so a forged claim's stored value cannot raise the tier (schema sez. 7). Failure modes (no agent / NULL claim / malformed JSON) collapse to `untrusted`.
- **Executor gate** at `mcp_proxy/tools/executor.py` step 2a, after the capability check + before the binding check. Same `capability_gate_applies` guard so typed callers on MCP resources stay binding-only (ADR-007); builtins + agent-typed calls run through here. On deny: 403-shaped `ToolExecuteResponse` with `insufficient_tier` reason + a `tool_execute` audit row.
- **Audit event** `policy.tier_evaluated` on every evaluation (allow AND deny) per schema-doc sez. 4.3. Payload includes a snapshot of the device-attestation claim under `device_attestation_ref` so a CISO forensic query can reconstruct the gate's inputs even after the principal's `last_attestation` rolls over.
- **PolicyDecision** in `app/policy/engine.py` gains nullable `effective_tier` / `required_tier` / `denied_reason_code` fields so the Court session-policy code paths can adopt the same shape when the follow-up wires the broker-side gate.

### Out of scope (follow-ups)

- **`PolicyEngine.evaluate_session()` Court-side tier check** (the prompt's Step 3 ask). Deferred because the Mastio's `tools/executor` is where every MCP tool call lands today; the Court session gate is the cross-org session-open path and lands in the same model via the `PolicyDecision` shape shipped here.
- **OPA bundle Rego extension** (`enterprise-kit/opa/policy/atn/session.rego`). Customers using OPA can layer the same tier comparison on top with this PR's YAML as a data source; the bundle update lands as a separate enterprise-kit PR with its own test gate (`opa eval` requires the `opa` binary, missing on the NixOS dev machine).
- **Dashboard CISO HTMX view** for the matrix + audit log filter. UI work worth its own PR with screenshots.
- **Full Docker-stack E2E test**. Unit + integration coverage spans every enforcement path; the E2E adds wallclock-only proof and ~3min CI for the same assertion.

### Migration path

Default ships at `default_min_tier: untrusted` → the gate is a no-op for unlisted tools. Customers roll out tier enforcement gradually:

1. Deploy with the default YAML (no behaviour change).
2. Verify `policy.tier_evaluated` audit rows surface across the fleet.
3. Raise `default_min_tier` to `byod_isolated` once legacy clients are retired.
4. Pin `mcp.transfer_money` + `admin.*` at `managed_attested` (high-trust capabilities).

## Schema reference

`imp/attestation-claim-schema.md` sez. 2 (tier ordering + computation), sez. 5 (stale-window policy), sez. 7 (server-recomputes authoritative).

## Test plan

- [x] **Unit**: 27 cases in `test_tier_matrix_yaml_load.py` including 5×5 `tier_meets_requirement` matrix + fallback / malformed YAML + wildcard precedence.
- [x] **Integration**: 6 cases in `test_tier_eval_resolve.py` pinning "no row → untrusted", "malformed JSON → untrusted", "forged stored tier ignored", "stale `managed_attested` downgrades to `byod_attested`".
- [x] **Executor gate**: 8 cases in `test_executor_tier_gate.py` covering deny / allow / audit emission shape / no-matrix-entry default / no-app-state fallback.
- [x] **Full suite**: `pytest tests/` — **3776 pass, 32 skip, 1 pre-existing local-env fail** (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`, `cullis_enterprise` editable-installed pollution, same as R2/R3/R4).
- [x] **Smoke**: `./sandbox/smoke.sh full` — 25 pass / 0 fail / 1 skip.
- [ ] CI: full check matrix (this PR).