### PR TITLE
fix(mdm): close F6 audit no-op storm on persistent non_compliant

### DIFF
--- a/mcp_proxy/mdm/compliance_change.py
+++ b/mcp_proxy/mdm/compliance_change.py
@@ -273,20 +273,27 @@ async def reconcile_devices_and_revoke(
                     conn=conn,
                     now=now,
                 )
-                await _update_agent_attestation(
-                    conn, agent["agent_id"], fresh_claim,
-                )
-                await log_device_attestation_change(
-                    conn,
-                    agent_id=agent["agent_id"],
-                    event_subtype="revoked",
-                    device_attestation=fresh_claim["device_attestation"],
-                    effective_tier=fresh_claim["effective_tier"],
-                    previous_compliance=previous_compliance,
-                    trigger="polling",
-                    now=now,
-                )
+                # Gate attestation update + audit emission on
+                # ``transitioned`` so a persistently non_compliant
+                # device doesn't re-stamp the agent claim or emit a
+                # redundant ``revoked`` audit row on every poll tick
+                # (#749 follow-up). ``revoke_agent_cert`` stays
+                # outside the guard: it is idempotent and its own
+                # metric/audit are already gated on transition.
                 if transitioned:
+                    await _update_agent_attestation(
+                        conn, agent["agent_id"], fresh_claim,
+                    )
+                    await log_device_attestation_change(
+                        conn,
+                        agent_id=agent["agent_id"],
+                        event_subtype="revoked",
+                        device_attestation=fresh_claim["device_attestation"],
+                        effective_tier=fresh_claim["effective_tier"],
+                        previous_compliance=previous_compliance,
+                        trigger="polling",
+                        now=now,
+                    )
                     summary.revocations += 1
                     revoked_agent_ids.append(agent["agent_id"])
             change = ComplianceChange(

--- a/tests/test_compliance_change_detection.py
+++ b/tests/test_compliance_change_detection.py
@@ -215,6 +215,70 @@ async def test_revoke_is_idempotent_when_called_twice(db_engine):
 
 
 @pytest.mark.asyncio
+async def test_persistent_noncompliant_does_not_re_emit_audit(db_engine):
+    """A no-op revoke must NOT re-stamp last_attestation or re-emit audit.
+
+    Edge case: ``previous_compliance == 'compliant'`` in the cache but
+    the cert was already revoked (e.g. operator pushed the revocation
+    manually between poll ticks). The reconciler then calls
+    ``revoke_agent_cert`` which returns ``transitioned=False`` for the
+    second pass. Pre-fix the attestation update + audit emission ran
+    anyway → audit row per agent per poll tick on persistent
+    non_compliant devices (#749 follow-up #2).
+    """
+    now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
+    await upsert_device_rows([_graph_device(compliance="compliant")], now=now)
+    await create_agent(
+        agent_id="acme::agent-noop",
+        display_name="agent-noop",
+        capabilities=[],
+        cert_pem="dummy",
+    )
+    await _bind_agent_to_device("acme::agent-noop", "d1", "compliant")
+
+    # First reconcile: real transition → 1 audit row, agent revoked.
+    first = await _reconcile([_graph_device(compliance="noncompliant")], now=now)
+    assert first.revocations == 1
+
+    async with get_db() as conn:
+        first_rows = (await conn.execute(
+            text(
+                "SELECT count(*) FROM audit_log "
+                "WHERE agent_id = :a AND action = 'device_attestation'"
+            ),
+            {"a": "acme::agent-noop"},
+        )).scalar_one()
+    assert first_rows == 1
+
+    # Force the cache back to 'compliant' so the diff logic re-runs the
+    # noncompliant branch on the next call, but the cert is already
+    # revoked → revoke_agent_cert returns transitioned=False.
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "UPDATE mdm_device_state SET compliance = 'compliant' "
+                "WHERE mdm = 'intune' AND device_id = 'd1'"
+            ),
+        )
+
+    second = await _reconcile(
+        [_graph_device(compliance="noncompliant")], now=now,
+    )
+    assert second.transitions == 1  # diff still observes the flip
+    assert second.revocations == 0  # but no actual cert transition
+
+    async with get_db() as conn:
+        second_rows = (await conn.execute(
+            text(
+                "SELECT count(*) FROM audit_log "
+                "WHERE agent_id = :a AND action = 'device_attestation'"
+            ),
+            {"a": "acme::agent-noop"},
+        )).scalar_one()
+    assert second_rows == 1  # no second 'revoked' audit row emitted
+
+
+@pytest.mark.asyncio
 async def test_unknown_transition_does_not_revoke(db_engine):
     now = datetime(2026, 5, 17, 12, 0, 0, tzinfo=timezone.utc)
     await upsert_device_rows([_graph_device(compliance="compliant")], now=now)


### PR DESCRIPTION
## Summary

F6 reconciler emitted a redundant `device_attestation` audit row + re-stamped the agent attestation on every poll tick whenever a device stayed in `non_compliant` state across ticks. Root cause: `_update_agent_attestation` + `log_device_attestation_change` were called unconditionally after `revoke_agent_cert`, even when the cert was already revoked (`transitioned=False`).

Wrap both calls in the existing `if transitioned:` guard. `revoke_agent_cert` stays outside the guard: it is idempotent and gates its own metric + audit on transition (see docstring at `mcp_proxy/registry/revoke_cert.py:82`).

## Why

Post-merge review of #749 flagged this as a MAJOR follow-up (tracker entry #2 in `followup_f5_f6_post_merge_tracker.md`). On a customer where a device stays `non_compliant` for hours/days (mid-remediation, hardware lost, employee offboarded), every Intune poll tick produced N audit rows (1 per agent bound to that device). The audit chain hash chain still verifies, but compliance reports inflate and triage signal degrades.

## Test plan

- [x] New test `test_persistent_noncompliant_does_not_re_emit_audit` reproduces the cache-catch-up edge case (cert revoked manually between ticks → second `_reconcile` call sees `transitioned=False`) and asserts `audit_log.count == 1` after the second pass.
- [x] Existing `test_revoke_is_idempotent_when_called_twice` still passes (covers the diff-side gate at `mdm_device_state` cache level).
- [x] `pytest tests/test_compliance_change_detection.py -n auto --dist=loadfile -x` — 7/7 pass.
- [x] Wider regression: `pytest tests/ -k 'compliance or revoke or stale_watcher or intune' -n auto --dist=loadfile -x` — 91 pass, 0 fail.

Pre-pilot blocker (regulated bank pilot) chiuso.