### PR TITLE
feat(policy): expose machine-readable denied_reason_code on tool denies

### DIFF
--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -22,6 +22,12 @@ class ToolExecuteResponse(BaseModel):
     result: Any = None
     error: str | None = None
     execution_time_ms: float
+    # Machine-readable token for failure dispatch. Stable identifier from
+    # ``mcp_proxy.policy.denied_reason_codes``; SDK consumers branch on
+    # this instead of substring-matching ``error``. Set on every non-
+    # success path; ``None`` only on ``status="success"``. (F5 follow-up
+    # tracker #4.)
+    denied_reason_code: str | None = None
 
 
 class ToolInfo(BaseModel):

--- a/mcp_proxy/policy/denied_reason_codes.py
+++ b/mcp_proxy/policy/denied_reason_codes.py
@@ -1,0 +1,39 @@
+"""Stable machine-readable tokens for tool-denial outcomes (F5 follow-up #4).
+
+The executor returns one of these codes on every non-success
+``ToolExecuteResponse`` so SDK consumers can dispatch programmatically
+(retry vs UX prompt vs deny) without parsing the human-readable
+``error`` string. Codes are stable across releases; renaming requires a
+deprecation cycle.
+
+Token contract: ``^[a-z][a-z0-9_]+$``, < 64 chars, snake_case.
+"""
+from __future__ import annotations
+
+# Tool registry lookup missed — the request named a tool the proxy
+# doesn't know about.
+TOOL_NOT_FOUND = "tool_not_found"
+
+# Principal lacked the capability the tool requires, OR the capability
+# resolver failed closed (DB error during capability load).
+CAPABILITY_DENIED = "capability_denied"
+
+# Device tier resolved below the tier the capability requires.
+# Triggered by the F5 tier gate (ADR-032 Decision E).
+INSUFFICIENT_TIER = "insufficient_tier"
+
+# MCP-resource tool reached without an active binding row for this
+# principal — covers REST + JSON-RPC ingress symmetrically (CRIT-2 fix).
+MISSING_BINDING = "missing_binding"
+
+# Catch-all for handler-side failures: timeouts, ToolExecutionError,
+# unexpected exceptions. Operator-facing detail lives in audit + logs.
+INTERNAL_ERROR = "internal_error"
+
+ALL_CODES: frozenset[str] = frozenset({
+    TOOL_NOT_FOUND,
+    CAPABILITY_DENIED,
+    INSUFFICIENT_TIER,
+    MISSING_BINDING,
+    INTERNAL_ERROR,
+})

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -13,6 +13,13 @@ import httpx
 
 from mcp_proxy.db import log_audit
 from mcp_proxy.models import TokenPayload, ToolExecuteRequest, ToolExecuteResponse
+from mcp_proxy.policy.denied_reason_codes import (
+    CAPABILITY_DENIED,
+    INSUFFICIENT_TIER,
+    INTERNAL_ERROR,
+    MISSING_BINDING,
+    TOOL_NOT_FOUND,
+)
 from mcp_proxy.policy.tier_eval import resolve_effective_tier
 from mcp_proxy.policy.tier_matrix import tier_meets_requirement
 from mcp_proxy.tools.context import ToolContext
@@ -107,6 +114,7 @@ async def run(
             tool=tool_name,
             status="error",
             error=f"Tool '{tool_name}' not found",
+            denied_reason_code=TOOL_NOT_FOUND,
             execution_time_ms=duration_ms,
         )
 
@@ -181,6 +189,7 @@ async def run(
                 status="error",
                 error="Forbidden: capability lookup failed",
                 execution_time_ms=duration_ms,
+                denied_reason_code=CAPABILITY_DENIED,
             )
 
         if tool_def.required_capability not in principal_caps:
@@ -214,6 +223,7 @@ async def run(
                     f"'{tool_def.required_capability}'"
                 ),
                 execution_time_ms=duration_ms,
+                denied_reason_code=CAPABILITY_DENIED,
             )
 
     # 2a. Tier gate (ADR-032 Decision E / F5).
@@ -313,6 +323,7 @@ async def run(
                     f"'{tool_def.required_capability}'"
                 ),
                 execution_time_ms=duration_ms,
+                denied_reason_code=INSUFFICIENT_TIER,
             )
 
     # 2b. Binding check for MCP-resource tools (CRIT-2 fix, audit T3-F1).
@@ -353,6 +364,7 @@ async def run(
                 request_id=request_id,
                 tool=tool_name,
                 status="error",
+                denied_reason_code=MISSING_BINDING,
                 error=(
                     f"Forbidden: no active binding for resource "
                     f"'{tool_def.resource_id}'"
@@ -436,6 +448,7 @@ async def run(
                 status="error",
                 error=f"Tool execution timed out after {timeout}s",
                 execution_time_ms=duration_ms,
+                denied_reason_code=INTERNAL_ERROR,
             )
 
         except ToolExecutionError as exc:
@@ -461,6 +474,7 @@ async def run(
                 status="error",
                 error=str(exc),
                 execution_time_ms=duration_ms,
+                denied_reason_code=INTERNAL_ERROR,
             )
 
         except Exception as exc:
@@ -485,6 +499,7 @@ async def run(
                 status="error",
                 error="Internal tool execution error",
                 execution_time_ms=duration_ms,
+                denied_reason_code=INTERNAL_ERROR,
             )
 
 

--- a/tests/test_executor_denied_reason_codes.py
+++ b/tests/test_executor_denied_reason_codes.py
@@ -1,0 +1,325 @@
+"""Executor denied_reason_code coverage (F5 follow-up #4).
+
+Every non-success path returns a stable token from
+``mcp_proxy.policy.denied_reason_codes``. SDK consumers branch on the
+code instead of substring-matching ``error``. These tests pin one
+trigger per code so a future refactor that drops the field on any path
+fails loud.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.policy.denied_reason_codes import (
+    ALL_CODES,
+    CAPABILITY_DENIED,
+    INSUFFICIENT_TIER,
+    INTERNAL_ERROR,
+    MISSING_BINDING,
+    TOOL_NOT_FOUND,
+)
+from mcp_proxy.policy.tier_matrix import TierMatrix
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.http_whitelist import ToolExecutionError
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+
+
+_TOOL_NAME = "denied_code_fixture_tool"
+_TOOL_CAP = "mcp.transfer_money"
+
+
+@pytest.fixture
+def clean_registry():
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+class _FakeSecrets:
+    async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
+        return {}
+
+
+def _agent(scope: list[str] | None = None) -> TokenPayload:
+    return TokenPayload(
+        sub="spiffe://cullis.test/acme::daniele",
+        agent_id="acme::daniele",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-denied-codes",
+        scope=scope if scope is not None else [_TOOL_CAP],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+def _request(name: str = _TOOL_NAME) -> ToolExecuteRequest:
+    return ToolExecuteRequest.model_construct(
+        tool=name, parameters={}, request_id="rq-denied",
+    )
+
+
+def _matrix(min_tier: str) -> TierMatrix:
+    return TierMatrix(
+        version="test",
+        default_min_tier="untrusted",
+        by_exact={_TOOL_CAP: min_tier},
+        by_prefix=(),
+        source_path="<test>",
+    )
+
+
+def _register_tool(
+    *,
+    handler: AsyncMock | None = None,
+    required_capability: str = _TOOL_CAP,
+    resource_id: str | None = None,
+) -> AsyncMock:
+    h = handler or AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name=_TOOL_NAME,
+        description="Denied-code fixture",
+        required_capability=required_capability,
+        allowed_domains=[],
+        handler=h,
+        resource_id=resource_id,
+    ))
+    return h
+
+
+# ── code coverage ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_not_found_emits_tool_not_found(clean_registry):
+    with patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_request("does_not_exist"),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=None,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == TOOL_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_capability_lookup_failure_emits_capability_denied(
+    clean_registry,
+):
+    _register_tool()
+    with patch(
+        "mcp_proxy.tools.executor._load_principal_capabilities",
+        AsyncMock(side_effect=RuntimeError("db gone")),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(scope=[]),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=None,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == CAPABILITY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_missing_capability_emits_capability_denied(clean_registry):
+    _register_tool()
+    with patch(
+        "mcp_proxy.tools.executor._load_principal_capabilities",
+        AsyncMock(return_value=set()),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(scope=[]),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=None,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == CAPABILITY_DENIED
+
+
+@pytest.mark.asyncio
+async def test_insufficient_tier_emits_insufficient_tier(clean_registry):
+    _register_tool()
+    app_state = SimpleNamespace(tier_matrix=_matrix("managed_attested"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("untrusted", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == INSUFFICIENT_TIER
+
+
+@pytest.mark.asyncio
+async def test_missing_binding_emits_missing_binding(clean_registry):
+    _register_tool(resource_id="acme::pg-prod")
+    app_state = SimpleNamespace(tier_matrix=_matrix("untrusted"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("managed_attested", None)),
+    ), patch(
+        "mcp_proxy.local.bindings.has_active_binding",
+        AsyncMock(return_value=False),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == MISSING_BINDING
+
+
+@pytest.mark.asyncio
+async def test_handler_timeout_emits_internal_error(clean_registry):
+    import asyncio
+
+    async def _slow_handler(ctx):
+        await asyncio.sleep(10)
+        return {"ok": True}
+
+    handler = AsyncMock(side_effect=_slow_handler)
+    _register_tool(handler=handler)
+    app_state = SimpleNamespace(tier_matrix=_matrix("untrusted"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("managed_attested", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+            timeout=0.05,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == INTERNAL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_error_emits_internal_error(clean_registry):
+    _register_tool(handler=AsyncMock(side_effect=ToolExecutionError("boom")))
+    app_state = SimpleNamespace(tier_matrix=_matrix("untrusted"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("managed_attested", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == INTERNAL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_emits_internal_error(clean_registry):
+    _register_tool(handler=AsyncMock(side_effect=ValueError("kaboom")))
+    app_state = SimpleNamespace(tier_matrix=_matrix("untrusted"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("managed_attested", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == INTERNAL_ERROR
+
+
+# ── success path ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_success_path_leaves_denied_reason_code_none(clean_registry):
+    _register_tool()
+    app_state = SimpleNamespace(tier_matrix=_matrix("untrusted"))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier",
+        AsyncMock(return_value=("managed_attested", None)),
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", AsyncMock(),
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    assert resp.status == "success"
+    assert resp.denied_reason_code is None
+
+
+# ── stability contract ───────────────────────────────────────────────
+
+
+def test_all_codes_are_well_formed():
+    import re
+
+    pattern = re.compile(r"^[a-z][a-z0-9_]+$")
+    for code in ALL_CODES:
+        assert pattern.match(code), f"malformed code: {code!r}"
+        assert len(code) < 64, f"code too long: {code!r}"
+
+
+def test_all_codes_unique():
+    assert len(ALL_CODES) == len({
+        TOOL_NOT_FOUND,
+        CAPABILITY_DENIED,
+        INSUFFICIENT_TIER,
+        MISSING_BINDING,
+        INTERNAL_ERROR,
+    })


### PR DESCRIPTION
## Summary

`ToolExecuteResponse` now carries an optional `denied_reason_code: str | None` populated on every non-success path. SDK consumers branch on a stable token instead of substring-matching `error`.

| Code | Triggered by | File:line |
|---|---|---|
| `tool_not_found` | Tool registry lookup miss | `executor.py:112` |
| `capability_denied` | Missing scope or fail-closed capability lookup | `executor.py:186, 217` |
| `insufficient_tier` | F5 device tier below required | `executor.py:316` |
| `missing_binding` | MCP resource without active binding row (CRIT-2) | `executor.py:363` |
| `internal_error` | Handler timeout / ToolExecutionError / unexpected | `executor.py:445, 471, 496` |

Token contract: `^[a-z][a-z0-9_]+$`, < 64 chars. All codes are exported as constants from `mcp_proxy.policy.denied_reason_codes` and aggregated in `ALL_CODES: frozenset[str]`.

## Why

Post-merge review of #748 flagged this as MAJOR follow-up #4 in `followup_f5_f6_post_merge_tracker.md`. Customer SDK that wants to programmatically retry on `insufficient_tier` (e.g. trigger re-attestation) vs prompt the user on `capability_denied` was forced into substring matching, which breaks the first time a release reworded the human-readable string.

The token is consistent with `policy.tier_evaluated` audit detail (executor.py:571 already wrote this exact field into the audit JSON), so audit + SDK now share the same vocabulary.

`status="success"` keeps `denied_reason_code=None`, Pydantic default → zero backward-compat break.

## Test plan

- [x] New `tests/test_executor_denied_reason_codes.py`: one test per code (5 codes × 7 trigger sites = 8 tests) + success-path assertion + stability contract (well-formedness + uniqueness).
- [x] `pytest tests/test_executor_denied_reason_codes.py -n auto --dist=loadfile` → 11/11 pass.
- [x] Wider regression `pytest tests/ -k 'executor or denied or tool_execute' -n auto --dist=loadfile` → 70 pass, 2 skipped, 0 fail.

Pre-pilot blocker (regulated bank pilot) chiuso.