### PR TITLE
perf(policy): cache tier matrix once at lifespan, eliminate per-call YAML read

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -192,6 +192,28 @@ async def lifespan(app: FastAPI):
     from mcp_proxy.redis.pool import init_redis
     await init_redis(settings.redis_url)
 
+    # 2c. Cache the capability-tier matrix once at boot (ADR-032 F5
+    # follow-up #5). The executor's tier gate
+    # (``_resolve_tier_matrix`` in ``mcp_proxy/tools/executor.py``)
+    # reads ``app.state.tier_matrix`` on every tool call and falls
+    # back to ``load_default_tier_matrix()`` (disk YAML read) when
+    # absent. Without this stash every gated tool call re-parses
+    # ``enterprise-kit/policy/capability-tiers.yaml`` — wasted I/O at
+    # scale. Boot-time load caches the parsed matrix once; the gate
+    # then hits an in-memory attribute. A failure here intentionally
+    # does NOT abort startup: the per-call fallback remains, matching
+    # the permissive-default semantics the gate already implements.
+    try:
+        from mcp_proxy.policy.tier_matrix import load_default_tier_matrix
+        app.state.tier_matrix = load_default_tier_matrix()
+        _log.info("tier_matrix loaded at lifespan startup")
+    except Exception as exc:  # noqa: BLE001 — defensive, do not block boot
+        _log.warning(
+            "tier_matrix load failed at lifespan, falling back to "
+            "per-call disk read: %s", exc,
+        )
+        app.state.tier_matrix = None
+
     # 3. Initialize JWKS client (for external JWT validation)
     from mcp_proxy.auth.jwks_client import JWKSClient
     _jwks_client = JWKSClient(

--- a/tests/test_executor_tier_gate_perf.py
+++ b/tests/test_executor_tier_gate_perf.py
@@ -19,8 +19,6 @@ os.environ.setdefault("SKIP_ALEMBIC", "1")
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import pytest
-
 from mcp_proxy.policy.tier_matrix import TierMatrix
 from mcp_proxy.tools import executor
 

--- a/tests/test_executor_tier_gate_perf.py
+++ b/tests/test_executor_tier_gate_perf.py
@@ -1,0 +1,72 @@
+"""F5 follow-up #5 — tier gate uses cached matrix, no per-call disk read.
+
+The executor's ``_resolve_tier_matrix`` reads ``app.state.tier_matrix``
+first. With the boot-time stash in place, no disk YAML read should
+happen at gate-time on the hot path.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from mcp_proxy.policy.tier_matrix import TierMatrix
+from mcp_proxy.tools import executor
+
+
+def _matrix() -> TierMatrix:
+    return TierMatrix(
+        version="test",
+        default_min_tier="untrusted",
+        by_exact={},
+        by_prefix=(),
+        source_path="<test>",
+    )
+
+
+def test_gate_reads_cached_matrix_when_present_no_disk_load():
+    app_state = SimpleNamespace(tier_matrix=_matrix())
+    with patch(
+        "mcp_proxy.policy.tier_matrix.load_default_tier_matrix",
+    ) as loader:
+        result = executor._resolve_tier_matrix(app_state)
+        loader.assert_not_called()
+        assert result is app_state.tier_matrix
+
+
+def test_gate_falls_back_to_loader_when_cache_missing():
+    """When `app_state.tier_matrix` is None the gate still loads from
+    disk — keeps test-time loaders working when the lifespan didn't run.
+    """
+    app_state = SimpleNamespace(tier_matrix=None)
+    fake = _matrix()
+    with patch(
+        "mcp_proxy.policy.tier_matrix.load_default_tier_matrix",
+        return_value=fake,
+    ) as loader:
+        result = executor._resolve_tier_matrix(app_state)
+        loader.assert_called_once()
+        assert result is fake
+
+
+def test_gate_handles_none_app_state():
+    """Test paths that pass ``app_state=None`` still go through the
+    disk loader once — they don't error out."""
+    fake = _matrix()
+    with patch(
+        "mcp_proxy.policy.tier_matrix.load_default_tier_matrix",
+        return_value=fake,
+    ):
+        result = executor._resolve_tier_matrix(None)
+        assert result is fake

--- a/tests/test_lifespan_tier_matrix_cache.py
+++ b/tests/test_lifespan_tier_matrix_cache.py
@@ -1,0 +1,57 @@
+"""F5 follow-up #5 — tier-matrix is cached at lifespan startup.
+
+Pre-fix the executor's tier gate fell back to ``load_default_tier_matrix()``
+(disk YAML read) on every tool call because nothing populated
+``app.state.tier_matrix``. These tests pin the wiring so a future
+refactor that drops the stash falls red.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from unittest.mock import patch
+
+import pytest
+
+from mcp_proxy.policy.tier_matrix import TierMatrix, load_default_tier_matrix
+
+
+@pytest.mark.asyncio
+async def test_lifespan_stashes_tier_matrix_on_app_state():
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        cached = getattr(app.state, "tier_matrix", None)
+        assert cached is not None
+        assert isinstance(cached, TierMatrix)
+        # Identity with a direct load is the contract for the cache —
+        # both go through the same loader, both produce the same
+        # parsed matrix.
+        fresh = load_default_tier_matrix()
+        assert cached.version == fresh.version
+        assert cached.default_min_tier == fresh.default_min_tier
+        assert cached.by_exact == fresh.by_exact
+
+
+@pytest.mark.asyncio
+async def test_lifespan_handles_matrix_load_failure_without_crash():
+    """A YAML loader failure during boot must NOT abort the lifespan —
+    the executor's per-call fallback keeps the proxy permissive in
+    that degraded mode (matching the existing `_resolve_tier_matrix`
+    semantics)."""
+    from mcp_proxy.main import app
+
+    with patch(
+        "mcp_proxy.policy.tier_matrix.load_default_tier_matrix",
+        side_effect=RuntimeError("boom"),
+    ):
+        async with app.router.lifespan_context(app):
+            assert getattr(app.state, "tier_matrix", "missing") is None


### PR DESCRIPTION
## Summary

`mcp_proxy/main.py` lifespan now loads `load_default_tier_matrix()` once at boot and stashes the parsed `TierMatrix` on `app.state.tier_matrix`. The executor's `_resolve_tier_matrix` (executor.py:495) already reads from there with disk fallback — the only missing piece was the wiring.

## Why

Post-merge review of #748 flagged this as MAJOR follow-up #5 in `followup_f5_f6_post_merge_tracker.md`. Pre-fix every gated tool call re-parsed `enterprise-kit/policy/capability-tiers.yaml` (~140 LOC YAML). At 1k req/s that's 1k disk reads/sec for unchanged data.

A loader failure at boot intentionally does NOT abort the lifespan: `app.state.tier_matrix=None` makes the executor fall back to per-call disk reads, matching the existing `_resolve_tier_matrix` permissive-default semantics (the gate accepts None as "tier gate disabled" rather than denying every call).

## Test plan

- [x] New `tests/test_lifespan_tier_matrix_cache.py`: lifespan stash present + value matches direct loader + boot survives loader failure (cache becomes None, no crash).
- [x] New `tests/test_executor_tier_gate_perf.py`: cached matrix used, loader NOT called when stash is present; loader called when stash is None; `app_state=None` test path still loads via fallback.
- [x] `pytest tests/test_lifespan_tier_matrix_cache.py tests/test_executor_tier_gate_perf.py -n auto --dist=loadfile` → 5/5 pass.
- [x] Wider regression `pytest tests/ -k 'tier_matrix or tier_gate or lifespan' -n auto --dist=loadfile` → 57 pass, 2 skipped, 0 fail.

Should-have tracker entry chiuso.