### PR TITLE
feat(frontdesk): add --rotate-admin-secret flag to deploy.sh

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -176,6 +176,42 @@ For oauth2-proxy specifically, the upstream config `--pass-user-headers=true` is
 docker compose --env-file frontdesk.env down -v   # also wipe connector_data (forces re-enrollment)
 ```
 
+## Lost admin secret recovery
+
+If `CULLIS_CONNECTOR_ADMIN_SECRET` is lost or suspected to be compromised:
+
+```bash
+./deploy.sh --rotate-admin-secret
+```
+
+Effect:
+
+- Mints a fresh 48-char hex secret via the shared `_lib-admin-secret.sh`
+  helper (`openssl rand -hex 24`, with `/dev/urandom` fallback).
+- Rewrites `frontdesk.env` atomically with a timestamped backup on
+  disk (`frontdesk.env.bak-<YYYYMMDD-HHMMSS>`).
+- Prints the new secret to stdout (copy it into your password manager
+  immediately, it is not stored anywhere else).
+- Restarts only the `connector` container with `docker compose up -d
+  --wait --force-recreate connector`. The `mcp-proxy` + `cullis-chat`
+  containers stay up, so live Cullis Chat user sessions are **not**
+  disrupted.
+- If the sibling Mastio bundle's dashboard wiring is present
+  (`MCP_PROXY_FRONTDESK_ADMIN_SECRET` in `../cullis-mastio-bundle/proxy.env`,
+  issue #644 pattern), rewrites that file too and force-recreates the
+  Mastio `mcp-proxy` so the dashboard's Create / Reset / Delete user
+  flows keep working.
+
+After rotation the old secret is invalid: any in-flight `X-Admin-Secret`
+call using the old value returns 403. Update any CI jobs or scripts
+that scripted against the old value.
+
+Smoke test (no Docker required):
+
+```bash
+./test-rotate-admin-secret.sh
+```
+
 ## Threat model & exposure
 
 The Frontdesk bundle serves **plain HTTP** on `:80` inside the

--- a/packaging/frontdesk-bundle/_lib-admin-secret.sh
+++ b/packaging/frontdesk-bundle/_lib-admin-secret.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Frontdesk — shared helper: mint a Connector admin secret
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Sourced by:
+#   - generate-frontdesk-env.sh   (first-run env mint)
+#   - deploy.sh                   (--rotate-admin-secret subcommand)
+#
+# The Connector validates ``X-Admin-Secret`` against
+# ``CULLIS_CONNECTOR_ADMIN_SECRET`` (cullis_connector/admin/auth.py) on
+# every admin API call. Keep the generator centralized so both first-mint
+# and rotation paths produce wire-compatible secrets.
+#
+# Output: 48 lowercase hex chars (matching ``openssl rand -hex 24``),
+# with a /dev/urandom + coreutils fallback for hosts without openssl
+# (minimal NixOS, Alpine, distroless, trimmed WSL2 Ubuntu). Issue #638.
+
+gen_admin_secret() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 24
+    else
+        head -c 24 /dev/urandom | od -An -vtx1 | tr -d ' \n'
+    fi
+}

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -83,6 +83,15 @@ Options:
                               frontdesk.env must exist with real values
   --down                      Stop and remove containers
   --pull                      Force-pull the images before starting
+  --rotate-admin-secret       Mint a fresh CULLIS_CONNECTOR_ADMIN_SECRET,
+                              rewrite frontdesk.env atomically (timestamped
+                              backup kept on disk), restart only the
+                              Connector container (live Cullis Chat
+                              sessions are NOT disrupted), and re-wire
+                              the sibling Mastio bundle's
+                              MCP_PROXY_FRONTDESK_ADMIN_SECRET if present.
+                              Use when the admin secret is lost or
+                              suspected to be compromised.
   --tls                       Force the built-in TLS sidecar ON
                               (default; mints a self-signed cert in
                               ./tls/, terminates HTTPS on :8443)
@@ -147,6 +156,7 @@ while [[ $# -gt 0 ]]; do
     case "$arg" in
         --down)             ACTION="down"; shift ;;
         --pull)             FORCE_PULL=1; shift ;;
+        --rotate-admin-secret) ACTION="rotate-admin-secret"; shift ;;
         --prod)             MODE="production"; shift ;;
         --skip-enroll)      SKIP_ENROLL=1; shift ;;
         --no-wizard)        NO_WIZARD=1; shift ;;
@@ -186,6 +196,117 @@ if [[ "$ACTION" == "down" ]]; then
     $COMPOSE --env-file frontdesk.env --profile tls down 2>/dev/null \
         || $COMPOSE --profile tls down
     ok "Frontdesk stopped"
+    exit 0
+fi
+
+# ── Rotate admin secret ─────────────────────────────────────────────────────
+# Operator-facing recovery path for a lost or compromised
+# ``CULLIS_CONNECTOR_ADMIN_SECRET``. Mints a fresh secret via the shared
+# helper (``_lib-admin-secret.sh``), atomically rewrites frontdesk.env
+# (keeping a timestamped ``frontdesk.env.bak-…`` on disk), restarts only
+# the ``connector`` container with ``--wait`` so the new env is read
+# (compose ``restart`` does NOT re-read env files), and updates the
+# sibling Mastio bundle's ``MCP_PROXY_FRONTDESK_ADMIN_SECRET`` if the
+# bridge is wired (issue #644 pattern). The plain ``mcp-proxy`` +
+# ``cullis-chat`` services stay up so live Cullis Chat user sessions
+# are NOT disrupted by the rotation.
+if [[ "$ACTION" == "rotate-admin-secret" ]]; then
+    step "Rotating Connector admin secret"
+
+    [[ -f "$SCRIPT_DIR/frontdesk.env" ]] || die "frontdesk.env not found at $SCRIPT_DIR/frontdesk.env — run ./deploy.sh first to provision the bundle"
+
+    # shellcheck source=_lib-admin-secret.sh
+    source "$SCRIPT_DIR/_lib-admin-secret.sh"
+    NEW_SECRET="$(gen_admin_secret)"
+    [[ -n "$NEW_SECRET" ]] || die "gen_admin_secret produced an empty value — check $SCRIPT_DIR/_lib-admin-secret.sh"
+
+    BACKUP="$SCRIPT_DIR/frontdesk.env.bak-$(date +%Y%m%d-%H%M%S)"
+    cp "$SCRIPT_DIR/frontdesk.env" "$BACKUP"
+    ok "Backed up frontdesk.env → $(basename "$BACKUP")"
+
+    # Anchored regex so we never match a stray substring elsewhere in
+    # the file (e.g. a comment or a different var that happens to
+    # contain ``CULLIS_CONNECTOR_ADMIN_SECRET``). If no line existed
+    # yet (operator hand-edited it out), append one — generate-…sh
+    # appends rather than substitutes for the same reason.
+    if grep -qE '^CULLIS_CONNECTOR_ADMIN_SECRET=' "$SCRIPT_DIR/frontdesk.env"; then
+        sed -i "s|^CULLIS_CONNECTOR_ADMIN_SECRET=.*|CULLIS_CONNECTOR_ADMIN_SECRET=${NEW_SECRET}|" \
+            "$SCRIPT_DIR/frontdesk.env"
+    else
+        echo "CULLIS_CONNECTOR_ADMIN_SECRET=${NEW_SECRET}" >> "$SCRIPT_DIR/frontdesk.env"
+    fi
+    ok "Rewrote frontdesk.env with new admin secret"
+
+    echo ""
+    echo -e "  ${BOLD}New admin secret:${RESET} ${GRAY}${NEW_SECRET}${RESET}"
+    echo "  (save this to your password manager — the old secret is now invalid)"
+    echo ""
+
+    # Restart only the connector. mcp-proxy + cullis-chat keep serving
+    # live user sessions — the rotation is invisible to non-admin
+    # traffic. ``--wait`` blocks until the new container's healthcheck
+    # passes, otherwise the next admin call would race the listener.
+    # See feedback memory ``frontdesk_deploy_force_recreate_mcp_proxy_race``
+    # (PR #663) for the documented failure mode.
+    step "Restarting Connector with new env"
+    if $COMPOSE --env-file "$SCRIPT_DIR/frontdesk.env" up -d --wait --force-recreate connector; then
+        ok "Connector restarted, healthcheck passed"
+    else
+        warn "Connector restart did not converge — check ``$COMPOSE --env-file frontdesk.env logs connector``"
+        warn "Old secret is no longer in frontdesk.env. Backup: $(basename "$BACKUP")"
+        exit 1
+    fi
+
+    # ── Update sibling Mastio dashboard wiring if present ───────────────
+    # The ``up`` path (line ~610) writes
+    # ``MCP_PROXY_FRONTDESK_ADMIN_SECRET=<our secret>`` into the sibling
+    # Mastio bundle's proxy.env so the dashboard's Create/Reset/Delete
+    # user flows can hit our admin API. If that bridge is wired, the
+    # old secret on the Mastio side is now stale and every dashboard
+    # provisioning call would 403 against the rotated Connector. Patch
+    # it in place + force-recreate the Mastio mcp-proxy (compose
+    # ``restart`` does not re-read env files). Idempotent: if the
+    # bridge env vars aren't there, this block no-ops.
+    SIBLING_MASTIO_BUNDLE=""
+    for cand in "$SCRIPT_DIR/../cullis-mastio-bundle" "$SCRIPT_DIR/../mastio-bundle"; do
+        if [[ -f "$cand/proxy.env" ]]; then
+            SIBLING_MASTIO_BUNDLE="$(cd "$cand" && pwd)"
+            break
+        fi
+    done
+
+    if [[ -n "$SIBLING_MASTIO_BUNDLE" ]] && grep -qE '^MCP_PROXY_FRONTDESK_ADMIN_SECRET=' "$SIBLING_MASTIO_BUNDLE/proxy.env"; then
+        step "Updating sibling Mastio dashboard wiring"
+        sed -i "s|^MCP_PROXY_FRONTDESK_ADMIN_SECRET=.*|MCP_PROXY_FRONTDESK_ADMIN_SECRET=${NEW_SECRET}|" \
+            "$SIBLING_MASTIO_BUNDLE/proxy.env"
+        ok "Rewrote $SIBLING_MASTIO_BUNDLE/proxy.env"
+
+        MASTIO_PROXY_CONTAINER="$(docker ps --filter 'label=com.docker.compose.service=mcp-proxy' --format '{{.Names}}' | head -1)"
+        if [[ -n "$MASTIO_PROXY_CONTAINER" ]]; then
+            (
+                cd "$SIBLING_MASTIO_BUNDLE"
+                COMPOSE_PROJECT_NAME=cullis-mastio \
+                    $COMPOSE --env-file proxy.env up -d --wait --force-recreate mcp-proxy \
+                    >/dev/null 2>&1 \
+                    || warn "Could not force-recreate Mastio mcp-proxy — dashboard provisioning will keep using the OLD secret until the next Mastio restart"
+            )
+            ok "Mastio mcp-proxy reloaded with new admin secret"
+        else
+            warn "No running Mastio mcp-proxy detected — sibling proxy.env updated; restart Mastio when convenient"
+        fi
+    else
+        echo -e "  ${GRAY}No sibling Mastio dashboard bridge to update${RESET}"
+    fi
+
+    echo ""
+    echo -e "${GREEN}${BOLD}Admin secret rotated.${RESET}"
+    echo ""
+    echo "  Live Cullis Chat sessions: preserved (mcp-proxy / cullis-chat not restarted)."
+    echo "  Old secret: invalid (any in-flight X-Admin-Secret call with the old"
+    echo "  value will now return 403). Update your password manager + any CI"
+    echo "  jobs that scripted against the old value."
+    echo "  Backup of previous frontdesk.env: $(basename "$BACKUP")"
+    echo ""
     exit 0
 fi
 

--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -177,17 +177,12 @@ esac
 # MCP_PROXY_ADMIN_SECRET, which is a different secret on a different
 # component (the Mastio dashboard) and cannot authenticate the Connector
 # admin API. See bug 1 in the v0.2.0 dogfood notes.
-# gen_secret — prefer openssl, fall back to /dev/urandom + coreutils on
-# hosts that ship without openssl (minimal NixOS, Alpine, distroless,
-# trimmed WSL2 Ubuntu). Issue #638. Output: 48 lowercase hex chars,
-# matching the openssl rand -hex 24 shape.
-gen_admin_secret() {
-    if command -v openssl >/dev/null 2>&1; then
-        openssl rand -hex 24
-    else
-        head -c 24 /dev/urandom | od -An -vtx1 | tr -d ' \n'
-    fi
-}
+#
+# ``gen_admin_secret`` lives in ``_lib-admin-secret.sh`` so the rotation
+# path in ``deploy.sh --rotate-admin-secret`` mints wire-compatible
+# secrets without copy-pasting the generator.
+# shellcheck source=_lib-admin-secret.sh
+source "$SCRIPT_DIR/_lib-admin-secret.sh"
 ADMIN_SECRET="${CULLIS_CONNECTOR_ADMIN_SECRET:-$(gen_admin_secret)}"
 
 cp "$SCRIPT_DIR/frontdesk.env.example" "$OUT"

--- a/packaging/frontdesk-bundle/test-rotate-admin-secret.sh
+++ b/packaging/frontdesk-bundle/test-rotate-admin-secret.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Frontdesk — smoke test for --rotate-admin-secret
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Verifies the wiring of the rotation flow without bringing up Docker:
+#   1. ``_lib-admin-secret.sh`` is sourceable and ``gen_admin_secret``
+#      emits a 48-char lowercase hex string (matching openssl rand -hex 24).
+#   2. ``generate-frontdesk-env.sh`` references the shared helper (the
+#      old inline definition is gone).
+#   3. ``deploy.sh`` exposes the ``--rotate-admin-secret`` flag in both
+#      the argument parser and ``--help`` output.
+#   4. The anchored sed substitution rewrites only the
+#      ``CULLIS_CONNECTOR_ADMIN_SECRET=`` line and leaves comments /
+#      sibling vars containing the substring intact.
+#
+# Run:
+#   ./test-rotate-admin-secret.sh
+
+set -euo pipefail
+
+BUNDLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GREEN=$'\033[32m'; RED=$'\033[31m'; RESET=$'\033[0m'
+fail() { echo -e "${RED}FAIL${RESET}: $1" >&2; exit 1; }
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; }
+
+# ── 1. Helper sources cleanly and produces a 48-hex secret ──────────────────
+[[ -f "$BUNDLE_DIR/_lib-admin-secret.sh" ]] \
+    || fail "_lib-admin-secret.sh not found at $BUNDLE_DIR/_lib-admin-secret.sh"
+
+# shellcheck source=_lib-admin-secret.sh
+source "$BUNDLE_DIR/_lib-admin-secret.sh"
+
+declare -F gen_admin_secret >/dev/null \
+    || fail "gen_admin_secret function not defined after sourcing the helper"
+
+NEW="$(gen_admin_secret)"
+[[ -n "$NEW" ]] || fail "gen_admin_secret returned empty string"
+[[ ${#NEW} -eq 48 ]] \
+    || fail "gen_admin_secret length is ${#NEW}, expected 48 (openssl rand -hex 24 shape)"
+[[ "$NEW" =~ ^[0-9a-f]{48}$ ]] \
+    || fail "gen_admin_secret output is not lowercase hex: $NEW"
+
+# Two consecutive calls must not collide (sanity check on randomness).
+NEW2="$(gen_admin_secret)"
+[[ "$NEW" != "$NEW2" ]] || fail "gen_admin_secret returned the same value twice"
+pass "_lib-admin-secret.sh emits 48-char lowercase hex secrets"
+
+# ── 2. generate-frontdesk-env.sh sources the shared helper ──────────────────
+GEN_SH="$BUNDLE_DIR/generate-frontdesk-env.sh"
+[[ -f "$GEN_SH" ]] || fail "generate-frontdesk-env.sh not found"
+grep -q 'source.*_lib-admin-secret.sh' "$GEN_SH" \
+    || fail "generate-frontdesk-env.sh does not source _lib-admin-secret.sh"
+# The inline definition (``openssl rand -hex 24`` body) must be gone so
+# the helper is the single source of truth.
+if grep -q 'gen_admin_secret()' "$GEN_SH"; then
+    fail "generate-frontdesk-env.sh still defines gen_admin_secret() inline — remove the duplicate"
+fi
+pass "generate-frontdesk-env.sh sources the shared helper, no inline duplicate"
+
+# ── 3. deploy.sh wires the --rotate-admin-secret flag + help text ───────────
+DEPLOY_SH="$BUNDLE_DIR/deploy.sh"
+[[ -f "$DEPLOY_SH" ]] || fail "deploy.sh not found"
+grep -q -- '--rotate-admin-secret) ACTION="rotate-admin-secret"' "$DEPLOY_SH" \
+    || fail "deploy.sh does not wire --rotate-admin-secret in the arg parser"
+grep -q -- '--rotate-admin-secret' "$DEPLOY_SH" \
+    || fail "deploy.sh does not mention --rotate-admin-secret at all"
+grep -qE '\$ACTION" == "rotate-admin-secret"' "$DEPLOY_SH" \
+    || fail "deploy.sh has no handler block for rotate-admin-secret"
+# Help text must surface the flag for operators.
+"$DEPLOY_SH" --help 2>&1 | grep -q -- '--rotate-admin-secret' \
+    || fail "deploy.sh --help does not document --rotate-admin-secret"
+pass "deploy.sh exposes --rotate-admin-secret in parser, handler, and --help"
+
+# ── 4. Anchored sed substitution scope is correct ───────────────────────────
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/frontdesk.env" <<EOF
+# This comment mentions CULLIS_CONNECTOR_ADMIN_SECRET on purpose
+CULLIS_FRONTDESK_ORG_ID=acme
+CULLIS_CONNECTOR_ADMIN_SECRET=old-secret-placeholder
+OTHER_VAR_REFERENCING_CULLIS_CONNECTOR_ADMIN_SECRET=untouched
+EOF
+
+FAKE_NEW="abcdef0123456789abcdef0123456789abcdef0123456789"
+sed -i "s|^CULLIS_CONNECTOR_ADMIN_SECRET=.*|CULLIS_CONNECTOR_ADMIN_SECRET=${FAKE_NEW}|" \
+    "$WORK/frontdesk.env"
+
+grep -qE "^CULLIS_CONNECTOR_ADMIN_SECRET=${FAKE_NEW}\$" "$WORK/frontdesk.env" \
+    || fail "anchored sed did not rewrite the target line"
+grep -q "old-secret-placeholder" "$WORK/frontdesk.env" \
+    && fail "old secret value still present in frontdesk.env after rotation"
+grep -q "^# This comment mentions CULLIS_CONNECTOR_ADMIN_SECRET on purpose\$" \
+    "$WORK/frontdesk.env" \
+    || fail "comment line was modified (anchored regex regression)"
+grep -q "^OTHER_VAR_REFERENCING_CULLIS_CONNECTOR_ADMIN_SECRET=untouched\$" \
+    "$WORK/frontdesk.env" \
+    || fail "sibling var line was modified (anchored regex regression)"
+pass "anchored sed rewrites only the target line"
+
+echo ""
+echo -e "${GREEN}All checks passed.${RESET}"


### PR DESCRIPTION
## Summary

- New `./deploy.sh --rotate-admin-secret` subcommand for Cullis Frontdesk bundle: mints a fresh `CULLIS_CONNECTOR_ADMIN_SECRET`, rewrites `frontdesk.env` atomically with a timestamped backup, restarts only the `connector` container (`mcp-proxy` + `cullis-chat` stay up, so live Cullis Chat user sessions are NOT disrupted), and re-syncs the sibling Mastio bundle's `MCP_PROXY_FRONTDESK_ADMIN_SECRET` if the dashboard bridge (issue #644) is wired.
- Extract `gen_admin_secret` to a shared `_lib-admin-secret.sh` helper, sourced by both `generate-frontdesk-env.sh` (first mint) and `deploy.sh` (rotation). Keeps the `openssl rand -hex 24` shape (with `/dev/urandom` fallback for Alpine/distroless) as the single source of truth.
- Bash smoke test `test-rotate-admin-secret.sh` covers helper sourcing, hex shape, anchored-regex scope (comments and sibling vars are not touched), and `deploy.sh` argparse + help-text wiring. No Docker required.
- README: new `## Lost admin secret recovery` section.

## Why

P3 operability audit MAJOR-3 (`imp/p3-operability-audit.md`). Customer IT had no standalone path to rotate the admin secret if lost or compromised: only a manual `frontdesk.env` edit + full `docker compose down && up`, which drops every live Cullis Chat session.

Mirrors the existing pattern of `cullis-mastio reset-password` (Mastio CLI, `mcp_proxy/cli/__init__.py:48-173`) and the auto-sync `ORG_ID` flow added in PR #663 (`feedback_frontdesk_bundle_auto_sync_org_id`).

## Test plan

- [x] `./packaging/frontdesk-bundle/test-rotate-admin-secret.sh` — all four checks PASS locally
- [x] `bash -n` on all 4 bundle bash scripts
- [x] `bash deploy.sh --help` surfaces `--rotate-admin-secret`
- [x] `bash generate-frontdesk-env.sh --help` still works after the helper extraction
- [ ] Live rotation against a real Frontdesk + sibling Mastio stack (requires Docker; out of scope for this PR but smoke covers the argparse + file-mutation contract)

## Notes / edge cases

- Sibling Mastio bridge update is **idempotent + best-effort**: if `proxy.env` has no `MCP_PROXY_FRONTDESK_ADMIN_SECRET` line yet (bridge never wired), the rotation no-ops on that side, prints a `No sibling Mastio dashboard bridge to update` line, and exits 0. Operators can run the regular `./deploy.sh` afterwards to wire the bridge with the new secret.
- `--wait` is mandatory on the `docker compose up -d --force-recreate connector` call (`feedback_frontdesk_deploy_force_recreate_mcp_proxy_race`, PR #663) — without it, the next admin call would race the uvicorn listener.
- The new secret is printed to stdout exactly once. Old secret is **never** echoed (privacy invariant from the prompt).
- Backup file naming: `frontdesk.env.bak-<YYYYMMDD-HHMMSS>` — keeps the last N rotations on disk for emergency restore; operators can prune manually.