### PR TITLE
feat(auth): actionable DPoP htu mismatch error + diagnostic hint header

### DIFF
--- a/mcp_proxy/auth/dpop.py
+++ b/mcp_proxy/auth/dpop.py
@@ -311,9 +311,34 @@ async def verify_dpop_proof(
         )
 
     # -- 10. htu
-    if _normalize_htu(claims.get("htu", "")) != _normalize_htu(htu):
+    expected_norm = _normalize_htu(htu)
+    got_norm = _normalize_htu(claims.get("htu", ""))
+    if got_norm != expected_norm:
+        # Server-side: log structured diagnostics so operators can correlate
+        # 401s with a wrong MCP_PROXY_PROXY_PUBLIC_URL (memory:
+        # feedback_proxy_env_public_url_vm). Do NOT log the jkt to keep
+        # client-key privacy invariant.
+        _log.warning(
+            "DPoP htu mismatch",
+            extra={
+                "expected_htu": expected_norm,
+                "got_htu": got_norm,
+                "hint": "htu_mismatch_check_proxy_public_url",
+            },
+        )
+        # Header is a stable machine-readable diagnostic token. Safe in prod:
+        # it does not leak the internal URL, but tells customer admins which
+        # config knob to inspect (MCP_PROXY_PROXY_PUBLIC_URL / frontdesk.env).
+        headers = {"X-Cullis-Hint": "htu_mismatch_check_proxy_public_url"}
+        if settings.environment == "production":
+            detail = "Invalid DPoP proof: htu mismatch"
+        else:
+            detail = (
+                f"Invalid DPoP proof: htu mismatch "
+                f"(expected={expected_norm!r}, got={got_norm!r})"
+            )
         raise HTTPException(
-            status.HTTP_401_UNAUTHORIZED, "Invalid DPoP proof: htu mismatch"
+            status.HTTP_401_UNAUTHORIZED, detail, headers=headers
         )
 
     # -- 11. ath (access token hash)

--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -244,6 +244,26 @@ TLS terminator into the bundle (the same pattern Mastio's
 ``mastio-nginx`` uses) is on the roadmap as ADR-024 — track that ADR
 draft for the design discussion.
 
+## Troubleshooting
+
+### Troubleshooting: tutti gli agent rispondono 401 dopo restart VM
+
+Sintomo: dopo `docker compose restart` o reboot VM, tutti i Connector ricevono 401
+"Invalid DPoP proof: htu mismatch". L'header `X-Cullis-Hint:
+htu_mismatch_check_proxy_public_url` è la firma diagnostica.
+
+Causa: il valore di `MCP_PROXY_PROXY_PUBLIC_URL` in `proxy.env` (o
+`frontdesk.env`) non coincide con l'URL che il Connector usa per
+raggiungere Mastio. DPoP RFC 9449 firma `htu` sul URL atteso.
+
+Diagnosi:
+  1. Verifica env: `grep MCP_PROXY_PROXY_PUBLIC_URL proxy.env`
+  2. Verifica URL Connector: `cullis-connector doctor`
+  3. Devono coincidere (incluso schema + porta).
+
+Fix: allinea `MCP_PROXY_PROXY_PUBLIC_URL` al valore corretto, esegui
+`./deploy.sh --pull` per restart pulito.
+
 ## Known limitations
 
 - **No autoscale.** Single Connector replica per bundle; the cookie secret lives on local disk so horizontal scale needs a shared secret store. Roadmap.

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -175,6 +175,24 @@ full values reference.
 | Agent fails with `getaddrinfo failed` / `Name or service not known` | The hostname you set as the public URL must resolve to the Mastio host's IP from the agent's machine. Three paths: (1) corporate DNS (e.g. Active Directory) — recommended; (2) public DNS A record if the Mastio is internet-reachable; (3) `/etc/hosts` line on each agent machine (`192.168.10.42  mastio.acme.local`) — okay for 2-3 employees, brittle past that. |
 | `Bind for 0.0.0.0:9443 failed: port is already allocated` | Another service on the host is using 9443 (Caddy / Traefik / nginx-proxy / a previous Mastio that didn't shut down cleanly). Override the host port in `proxy.env`: `MCP_PROXY_PORT=9444`. **Critical:** also update `MCP_PROXY_PROXY_PUBLIC_URL` to use the same port (e.g. `https://mastio.acme.local:9444`) — agents firma DPoP htu against that exact URL+port and a mismatch silently 401s. |
 
+### Troubleshooting: tutti gli agent rispondono 401 dopo restart VM
+
+Sintomo: dopo `docker compose restart` o reboot VM, tutti i Connector ricevono 401
+"Invalid DPoP proof: htu mismatch". L'header `X-Cullis-Hint:
+htu_mismatch_check_proxy_public_url` è la firma diagnostica.
+
+Causa: il valore di `MCP_PROXY_PROXY_PUBLIC_URL` in `proxy.env` (o
+`frontdesk.env`) non coincide con l'URL che il Connector usa per
+raggiungere Mastio. DPoP RFC 9449 firma `htu` sul URL atteso.
+
+Diagnosi:
+  1. Verifica env: `grep MCP_PROXY_PROXY_PUBLIC_URL proxy.env`
+  2. Verifica URL Connector: `cullis-connector doctor`
+  3. Devono coincidere (incluso schema + porta).
+
+Fix: allinea `MCP_PROXY_PROXY_PUBLIC_URL` al valore corretto, esegui
+`./deploy.sh --pull` per restart pulito.
+
 ## Updating
 
 **Recommended — full bundle refresh (ADR-030):**

--- a/packaging/mastio-enterprise-bundle/README.md
+++ b/packaging/mastio-enterprise-bundle/README.md
@@ -118,6 +118,26 @@ sed -i 's/^CULLIS_MASTIO_VERSION=.*/CULLIS_MASTIO_VERSION=<new>/' proxy.env
 Operator-side data (`./data/mcp_proxy.db`, `./nginx-certs/`,
 `./saml-keys/`) survives the image bump.
 
+## Troubleshooting
+
+### Troubleshooting: tutti gli agent rispondono 401 dopo restart VM
+
+Sintomo: dopo `docker compose restart` o reboot VM, tutti i Connector ricevono 401
+"Invalid DPoP proof: htu mismatch". L'header `X-Cullis-Hint:
+htu_mismatch_check_proxy_public_url` è la firma diagnostica.
+
+Causa: il valore di `MCP_PROXY_PROXY_PUBLIC_URL` in `proxy.env` (o
+`frontdesk.env`) non coincide con l'URL che il Connector usa per
+raggiungere Mastio. DPoP RFC 9449 firma `htu` sul URL atteso.
+
+Diagnosi:
+  1. Verifica env: `grep MCP_PROXY_PROXY_PUBLIC_URL proxy.env`
+  2. Verifica URL Connector: `cullis-connector doctor`
+  3. Devono coincidere (incluso schema + porta).
+
+Fix: allinea `MCP_PROXY_PROXY_PUBLIC_URL` al valore corretto, esegui
+`./deploy.sh --pull` per restart pulito.
+
 ## Where things live
 
 | Path | What |

--- a/tests/test_mcp_proxy_dpop_htu_mismatch.py
+++ b/tests/test_mcp_proxy_dpop_htu_mismatch.py
@@ -1,0 +1,114 @@
+"""
+Unit tests for ``mcp_proxy/auth/dpop.py`` htu-mismatch operability
+(P3 MAJOR-2 of imp/p3-operability-audit.md).
+
+Coverage:
+  - htu mismatch always emits ``X-Cullis-Hint: htu_mismatch_check_proxy_public_url``
+  - in non-production environments the body includes expected+got for dev UX
+  - in production the body is generic (no internal URL leak)
+
+These tests call ``mcp_proxy.auth.dpop.verify_dpop_proof`` directly with
+``require_nonce=False`` so we exercise the htu branch without involving the
+nonce machinery.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.auth.dpop import verify_dpop_proof
+from mcp_proxy.auth.dpop_jti_store import reset_dpop_jti_store
+from mcp_proxy.config import get_settings
+from tests.cert_factory import make_dpop_key_pair, make_dpop_proof
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _reset_jti_store():
+    reset_dpop_jti_store()
+    yield
+    reset_dpop_jti_store()
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _build_proof(claimed_htu: str) -> str:
+    priv, jwk = make_dpop_key_pair()
+    return make_dpop_proof(priv, jwk, "POST", claimed_htu)
+
+
+async def test_htu_mismatch_includes_hint_header(monkeypatch):
+    """htu mismatch must always carry X-Cullis-Hint, in any environment."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    get_settings.cache_clear()
+
+    proof = _build_proof("http://wrong-host.example/v1/mcp")
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_dpop_proof(
+            proof,
+            htm="POST",
+            htu="http://right-host.example/v1/mcp",
+            require_nonce=False,
+        )
+    err = exc_info.value
+    assert err.status_code == 401
+    assert err.headers is not None
+    assert err.headers.get("X-Cullis-Hint") == "htu_mismatch_check_proxy_public_url"
+
+
+async def test_htu_mismatch_dev_body_includes_expected_got(monkeypatch):
+    """Non-production: expected+got included in body for fast diagnosis."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    get_settings.cache_clear()
+
+    expected_url = "http://right-host.example/v1/mcp"
+    wrong_url = "http://wrong-host.example/v1/mcp"
+    proof = _build_proof(wrong_url)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_dpop_proof(
+            proof, htm="POST", htu=expected_url, require_nonce=False
+        )
+    detail = exc_info.value.detail
+    assert "htu mismatch" in detail
+    assert "expected=" in detail
+    assert "got=" in detail
+    # Both normalized URLs surface in the message
+    assert "right-host.example" in detail
+    assert "wrong-host.example" in detail
+    # Hint header still present
+    assert (
+        exc_info.value.headers.get("X-Cullis-Hint")
+        == "htu_mismatch_check_proxy_public_url"
+    )
+
+
+async def test_htu_mismatch_prod_body_generic(monkeypatch):
+    """Production: body is exactly generic, no internal URL leak."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    get_settings.cache_clear()
+
+    expected_url = "https://mastio.internal.corp/v1/mcp"
+    wrong_url = "https://mastio-leaked.example/v1/mcp"
+    proof = _build_proof(wrong_url)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_dpop_proof(
+            proof, htm="POST", htu=expected_url, require_nonce=False
+        )
+    err = exc_info.value
+    assert err.status_code == 401
+    assert err.detail == "Invalid DPoP proof: htu mismatch"
+    # Header present in prod too (machine-readable, does not leak URL)
+    assert (
+        err.headers.get("X-Cullis-Hint") == "htu_mismatch_check_proxy_public_url"
+    )
+    # Defense in depth: the internal URL must not appear anywhere in detail
+    assert "mastio.internal.corp" not in err.detail
+    assert "mastio-leaked" not in err.detail


### PR DESCRIPTION
## Summary

- On DPoP `htu` mismatch, the proxy now (a) logs `expected_htu`/`got_htu` server-side at WARNING level for operator correlation, (b) attaches `X-Cullis-Hint: htu_mismatch_check_proxy_public_url` to every 401 (machine-readable, safe in prod), and (c) embeds `expected`/`got` in the response body only when `MCP_PROXY_ENVIRONMENT != "production"` — prod bodies stay generic and never leak the internal URL.
- New unit-test file `tests/test_mcp_proxy_dpop_htu_mismatch.py` covers the hint header, dev-mode body, and prod-mode generic body (defense-in-depth assertion that the internal URL is absent).
- Adds a `### Troubleshooting: tutti gli agent rispondono 401 dopo restart VM` runbook section to the three customer-facing bundle READMEs (`mastio-bundle`, `mastio-enterprise-bundle`, `frontdesk-bundle`).

## Why

P3 MAJOR-2 from `imp/p3-operability-audit.md`. Pattern from `feedback_proxy_env_public_url_vm.md`: a customer admin restarts Mastio in a VM with a wrong `MCP_PROXY_PROXY_PUBLIC_URL`, and every Connector fails with `401 "Invalid DPoP proof: htu mismatch"` with no actionable signal — the CISO interprets it as a security failure rather than a config mismatch. Now the runbook says "if you see `X-Cullis-Hint: htu_mismatch_check_proxy_public_url`, grep your env and check `cullis-connector doctor`". Diagnosis goes from hours to a single curl.

## Test plan

- [x] `pytest tests/ -k 'dpop and htu'` — 7 passed, 2 skipped (existing app/auth + new mcp_proxy)
- [x] `python -m ruff check mcp_proxy/auth/dpop.py tests/test_mcp_proxy_dpop_htu_mismatch.py --select E,F,W --ignore E501,E402` — only pre-existing F401 on `asyncio` import, untouched by this PR
- [x] DCO `Signed-off-by:` present
- [ ] CI green