### PR TITLE
feat(policy): exempt typed principals from device tier gate (F5 #6)

### DIFF
--- a/mcp_proxy/policy/tier_eval.py
+++ b/mcp_proxy/policy/tier_eval.py
@@ -18,6 +18,21 @@ Mastio is the authoritative source for ``effective_tier`` because
 The helper is intentionally synchronous in spirit (no DB session
 needed beyond ``get_agent``) and async in shape so callers can
 ``await`` without restructuring.
+
+**Agent-only by construction (F5 follow-up #6).** The read path
+targets ``internal_agents`` because that's where the per-device
+``last_attestation`` claim lives (migration 0035; see the commit
+message there for the lifetime reasoning). Typed principals
+(``user`` / ``workload``, ADR-020) have no row in that table — a
+typed ``agent_id`` like ``user::alice`` resolves to ``None`` in
+``get_agent`` and collapses to ``untrusted`` here. Callers
+(``mcp_proxy.tools.executor`` today) MUST guard the call with
+``principal_type == "agent"``; this module does not branch on type
+because it only sees an opaque string id. When ADR-021 v2 wires a
+per-user attestation column (likely on ``user_sessions`` per
+migration 0035 for shared-mode Frontdesk F4 R2, not on
+``local_user_principals``), add a typed-principal read path here
+and let the executor drop its agent-only guard.
 """
 from __future__ import annotations
 

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -226,13 +226,30 @@ async def run(
     # scope can still get refused if their device's last
     # attestation shows ``soft_only`` strength.
     #
-    # The gate runs whenever the capability gate ran above
-    # (same ``capability_gate_applies`` guard) so we don't double-
-    # restrict typed callers on MCP-resource tools (those are
-    # authorised via the binding table at step 2b, which the F5
-    # follow-up will tier-gate separately when we wire the same
-    # check into ``has_active_binding``). Builtins + agent-typed
-    # MCP-resource calls run through here.
+    # **Agent-only by design (F5 follow-up #6).** The gate reads
+    # ``internal_agents.last_attestation`` via
+    # :func:`resolve_effective_tier`; that column exists by
+    # construction (migration 0035) because the Connector device IS
+    # the agent under ADR-014. Typed principals (``user`` /
+    # ``workload`` per ADR-020) do NOT have an ``internal_agents``
+    # row — a ``user::alice`` ``agent_id`` resolves to ``None`` in
+    # ``get_agent``, which collapses the tier to ``untrusted`` and
+    # would deny every tier-gated capability for every typed caller.
+    # That's a wrong default: user attestation is a separate path
+    # (ADR-021 multi-user KMS, Frontdesk SSO/IdP, Connector
+    # local-credentials), not a device claim on the agent row.
+    # Migration 0035's commit message documents this explicitly:
+    # "the attestation is a per-device claim ... a similar column
+    # on ``user_sessions``" is the planned home for shared-mode F4
+    # R2. Until that wire-up lands, typed principals are exempt.
+    #
+    # The gate runs whenever the capability gate ran above AND the
+    # principal is agent-typed. Builtins called by typed principals
+    # still get their capability check at step 2 — they just skip
+    # the device tier check that has no data source for them.
+    # MCP-resource calls by typed principals get the binding gate at
+    # step 2b, which the F5 follow-up will tier-gate separately when
+    # we wire the same check into ``has_active_binding``.
     #
     # Fail-closed on the resolver: if ``resolve_effective_tier``
     # crashes (DB outage, malformed JSON), the helper already
@@ -244,6 +261,7 @@ async def run(
         tier_matrix is not None
         and capability_gate_applies
         and tool_def.required_capability
+        and principal_type == "agent"
     ):
         try:
             effective_tier, attestation_claim = await resolve_effective_tier(

--- a/tests/test_executor_tier_gate.py
+++ b/tests/test_executor_tier_gate.py
@@ -57,17 +57,21 @@ def _register_tool() -> AsyncMock:
     return handler
 
 
-def _agent(scope: list[str] | None = None) -> TokenPayload:
+def _agent(
+    scope: list[str] | None = None,
+    principal_type: str = "agent",
+    agent_id: str = "acme::daniele",
+) -> TokenPayload:
     return TokenPayload(
-        sub="spiffe://cullis.test/acme::daniele",
-        agent_id="acme::daniele",
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
         org="acme",
         exp=9_999_999_999,
         iat=0,
         jti="jti-tier-test",
         scope=scope or [_TOOL_CAP],
         cnf={"jkt": "fake-jkt"},
-        principal_type="agent",
+        principal_type=principal_type,
     )
 
 
@@ -291,3 +295,101 @@ async def test_no_app_state_falls_back_to_load_default_matrix(
     # default_min_tier=untrusted ⇒ gate passes ⇒ handler fires.
     assert resp.status == "success"
     handler.assert_awaited_once()
+
+
+# ── typed-principal exemption (F5 follow-up #6) ───────────────────────
+
+
+async def _run_typed_with_tier(
+    *, principal_type: str, agent_id: str,
+    required_tier: str = "managed_attested",
+):
+    """Driver for typed-principal tier-gate cases.
+
+    Uses a tier matrix that would *deny* every agent-typed call
+    (required=managed_attested vs. a mocked effective=untrusted).
+    The point is to assert the resolver isn't even consulted for
+    typed callers — the gate is skipped, the handler fires, and
+    no ``policy.tier_evaluated`` audit row is emitted.
+    """
+    handler = _register_tool()
+    agent = _agent(principal_type=principal_type, agent_id=agent_id)
+    app_state = SimpleNamespace(tier_matrix=_matrix(required_tier))
+    audit = AsyncMock()
+    resolver = AsyncMock(return_value=("untrusted", None))
+    with patch(
+        "mcp_proxy.tools.executor.resolve_effective_tier", resolver,
+    ), patch(
+        "mcp_proxy.tools.executor.log_audit", audit,
+    ):
+        resp = await executor.run(
+            request=_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=app_state,
+        )
+    return resp, handler, audit, resolver
+
+
+@pytest.mark.asyncio
+async def test_user_principal_bypasses_tier_gate(clean_registry):
+    """A ``user::*`` principal must skip the device tier check.
+
+    The user-typed caller has no ``internal_agents`` row, so reading
+    ``last_attestation`` would always return ``None`` and collapse to
+    ``untrusted``. Denying every typed call is the wrong default —
+    user attestation belongs to a separate path (ADR-021 multi-user
+    KMS, Frontdesk SSO, Connector local-credentials).
+    """
+    resp, handler, audit, resolver = await _run_typed_with_tier(
+        principal_type="user",
+        agent_id="acme::alice",
+    )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+    resolver.assert_not_awaited()
+
+    actions = [call.kwargs.get("action") for call in audit.await_args_list]
+    assert "policy.tier_evaluated" not in actions, (
+        "tier gate must not emit policy.tier_evaluated for typed principals"
+    )
+
+
+@pytest.mark.asyncio
+async def test_workload_principal_bypasses_tier_gate(clean_registry):
+    """A ``workload::*`` principal must skip the device tier check.
+
+    Workloads (M2M) authenticate server-side via SPIRE / cert chain;
+    they have no Connector device claim. Same exemption as user.
+    """
+    resp, handler, audit, resolver = await _run_typed_with_tier(
+        principal_type="workload",
+        agent_id="acme::pipeline-batch",
+    )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+    resolver.assert_not_awaited()
+
+    actions = [call.kwargs.get("action") for call in audit.await_args_list]
+    assert "policy.tier_evaluated" not in actions
+
+
+@pytest.mark.asyncio
+async def test_agent_principal_still_gated_after_typed_exemption(
+    clean_registry,
+):
+    """Regression pin: the agent path keeps the tier gate.
+
+    Same matrix that the typed tests above use to prove the
+    exemption — here it must DENY because the principal is
+    agent-typed and the mocked effective tier (``untrusted``) is
+    below the requirement (``managed_attested``).
+    """
+    resp, handler, _ = await _run_with_tier(
+        effective_tier="untrusted",
+        required_tier="managed_attested",
+    )
+    assert resp.status == "error"
+    handler.assert_not_awaited()
+    assert "untrusted" in (resp.error or "").lower()


### PR DESCRIPTION
## Summary

- Guard the ADR-032 Decision E / F5 tier gate with `principal_type == "agent"` so typed callers (user / workload, ADR-020) skip the device-tier check that has no data source for them.
- Capability gate (PR #730) still runs for typed callers; MCP-resource binding gate (CRIT-2) still runs. Only the device tier check is skipped.
- Docstring on `mcp_proxy/policy/tier_eval.py` now documents the agent-only contract + the ADR-021 v2 extension point (per-user attestation likely landing on `user_sessions` per migration 0035's note for Frontdesk F4 R2 shared-mode).

## Decision rationale

Schema-grounded. Verified pre-impl:

- `internal_agents.last_attestation` is the only attestation column today (migration 0035).
- `local_user_principals.last_attestation` was **explicitly** rejected by the schema author of 0035 — see the migration's module docstring: *"the attestation is a per-device claim ... a similar column on `user_sessions` once F4 R2 wires that flow end-to-end"*. The principal row is durable identity; the claim is per-device.
- Therefore Opzione A (exempt typed) is the only coherent default for the current schema. Opzione B (read from `local_user_principals`) would have required schema work that contradicts the existing architectural call.

Without this guard a `user::alice` caller resolves to `agent_row = None` → tier collapses to `untrusted` → any capability requiring tier ≥ `byod_isolated` denies. That bypasses all the typed-principal capability work landed by #730.

## Test plan

- [x] `pytest tests/test_executor_tier_gate.py tests/test_tier_eval_resolve.py -n auto --dist=loadfile` — 17 passed
- [x] `pytest tests/ -k 'tier or executor' -n auto --dist=loadfile` — 90 passed, 2 skipped
- [x] `pytest tests/ -n auto --dist=loadfile` — 3811 passed, 32 skipped, 1 unrelated pre-existing failure (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable` — env contamination from editable `cullis_enterprise` install in the local shared venv; CI is clean)
- [x] `./demo_network/smoke.sh full` — all PASS (round-trip + A4 dashboard restart + A7 hash chain + A8 mcp-echo)
- [x] New tests cover: `user` bypass + `workload` bypass + `agent` still-gated regression. All three assert `resolver.assert_not_awaited()` / `assert_awaited_once()` and `policy.tier_evaluated` audit emission absence/presence as required.
- [ ] CI: `test (3.11)` + `Signed-off-by check` + `demo_network smoke (ec/rsa/rsa-postgres)` + `customer-path smoke` green.

## Scope chiuso (not in this PR)

- ADR-032 `Decision E` text update — the ADR lives in `imp/adrs/` (gitignored, internal-only per recent ratification policy) so this PR cannot touch it. The agent-only constraint is captured in the executor comment block + `tier_eval.py` docstring instead; ADR file update is a separate orchestrator-side task.
- ADR-021 v2 per-user attestation read path. The docstring marks the extension point but does not implement.
- MCP-resource binding-gate tier-gating — explicitly deferred to a separate F5 follow-up per the existing comment at `executor.py` step 2b.