### PR TITLE
feat(connector): add 'users reset-password' CLI subcommand

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -454,6 +454,34 @@ cullis-connector --config-dir ~/.cullis-orgB serve
   user bin directory is probably missing; add `python -m site --user-base`
   + `/bin` to `$PATH`, or install in a venv.
 
+## Lost end-user password recovery
+
+Un employee non riesce ad accedere alla SPA Frontdesk perché ha perso
+la password. L'IT manager può resettarla senza fermare il bundle e
+senza esportare l'`X-Admin-Secret`:
+
+```bash
+# Frontdesk container (no X-Admin-Secret needed):
+docker exec -it cullis-frontdesk-connector \
+  cullis-connector users reset-password alice
+```
+
+L'output stampa una password temporanea generata (16 char URL-safe).
+Comunicala all'employee via canale sicuro. Al prossimo login alice
+sarà forzata a cambiarla.
+
+Per impostare un valore esplicito invece di generarlo:
+
+```bash
+docker exec -it cullis-frontdesk-connector \
+  cullis-connector users reset-password alice \
+  --new-password "TempPass2026!"
+```
+
+Sul Connector standalone (desktop / dev install) usa lo stesso comando
+senza `docker exec` — opera direttamente su `~/.cullis/.../users.db`
+e non richiede admin secret.
+
 ---
 
 ## License

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -331,6 +331,45 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_shared_args(whoami)
 
+    # P3 MAJOR-1 — direct users.db administration for in-container or
+    # on-host recovery. Bypasses the X-Admin-Secret HTTP path (useful
+    # on hardened Frontdesk bundles where exporting the secret is
+    # awkward, and on Connector standalone where no admin secret is
+    # provisioned by default). Today only ``reset-password`` is wired;
+    # future siblings (list, disable, enable) plug into the same
+    # subparser tree.
+    users = subparsers.add_parser(
+        "users",
+        help="Manage local users (admin path, no HTTP required).",
+        description=(
+            "Direct local users.db management for in-container or "
+            "on-host administration. Does NOT require X-Admin-Secret "
+            "since it operates on the SQLite file directly. Intended "
+            "for use via `docker exec` on the Frontdesk Connector "
+            "container, or directly on the host for Connector standalone."
+        ),
+    )
+    users_sub = users.add_subparsers(dest="users_command")
+
+    reset_pwd = users_sub.add_parser(
+        "reset-password",
+        help="Reset a local user's password and force a change on next login.",
+    )
+    _add_shared_args(reset_pwd)
+    reset_pwd.add_argument(
+        "user_name",
+        help="The user name (case-insensitive) whose password to reset.",
+    )
+    reset_pwd.add_argument(
+        "--new-password",
+        dest="new_password",
+        default=None,
+        help=(
+            "New password to set. If omitted, a 16-char URL-safe random "
+            "password is generated and printed to stdout."
+        ),
+    )
+
     return parser
 
 
@@ -346,6 +385,7 @@ _KNOWN_SUBCOMMANDS = frozenset({
     "login",
     "logout",
     "whoami",
+    "users",
 })
 
 # Shared flags are parsed by the subparser that owns the chosen command.
@@ -967,6 +1007,65 @@ def _cmd_show_token(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_users_reset_password(
+    cfg: ConnectorConfig, args: argparse.Namespace,
+) -> int:
+    """Reset a user's password via direct users.db access.
+
+    Bypasses X-Admin-Secret HTTP path: useful for ``docker exec`` on
+    the Frontdesk bundle host (P3 MAJOR-1 operability gap, audit in
+    ``imp/p3-operability-audit.md``) and on Connector standalone
+    desktop where no admin secret is provisioned by default.
+    """
+    import asyncio
+    import secrets
+
+    new_pwd = args.new_password
+    pwd_generated = False
+    if not new_pwd:
+        # token_urlsafe(12) yields ~16 URL-safe ASCII characters, which
+        # comfortably clears the MIN_PASSWORD_LENGTH=8 floor in
+        # ``identity/users.py`` while staying short enough to paste.
+        new_pwd = secrets.token_urlsafe(12)
+        pwd_generated = True
+
+    async def _run() -> bool:
+        from cullis_connector.identity import get_users_session
+        from cullis_connector.identity.users import reset_password
+
+        async with get_users_session(cfg.config_dir) as session:
+            return await reset_password(session, args.user_name, new_pwd)
+
+    try:
+        ok = asyncio.run(_run())
+    except ValueError as exc:
+        # ``set_password_hash`` raises on weak / non-string passwords.
+        # An explicit ``--new-password`` below MIN_PASSWORD_LENGTH is
+        # the only realistic trigger (generated paths use 16 chars).
+        print(f"Cannot reset password: {exc}", file=sys.stderr)
+        return 2
+
+    if not ok:
+        print(
+            f"User {args.user_name!r} not found in users.db",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Password reset for user {args.user_name!r}.")
+    if pwd_generated:
+        # Password goes to stdout only — never to the structured log
+        # (the _log object writes to stderr at INFO above).
+        print(f"Temporary password: {new_pwd}")
+        print(
+            "Share this once via secure channel. "
+            "Must be changed at next login."
+        )
+    else:
+        print("User must change password at next login.")
+    return 0
+
+
 def _cmd_doctor(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     """Audit IDE MCP configs for stale Cullis entries (Finding #8)."""
     from cullis_connector.doctor import has_problems, scan
@@ -1035,6 +1134,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_logout(cfg, args)
     if command == "whoami":
         return _cmd_whoami(cfg, args)
+    if command == "users":
+        if getattr(args, "users_command", None) == "reset-password":
+            return _cmd_users_reset_password(cfg, args)
+        # No (or unknown) sub-sub command — surface a usage hint, since
+        # argparse on an empty users-subcommand otherwise prints the
+        # global usage without the sub-sub options.
+        print(
+            "Use: cullis-connector users reset-password <user_name>",
+            file=sys.stderr,
+        )
+        return 2
     return _cmd_serve(cfg)
 
 

--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -158,6 +158,35 @@ If both rows show the same principal, the `X-Forwarded-User` header is not reach
 | Both users land as `unknown@frontdesk.dev` | nginx is not seeing the `?user=` query (it only triggers on the cookie-mint path). Open in incognito so each tab starts cookie-less. |
 | 502 from nginx | Connector cannot reach the Mastio. Check enrollment is good (`docker compose exec connector cullis-connector doctor`). |
 
+## Lost end-user password recovery
+
+Un employee non riesce ad accedere alla SPA Frontdesk perché ha perso
+la password. L'IT manager può resettarla senza fermare il bundle e
+senza esportare l'`X-Admin-Secret`:
+
+```bash
+# Frontdesk container (no X-Admin-Secret needed):
+docker exec -it cullis-frontdesk-connector \
+  cullis-connector users reset-password alice
+```
+
+L'output stampa una password temporanea generata (16 char URL-safe).
+Comunicala all'employee via canale sicuro. Al prossimo login alice
+sarà forzata a cambiarla.
+
+Per impostare un valore esplicito invece di generarlo:
+
+```bash
+docker exec -it cullis-frontdesk-connector \
+  cullis-connector users reset-password alice \
+  --new-password "TempPass2026!"
+```
+
+Il comando opera direttamente su `users.db` dentro il container — non
+richiede `CULLIS_CONNECTOR_ADMIN_SECRET` e non passa per la rete, per
+cui resta utilizzabile anche su deploy hardenati che non espongono
+l'admin secret all'host.
+
 ## Production: replace nginx with oauth2-proxy + IDP
 
 `nginx/default.conf` is dev-grade. The contracts the rest of the bundle relies on are exactly two:

--- a/tests/connector/test_cli_users_reset_password.py
+++ b/tests/connector/test_cli_users_reset_password.py
@@ -1,0 +1,163 @@
+"""CLI tests for ``cullis-connector users reset-password`` — P3 MAJOR-1.
+
+Covers the four customer-facing branches:
+
+* explicit ``--new-password`` succeeds and rewrites the bcrypt hash;
+* generated path prints "Temporary password:" plus a URL-safe token;
+* missing user → exit 1 + "not found" on stderr;
+* ``must_change_password`` is forced back to 1 after a successful reset.
+
+Reuses the existing ``users.db`` engine cache invalidation pattern
+(``dispose_users_engines``) so each test sees a clean SQLite file at
+its own ``tmp_path``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cullis_connector.cli import main as cli_main
+from cullis_connector.identity import get_users_session
+from cullis_connector.identity.users import (
+    LocalUser,
+    create_user,
+    verify_password,
+)
+from cullis_connector.identity.users_db import dispose_users_engines
+from sqlalchemy import select
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    yield
+    await dispose_users_engines()
+
+
+@pytest.fixture
+def config_dir(tmp_path, monkeypatch):
+    """Isolated config_dir for this test, exported via CLI flag."""
+    cd = tmp_path / "connector"
+    cd.mkdir(parents=True, exist_ok=True)
+    # Avoid the CLI picking up the dev profile under ~/.cullis.
+    monkeypatch.delenv("CULLIS_CONNECTOR_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CULLIS_PROFILE", raising=False)
+    return cd
+
+
+def _seed_user(config_dir, name: str, password: str = "initialpass") -> None:
+    async def _run():
+        async with get_users_session(config_dir) as session:
+            await create_user(
+                session, name=name, password=password, must_change=False,
+            )
+        await dispose_users_engines()
+
+    asyncio.run(_run())
+
+
+def _load_row(config_dir, name: str) -> LocalUser | None:
+    async def _run():
+        async with get_users_session(config_dir) as session:
+            result = await session.execute(
+                select(LocalUser).where(LocalUser.user_name == name)
+            )
+            row = result.scalar_one_or_none()
+            # Detach so the row survives session teardown for assertions
+            if row is not None:
+                session.expunge(row)
+            return row
+
+    return asyncio.run(_run())
+
+
+def test_users_reset_password_with_explicit_pwd(config_dir, capsys):
+    _seed_user(config_dir, "alice", password="initialpass")
+
+    exit_code = cli_main(
+        [
+            "users", "reset-password", "alice",
+            "--new-password", "newstrongpw",
+            "--config-dir", str(config_dir),
+        ]
+    )
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    assert "Password reset for user 'alice'" in captured.out
+    # Explicit-password path must NOT echo the password back.
+    assert "newstrongpw" not in captured.out
+    assert "User must change password at next login." in captured.out
+
+    async def _check():
+        async with get_users_session(config_dir) as session:
+            assert await verify_password(session, "alice", "newstrongpw") is True
+            # Old password is rejected.
+            assert await verify_password(session, "alice", "initialpass") is False
+
+    asyncio.run(_check())
+
+
+def test_users_reset_password_generated(config_dir, capsys):
+    _seed_user(config_dir, "bob", password="initialpass")
+
+    exit_code = cli_main(
+        [
+            "users", "reset-password", "bob",
+            "--config-dir", str(config_dir),
+        ]
+    )
+    assert exit_code == 0
+
+    out = capsys.readouterr().out
+    assert "Temporary password:" in out
+    # Extract the temp password and assert it works against the DB.
+    line = next(
+        ln for ln in out.splitlines() if ln.startswith("Temporary password:")
+    )
+    temp_pwd = line.split("Temporary password:", 1)[1].strip()
+    # secrets.token_urlsafe(12) produces 16 ASCII chars.
+    assert len(temp_pwd) >= 12
+    assert temp_pwd.isascii()
+
+    async def _check():
+        async with get_users_session(config_dir) as session:
+            assert await verify_password(session, "bob", temp_pwd) is True
+
+    asyncio.run(_check())
+
+
+def test_users_reset_password_user_not_found(config_dir, capsys):
+    # users.db will be created empty on first session open
+    exit_code = cli_main(
+        [
+            "users", "reset-password", "nosuchuser",
+            "--new-password", "newstrongpw",
+            "--config-dir", str(config_dir),
+        ]
+    )
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "not found" in err
+    assert "nosuchuser" in err
+
+
+def test_users_reset_password_forces_must_change(config_dir):
+    _seed_user(config_dir, "carol", password="initialpass")
+    # Sanity: seeded user has must_change=False (must_change_password=0)
+    seeded = _load_row(config_dir, "carol")
+    assert seeded is not None
+    assert seeded.must_change_password == 0
+
+    exit_code = cli_main(
+        [
+            "users", "reset-password", "carol",
+            "--new-password", "newstrongpw",
+            "--config-dir", str(config_dir),
+        ]
+    )
+    assert exit_code == 0
+
+    after = _load_row(config_dir, "carol")
+    assert after is not None
+    assert after.must_change_password == 1


### PR DESCRIPTION
## Summary

- New CLI subcommand: `cullis-connector users reset-password <name> [--new-password <pw>]`. Operates directly on `users.db`, bypassing the X-Admin-Secret HTTP path.
- Generated path prints a ~16-char URL-safe temporary password and forces `must_change_password=1` on next login. Explicit `--new-password` accepts an operator-provided value validated against the same `MIN_PASSWORD_LENGTH=8` floor `create_user` uses.
- New `tests/connector/test_cli_users_reset_password.py` (4 tests): explicit-password, generated, user-not-found (exit 1), forces-must-change.
- Adds `## Lost end-user password recovery` runbook section to `cullis_connector/README.md` and `packaging/frontdesk-bundle/README.md` with the `docker exec` one-liner.
- Wires `users` into `_KNOWN_SUBCOMMANDS` so the `test_cli_dispatch.test_known_subcommands_matches_parser` regression guard pins the new subcommand.

## Why

P3 MAJOR-1 from `imp/p3-operability-audit.md`. Customer IT teams who need to reset a forgotten employee password today must export `CULLIS_CONNECTOR_ADMIN_SECRET` from `frontdesk.env` and curl `/admin/users/.../reset-password` — awkward on hardened Frontdesk bundles where the secret is not surfaced to the host, and impossible on Connector standalone desktop installs that ship without an admin secret. Aligns with the customer "coworker who lost their badge" framing: the IT manager resets in one `docker exec` without disrupting the running bundle. The existing HTTP admin route stays unchanged — dual-path: HTTP for programmatic clients, CLI for operator-driven recovery.

## Test plan

- [x] `pytest tests/ -k 'users or reset_password' -x` — 85 passed, 2 skipped (existing identity/users + admin-router + new CLI suite).
- [x] `pytest tests/connector/test_cli_dispatch.py` — 11 passed (registry-vs-parser invariant intact).
- [x] `pytest tests/connector/test_cli_users_reset_password.py` — 4 passed (explicit / generated / not-found / must-change).
- [x] DCO `Signed-off-by:` present.
- [x] Ruff: no new findings (only pre-existing F821 on `_resolve_token_path` annotation).
- [ ] CI green.

## Documentation

- `cullis_connector/README.md` — new `## Lost end-user password recovery` section right after `## Troubleshooting`.
- `packaging/frontdesk-bundle/README.md` — same section after `## Verify per-user audit attribution`, framed for the `docker exec` flow.
- `--help` output picks up the new `users` / `users reset-password` parsers via the `description` strings; no docs/cli.md edits needed.