### PR TITLE
feat(bundle): add --upgrade-bundle + backup hook to enterprise bundle

### DIFF
--- a/packaging/_common-deploy-helpers.sh
+++ b/packaging/_common-deploy-helpers.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Mastio bundles — shared deploy helpers (backup + bind-mount paths)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Sourced by:
+#   - packaging/mastio-bundle/deploy.sh             (open-core)
+#   - packaging/mastio-enterprise-bundle/deploy.sh  (private)
+#
+# Single source of truth for pre-upgrade snapshot logic so the two
+# bundles do not drift (MAJOR-5 of imp/p3-operability-audit.md).
+#
+# Contract the caller must provide before sourcing:
+#   - SCRIPT_DIR  absolute path to the bundle dir (so proxy.env can be
+#                 read and ./backups/ lands inside the bundle)
+#   - ok / warn / err / die / step  the colour-aware log helpers used
+#                 by every bundle deploy.sh
+#
+# These helpers were the inline definitions in
+# packaging/mastio-bundle/deploy.sh:90-189 before this extraction.
+# Mechanical extraction only: no logic changes, no perf tweaks, no
+# parameter renames. The busybox-root pattern
+# (feedback_busybox_root_for_bind_dir_post_init_perms.md) is preserved
+# bit-for-bit so 0600 files (mcp_proxy.db, mastio-server.key) survive
+# the backup read.
+
+# proxy.env value lookup. Mirrors the inline lambda used in the prod
+# validation block, hoisted here so the ADR-030 helpers can share it
+# without forward-references.
+_load_env() {
+    grep -E "^$1=" "$SCRIPT_DIR/proxy.env" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+# Bind-mount targets resolved from proxy.env (with the compose-level
+# defaults baked in). Echoed as absolute paths so the rest of the script
+# does not have to care about relative-to-bundle semantics.
+_data_dir_host() {
+    local p
+    p="$(_load_env MASTIO_DATA_DIR 2>/dev/null || true)"
+    p="${p:-./data}"
+    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
+    echo "$p"
+}
+_nginx_certs_dir_host() {
+    local p
+    p="$(_load_env MASTIO_NGINX_CERTS_DIR 2>/dev/null || true)"
+    p="${p:-./nginx-certs}"
+    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
+    echo "$p"
+}
+
+# Copy a bind dir into the backup target. Must run as root through a
+# busybox sidecar because post-init-permissions the dir + sensitive
+# files (mastio-server.key 0600, mcp_proxy.db 0600) are owned by uid
+# 10001 and unreadable by the invoking ``cullis``/operator user. The
+# in-container cp also handles ownership preservation cleanly. Chown
+# the *backup copy* back to the invoking user so the operator can read
+# / restore it without sudo.
+_copy_bind_dir_for_backup() {
+    local src_dir="$1" dst_dir="$2"
+    [[ -d "$src_dir" ]] || return 0
+    compgen -G "$src_dir/*" >/dev/null 2>&1 || return 0
+    mkdir -p "$(dirname "$dst_dir")"
+    docker run --rm \
+        -v "$src_dir:/src:ro" \
+        -v "$(dirname "$dst_dir"):/dst-parent" \
+        --user 0:0 \
+        busybox:stable sh -c "
+            cp -a /src /dst-parent/$(basename "$dst_dir")
+            chown -R $(id -u):$(id -g) /dst-parent/$(basename "$dst_dir")
+        " >/dev/null
+}
+
+# Tar-aware backup. Snapshots proxy.env + data dir + nginx-certs dir into
+# ./backups/<label>-<ts>/ so an operator who hits a regression mid-upgrade
+# has an obvious restore target. Cheap (rsync-style copy, not tar) so the
+# operator can ``cp -a`` it back without untar tooling. The bind-dir
+# copies route through a root busybox so 0600 files (mastio-server.key,
+# mcp_proxy.db) survive the read.
+_backup_user_state() {
+    local label="$1" ts backup_dir data_dir nginx_certs_dir
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    backup_dir="$SCRIPT_DIR/backups/${label}-${ts}"
+    data_dir="$(_data_dir_host)"
+    nginx_certs_dir="$(_nginx_certs_dir_host)"
+    mkdir -p "$backup_dir"
+    if [[ -f "$SCRIPT_DIR/proxy.env" ]]; then
+        cp -a "$SCRIPT_DIR/proxy.env" "$backup_dir/proxy.env"
+    fi
+    _copy_bind_dir_for_backup "$data_dir"         "$backup_dir/data"
+    _copy_bind_dir_for_backup "$nginx_certs_dir"  "$backup_dir/nginx-certs"
+    ok "Backup written to ${backup_dir#$SCRIPT_DIR/}"
+    BACKUP_DIR="$backup_dir"
+}

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -84,30 +84,13 @@ _volume_full_name() {
     echo "${COMPOSE_PROJECT_NAME}_$1"
 }
 
-# Bind-mount targets resolved from proxy.env (with the compose-level
-# defaults baked in). Echoed as absolute paths so the rest of the script
-# does not have to care about relative-to-bundle semantics.
-_data_dir_host() {
-    local p
-    p="$(_load_env MASTIO_DATA_DIR 2>/dev/null || true)"
-    p="${p:-./data}"
-    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
-    echo "$p"
-}
-_nginx_certs_dir_host() {
-    local p
-    p="$(_load_env MASTIO_NGINX_CERTS_DIR 2>/dev/null || true)"
-    p="${p:-./nginx-certs}"
-    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
-    echo "$p"
-}
-
-# proxy.env value lookup. Mirrors the inline lambda used in the prod
-# validation block, hoisted here so the ADR-030 helpers can share it
-# without forward-references.
-_load_env() {
-    grep -E "^$1=" "$SCRIPT_DIR/proxy.env" 2>/dev/null | head -1 | cut -d= -f2- || true
-}
+# Backup + bind-mount path helpers live in the shared file so the
+# enterprise bundle picks the same implementation (MAJOR-5 audit).
+# Sourcing here, before any ADR-030 helper that references them, keeps
+# the call order intact and the diff against the pre-extraction layout
+# limited to a deletion + a single source line.
+# shellcheck source=../_common-deploy-helpers.sh
+source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
 
 # mkdir + chown the host bind targets. The chown is the same operation
 # the init-permissions compose service runs at boot, just earlier so a
@@ -144,49 +127,8 @@ _rewrite_env_pin() {
     echo "${var}=${value}" >> "$envfile"
 }
 
-# Copy a bind dir into the backup target. Must run as root through a
-# busybox sidecar because post-init-permissions the dir + sensitive
-# files (mastio-server.key 0600, mcp_proxy.db 0600) are owned by uid
-# 10001 and unreadable by the invoking ``cullis``/operator user. The
-# in-container cp also handles ownership preservation cleanly. Chown
-# the *backup copy* back to the invoking user so the operator can read
-# / restore it without sudo.
-_copy_bind_dir_for_backup() {
-    local src_dir="$1" dst_dir="$2"
-    [[ -d "$src_dir" ]] || return 0
-    compgen -G "$src_dir/*" >/dev/null 2>&1 || return 0
-    mkdir -p "$(dirname "$dst_dir")"
-    docker run --rm \
-        -v "$src_dir:/src:ro" \
-        -v "$(dirname "$dst_dir"):/dst-parent" \
-        --user 0:0 \
-        busybox:stable sh -c "
-            cp -a /src /dst-parent/$(basename "$dst_dir")
-            chown -R $(id -u):$(id -g) /dst-parent/$(basename "$dst_dir")
-        " >/dev/null
-}
-
-# Tar-aware backup. Snapshots proxy.env + data dir + nginx-certs dir into
-# ./backups/<label>-<ts>/ so an operator who hits a regression mid-upgrade
-# has an obvious restore target. Cheap (rsync-style copy, not tar) so the
-# operator can ``cp -a`` it back without untar tooling. The bind-dir
-# copies route through a root busybox so 0600 files (mastio-server.key,
-# mcp_proxy.db) survive the read.
-_backup_user_state() {
-    local label="$1" ts backup_dir data_dir nginx_certs_dir
-    ts="$(date -u +%Y%m%dT%H%M%SZ)"
-    backup_dir="$SCRIPT_DIR/backups/${label}-${ts}"
-    data_dir="$(_data_dir_host)"
-    nginx_certs_dir="$(_nginx_certs_dir_host)"
-    mkdir -p "$backup_dir"
-    if [[ -f "$SCRIPT_DIR/proxy.env" ]]; then
-        cp -a "$SCRIPT_DIR/proxy.env" "$backup_dir/proxy.env"
-    fi
-    _copy_bind_dir_for_backup "$data_dir"         "$backup_dir/data"
-    _copy_bind_dir_for_backup "$nginx_certs_dir"  "$backup_dir/nginx-certs"
-    ok "Backup written to ${backup_dir#$SCRIPT_DIR/}"
-    BACKUP_DIR="$backup_dir"
-}
+# _copy_bind_dir_for_backup + _backup_user_state extracted to
+# packaging/_common-deploy-helpers.sh (sourced near the top of the file).
 
 # Move a single legacy named volume's contents into a host bind dir.
 # Safety: refuses if the destination bind dir already has files in it

--- a/packaging/mastio-enterprise-bundle/README.md
+++ b/packaging/mastio-enterprise-bundle/README.md
@@ -107,16 +107,68 @@ cross-worker replay enforcement, point the Mastio at Redis via
 deploys). For sustained Tier 2 throughput (>500 RPS under p99 1s),
 batched audit chain (ADR-033) lands in Mastio v0.5.
 
-## Upgrading
+## Upgrading the bundle
+
+Recommended: use the wrapped path. Snapshots `proxy.env` + `./data/` +
+`./nginx-certs/` to `./backups/pre-upgrade-<version>-<timestamp>/`
+**before** anything mutates, so an operator who hits a regression
+mid-upgrade has an obvious in-place restore target.
 
 ```bash
-# Edit proxy.env, bump CULLIS_MASTIO_VERSION to the new tag.
+./deploy.sh --upgrade-bundle 0.4.5
+```
+
+Effect:
+
+1. Snapshot of the bind-mount data (`proxy.env`, `./data/`, `./nginx-certs/`)
+   into `./backups/pre-upgrade-0.4.5-<UTC-ts>/`. Files with 0600 perms
+   (`mcp_proxy.db`, `mastio-server.key`) are copied through a root
+   `busybox:stable` sidecar then chown'd back to the invoking operator
+   — same pattern the open-core `mastio-bundle` uses, shared via
+   `packaging/_common-deploy-helpers.sh` so the two bundles cannot drift.
+2. `docker compose --env-file proxy.env down`
+   (project-scoped to `cullis-mastio-enterprise`).
+3. `CULLIS_MASTIO_VERSION` rewritten in `proxy.env`.
+4. `docker compose --env-file proxy.env pull` against the new tag (fails
+   fast if the GHCR PAT is unauthorized for the new release).
+5. `docker compose --env-file proxy.env up -d --wait` blocks until the
+   healthcheck passes — never returns "started" before the listener
+   binds (memoria `feedback_frontdesk_deploy_force_recreate_mcp_proxy_race`).
+
+Restore in case of regression:
+
+```bash
+./deploy.sh --down
+cp -a backups/pre-upgrade-0.4.5-<ts>/proxy.env       ./proxy.env
+cp -a backups/pre-upgrade-0.4.5-<ts>/data/.          ./data/
+cp -a backups/pre-upgrade-0.4.5-<ts>/nginx-certs/.   ./nginx-certs/
+CULLIS_MASTIO_VERSION=<previous-tag> ./deploy.sh
+```
+
+Pre-upgrade snapshots are **not** auto-pruned. Once the new release is
+proven stable, remove them by hand:
+
+```bash
+rm -rf backups/pre-upgrade-*
+```
+
+For a compliance-grade, GPG-encrypted, off-host archive (different shape,
+slower) use `./backup.sh` + `./restore.sh` instead — that pair is for
+disaster recovery and audit retention, not for in-place rollbacks.
+
+### Legacy image-only path
+
+The pre-`--upgrade-bundle` workflow still works, but skips the snapshot
+step:
+
+```bash
 sed -i 's/^CULLIS_MASTIO_VERSION=.*/CULLIS_MASTIO_VERSION=<new>/' proxy.env
 ./deploy.sh --pull
 ```
 
 Operator-side data (`./data/mcp_proxy.db`, `./nginx-certs/`,
-`./saml-keys/`) survives the image bump.
+`./saml-keys/`) survives the image bump in both flows. The wrapped path
+is the one to run in a regulated environment.
 
 ## Where things live
 

--- a/packaging/mastio-enterprise-bundle/deploy.sh
+++ b/packaging/mastio-enterprise-bundle/deploy.sh
@@ -15,14 +15,18 @@
 #     PAT issued at deal close.
 #
 # Modes:
-#   (default)         standalone enterprise Mastio
-#   --down            stop + remove containers
-#   --pull            re-pull image
+#   (default)                   standalone enterprise Mastio
+#   --down                      stop + remove containers
+#   --pull                      re-pull image
+#   --upgrade-bundle <version>  snapshot user state to ./backups/, bump
+#                               CULLIS_MASTIO_VERSION in proxy.env, pull
+#                               the new image, restart with --wait
 #
 # Usage:
 #   ./deploy.sh
 #   CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh
 #   ./deploy.sh --down
+#   ./deploy.sh --upgrade-bundle 0.4.5
 #
 set -euo pipefail
 
@@ -45,14 +49,37 @@ err()  { echo -e "  ${RED}✗${RESET}  $1"; }
 die()  { err "$1"; exit 1; }
 step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
 
+# Source shared backup helpers (same file the open-core mastio-bundle
+# uses, so the two bundles cannot drift on backup semantics). MAJOR-5
+# of imp/p3-operability-audit.md.
+# shellcheck source=../_common-deploy-helpers.sh
+source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+
 MODE="up"
 PULL=0
-for arg in "$@"; do
+UPGRADE_BUNDLE_TO=""
+# Manual loop because --upgrade-bundle consumes the next positional
+# arg; the original ``for arg in "$@"`` cannot shift mid-iteration.
+while [[ $# -gt 0 ]]; do
+    arg="$1"
     case "$arg" in
-        --down)  MODE="down" ;;
-        --pull)  PULL=1 ;;
+        --down)  MODE="down"; shift ;;
+        --pull)  PULL=1; shift ;;
+        --upgrade-bundle)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--upgrade-bundle requires a version (e.g. --upgrade-bundle 0.4.5)"
+            UPGRADE_BUNDLE_TO="$1"
+            MODE="upgrade_bundle"
+            shift
+            ;;
+        --upgrade-bundle=*)
+            UPGRADE_BUNDLE_TO="${arg#--upgrade-bundle=}"
+            [[ -n "$UPGRADE_BUNDLE_TO" ]] || die "--upgrade-bundle= requires a value"
+            MODE="upgrade_bundle"
+            shift
+            ;;
         -h|--help)
-            sed -n '2,30p' "$0" | sed 's/^# \?//'
+            sed -n '2,35p' "$SCRIPT_DIR/deploy.sh" | sed 's/^# \?//'
             exit 0
             ;;
         *) die "unknown arg: $arg (use --help)" ;;
@@ -79,6 +106,87 @@ if [[ "$MODE" == "down" ]]; then
     step "stopping cullis-mastio-enterprise stack"
     docker compose --env-file proxy.env down
     ok "stack stopped"
+    exit 0
+fi
+
+# ── upgrade-bundle (image-only, pre-upgrade backup) ─────────────────────────
+# Customer-facing recovery target: every Mastio Enterprise upgrade lands
+# a timestamped snapshot of proxy.env + ./data + ./nginx-certs under
+# ./backups/pre-upgrade-<version>-<ts>/ BEFORE the new image is pulled.
+# Operator can ``cp -a`` it back on the spot if the new release misbehaves
+# (or use ./restore.sh for a full GPG-encrypted off-host copy, see
+# backup.sh — that path is for compliance archives, not in-place
+# rollbacks).
+#
+# Mirrors the open-core ``--upgrade-bundle`` pattern but stops short of
+# downloading a tarball — the enterprise bundle's scripts ship with the
+# private image release, not a public GitHub tarball, so an image-only
+# bump is the right operation. memoria
+# feedback_bundle_upgrade_must_use_deploy_sh.md: never invoke compose
+# plain, always --wait and route through deploy.sh so
+# COMPOSE_PROJECT_NAME and env-file stay aligned.
+if [[ "$MODE" == "upgrade_bundle" ]]; then
+    step "upgrading cullis-mastio-enterprise bundle to ${UPGRADE_BUNDLE_TO}"
+
+    # Version safety: same regex as mcp_proxy.dashboard.update_check
+    # _TAG_SAFE_RE (PR #668). Refuses anything that could land as a
+    # shell metacharacter in the compose / pull argv.
+    if [[ ! "$UPGRADE_BUNDLE_TO" =~ ^[A-Za-z0-9.\-]+$ ]]; then
+        die "refusing version with unsafe characters: ${UPGRADE_BUNDLE_TO} (allowed: A-Z a-z 0-9 . -)"
+    fi
+
+    # 1. Snapshot user state. Helper writes to ./backups/<label>-<ts>/
+    # and chowns the copy back to the invoking user (busybox-root
+    # pattern preserves 0600 mcp_proxy.db + mastio-server.key reads).
+    _backup_user_state "pre-upgrade-${UPGRADE_BUNDLE_TO}"
+
+    # 2. Pin the new version in proxy.env so this run AND every future
+    # ./deploy.sh see the new tag without re-sourcing. Idempotent: any
+    # pre-existing CULLIS_MASTIO_VERSION line is dropped first.
+    sed -i.bak "/^#*[[:space:]]*CULLIS_MASTIO_VERSION=/d" "$SCRIPT_DIR/proxy.env"
+    rm -f "$SCRIPT_DIR/proxy.env.bak"
+    echo "CULLIS_MASTIO_VERSION=${UPGRADE_BUNDLE_TO}" >> "$SCRIPT_DIR/proxy.env"
+    export CULLIS_MASTIO_VERSION="$UPGRADE_BUNDLE_TO"
+    ok "proxy.env: CULLIS_MASTIO_VERSION=${UPGRADE_BUNDLE_TO}"
+
+    # 3. Down the stack BEFORE pulling — running containers do not pick
+    # up a new image and force-recreating live would leave an open
+    # SQLite WAL on /data mid-restart. Use the env-file flag so
+    # COMPOSE_PROJECT_NAME inherits correctly even if a stale shell
+    # forgot the export.
+    step "stopping current stack"
+    docker compose --env-file proxy.env down || warn "down returned non-zero — continuing (may already be stopped)"
+
+    # 4. Pull the new image. Fails fast if the PAT is unauthorized
+    # for the new tag.
+    step "pulling ${UPGRADE_BUNDLE_TO}"
+    if ! docker compose --env-file proxy.env pull; then
+        err "pull failed — restore proxy.env from backup: ${BACKUP_DIR}/proxy.env"
+        die "aborting upgrade"
+    fi
+
+    # 5. Up with --wait so we block until the healthcheck passes (memoria
+    # feedback_frontdesk_deploy_force_recreate_mcp_proxy_race).
+    step "starting ${UPGRADE_BUNDLE_TO}"
+    docker compose --env-file proxy.env up -d --wait
+
+    echo
+    echo -e "${GREEN}${BOLD}Cullis Mastio Enterprise upgraded to ${UPGRADE_BUNDLE_TO}.${RESET}"
+    echo
+    echo -e "  Pre-upgrade backup: ${BACKUP_DIR#$SCRIPT_DIR/}/"
+    echo -e "  Restore in case of regression:"
+    echo -e "    ./deploy.sh --down"
+    echo -e "    cp -a ${BACKUP_DIR#$SCRIPT_DIR/}/proxy.env ./proxy.env"
+    echo -e "    cp -a ${BACKUP_DIR#$SCRIPT_DIR/}/data/.        ./data/"
+    echo -e "    cp -a ${BACKUP_DIR#$SCRIPT_DIR/}/nginx-certs/. ./nginx-certs/"
+    echo -e "    CULLIS_MASTIO_VERSION=<previous-tag> ./deploy.sh"
+    echo
+    echo -e "  Or the GPG-encrypted off-host copy from ./backup.sh + ./restore.sh"
+    echo -e "  if you need a compliance-grade archive (different flow, slower)."
+    echo
+    echo -e "  Pre-upgrade snapshots are NOT auto-pruned. Remove confirmed-good"
+    echo -e "  ones with:  rm -rf backups/pre-upgrade-*"
+    echo
     exit 0
 fi
 

--- a/packaging/test-bundle-backup-symmetry.sh
+++ b/packaging/test-bundle-backup-symmetry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Mastio bundles — backup symmetry smoke test
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Verifies that mastio-bundle (open-core) and mastio-enterprise-bundle
+# share the same backup helpers and both expose ``--upgrade-bundle``.
+# MAJOR-5 of imp/p3-operability-audit.md — without this gate the two
+# bundles silently drift on backup semantics every time someone touches
+# only one of the two deploy.sh files.
+#
+# No Docker required. Live upgrade verification is deferred to the
+# dogfood VM (out of scope for the pre-merge smoke).
+#
+# Run:
+#   ./packaging/test-bundle-backup-symmetry.sh
+
+set -euo pipefail
+
+PACKAGING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GREEN=$'\033[32m'; RED=$'\033[31m'; RESET=$'\033[0m'
+fail() { echo -e "${RED}FAIL${RESET}: $1" >&2; exit 1; }
+pass() { echo -e "${GREEN}PASS${RESET}: $1"; }
+
+HELPER="$PACKAGING_DIR/_common-deploy-helpers.sh"
+OC_DEPLOY="$PACKAGING_DIR/mastio-bundle/deploy.sh"
+ENT_DEPLOY="$PACKAGING_DIR/mastio-enterprise-bundle/deploy.sh"
+
+# ── 1. Shared helper is present and exports the expected functions ──────────
+[[ -f "$HELPER" ]] || fail "$HELPER missing"
+
+# Source under a minimal harness — the helper needs SCRIPT_DIR + an
+# ``ok`` log helper from the caller (contract documented in the file
+# header). We pass a throwaway SCRIPT_DIR and a no-op ``ok``.
+HELPER_FNS="$(
+    SCRIPT_DIR="/tmp" bash -c '
+        SCRIPT_DIR="/tmp"
+        ok() { :; }
+        # shellcheck source=_common-deploy-helpers.sh
+        source "'"$HELPER"'"
+        # ``declare -F <fn1> <fn2> ...`` prints one name per line on
+        # match, exits non-zero if any function is missing.
+        declare -F _backup_user_state _copy_bind_dir_for_backup \
+                   _load_env _data_dir_host _nginx_certs_dir_host
+    '
+)" || fail "sourcing $HELPER raised an error or a function is missing"
+
+for fn in _backup_user_state _copy_bind_dir_for_backup _load_env \
+          _data_dir_host _nginx_certs_dir_host; do
+    grep -qx "$fn" <<<"$HELPER_FNS" \
+        || fail "shared helper does not export $fn"
+done
+pass "_common-deploy-helpers.sh exports the 5 backup functions"
+
+# ── 2. Both deploy.sh files SOURCE the shared helper ────────────────────────
+for path in "$OC_DEPLOY" "$ENT_DEPLOY"; do
+    grep -q '_common-deploy-helpers.sh' "$path" \
+        || fail "$(basename "$(dirname "$path")")/deploy.sh does not source the shared helper"
+done
+pass "both deploy.sh files source the shared helper (no drift)"
+
+# ── 3. The open-core deploy.sh no longer defines the helpers inline ─────────
+# Pre-extraction the open-core deploy.sh had inline copies. After the
+# refactor those must be GONE — otherwise the inline copy can drift
+# from the shared helper while the source line below makes the file
+# *look* correct.
+for fn in _copy_bind_dir_for_backup _backup_user_state _data_dir_host \
+          _nginx_certs_dir_host _load_env; do
+    if grep -qE "^${fn}\(\)" "$OC_DEPLOY"; then
+        fail "$(basename "$(dirname "$OC_DEPLOY")")/deploy.sh still defines ${fn} inline — remove the duplicate"
+    fi
+done
+pass "open-core deploy.sh has no inline copies of the extracted helpers"
+
+# ── 4. --upgrade-bundle is wired on BOTH bundles ────────────────────────────
+for path in "$OC_DEPLOY" "$ENT_DEPLOY"; do
+    grep -q -- '--upgrade-bundle' "$path" \
+        || fail "$(basename "$(dirname "$path")")/deploy.sh does not mention --upgrade-bundle"
+    grep -qE 'UPGRADE_BUNDLE_TO=' "$path" \
+        || fail "$(basename "$(dirname "$path")")/deploy.sh has no UPGRADE_BUNDLE_TO assignment"
+done
+pass "--upgrade-bundle wired on both bundles"
+
+# ── 5. --help on both bundles documents --upgrade-bundle ────────────────────
+for path in "$OC_DEPLOY" "$ENT_DEPLOY"; do
+    "$path" --help 2>&1 | grep -q -- '--upgrade-bundle' \
+        || fail "$(basename "$(dirname "$path")")/deploy.sh --help does not document --upgrade-bundle"
+done
+pass "both --help outputs document --upgrade-bundle"
+
+# ── 6. Bash -n syntax check on all three files ──────────────────────────────
+for path in "$HELPER" "$OC_DEPLOY" "$ENT_DEPLOY"; do
+    bash -n "$path" || fail "bash -n failed on $path"
+done
+pass "bash -n clean on helper + both deploy.sh files"
+
+# ── 7. Both bundles export the right COMPOSE_PROJECT_NAME ───────────────────
+# memoria feedback_bundle_upgrade_must_use_deploy_sh: invoking compose
+# from the wrong project name spawns an orphan parallel stack with empty
+# volumes. The export must live in deploy.sh, not in a one-shot env.
+grep -q 'COMPOSE_PROJECT_NAME="cullis-mastio"' "$OC_DEPLOY" \
+    || fail "open-core deploy.sh does not export COMPOSE_PROJECT_NAME=cullis-mastio"
+grep -q 'COMPOSE_PROJECT_NAME="cullis-mastio-enterprise"' "$ENT_DEPLOY" \
+    || fail "enterprise deploy.sh does not export COMPOSE_PROJECT_NAME=cullis-mastio-enterprise"
+pass "both bundles export their project-scoped COMPOSE_PROJECT_NAME"
+
+echo ""
+echo -e "${GREEN}All symmetry checks passed.${RESET}"


### PR DESCRIPTION
## Summary

- New `./deploy.sh --upgrade-bundle <version>` on `packaging/mastio-enterprise-bundle/`. Snapshot-first sequence: backup proxy.env + bind-mount data → down → rewrite `CULLIS_MASTIO_VERSION` → pull → `up -d --wait`. Mirrors the open-core bundle's flow, stops short of tarball-download because the enterprise scripts ship with the private image release.
- Extract `_copy_bind_dir_for_backup`, `_backup_user_state`, `_load_env`, `_data_dir_host`, `_nginx_certs_dir_host` from `packaging/mastio-bundle/deploy.sh` into a new shared `packaging/_common-deploy-helpers.sh`. Bit-for-bit copy: no logic change, busybox-root pattern preserved.
- Both `deploy.sh` files now source the same helper, so future backup changes apply to both bundles in one place.
- `packaging/test-bundle-backup-symmetry.sh` enforces the no-drift contract: helper exports the 5 functions, both deploy.sh files source it, no inline copies remain, `--upgrade-bundle` is wired on both, `COMPOSE_PROJECT_NAME` exports are correct, `bash -n` clean across all three files.

## Why

P3 operability audit MAJOR-5 (`imp/p3-operability-audit.md`). Pre-PR asymmetry between the two Mastio bundles:

| Bundle | LOC | `_backup_user_state` | `--upgrade-bundle` |
|---|---|---|---|
| `mastio-bundle/` | 832 | yes | yes |
| `mastio-enterprise-bundle/` | 147 | no | no |

Customer-IT had no standalone pre-upgrade backup path on Enterprise. Bumping `CULLIS_MASTIO_VERSION` + `docker compose pull` + `up` left the operator with no in-place rollback target if the new release misbehaved. Pilot blocker for the regulated bank engagement (CISO requires documented restore path).

The shared helper also closes the "deploy.sh asymmetry" pattern flagged by `feedback_release_pipeline_asymmetry_deploy_vs_compose`: every time someone touched only one of the two `deploy.sh` files the bundles drifted. Symmetry test catches that in CI from now on.

## Test plan

- [x] `./packaging/test-bundle-backup-symmetry.sh` — 7 checks PASS
- [x] `bash -n` on helper + both deploy.sh files
- [x] `bash packaging/mastio-enterprise-bundle/deploy.sh --help` lists `--upgrade-bundle`
- [x] `bash packaging/mastio-bundle/deploy.sh --help` still lists `--upgrade-bundle` (unchanged)
- [x] Helper sourceable + 5 functions exported in a minimal harness (SCRIPT_DIR + ok stubbed)
- [ ] Live Docker upgrade against a real cullis-mastio-enterprise stack (deferred to next dogfood VM, out of scope here)

## Drift prevention

`packaging/test-bundle-backup-symmetry.sh` is the gate. It runs without Docker so it is cheap to add to CI later. Catches:

1. The shared helper missing one of the 5 expected functions (renames).
2. Either deploy.sh dropping the `source` line.
3. Either deploy.sh re-introducing an inline copy of an extracted helper (the most insidious drift: looks like the file uses the shared helper, but the inline copy shadows it).
4. `--upgrade-bundle` wired on only one of the two bundles.
5. `COMPOSE_PROJECT_NAME` exports wrong / missing (memoria `feedback_bundle_upgrade_must_use_deploy_sh.md`: invoking compose from the wrong project name spawns orphan parallel stacks).

## Residual drift (NOT in scope here, flag for backlog)

The two `deploy.sh` files still diverge on non-backup paths. Did not touch them per prompt constraint (mechanical extraction only):

- License JWT pre-flight, GHCR PAT pre-flight, plugin discovery report (enterprise-only, by design).
- `--shared-broker`, `--prod`, `--migrate-volumes`, `--from-banner`, full tarball download + extract upgrade flow (open-core-only, by design).
- Colour helpers initialization differs (`if [[ -t 1 ]]` block on enterprise, unconditional on open-core).

The first two are intentional per audience separation; the third is opportunistic cleanup for a separate small PR.

## Notes

- `backup.sh` (GPG-encrypted off-host compliance archive) is left untouched. Its semantics (hot SQLite `.backup` + GPG symmetric AES256 + license redaction) are orthogonal to the in-place pre-upgrade snapshot `--upgrade-bundle` writes. README now disambiguates the two.
- One drive-by fix on enterprise `--help`: replaced `sed -n '...' "$0"` with `sed -n '...' "$SCRIPT_DIR/deploy.sh"`. The original failed when invoked via a relative path from outside the bundle dir (because `cd "$SCRIPT_DIR"` runs before arg parsing). Caught by the symmetry smoke; safe trivial fix.