### PR TITLE
feat(lifespan): cross-worker leader election for background tasks (Cluster A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ vault/vault-keys.json
 
 # MCP Proxy local data
 mcp_proxy.db
+mcp_proxy.db.*.lock
 proxy.env
 proxy-*.env
 .keys/

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -21,6 +21,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -122,6 +123,47 @@ def _detect_legacy_unstamped(sync_conn) -> bool:
     return bool(_LEGACY_TABLES & table_names)
 
 
+def _run_migrations_sync_under_flock(url: str, sqlite_path: str) -> None:
+    """Run ``_run_migrations_sync`` under an exclusive blocking flock.
+
+    SQLite multi-worker migration gate (Cluster A, Wave 2b). Pre-fix,
+    4 uvicorn workers all called ``alembic.command.upgrade("head")``
+    concurrently against the same SQLite file — race on
+    CREATE/DROP/ALTER (sqlite3 IntegrityError or SQLITE_BUSY).
+
+    The blocking lock is intentional: a non-leader worker MUST wait
+    for the leader to finish the upgrade, THEN re-enter the upgrade
+    call (which is idempotent and no-ops when the chain is already at
+    head). LOCK_NB would have the non-leaders skip → some worker
+    might serve traffic before the schema is current.
+
+    The lockfile lives next to the DB file at ``<db>.alembic.lock``
+    so a fresh container with empty bind mount starts clean. Kernel
+    releases the flock on worker exit even if SIGKILL'd.
+    """
+    import fcntl
+    from pathlib import Path
+
+    db_path = Path(sqlite_path)
+    lock_path = db_path.with_name(f"{db_path.name}.alembic.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            os.ftruncate(fd, 0)
+            os.write(fd, f"{os.getpid()}\n".encode())
+        except OSError:
+            pass  # diagnostic write, not load-bearing
+        _run_migrations_sync(url)
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 def _run_migrations_sync(url: str) -> None:
     """Run alembic stamp (if needed) + upgrade head. Synchronous on purpose:
     invoked from a thread via asyncio.to_thread to avoid blocking the loop.
@@ -220,8 +262,17 @@ async def init_db(db_url: str) -> None:
     # race the same migration and fail mid-upgrade. Wrap the upgrade
     # in a Postgres session-level advisory lock keyed by a fixed
     # integer so only one worker runs the chain; others wait then
-    # no-op once head is reached. SQLite is single-writer by file,
-    # so the lock is skipped there.
+    # no-op once head is reached.
+    #
+    # SQLite gets the same treatment via ``fcntl.flock`` on a sidecar
+    # lockfile (Cluster A, Wave 2b). Pre-Wave-2b the SQLite path
+    # skipped the lock under the assumption that "SQLite is single-
+    # writer by file" — that's true for write transactions but NOT
+    # for ``alembic.command.upgrade`` which can race on
+    # CREATE/DROP/ALTER from 4 concurrent worker connections.
+    # See feedback_multiworker_uvicorn_systemic_gaps for the broader
+    # pattern. In-memory SQLite stays unlocked (single-process by
+    # definition).
     is_postgres = url.startswith("postgresql") or "+asyncpg" in url
     if is_postgres:
         lock_engine = create_async_engine(url, **_engine_kwargs(url))
@@ -240,9 +291,15 @@ async def init_db(db_url: str) -> None:
                     )
         finally:
             await lock_engine.dispose()
+    elif sqlite_path and sqlite_path != ":memory:":
+        # SQLite multi-worker migration gate: blocking flock on a
+        # sidecar lockfile. Blocking (not LOCK_NB) is correct here —
+        # the non-leader workers MUST wait for the leader to finish,
+        # then re-enter ``alembic.command.upgrade("head")`` which is
+        # idempotent and no-ops because the chain is already at head.
+        await asyncio.to_thread(_run_migrations_sync_under_flock, url, sqlite_path)
     else:
-        # Run alembic in a worker thread — alembic.command is synchronous
-        # and would block the event loop otherwise.
+        # In-memory SQLite (tests). Single-process by definition.
         await asyncio.to_thread(_run_migrations_sync, url)
 
     _engine = create_async_engine(url, echo=False, future=True)

--- a/mcp_proxy/lifespan/__init__.py
+++ b/mcp_proxy/lifespan/__init__.py
@@ -1,0 +1,24 @@
+"""Lifespan helpers shared across boot-time setup and background tasks.
+
+Currently houses :mod:`leader_election` (Cluster A, Wave 2b): the
+helper that elects exactly one uvicorn worker as owner of a named
+background loop or one-shot startup step, so multi-worker deployments
+don't run the same poller / sweeper / migration N times.
+"""
+from __future__ import annotations
+
+from mcp_proxy.lifespan.leader_election import (
+    LeaderElection,
+    NoopLeader,
+    PostgresAdvisoryLeader,
+    SQLiteFlockLeader,
+    get_leader,
+)
+
+__all__ = [
+    "LeaderElection",
+    "NoopLeader",
+    "PostgresAdvisoryLeader",
+    "SQLiteFlockLeader",
+    "get_leader",
+]

--- a/mcp_proxy/lifespan/leader_election.py
+++ b/mcp_proxy/lifespan/leader_election.py
@@ -1,0 +1,353 @@
+"""Cross-worker leader election for background tasks + boot-time singletons.
+
+Why
+---
+
+Mastio runs multiple uvicorn workers (`MASTIO_WORKERS=4` default,
+PR #742). Every background loop spawned in the lifespan hook
+(``intune_poll_loop``, ``stale_watcher_loop``, ``local_sweeper_loop``)
+runs in EACH worker. Without coordination that means:
+
+* 4x Microsoft Graph API calls per polling tick — burns Intune quota,
+  costs the customer real money on Azure Graph throttling tier
+* 4x audit rows per stale device — chain inflation
+* 4x SQLite migration concurrent at boot — race on
+  ``CREATE/DROP/ALTER`` even when each worker holds its own connection
+
+The pattern fix is leader election: exactly ONE worker owns each named
+task; the others log + skip. Two concrete implementations cover the
+two DB backends Mastio supports:
+
+* **Postgres**: ``pg_try_advisory_lock(key)`` (RFC pattern, also used
+  by Alembic gate in ``db.py:225-242``). Lock is session-scoped — when
+  the holder connection closes, the lock releases automatically.
+* **SQLite**: ``fcntl.flock(LOCK_EX | LOCK_NB)`` on a sidecar lockfile
+  next to the DB file. Works cross-process (the 4 uvicorn workers all
+  fork from the same uid + see the same filesystem) and survives
+  ungraceful worker death (kernel releases on exit).
+
+For tests, use :class:`NoopLeader` which always wins — keeps unit
+tests deterministic without needing flock or Postgres.
+
+Scope (V1, Wave 2b)
+-------------------
+
+Leader is captured **once at boot** by ``acquire()`` non-blocking. The
+winner holds the lock for the full lifetime of the worker process. If
+the leader worker dies, no automatic failover — the other workers do
+NOT pick up the dropped lock. This is intentional V1: keeps the helper
+simple, customer ops detects via "did the polling tick happen in the
+last 2x interval?" alert.
+
+V2 follow-up (when needed): lease + heartbeat with periodic
+re-acquire so a fresh worker takes over after the original leader
+dies. Tracked in ``followup_f5_f6_post_merge_tracker.md`` cluster A
+extension.
+"""
+from __future__ import annotations
+
+import asyncio
+import errno
+import logging
+import os
+import zlib
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from mcp_proxy.db import _engine_kwargs  # type: ignore[attr-defined]
+
+_log = logging.getLogger("mcp_proxy.lifespan.leader_election")
+
+
+class LeaderElection(ABC):
+    """Abstract leader-election contract.
+
+    Concrete implementations: :class:`PostgresAdvisoryLeader`,
+    :class:`SQLiteFlockLeader`, :class:`NoopLeader`. Pick the right one
+    via :func:`get_leader`.
+    """
+
+    def __init__(self, task_name: str) -> None:
+        self.task_name = task_name
+        self._held = False
+
+    @property
+    def held(self) -> bool:
+        return self._held
+
+    @abstractmethod
+    async def acquire(self) -> bool:
+        """Try to acquire the leader lock non-blocking.
+
+        Returns ``True`` if this worker won and now owns the lock,
+        ``False`` if another worker already holds it. Idempotent: a
+        second call after a successful first call returns ``True``
+        without re-trying.
+        """
+
+    @abstractmethod
+    async def release(self) -> None:
+        """Release the lock. No-op if not currently held."""
+
+
+class NoopLeader(LeaderElection):
+    """Always-wins leader for tests and single-worker deployments.
+
+    Use when the caller has external knowledge that only one process
+    will ever run (pytest, ``--workers 1``, dev mode). Skips all DB
+    coordination — zero overhead.
+    """
+
+    async def acquire(self) -> bool:
+        self._held = True
+        return True
+
+    async def release(self) -> None:
+        self._held = False
+
+
+class PostgresAdvisoryLeader(LeaderElection):
+    """Postgres ``pg_try_advisory_lock``-based leader.
+
+    Maps the task name to a stable int64 key via zlib.crc32 (XOR'd with
+    a fixed salt so collisions with Alembic's
+    ``_ALEMBIC_ADVISORY_LOCK_KEY`` and any customer-managed keys stay
+    out of band). Holds the lock on a dedicated long-lived connection;
+    release closes the connection so even a Python-side crash drops
+    the lock cleanly.
+    """
+
+    # Salt picked to be deterministic + visually distinct from
+    # ``_ALEMBIC_ADVISORY_LOCK_KEY = 0xC0115A1E_EB1C0DE`` so lock-key
+    # collisions across the codebase are impossible even if the crc32
+    # of a future task name happens to equal "EB1C0DE".
+    _SALT: int = 0x_C011_15_1EAD_E20001 & 0x_7FFF_FFFF_FFFF_FFFF
+
+    def __init__(self, task_name: str, url: str) -> None:
+        super().__init__(task_name)
+        self._url = url
+        self._engine: AsyncEngine | None = None
+        self._conn: AsyncConnection | None = None
+        self._key = self._key_for(task_name)
+
+    @classmethod
+    def _key_for(cls, task_name: str) -> int:
+        crc = zlib.crc32(task_name.encode("utf-8")) & 0xFFFF_FFFF
+        # Spread crc32 into the upper half of int64 to avoid collisions
+        # with hand-picked Alembic-style hex keys that pack into 64-bit.
+        return ((crc << 16) ^ cls._SALT) & 0x_7FFF_FFFF_FFFF_FFFF
+
+    async def acquire(self) -> bool:
+        if self._held:
+            return True
+        self._engine = create_async_engine(
+            self._url, **_engine_kwargs(self._url),
+        )
+        conn = await self._engine.connect()
+        try:
+            row = (
+                await conn.execute(
+                    text("SELECT pg_try_advisory_lock(:k)"),
+                    {"k": self._key},
+                )
+            ).first()
+            won = bool(row and row[0])
+        except Exception:
+            await conn.close()
+            await self._engine.dispose()
+            self._engine = None
+            raise
+        if not won:
+            await conn.close()
+            await self._engine.dispose()
+            self._engine = None
+            return False
+        self._conn = conn
+        self._held = True
+        return True
+
+    async def release(self) -> None:
+        if not self._held:
+            return
+        try:
+            if self._conn is not None:
+                try:
+                    await self._conn.execute(
+                        text("SELECT pg_advisory_unlock(:k)"),
+                        {"k": self._key},
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    _log.warning(
+                        "pg_advisory_unlock failed for task '%s': %s",
+                        self.task_name, exc,
+                    )
+                await self._conn.close()
+                self._conn = None
+        finally:
+            if self._engine is not None:
+                await self._engine.dispose()
+                self._engine = None
+            self._held = False
+
+
+class SQLiteFlockLeader(LeaderElection):
+    """SQLite leader via ``fcntl.flock`` on a sidecar lockfile.
+
+    Writes a small lockfile next to the SQLite DB at
+    ``<db_path>.<task_name>.lock`` and holds an exclusive non-blocking
+    flock on it. Cross-process safe — the 4 uvicorn workers fork from
+    the same uid and see the same inode, so flock semantics match
+    expectations. Survives ungraceful worker exit because the kernel
+    releases all open file descriptors at process death.
+
+    Why not just ``open(O_EXCL)`` on a pidfile? Because that would race
+    on stale pidfile detection after crashes. flock is the textbook
+    solution and is what Linux daemons (sudo, postfix, ...) use.
+    """
+
+    def __init__(self, task_name: str, db_path: Path | str) -> None:
+        super().__init__(task_name)
+        self._db_path = Path(db_path)
+        self._lock_path = self._db_path.with_name(
+            f"{self._db_path.name}.{task_name}.lock",
+        )
+        self._fd: int | None = None
+
+    async def acquire(self) -> bool:
+        if self._held:
+            return True
+
+        # flock is a blocking syscall by default; running in the event
+        # loop would freeze every other coroutine on contention. Wrap
+        # in a worker thread so the loop stays responsive. The actual
+        # syscall is microseconds when uncontended (just inode update).
+        def _try_flock() -> int | None:
+            import fcntl
+
+            # Create lockfile if missing, no truncation. Mode 0o644.
+            fd = os.open(
+                str(self._lock_path),
+                os.O_CREAT | os.O_WRONLY,
+                0o644,
+            )
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    os.close(fd)
+                    return None
+                os.close(fd)
+                raise
+            # Write our pid for ops visibility. Best-effort; not used
+            # for lock coordination (kernel handles that via the fd).
+            try:
+                os.ftruncate(fd, 0)
+                os.write(fd, f"{os.getpid()}\n".encode())
+            except OSError:
+                pass  # noqa: S110 — diagnostic write, not load-bearing
+            return fd
+
+        fd = await asyncio.to_thread(_try_flock)
+        if fd is None:
+            return False
+        self._fd = fd
+        self._held = True
+        return True
+
+    async def release(self) -> None:
+        if not self._held or self._fd is None:
+            return
+
+        def _unflock(fd: int) -> None:
+            import fcntl
+
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+        try:
+            await asyncio.to_thread(_unflock, self._fd)
+        finally:
+            self._fd = None
+            self._held = False
+
+
+def _sqlite_db_path(url: str) -> Path:
+    """Extract the on-disk file path from a SQLite SQLAlchemy URL.
+
+    Mirrors :func:`mcp_proxy.db._sqlite_path` semantics:
+
+    * ``sqlite:///foo.db`` (3 slash) → relative ``foo.db``
+    * ``sqlite+aiosqlite:///foo.db`` (3 slash) → relative ``foo.db``
+    * ``sqlite:////absolute/foo.db`` (4 slash) → absolute
+      ``/absolute/foo.db``
+
+    The caller is responsible for detecting in-memory URLs and
+    routing them to :class:`NoopLeader` — flock on a memory DB makes
+    no sense.
+    """
+    for prefix in ("sqlite+aiosqlite:///", "sqlite:///"):
+        if url.startswith(prefix):
+            return Path(url[len(prefix):])
+    # Defensive fallback: unrecognised SQLite-ish URL — strip scheme
+    # and treat whatever is left as a path.
+    return Path(url.split("://", 1)[-1])
+
+
+def get_leader(task_name: str, db_url: str | None = None) -> LeaderElection:
+    """Factory: pick the right leader implementation for the current DB.
+
+    - Postgres URL → :class:`PostgresAdvisoryLeader`
+    - SQLite file URL → :class:`SQLiteFlockLeader`
+    - SQLite ``:memory:`` URL (tests) → :class:`NoopLeader`
+    - Missing URL (defensive) → :class:`NoopLeader` (logs warning)
+
+    The DB URL defaults to the Mastio settings value when not passed;
+    tests can override directly.
+    """
+    if db_url is None:
+        from mcp_proxy.config import get_settings
+
+        db_url = get_settings().database_url
+
+    if not db_url:
+        _log.warning(
+            "No DATABASE_URL configured — leader election for '%s' "
+            "falls back to NoopLeader (assume single-worker)",
+            task_name,
+        )
+        return NoopLeader(task_name)
+
+    if db_url.startswith("postgresql") or "+asyncpg" in db_url:
+        return PostgresAdvisoryLeader(task_name, db_url)
+
+    if ":memory:" in db_url:
+        _log.info(
+            "SQLite in-memory DB — leader election for '%s' uses "
+            "NoopLeader (single-process test path)",
+            task_name,
+        )
+        return NoopLeader(task_name)
+
+    if db_url.startswith("sqlite"):
+        return SQLiteFlockLeader(task_name, _sqlite_db_path(db_url))
+
+    _log.warning(
+        "Unrecognised DATABASE_URL scheme for '%s' — falling back "
+        "to NoopLeader: %s",
+        task_name, db_url.split("://", 1)[0],
+    )
+    return NoopLeader(task_name)
+
+
+__all__ = [
+    "LeaderElection",
+    "NoopLeader",
+    "PostgresAdvisoryLeader",
+    "SQLiteFlockLeader",
+    "get_leader",
+]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -489,18 +489,27 @@ async def lifespan(app: FastAPI):
     # nothing to sweep). Also explicitly skippable via
     # PROXY_LOCAL_SWEEPER_DISABLED=1 for deterministic tests.
     if settings.intra_org_routing and os.environ.get("PROXY_LOCAL_SWEEPER_DISABLED") != "1":
+        from mcp_proxy.lifespan import get_leader
         from mcp_proxy.local.sweeper import sweeper_loop as _local_sweeper_loop
-        stop_event = asyncio.Event()
-        sweeper_task = asyncio.create_task(
-            _local_sweeper_loop(
-                local_store,
-                app.state.local_ws_manager,
-                stop_event=stop_event,
-            ),
-            name="local_sweeper",
-        )
-        app.state.local_sweeper_stop = stop_event
-        app.state.local_sweeper_task = sweeper_task
+        sweeper_leader = get_leader("local_sweeper")
+        if await sweeper_leader.acquire():
+            stop_event = asyncio.Event()
+            sweeper_task = asyncio.create_task(
+                _local_sweeper_loop(
+                    local_store,
+                    app.state.local_ws_manager,
+                    stop_event=stop_event,
+                ),
+                name="local_sweeper",
+            )
+            app.state.local_sweeper_stop = stop_event
+            app.state.local_sweeper_task = sweeper_task
+            app.state.local_sweeper_leader = sweeper_leader
+            _log.info("local_sweeper: leader acquired, loop spawned")
+        else:
+            _log.info(
+                "local_sweeper: another worker holds the leader lock — skipping"
+            )
 
     # ADR-032 Layer 1 (F2 spike) — Intune polling task. Gated on
     # MCP_PROXY_MDM_INTUNE_ENABLED + credential triple so a half-
@@ -526,22 +535,36 @@ async def lifespan(app: FastAPI):
                 ),
             )
         else:
+            from mcp_proxy.lifespan import get_leader
             from mcp_proxy.mdm import intune_poll_loop
-            mdm_stop = asyncio.Event()
-            mdm_task = asyncio.create_task(
-                intune_poll_loop(
-                    tenant_id=settings.mdm_intune_tenant_id,
-                    client_id=settings.mdm_intune_client_id,
-                    client_secret=settings.mdm_intune_client_secret,
-                    interval_seconds=max(
-                        60, settings.mdm_intune_poll_interval_seconds,
+            mdm_leader = get_leader("mdm_intune_poller")
+            if await mdm_leader.acquire():
+                mdm_stop = asyncio.Event()
+                mdm_task = asyncio.create_task(
+                    intune_poll_loop(
+                        tenant_id=settings.mdm_intune_tenant_id,
+                        client_id=settings.mdm_intune_client_id,
+                        client_secret=settings.mdm_intune_client_secret,
+                        interval_seconds=max(
+                            60, settings.mdm_intune_poll_interval_seconds,
+                        ),
+                        stop_event=mdm_stop,
                     ),
-                    stop_event=mdm_stop,
-                ),
-                name="mdm_intune_poller",
-            )
-            app.state.mdm_intune_stop = mdm_stop
-            app.state.mdm_intune_task = mdm_task
+                    name="mdm_intune_poller",
+                )
+                app.state.mdm_intune_stop = mdm_stop
+                app.state.mdm_intune_task = mdm_task
+                app.state.mdm_intune_leader = mdm_leader
+                _log.info("mdm_intune_poller: leader acquired, loop spawned")
+            else:
+                emit_lifespan_log(
+                    level="INFO",
+                    logger="mcp_proxy.mdm.poller",
+                    message=(
+                        "mdm_intune_poller: another worker holds the "
+                        "leader lock — skipping (Graph API quota saved)"
+                    ),
+                )
 
     # ADR-032 F6 — stale-watcher daemon. Decoupled from the polling
     # loop so customers running without an MDM integration still get
@@ -549,20 +572,30 @@ async def lifespan(app: FastAPI):
     # past the threshold). Cheap to run: one SELECT per minute over
     # ``internal_agents`` filtered to rows with a non-NULL claim.
     if settings.attestation_stale_watcher_enabled:
+        from mcp_proxy.lifespan import get_leader
         from mcp_proxy.mdm.stale_watcher import stale_watcher_loop
-        stale_stop = asyncio.Event()
-        stale_task = asyncio.create_task(
-            stale_watcher_loop(
-                interval_seconds=max(
-                    5, settings.attestation_stale_watcher_interval_seconds,
+        stale_leader = get_leader("attestation_stale_watcher")
+        if await stale_leader.acquire():
+            stale_stop = asyncio.Event()
+            stale_task = asyncio.create_task(
+                stale_watcher_loop(
+                    interval_seconds=max(
+                        5, settings.attestation_stale_watcher_interval_seconds,
+                    ),
+                    threshold_seconds=settings.attestation_stale_threshold_seconds,
+                    stop_event=stale_stop,
                 ),
-                threshold_seconds=settings.attestation_stale_threshold_seconds,
-                stop_event=stale_stop,
-            ),
-            name="attestation_stale_watcher",
-        )
-        app.state.attestation_stale_stop = stale_stop
-        app.state.attestation_stale_task = stale_task
+                name="attestation_stale_watcher",
+            )
+            app.state.attestation_stale_stop = stale_stop
+            app.state.attestation_stale_task = stale_task
+            app.state.attestation_stale_leader = stale_leader
+            _log.info("attestation_stale_watcher: leader acquired, loop spawned")
+        else:
+            _log.info(
+                "attestation_stale_watcher: another worker holds the "
+                "leader lock — skipping"
+            )
 
     # Phase 4c — federation SSE subscriber. Wires the Phase 4b cache
     # to the live broker stream. Off by default; flip via
@@ -820,6 +853,12 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("mdm intune poller teardown loop mismatch (xdist): %s", exc)
+    mdm_leader = getattr(app.state, "mdm_intune_leader", None)
+    if mdm_leader is not None:
+        try:
+            await mdm_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug("mdm_intune_poller leader release failed: %s", exc)
 
     # ADR-032 F6 — stop the stale-watcher.
     stale_stop = getattr(app.state, "attestation_stale_stop", None)
@@ -840,6 +879,12 @@ async def lifespan(app: FastAPI):
                 "attestation stale-watcher teardown loop mismatch (xdist): %s",
                 exc,
             )
+    stale_leader = getattr(app.state, "attestation_stale_leader", None)
+    if stale_leader is not None:
+        try:
+            await stale_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug("attestation_stale_watcher leader release failed: %s", exc)
 
     stop_event = getattr(app.state, "local_sweeper_stop", None)
     sweeper_task = getattr(app.state, "local_sweeper_task", None)
@@ -863,6 +908,12 @@ async def lifespan(app: FastAPI):
             # on every subsequent asyncio test. Tolerate it here — the
             # task will be GC'd at process exit.
             _log.debug("local sweeper teardown loop mismatch (xdist): %s", exc)
+    sweeper_leader = getattr(app.state, "local_sweeper_leader", None)
+    if sweeper_leader is not None:
+        try:
+            await sweeper_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug("local_sweeper leader release failed: %s", exc)
 
     sub_stop = getattr(app.state, "federation_subscriber_stop", None)
     sub_task = getattr(app.state, "federation_subscriber_task", None)

--- a/tests/test_leader_election.py
+++ b/tests/test_leader_election.py
@@ -1,0 +1,197 @@
+"""Cross-worker leader election (Cluster A, Wave 2b).
+
+Pin SQLite flock + NoopLeader + the factory dispatch. Postgres
+``pg_try_advisory_lock`` path is exercised in `test_postgres_bindings`
+when a Postgres URL is in the env — these tests stay sqlite + noop so
+they run on every shard without external infra.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+
+from mcp_proxy.lifespan.leader_election import (
+    NoopLeader,
+    PostgresAdvisoryLeader,
+    SQLiteFlockLeader,
+    get_leader,
+)
+
+
+# ── factory dispatch ─────────────────────────────────────────────────
+
+
+def test_factory_picks_postgres_for_postgres_url():
+    leader = get_leader(
+        "task_pg",
+        db_url="postgresql+asyncpg://u:p@h/d",
+    )
+    assert isinstance(leader, PostgresAdvisoryLeader)
+    assert leader.task_name == "task_pg"
+
+
+def test_factory_picks_sqlite_for_sqlite_file_url(tmp_path):
+    db = tmp_path / "x.sqlite"
+    leader = get_leader(
+        "task_sqlite",
+        db_url=f"sqlite+aiosqlite:///{db}",
+    )
+    assert isinstance(leader, SQLiteFlockLeader)
+
+
+def test_factory_returns_noop_for_in_memory_sqlite():
+    leader = get_leader(
+        "task_mem",
+        db_url="sqlite+aiosqlite:///:memory:",
+    )
+    assert isinstance(leader, NoopLeader)
+
+
+def test_factory_returns_noop_for_missing_url():
+    leader = get_leader("task_none", db_url="")
+    assert isinstance(leader, NoopLeader)
+
+
+def test_factory_returns_noop_for_unknown_scheme():
+    leader = get_leader("task_weird", db_url="mysql://h/d")
+    assert isinstance(leader, NoopLeader)
+
+
+# ── postgres key derivation ──────────────────────────────────────────
+
+
+def test_postgres_keys_are_deterministic_and_distinct():
+    """Two task names produce two distinct int64-safe keys."""
+    k1 = PostgresAdvisoryLeader._key_for("task_a")
+    k2 = PostgresAdvisoryLeader._key_for("task_b")
+    k1b = PostgresAdvisoryLeader._key_for("task_a")
+    assert k1 == k1b
+    assert k1 != k2
+    # Both keys fit in int64-positive range (Postgres advisory_lock
+    # accepts bigint = int64 signed).
+    assert 0 <= k1 < (1 << 63)
+    assert 0 <= k2 < (1 << 63)
+
+
+# ── noop leader ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_noop_leader_always_wins():
+    leader = NoopLeader("task_noop")
+    assert await leader.acquire() is True
+    assert leader.held is True
+    await leader.release()
+    assert leader.held is False
+
+
+@pytest.mark.asyncio
+async def test_noop_leader_acquire_is_idempotent():
+    leader = NoopLeader("task_noop_idem")
+    assert await leader.acquire() is True
+    assert await leader.acquire() is True
+    await leader.release()
+
+
+# ── sqlite flock leader ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sqlite_flock_first_caller_wins(tmp_path):
+    db = tmp_path / "lock-test.sqlite"
+    leader = SQLiteFlockLeader("task_one", db)
+    assert await leader.acquire() is True
+    assert leader.held is True
+    await leader.release()
+    assert leader.held is False
+
+
+@pytest.mark.asyncio
+async def test_sqlite_flock_concurrent_only_one_wins(tmp_path):
+    """Two SQLiteFlockLeader instances on the same lockfile: only one
+    wins. The other gets False (LOCK_NB). After the winner releases,
+    the loser CAN now acquire — verifies LOCK_UN releases the inode
+    lock properly."""
+    db = tmp_path / "race-test.sqlite"
+
+    a = SQLiteFlockLeader("task_race", db)
+    b = SQLiteFlockLeader("task_race", db)
+
+    got_a = await a.acquire()
+    got_b = await b.acquire()
+
+    assert got_a is True
+    assert got_b is False
+    assert a.held is True
+    assert b.held is False
+
+    await a.release()
+    assert a.held is False
+
+    got_b_after = await b.acquire()
+    assert got_b_after is True
+    await b.release()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_flock_writes_pid_for_ops_visibility(tmp_path):
+    db = tmp_path / "pid-test.sqlite"
+    leader = SQLiteFlockLeader("task_pid", db)
+    assert await leader.acquire() is True
+
+    lock_file = db.with_name(f"{db.name}.task_pid.lock")
+    assert lock_file.exists()
+    content = lock_file.read_text().strip()
+    assert content == str(os.getpid())
+
+    await leader.release()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_flock_release_when_not_held_is_noop(tmp_path):
+    db = tmp_path / "release-noop.sqlite"
+    leader = SQLiteFlockLeader("task_unheld", db)
+    # Never acquired — release must not raise.
+    await leader.release()
+    assert leader.held is False
+
+
+@pytest.mark.asyncio
+async def test_sqlite_flock_lockfile_path_uses_task_name(tmp_path):
+    db = tmp_path / "naming.sqlite"
+    a = SQLiteFlockLeader("task_a", db)
+    b = SQLiteFlockLeader("task_b", db)
+
+    # Different task names share the same DB but get distinct
+    # lockfiles, so they don't contend.
+    assert await a.acquire() is True
+    assert await b.acquire() is True
+
+    await a.release()
+    await b.release()
+
+
+# ── separation between tasks ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_different_tasks_can_both_acquire(tmp_path):
+    """task_x and task_y on the same DB don't block each other."""
+    db = tmp_path / "two-tasks.sqlite"
+    x = get_leader("task_x", db_url=f"sqlite+aiosqlite:///{db}")
+    y = get_leader("task_y", db_url=f"sqlite+aiosqlite:///{db}")
+
+    assert await x.acquire() is True
+    assert await y.acquire() is True
+
+    await x.release()
+    await y.release()


### PR DESCRIPTION
## Summary

Multi-worker uvicorn deployments (default `MASTIO_WORKERS=4` per PR #742) ran every lifespan background task in every worker. Result: 4x Microsoft Graph quota burn, 4x audit row dedupe storm, 4x SQLite migration race at boot. This PR introduces a leader-election helper that gates each named task so only one worker owns the loop.

## What's in

### New helper module

`mcp_proxy/lifespan/leader_election.py`:

- `LeaderElection` ABC
- `PostgresAdvisoryLeader` — `pg_try_advisory_lock` on a session-scoped connection. Lock key derived deterministically via `crc32(task_name) XOR salt`, packed into int64-positive
- `SQLiteFlockLeader` — `fcntl.flock(LOCK_EX | LOCK_NB)` on a sidecar lockfile next to the DB. Kernel releases on worker exit even on SIGKILL
- `NoopLeader` — always-wins for in-memory DB + tests + dev (single-process)
- `get_leader(task_name, db_url=None)` factory dispatches on DB scheme

### Lifespan task gating

`mcp_proxy/main.py`: wrap the 3 spawn points behind `leader.acquire()`:
- `local_sweeper` (PROXY_INTRA_ORG)
- `mdm_intune_poller` (MCP_PROXY_MDM_INTUNE_ENABLED) — emits an explicit lifespan log when skipped so the operator sees the Graph-quota saving
- `attestation_stale_watcher` (MCP_PROXY_ATTESTATION_STALE_WATCHER_ENABLED)

Leader released on lifespan teardown (best-effort, kernel handles ungraceful exit).

### SQLite migration gate

`mcp_proxy/db.py:225-246`: SQLite branch now runs `alembic.upgrade("head")` under a blocking flock on `<db>.alembic.lock`. Pre-fix the SQLite branch skipped the lock entirely (assumption: "SQLite is single-writer by file"), which is true for write txns but NOT for DDL race during multi-worker concurrent upgrade. Blocking is intentional: non-leader workers wait for the leader to finish, then re-enter the idempotent `upgrade("head")` no-op path.

### Tests

`tests/test_leader_election.py` — 14 tests:
- Factory dispatch (Postgres / SQLite file / SQLite memory / missing URL / unknown scheme)
- Postgres key derivation (deterministic + distinct + int64-safe)
- Noop leader (always wins, idempotent acquire)
- SQLiteFlockLeader: first wins, second loses, release re-allows acquire, lockfile contains pid for ops visibility, release-when-unheld is no-op, distinct task names don't contend on same DB

Postgres path covered indirectly by `test_postgres_bindings` when the env is configured.

## Scope and follow-ups

V1: leader captured **once at boot** non-blocking. If the leader worker dies, no automatic failover — other workers do NOT pick up the lock. Customer ops detects via "did the polling tick fire in the last 2x interval?" alert.

V2 (post-revenue, tracked as cluster A extension): lease + heartbeat with periodic re-acquire so a fresh worker takes over after the original leader dies.

## Why

Pre-pilot blocker (regulated bank pilot). Follow-up tracker #1, MAJOR-4 from audit operability (SQLite race) overlaps with the poller/stale_watcher race not yet flagged elsewhere — closes both with one systemic pattern.

## Test plan

- [x] `pytest tests/test_leader_election.py -n auto --dist=loadfile` → 14/14 pass
- [x] `pytest tests/test_lifespan_tier_matrix_cache.py tests/test_leader_election.py -n auto --dist=loadfile` → 16/16 pass (smoke regression on lifespan startup wiring)
- [x] `pytest tests/ -k 'sweeper or oneshot_cross' -n auto --dist=loadfile` → 38/38 pass (regression on local_sweeper consumers)
- [x] Ruff clean on touched files
- [ ] Customer-path smoke + demo_network full → CI
- [ ] Postgres advisory path → covered indirectly by `test_postgres_bindings` shard when configured

## Memorie correlate

- `feedback_multiworker_uvicorn_systemic_gaps.md` (originating pattern)
- `followup_f5_f6_post_merge_tracker.md` Fix #1
- `imp/p3-operability-audit.md` MAJOR-4