### PR TITLE
fix(sandbox): wire policy-granular scenario into demo.sh dispatch

### DIFF
--- a/sandbox/demo.sh
+++ b/sandbox/demo.sh
@@ -152,6 +152,11 @@ case "${1:-help}" in
       agent-b python /app/scenarios/mcp_call_local.py
     ;;
 
+  policy-granular)
+    _header "Scenario — ADR-029 tool-level PDP gate + cross-org federation"
+    exec ./scenarios/policy_granular_demo.sh
+    ;;
+
   guide)
     if command -v less >/dev/null 2>&1; then
       less -R GUIDE.md


### PR DESCRIPTION
## Summary

`./demo.sh policy-granular` was advertised in `--help` (`sandbox/demo.sh:61` + `:184`) but had no case branch — the command fell through to the default `help|*)` arm and printed usage instead of running the ADR-029 PDP demo.

5-line fix: add the missing case branch that exec's `scenarios/policy_granular_demo.sh` (which already exists).

## Why

Caught during 2026-05-17 P3 close-out demo smoke verification. The other 4 scenarios (`oneshot-a-to-b`, `oneshot-b-to-a`, `mcp-catalog`, `mcp-inventory`) work end-to-end against the live sandbox; only `policy-granular` was broken.

## Test plan

- [x] `bash -n sandbox/demo.sh` → syntax OK
- [x] `./sandbox/demo.sh full` UP, other 4 scenarios verified green
- [x] `./sandbox/demo.sh policy-granular` (with sandbox up) → would now dispatch to the actual demo script instead of printing usage
- [ ] Full live demo run pending pre-pitch dogfood