### PR TITLE
fix(connector): install Ambassador immediately after enrollment completes

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -266,6 +266,68 @@ def _ensure_inbox_poller_running(app: FastAPI) -> bool:
     return True
 
 
+def _ensure_ambassador_installed(app: FastAPI) -> bool:
+    """Idempotently mount the Ambassador router on the running dashboard.
+
+    Mirrors ``_ensure_inbox_poller_running``: the dashboard process may
+    have been launched before enrollment (the Frontdesk bundle starts
+    the Connector first so the operator can drive the wizard from the
+    UI). In that boot the lifespan install at :func:`_dashboard_lifespan`
+    short-circuits via ``has_identity`` and the Ambassador stays unmounted,
+    so every ``/v1/chat/completions``, ``/v1/models``, ``/api/session/*``
+    returns 404 until someone manually restarts the container.
+
+    Calling this from ``/api/status`` the moment the enrollment flips
+    to ``approved`` (or the moment a poll lands on an already-enrolled
+    profile) closes the gap without an operator restart. Both single
+    and shared variants of ``_maybe_install_ambassador`` are themselves
+    idempotent, so this helper is safe on every poll.
+
+    Returns ``True`` if the Ambassador is now mounted (either we just
+    installed it or it was already there), ``False`` if install failed
+    or was skipped — failure is intentionally best-effort: we log a
+    warning and let the rest of the enrollment flow continue, because
+    an Ambassador wiring error mustn't strand the operator on the
+    "Approved" screen.
+    """
+    config = app.state.connector_config
+
+    if getattr(app.state, "ambassador", None) is not None:
+        return True
+    if getattr(app.state, "shared_ambassador", None) is not None:
+        return True
+
+    try:
+        from cullis_connector.ambassador.shared.wire import (
+            shared_mode_settings_from_env,
+        )
+        shared_settings = shared_mode_settings_from_env()
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "post-enrollment Ambassador install skipped — could not read "
+            "shared-mode settings: %s", exc,
+        )
+        return False
+
+    try:
+        if shared_settings.enabled:
+            _maybe_install_shared_ambassador(app, config, shared_settings)
+            return getattr(app.state, "shared_ambassador", None) is not None
+        _maybe_install_ambassador(app, config)
+        return getattr(app.state, "ambassador", None) is not None
+    except Exception as exc:  # noqa: BLE001
+        # Best-effort: never abort enrollment on Ambassador install
+        # failure. The most likely cause is the Mastio Site being
+        # unreachable during the post-CSR ``ensure_local_token`` step;
+        # the operator can retry via a container restart once the
+        # network settles.
+        _log.warning(
+            "post-enrollment Ambassador install failed (will retry on "
+            "next /api/status poll): %s", exc,
+        )
+        return False
+
+
 def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
     """Build the poller if the identity is ready, return None otherwise.
 
@@ -308,10 +370,19 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
     Silent no-op when ``ambassador.enabled`` is false or when there is
     no identity yet (pre-enrollment dashboard). Logs the outcome
     explicitly for operator visibility.
+
+    Idempotent: re-calling after the Ambassador is already mounted is a
+    no-op. The post-enrollment hook in ``/api/status`` and the lifespan
+    bootstrap can both call this safely — the second caller short-circuits
+    here instead of tripping the loud ``RuntimeError`` raised by
+    :func:`install_ambassador` on double-mount.
     """
     import logging
     log = logging.getLogger("cullis_connector.web")
 
+    if getattr(app.state, "ambassador", None):
+        log.info("Ambassador already installed; skipping re-install")
+        return
     if not config.ambassador.enabled:
         log.info("Ambassador disabled by config (ambassador.enabled=False)")
         return
@@ -527,6 +598,9 @@ def _maybe_install_shared_ambassador(
     import logging
     log = logging.getLogger("cullis_connector.web")
 
+    if getattr(app.state, "shared_ambassador", None):
+        log.info("shared Ambassador already installed; skipping re-install")
+        return
     if not has_identity(config.config_dir):
         log.warning(
             "shared Ambassador install deferred: no identity at %s yet "
@@ -1260,6 +1334,13 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             # should start receiving notifications without having to
             # restart the dashboard. Idempotent + cheap.
             _ensure_inbox_poller_running(request.app)
+            # Same shape for the Ambassador router — when the dashboard
+            # was launched pre-enrollment the lifespan saw no identity
+            # and skipped the mount, so ``/v1/chat/completions`` and
+            # ``/api/session/*`` would 404 forever. Mount lazily here
+            # (idempotent) so a restart is never required for the
+            # customer to start chatting after approval.
+            _ensure_ambassador_installed(request.app)
             return JSONResponse({"status": "approved"})
         if _pending is None:
             return JSONResponse({"status": "idle"})
@@ -1346,6 +1427,14 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             # closes the small window between approval and the
             # following HTMX poll.
             _ensure_inbox_poller_running(request.app)
+            # Same window applies to the Ambassador mount — without
+            # this hook the Frontdesk bundle leaves ``/v1/chat`` 404
+            # until ``docker compose restart`` because the Connector
+            # boots before the operator runs the wizard. The helper
+            # is idempotent and best-effort (logs + continues on
+            # failure), so the approval response is never blocked
+            # on Mastio reachability.
+            _ensure_ambassador_installed(request.app)
             return JSONResponse({"status": "approved", "agent_id": agent_id})
 
         if remote_status == "rejected":

--- a/tests/connector/test_ambassador_install_post_enrollment.py
+++ b/tests/connector/test_ambassador_install_post_enrollment.py
@@ -339,7 +339,7 @@ def test_ensure_ambassador_installed_helper_is_idempotent(
 
 
 def test_ensure_ambassador_installed_swallows_install_errors(
-    fresh_app_pre_enrollment, cfg, monkeypatch, caplog,
+    fresh_app_pre_enrollment, cfg, monkeypatch,
 ):
     """Best-effort contract: an install failure (e.g. Mastio unreachable
     during ``ensure_local_token``) must NOT propagate. The enrollment
@@ -363,11 +363,20 @@ def test_ensure_ambassador_installed_swallows_install_errors(
         connector_web, "_maybe_install_ambassador", _raise,
     )
 
-    import logging as _logging
-    with caplog.at_level(
-        _logging.WARNING, logger="cullis_connector.web",
-    ):
-        result = _ensure_ambassador_installed(fresh_app_pre_enrollment)
+    # ``cullis_connector`` sets ``propagate=False`` (see
+    # ``cullis_connector/_logging.py:50``) so caplog — which attaches
+    # to the root logger by default — never sees these warnings. Patch
+    # the module-level logger's ``warning`` directly; same pattern as
+    # ``feedback_mcp_proxy_logger_caplog`` (mcp_proxy has the identical
+    # propagate=False contract).
+    captured: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        captured.append(msg % args if args else msg)
+
+    monkeypatch.setattr(connector_web._log, "warning", _capture)
+
+    result = _ensure_ambassador_installed(fresh_app_pre_enrollment)
 
     assert result is False
     assert (
@@ -375,6 +384,6 @@ def test_ensure_ambassador_installed_swallows_install_errors(
         is None
     )
     assert any(
-        "post-enrollment Ambassador install failed" in rec.message
-        for rec in caplog.records
-    ), [r.message for r in caplog.records]
+        "post-enrollment Ambassador install failed" in line
+        for line in captured
+    ), captured

--- a/tests/connector/test_ambassador_install_post_enrollment.py
+++ b/tests/connector/test_ambassador_install_post_enrollment.py
@@ -1,0 +1,381 @@
+"""Regression tests for the Ambassador post-enrollment install hook.
+
+Architectural bug discovered 2026-05-17 during a demo smoke run:
+
+  * In the Frontdesk bundle the Connector container starts BEFORE
+    the operator drives the enrollment wizard (the wizard *is*
+    served by the Connector dashboard). At that boot,
+    ``_dashboard_lifespan`` calls ``_maybe_install_ambassador``,
+    sees ``has_identity()=False`` on the still-empty profile, and
+    returns early. The router is never mounted.
+
+  * After the admin approves the enrollment ticket, the on-disk
+    identity lands but the Ambassador stays unmounted, so every
+    ``/v1/chat/completions``, ``/v1/models``, ``/api/session/*`` 404s.
+
+  * Pre-fix the only way out was a manual ``docker compose restart
+    cullis-frontdesk-connector-1``. No customer admin will do that.
+
+The fix in ``cullis_connector/web.py``:
+
+  1. ``_maybe_install_ambassador`` and ``_maybe_install_shared_ambassador``
+     gained an early-return idempotency guard so they can be called more
+     than once on the same FastAPI app without tripping the loud
+     ``RuntimeError`` raised by ``install_ambassador`` on double-mount.
+
+  2. A new helper ``_ensure_ambassador_installed`` dispatches to the
+     single or shared variant based on ``AMBASSADOR_MODE`` and swallows
+     install errors (logs + returns False) so an Ambassador wiring
+     failure never blocks the enrollment "approved" response.
+
+  3. ``/api/status`` calls the helper both in the ``has_identity``
+     early-return branch (covers polling on an already-enrolled
+     profile after a pre-enrollment dashboard boot) and right after
+     ``save_identity`` succeeds on the approved-polling path.
+
+These tests pin all four legs of the contract so a future refactor that
+drops the hook is caught immediately by ``pytest``.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi.testclient import TestClient
+
+from cullis_connector import web as connector_web
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity import generate_keypair, save_identity
+from cullis_connector.identity.store import IdentityMetadata
+from cullis_connector.web import (
+    RequesterInfo,
+    _ensure_ambassador_installed,
+    _maybe_install_ambassador,
+    build_app,
+)
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _self_signed_cert_pem(private_key, *, common_name: str) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.x509.oid import NameOID
+
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(
+            NameOID.ORGANIZATION_NAME, common_name.split("::", 1)[0],
+        ),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .sign(private_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _seed_identity(
+    config_dir: Path, *, agent_id: str = "acme::frontdesk",
+) -> None:
+    key = generate_keypair()
+    cert_pem = _self_signed_cert_pem(key, common_name=agent_id)
+    metadata = IdentityMetadata(
+        agent_id=agent_id,
+        capabilities=[],
+        site_url="https://mastio.test",
+        issued_at="2026-05-17T10:00:00+00:00",
+    )
+    save_identity(
+        config_dir=config_dir,
+        cert_pem=cert_pem,
+        private_key=key,
+        ca_chain_pem=None,
+        metadata=metadata,
+    )
+
+
+class _FakeCullisClient:
+    """No-op stand-in for ``cullis_sdk.CullisClient``.
+
+    The Ambassador's ``install_ambassador`` only constructs the holder
+    (``AmbassadorClient``); the actual SDK login is lazy on first
+    ``/v1/chat/completions`` so a no-op fake is enough for the install
+    path. Inbox poller bootstrap also calls ``from_connector`` which
+    we cover with the no-arg classmethod below.
+    """
+
+    @classmethod
+    def from_connector(cls, *args, **kwargs):
+        return cls()
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.identity = None
+        self.agent_id = ""
+
+    def close(self) -> None:
+        pass
+
+    def list_inbox(self, *args, **kwargs):
+        return []
+
+    def discover(self, *args, **kwargs):
+        return []
+
+    def login_from_pem(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _patch_sdk(monkeypatch):
+    monkeypatch.setattr("cullis_sdk.CullisClient", _FakeCullisClient)
+    # Make sure the test isn't running in shared-mode by accident
+    # (env may have AMBASSADOR_MODE set from a sibling test).
+    monkeypatch.delenv("AMBASSADOR_MODE", raising=False)
+    yield
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> ConnectorConfig:
+    cfg = ConnectorConfig(
+        site_url="https://mastio.test",
+        config_dir=tmp_path,
+        verify_tls=False,
+        request_timeout_s=2.0,
+    )
+    # TestClient sends client.host=testclient, which is rejected by
+    # the loopback gate. Disable for unit tests; production keeps it on.
+    cfg.ambassador.require_local_only = False
+    return cfg
+
+
+@pytest.fixture
+def fresh_app_pre_enrollment(cfg):
+    """App built with NO identity on disk yet.
+
+    Mirrors the Frontdesk bundle's boot: the Connector container starts
+    before the operator runs the enrollment wizard. The lifespan will
+    skip the Ambassador mount because ``has_identity()`` is False.
+    """
+    return build_app(cfg)
+
+
+@pytest.fixture
+def enrolled_app(cfg):
+    """App built with an identity already on disk before lifespan runs.
+
+    Mirrors a normal restart after a successful enrollment — the
+    lifespan should mount the Ambassador on its own.
+    """
+    _seed_identity(cfg.config_dir)
+    return build_app(cfg)
+
+
+# ── tests ───────────────────────────────────────────────────────────
+
+
+def test_ambassador_unmounted_when_app_boots_pre_enrollment(
+    fresh_app_pre_enrollment,
+):
+    """Bug repro: Connector booted before enrollment → no Ambassador.
+
+    This is the pre-fix state we are explicitly NOT trying to remove —
+    boot-time mount is still gated on identity presence. What we ARE
+    fixing is the absence of a recovery path when identity lands later;
+    the other tests in this file exercise that.
+    """
+    with TestClient(fresh_app_pre_enrollment) as client:
+        resp = client.get("/v1/ambassador/health")
+    # FastAPI returns 404 for routes that were never mounted.
+    assert resp.status_code == 404
+    assert (
+        getattr(fresh_app_pre_enrollment.state, "ambassador", None) is None
+    )
+
+
+def test_ambassador_mounts_lazily_when_identity_appears_then_status_polls(
+    fresh_app_pre_enrollment, cfg,
+):
+    """The Frontdesk bundle's primary recovery path.
+
+    The Connector boots empty, the operator completes the wizard via
+    a different code path (CLI ``cullis users add`` or the shared-mode
+    SSO subject populates the identity directly), and the dashboard's
+    ``/api/status`` poller hits the ``has_identity`` early-return branch.
+    That branch must trigger the lazy Ambassador install so the SPA's
+    next request to ``/v1/chat/completions`` actually reaches the router.
+    """
+    with TestClient(fresh_app_pre_enrollment) as client:
+        # 1. Pre-enrollment: router not mounted.
+        assert client.get("/v1/ambassador/health").status_code == 404
+
+        # 2. Identity lands on disk (simulates the side-channel that
+        #    can write identity without going through /api/status,
+        #    e.g. CLI enrollment or shared-mode bootstrap).
+        _seed_identity(cfg.config_dir)
+
+        # 3. The next ``/api/status`` poll hits the ``has_identity``
+        #    branch and must lazily mount the Ambassador.
+        status = client.get("/api/status")
+        assert status.status_code == 200
+        assert status.json()["status"] == "approved"
+
+        # 4. Router is now live and unauth health surfaces agent_id.
+        health = client.get("/v1/ambassador/health")
+        assert health.status_code == 200
+        body = health.json()
+        assert body["status"] == "ok"
+        assert body["agent_id"] == "acme::frontdesk"
+
+    assert (
+        getattr(fresh_app_pre_enrollment.state, "ambassador", None)
+        is not None
+    )
+
+
+def test_ambassador_mounts_after_admin_approved_polling_flow(
+    fresh_app_pre_enrollment, cfg, monkeypatch,
+):
+    """The HTMX wizard path: ``/api/status`` polls the proxy, gets the
+    approved record (cert_pem + agent_id), persists the identity, and
+    must mount the Ambassador BEFORE returning ``{"status": "approved"}``
+    so the SPA's first chat request lands on a live router."""
+    cert_pem = _self_signed_cert_pem(
+        generate_keypair(), common_name="acme::wizard-agent",
+    )
+
+    # Install a pending session as if the wizard had just submitted
+    # the enrollment request.
+    pending_key = ec.generate_private_key(ec.SECP256R1())
+    prev = connector_web._pending
+    connector_web._pending = connector_web._Pending(
+        session_id="ticket-xyz-001",
+        enroll_url="https://mastio.test/v1/enrollment/ticket-xyz-001",
+        site_url="https://mastio.test",
+        verify_tls=False,
+        private_key=pending_key,
+        requester=RequesterInfo(
+            name="demo", email="demo@cullis.local", reason="t",
+        ),
+        started_at=time.time(),
+    )
+
+    def _fake_get(url, *, headers=None, verify=None, timeout=None, **kwargs):
+        return httpx.Response(
+            200,
+            json={
+                "session_id": "ticket-xyz-001",
+                "status": "approved",
+                "agent_id": "acme::wizard-agent",
+                "cert_pem": cert_pem,
+                "capabilities": ["chat.query"],
+            },
+            request=httpx.Request("GET", url),
+        )
+    monkeypatch.setattr(connector_web.httpx, "get", _fake_get)
+
+    try:
+        with TestClient(fresh_app_pre_enrollment) as client:
+            # Pre-poll: router not mounted (boot was pre-enrollment).
+            assert (
+                client.get("/v1/ambassador/health").status_code == 404
+            )
+
+            status = client.get("/api/status")
+            assert status.status_code == 200
+            body = status.json()
+            assert body["status"] == "approved", body
+            assert body["agent_id"] == "acme::wizard-agent"
+
+            # Post-poll: Ambassador is live without any restart.
+            health = client.get("/v1/ambassador/health")
+            assert health.status_code == 200
+            assert (
+                health.json()["agent_id"] == "acme::wizard-agent"
+            )
+    finally:
+        connector_web._pending = prev
+
+
+def test_maybe_install_ambassador_is_idempotent(enrolled_app, cfg):
+    """The boot path and the post-enrollment hook share the same helper.
+
+    Calling it twice MUST be safe — the second call short-circuits on
+    the idempotency guard instead of bubbling the ``RuntimeError``
+    raised by ``install_ambassador`` on double-mount.
+    """
+    with TestClient(enrolled_app) as _client:
+        first = enrolled_app.state.ambassador
+        assert first is not None, (
+            "lifespan should have mounted on boot when identity exists"
+        )
+
+        # Second call: no-op, no error, same state object.
+        _maybe_install_ambassador(enrolled_app, cfg)
+        assert enrolled_app.state.ambassador is first
+
+
+def test_ensure_ambassador_installed_helper_is_idempotent(
+    enrolled_app, cfg,
+):
+    """Public helper returns True on every call once mounted."""
+    with TestClient(enrolled_app) as _client:
+        assert _ensure_ambassador_installed(enrolled_app) is True
+        assert _ensure_ambassador_installed(enrolled_app) is True
+        assert _ensure_ambassador_installed(enrolled_app) is True
+
+
+def test_ensure_ambassador_installed_swallows_install_errors(
+    fresh_app_pre_enrollment, cfg, monkeypatch, caplog,
+):
+    """Best-effort contract: an install failure (e.g. Mastio unreachable
+    during ``ensure_local_token``) must NOT propagate. The enrollment
+    polling response stays ``approved`` and the operator retries on the
+    next poll. We force a failure by monkeypatching ``install_ambassador``
+    to raise and assert the helper logs + returns False without bubbling.
+    """
+    _seed_identity(cfg.config_dir)
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("simulated Mastio reachability failure")
+
+    # Patch the single-mode installer at its call site
+    # (``_ensure_ambassador_installed`` dispatches to it when shared
+    # mode is off). Patching at the module the helper actually reads
+    # is more robust against test pollution than reaching for
+    # ``cullis_connector.ambassador.router`` — that package re-exports
+    # ``router`` as an APIRouter object so dotted-path lookups confuse
+    # the resolver.
+    monkeypatch.setattr(
+        connector_web, "_maybe_install_ambassador", _raise,
+    )
+
+    import logging as _logging
+    with caplog.at_level(
+        _logging.WARNING, logger="cullis_connector.web",
+    ):
+        result = _ensure_ambassador_installed(fresh_app_pre_enrollment)
+
+    assert result is False
+    assert (
+        getattr(fresh_app_pre_enrollment.state, "ambassador", None)
+        is None
+    )
+    assert any(
+        "post-enrollment Ambassador install failed" in rec.message
+        for rec in caplog.records
+    ), [r.message for r in caplog.records]

--- a/tests/connector/test_ambassador_install_post_enrollment.py
+++ b/tests/connector/test_ambassador_install_post_enrollment.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Any
 
 import httpx
 import pytest


### PR DESCRIPTION
## Summary

Architectural bug discovered 2026-05-17 during a demo smoke run: the Frontdesk bundle starts the Connector container BEFORE the operator runs the enrollment wizard (the wizard is served by the Connector dashboard). At boot, ``_dashboard_lifespan`` calls ``_maybe_install_ambassador``, sees ``has_identity()=False`` on the still-empty profile, and skips the mount. After the admin approves the ticket, the on-disk identity lands but the Ambassador stays unmounted — every ``/v1/chat/completions``, ``/v1/models``, ``/api/session/*`` 404s until someone manually runs ``docker compose restart cullis-frontdesk-connector-1``. No customer admin does that. Companion gap to the ``chat_completion`` DPoP pinning trail discovered the same day (see ``feedback_chat_completion_dpop_pinning_bug.md``).

Closes the gap by mounting the Ambassador the moment the identity lands on disk — no operator restart required.

- ``_maybe_install_ambassador`` and ``_maybe_install_shared_ambassador`` get an idempotency early-return so the boot path and the post-enrollment hook can both call them without tripping the loud ``RuntimeError`` raised by ``install_ambassador`` on double-mount.
- New helper ``_ensure_ambassador_installed`` (``cullis_connector/web.py`` next to ``_ensure_inbox_poller_running``) dispatches to the single / shared variant based on ``AMBASSADOR_MODE`` and is best-effort: install failures (e.g. Mastio unreachable during ``ensure_local_token``) are logged + swallowed so the enrollment ``approved`` response is never blocked. The operator retries on the next ``/api/status`` poll.
- ``/api/status`` calls the helper in BOTH branches: the ``has_identity`` early-return (side-channel identity write — CLI enrollment, shared-mode bootstrap) AND right after ``save_identity`` succeeds on the HTMX approved-polling path.

## Files

- ``cullis_connector/web.py`` — idempotency guards + ``_ensure_ambassador_installed`` + two ``/api/status`` call sites.
- ``tests/connector/test_ambassador_install_post_enrollment.py`` — 6 new tests.

## Test plan

- [x] ``pytest tests/connector/test_ambassador_install_post_enrollment.py -n auto`` — 6 passed
- [x] ``pytest tests/connector/ -n auto`` — 678 passed, 4 skipped (no regressions)
- [x] Full suite — 3854 passed; the 2 fails (``test_badge_approvals_empty_when_plugin_unavailable``, ``test_tampered_signature_returns_none``) reproduce on ``main`` HEAD without this PR and are unrelated flakes
- [ ] Frontdesk bundle dogfood: ``./deploy.sh``, wizard → approve → confirm SPA chat works without ``docker compose restart`` (manual, follow-up)

## Edge cases handled

1. **Dashboard launched pre-enrollment, polling after identity already exists** — ``has_identity`` branch in ``/api/status`` triggers lazy install.
2. **HTMX approved-polling flow** — install fires after ``save_identity`` and before the ``{"status":"approved"}`` response so the SPA's first request lands on a live router.
3. **Install failure (e.g. Mastio unreachable during local-token write)** — logged + swallowed; enrollment response stays ``approved`` and the next poll retries.
4. **Double-mount race** — both single and shared installers short-circuit on the idempotency guard before reaching the loud ``RuntimeError`` in ``install_ambassador``.
5. **Shared-mode topology** (``AMBASSADOR_MODE=shared``) — same dispatch path; ``_maybe_install_shared_ambassador`` also got the idempotency guard.