### PR TITLE
fix(connector): TLS verify fallback to env CA bundle (Frontdesk auto-enroll)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -72,16 +72,45 @@ def _build_user_client(request: Request, cred: Any):
             503, "Ambassador site_url unknown — cannot build per-user client",
         )
     from cullis_sdk import CullisClient
-    import os as _os_timeout
+    import os as _os
     try:
-        _req_timeout = float(_os_timeout.environ.get("CULLIS_REQUEST_TIMEOUT_S", "10"))
+        _req_timeout = float(_os.environ.get("CULLIS_REQUEST_TIMEOUT_S", "10"))
     except ValueError:
         _req_timeout = 10.0
+
+    # ADR-025 — surface the operator-pinned Org CA bundle to the per-
+    # user CullisClient so TLS verify against the Mastio's
+    # ``mastio.local``-signed cert succeeds. Pre-fix the factory
+    # defaulted to httpx's system CA store, which never carries the
+    # self-signed Org Root CA the Mastio bundle ships, and every
+    # ``/v1/principals/csr`` call collapsed to ``provisioning="deferred"``
+    # with ``CERTIFICATE_VERIFY_FAILED``. Read the bundle path from the
+    # Frontdesk env vars (the docker-compose maps ``CULLIS_FRONTDESK_
+    # CA_BUNDLE`` and falls back to ``SSL_CERT_FILE`` / ``REQUESTS_CA_
+    # BUNDLE`` for parity with the rest of the Python ecosystem).
+    _ca_chain_pem: str | None = None
+    _ca_path = (
+        _os.environ.get("CULLIS_FRONTDESK_CA_BUNDLE")
+        or _os.environ.get("SSL_CERT_FILE")
+        or _os.environ.get("REQUESTS_CA_BUNDLE")
+        or ""
+    )
+    if _ca_path and _os.path.exists(_ca_path):
+        try:
+            with open(_ca_path, "r", encoding="utf-8") as _f:
+                _ca_chain_pem = _f.read()
+        except OSError as _exc:
+            _log.warning(
+                "could not read CA bundle at %s: %s — TLS verify may fail",
+                _ca_path, _exc,
+            )
+
     client = CullisClient.from_user_principal_pem(
         site_url,
         principal_id=cred.principal_id,
         cert_pem=cred.cert_pem,
         key_pem=cred.key_pem,
+        ca_chain_pem=_ca_chain_pem,
         timeout=_req_timeout,
     )
     client.login_via_proxy_with_local_key()

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -143,12 +143,36 @@ def verify_arg_for(verify_tls: bool, ca_chain_path: Path) -> bool | str:
     verifying the Site's leaf cert end-to-end. Returns ``False`` when
     the operator has explicitly disabled verification (opt-out is
     opt-out — a pinned CA does not silently re-enable it). Falls back
-    to ``True`` when verification is on but no CA has been pinned yet
-    (first contact before TOFU bootstrap completes).
+    to the env-provided CA bundle (``CULLIS_FRONTDESK_CA_BUNDLE`` /
+    ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE``) when one exists,
+    otherwise ``True`` (system CA store).
+
+    The env fallback was added 2026-05-17 after the Frontdesk
+    customer-path smoke surfaced ``CERTIFICATE_VERIFY_FAILED`` on every
+    post-login ``/v1/principals/csr`` call: the Connector bundle ships
+    the Mastio Org Root CA at ``/etc/cullis/ca-bundle.pem`` and exports
+    ``CULLIS_FRONTDESK_CA_BUNDLE`` pointing to it, but ``verify_arg_for``
+    ignored that path because the auto-enrollment wizard never writes
+    the per-profile ``ca-chain.pem`` (the manual ``/setup/pin-ca`` step
+    is what populates it, and the bundle skips that for headless
+    deploys). Result: ``provisioning="deferred"`` forever after login,
+    user TOFU pin never written on Mastio, ``/v1/llm/chat`` 401 (the
+    chat surface broken on every fresh Frontdesk deploy).
     """
     if not verify_tls:
         return False
-    return str(ca_chain_path) if ca_chain_path.exists() else True
+    if ca_chain_path.exists():
+        return str(ca_chain_path)
+    import os
+    for env_name in (
+        "CULLIS_FRONTDESK_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ):
+        env_path = os.environ.get(env_name, "").strip()
+        if env_path and Path(env_path).exists():
+            return env_path
+    return True
 
 
 def _read_yaml(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

L3a of the Cullis Chat customer-path 401 investigation. The Frontdesk bundle ships the Mastio Org Root CA at `/etc/cullis/ca-bundle.pem` and exports it via `CULLIS_FRONTDESK_CA_BUNDLE` / `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`, but `verify_arg_for` (`cullis_connector/config.py`) only checked the per-profile `ca-chain.pem` populated by `/setup/pin-ca`. Headless auto-enrollment (the bundle path) never writes that file, so every Connector → Mastio HTTPS call fell through to httpx's system CA store, which doesn't carry the self-signed Org Root → `CERTIFICATE_VERIFY_FAILED`.

Concrete blast radius: `/v1/principals/csr` POST from `_bind_login_cert` errored out silently every login, leaving `provisioning="deferred"`. Mastio never wrote the user TOFU pin to `local_user_principals.pubkey_thumbprint`, and every subsequent `/v1/llm/chat` call by the per-user cert path failed cert-pin check → 401.

This PR closes the verify-CA root cause:

1. **`verify_arg_for`** (`cullis_connector/config.py`): pinned `ca-chain.pem` still wins (operator-controlled trust anchor never silently overridden); when absent, fall back to the same env vars the Python ecosystem uses (`CULLIS_FRONTDESK_CA_BUNDLE`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`) before returning `True` (system CA).

2. **`_build_user_client`** (`cullis_connector/ambassador/router.py`): defense-in-depth — read the same env CA bundle inline and pass it to `CullisClient.from_user_principal_pem(ca_chain_pem=...)` so short-lived per-user clients carry the trust anchor even if the profile-level pin is unavailable.

## Why

Customer-path smoke gate has masked this since v0.2.0 because `ANTHROPIC_API_KEY` is unconfigured in CI and `smoke-customer-path.sh:46-54` auto-skips the chat turn. Local validation with the secret set surfaces it deterministically on every fresh bundle.

## Test plan

- [x] Local `customer-path-smoke.sh` with `ANTHROPIC_API_KEY` exported: login response flips from `provisioning="deferred"` to `provisioning="ok"`, `attribution="ok"`. Mastio `local_user_principals.pubkey_thumbprint` is populated.
- [ ] L3b residual ("client cert pubkey pin mismatch" trace on `/v1/llm/chat` despite stored == SHA256(SPKI from cert)) — separate PR, investigation continues.
- [ ] CI customer-path will still skip the chat turn (secret not seeded).

## Related

- PR #761 (L1: mint cullis_session cookie on local-auth login) — companion fix
- L2 (Ambassador install hook post-enrollment) — separate PR pending