### PR TITLE
fix(tests): deterministic base64url tampering in local_session tests

### DIFF
--- a/tests/connector/test_local_session.py
+++ b/tests/connector/test_local_session.py
@@ -129,18 +129,26 @@ def test_pre_expiry_returns_payload():
 
 
 def test_tampered_signature_returns_none():
+    # Tamper the FIRST base64url char of the sig, not the last. In an
+    # un-padded base64url string only the last char may carry filler
+    # bits: HMAC-SHA256 is 32 bytes → 43 chars where the last char
+    # encodes 4 useful bits + 2 filler bits, so swaps inside the same
+    # top-4-bit cluster (A↔B, C↔D, …) leave the decoded sig bytes
+    # identical and the HMAC compare still passes ~25 % of the time.
     payload = build_payload(user_name="mario", must_change_password=False)
     cookie = issue_local_cookie(payload, SECRET)
     body, sig = cookie.split(".", 1)
-    bad = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+    bad = ("A" if sig[0] != "A" else "B") + sig[1:]
     assert parse_local_cookie(f"{body}.{bad}", SECRET) is None
 
 
 def test_tampered_payload_returns_none():
+    # Same rationale as test_tampered_signature_returns_none — tamper
+    # the first base64url char so the decoded bytes always change.
     payload = build_payload(user_name="mario", must_change_password=False)
     cookie = issue_local_cookie(payload, SECRET)
     body, sig = cookie.split(".", 1)
-    bad_body = body[:-1] + ("A" if body[-1] != "A" else "B")
+    bad_body = ("A" if body[0] != "A" else "B") + body[1:]
     assert parse_local_cookie(f"{bad_body}.{sig}", SECRET) is None
 
 


### PR DESCRIPTION
## Summary

`tests/connector/test_local_session.py::test_tampered_signature_returns_none` (and its sibling `test_tampered_payload_returns_none`) tamper the **last** base64url character of an un-padded encoding. HMAC-SHA256 is 32 bytes → 43 base64 chars; only 4 of the 6 bits in the last char are useful, the other 2 are filler. A swap that lands in the same top-4-bit cluster (A↔B, C↔D, E↔F, …) leaves the decoded bytes identical and the HMAC compare still passes.

**Concrete impact:** ~25 % flake rate observed on CI shard 1/3 (`test (3.11)`) over the past 24 h, including two main-branch runs (25989681189, 25993734938) and PR #763 (L3a TLS verify fallback) which the flake blocked.

Reproduce locally: `pytest tests/connector/test_local_session.py --count 100` fails 5-15 / 100 iterations on `main`.

## Fix

Mutate the **first** base64url char instead. In an un-padded base64 string only the last char may carry filler bits, so every other position always encodes six useful bits → swap → decoded bytes always change → assert fires deterministically.

Two lines of test code, no production change.

## Test plan

- [x] `pytest tests/connector/test_local_session.py --count 100` → 2800 / 2800 pass post-fix (28 tests × 100 iterations).
- [x] CI `test (3.11)` previously failed shard 1/3 on tampered-sig assertion → should pass.

## Related

Unblocks the re-application of PR #763 (L3a CA bundle fallback for Frontdesk auto-enroll).