### PR TITLE
fix(connector): TLS verify fallback to env CA bundle (Frontdesk auto-enroll)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -72,16 +72,44 @@ def _build_user_client(request: Request, cred: Any):
             503, "Ambassador site_url unknown — cannot build per-user client",
         )
     from cullis_sdk import CullisClient
-    import os as _os_timeout
+    import os as _os
     try:
-        _req_timeout = float(_os_timeout.environ.get("CULLIS_REQUEST_TIMEOUT_S", "10"))
+        _req_timeout = float(_os.environ.get("CULLIS_REQUEST_TIMEOUT_S", "10"))
     except ValueError:
         _req_timeout = 10.0
+
+    # Defence-in-depth for headless Frontdesk auto-enroll: surface the
+    # operator-pinned Org CA bundle to the per-user CullisClient so its
+    # TLS verify against the Mastio's self-signed cert succeeds even if
+    # the profile-level ``ca-chain.pem`` is missing (the bundle skips
+    # the manual ``/setup/pin-ca`` step). Pre-fix the factory defaulted
+    # to httpx's system CA store, which never carries the Org Root and
+    # every ``/v1/principals/csr`` call collapsed to
+    # ``provisioning="deferred"`` with ``CERTIFICATE_VERIFY_FAILED``.
+    # Same env precedence as ``config.verify_arg_for``.
+    _ca_chain_pem: str | None = None
+    _ca_path = (
+        _os.environ.get("CULLIS_FRONTDESK_CA_BUNDLE")
+        or _os.environ.get("SSL_CERT_FILE")
+        or _os.environ.get("REQUESTS_CA_BUNDLE")
+        or ""
+    ).strip()
+    if _ca_path and _os.path.exists(_ca_path):
+        try:
+            with open(_ca_path, "r", encoding="utf-8") as _f:
+                _ca_chain_pem = _f.read()
+        except OSError as _exc:
+            _log.warning(
+                "could not read CA bundle at %s: %s — TLS verify may fail",
+                _ca_path, _exc,
+            )
+
     client = CullisClient.from_user_principal_pem(
         site_url,
         principal_id=cred.principal_id,
         cert_pem=cred.cert_pem,
         key_pem=cred.key_pem,
+        ca_chain_pem=_ca_chain_pem,
         timeout=_req_timeout,
     )
     client.login_via_proxy_with_local_key()

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -143,12 +143,39 @@ def verify_arg_for(verify_tls: bool, ca_chain_path: Path) -> bool | str:
     verifying the Site's leaf cert end-to-end. Returns ``False`` when
     the operator has explicitly disabled verification (opt-out is
     opt-out — a pinned CA does not silently re-enable it). Falls back
-    to ``True`` when verification is on but no CA has been pinned yet
-    (first contact before TOFU bootstrap completes).
+    to the env-provided CA bundle (``CULLIS_FRONTDESK_CA_BUNDLE`` /
+    ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE``) when one exists,
+    otherwise ``True`` (system CA store).
+
+    Order of precedence: explicit ``verify_tls=False`` > per-profile
+    pinned ``ca-chain.pem`` > env CA bundle > system store. Pinning
+    still wins so an operator-controlled TOFU trust anchor is never
+    silently overridden by an env var.
+
+    The env fallback was added 2026-05-17 after the Frontdesk
+    customer-path smoke surfaced ``CERTIFICATE_VERIFY_FAILED`` on every
+    post-login ``/v1/principals/csr`` call. The bundle ships the Org
+    Root CA at ``/etc/cullis/ca-bundle.pem`` and exports
+    ``CULLIS_FRONTDESK_CA_BUNDLE`` pointing to it, but this function
+    only honoured the per-profile ``ca-chain.pem`` (populated by the
+    manual ``/setup/pin-ca`` step, which headless auto-enrollment
+    skips). Result: ``provisioning="deferred"`` forever after login,
+    user TOFU pin never written on Mastio, ``/v1/llm/chat`` 401.
     """
     if not verify_tls:
         return False
-    return str(ca_chain_path) if ca_chain_path.exists() else True
+    if ca_chain_path.exists():
+        return str(ca_chain_path)
+    import os
+    for env_name in (
+        "CULLIS_FRONTDESK_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    ):
+        env_path = os.environ.get(env_name, "").strip()
+        if env_path and Path(env_path).exists():
+            return env_path
+    return True
 
 
 def _read_yaml(path: Path) -> dict[str, Any]:

--- a/tests/connector/test_config.py
+++ b/tests/connector/test_config.py
@@ -97,7 +97,24 @@ def test_invalid_yaml_top_level_raises(tmp_path: Path) -> None:
 # ── verify_arg / verify_arg_for ────────────────────────────────────────────
 
 
-def test_verify_arg_returns_false_when_user_disabled_tls(tmp_path: Path) -> None:
+_VERIFY_ENV_VARS = (
+    "CULLIS_FRONTDESK_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+)
+
+
+@pytest.fixture
+def _no_ca_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear the env-CA fallbacks ``verify_arg_for`` honours so the
+    "no CA anywhere" tests are deterministic regardless of the host."""
+    for name in _VERIFY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_verify_arg_returns_false_when_user_disabled_tls(
+    tmp_path: Path, _no_ca_env: None,
+) -> None:
     """Opt-out is opt-out: a pinned CA on disk does NOT silently
     re-enable verification when the operator passed --no-verify-tls."""
     ca = tmp_path / "identity" / "ca-chain.pem"
@@ -107,7 +124,9 @@ def test_verify_arg_returns_false_when_user_disabled_tls(tmp_path: Path) -> None
     assert cfg.verify_arg is False
 
 
-def test_verify_arg_returns_path_when_ca_pinned(tmp_path: Path) -> None:
+def test_verify_arg_returns_path_when_ca_pinned(
+    tmp_path: Path, _no_ca_env: None,
+) -> None:
     """TOFU pinning happy path: with verification on and a pinned CA
     on disk, httpx receives the absolute path so it uses the pinned
     CA as trust store instead of the system bundle."""
@@ -118,7 +137,9 @@ def test_verify_arg_returns_path_when_ca_pinned(tmp_path: Path) -> None:
     assert cfg.verify_arg == str(ca)
 
 
-def test_verify_arg_returns_true_when_no_ca_pinned(tmp_path: Path) -> None:
+def test_verify_arg_returns_true_when_no_ca_pinned(
+    tmp_path: Path, _no_ca_env: None,
+) -> None:
     """First-contact / pre-TOFU state: verification on but no CA on
     disk yet → httpx uses its default CA bundle (system trust store).
     This still fails for self-signed Sites, which is the cue for the
@@ -127,7 +148,9 @@ def test_verify_arg_returns_true_when_no_ca_pinned(tmp_path: Path) -> None:
     assert cfg.verify_arg is True
 
 
-def test_verify_arg_for_module_helper_matches_property(tmp_path: Path) -> None:
+def test_verify_arg_for_module_helper_matches_property(
+    tmp_path: Path, _no_ca_env: None,
+) -> None:
     """``verify_arg_for`` must produce the same result as the
     instance property when given the same inputs — callers with a
     form-supplied ``verify_tls`` rely on this equivalence."""
@@ -148,3 +171,95 @@ def test_verify_arg_for_module_helper_matches_property(tmp_path: Path) -> None:
     # CA pinned, verify off — both paths must collapse to False.
     cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=False)
     assert verify_arg_for(False, ca_path) == cfg.verify_arg == False  # noqa: E712
+
+
+# ── env-CA fallback (Frontdesk auto-enroll) ───────────────────────────────
+
+
+def test_verify_arg_for_uses_env_bundle_when_no_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless Frontdesk auto-enroll path: the bundle ships an Org
+    Root CA at a path exported via ``CULLIS_FRONTDESK_CA_BUNDLE`` and
+    skips the manual ``/setup/pin-ca`` wizard. ``verify_arg_for``
+    must fall back to that bundle so per-user HTTPS calls (in
+    particular ``/v1/principals/csr``) don't trip
+    ``CERTIFICATE_VERIFY_FAILED``."""
+    from cullis_connector.config import verify_arg_for
+
+    env_ca = tmp_path / "ca-bundle.pem"
+    env_ca.write_text("PEM")
+    for name in _VERIFY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("CULLIS_FRONTDESK_CA_BUNDLE", str(env_ca))
+
+    assert verify_arg_for(True, tmp_path / "missing-pin.pem") == str(env_ca)
+
+
+def test_verify_arg_for_pin_wins_over_env_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinning is operator-controlled trust and must never be silently
+    overridden by an env var. A populated per-profile ``ca-chain.pem``
+    wins even when ``CULLIS_FRONTDESK_CA_BUNDLE`` points at a real
+    file."""
+    from cullis_connector.config import verify_arg_for
+
+    pin = tmp_path / "ca-chain.pem"
+    pin.write_text("PIN")
+    env_ca = tmp_path / "env-bundle.pem"
+    env_ca.write_text("ENV")
+    monkeypatch.setenv("CULLIS_FRONTDESK_CA_BUNDLE", str(env_ca))
+
+    assert verify_arg_for(True, pin) == str(pin)
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    ["CULLIS_FRONTDESK_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"],
+)
+def test_verify_arg_for_env_fallback_priority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+) -> None:
+    """All three env names are honoured (Cullis-specific first, then
+    the two standard Python-ecosystem fallbacks)."""
+    from cullis_connector.config import verify_arg_for
+
+    env_ca = tmp_path / "ca.pem"
+    env_ca.write_text("PEM")
+    for name in _VERIFY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, str(env_ca))
+
+    assert verify_arg_for(True, tmp_path / "missing.pem") == str(env_ca)
+
+
+def test_verify_arg_for_skips_missing_env_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the env var points at a non-existent file, fall through to
+    the next candidate (or system store) instead of returning a path
+    httpx can't open."""
+    from cullis_connector.config import verify_arg_for
+
+    for name in _VERIFY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("CULLIS_FRONTDESK_CA_BUNDLE", str(tmp_path / "absent.pem"))
+
+    assert verify_arg_for(True, tmp_path / "also-absent.pem") is True
+
+
+def test_verify_arg_for_env_bundle_ignored_when_verify_off(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``verify_tls=False`` collapses to ``False`` even when an env CA
+    bundle is set. Opt-out is opt-out."""
+    from cullis_connector.config import verify_arg_for
+
+    env_ca = tmp_path / "ca.pem"
+    env_ca.write_text("PEM")
+    monkeypatch.setenv("CULLIS_FRONTDESK_CA_BUNDLE", str(env_ca))
+
+    assert verify_arg_for(False, tmp_path / "missing.pem") is False


### PR DESCRIPTION
## Summary

L3a re-application of closed PR #763. Original was blocked by the unrelated `test_tampered_signature_returns_none` base64url flake — fixed in #764.

The Frontdesk bundle ships the Mastio Org Root CA at `/etc/cullis/ca-bundle.pem` and exports it via `CULLIS_FRONTDESK_CA_BUNDLE` / `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`, but `verify_arg_for` (`cullis_connector/config.py`) only checked the per-profile `ca-chain.pem` populated by `/setup/pin-ca`. Headless auto-enrollment skips that wizard, so every Connector → Mastio HTTPS call fell through to httpx's system CA store, which doesn't carry the self-signed Org Root → `CERTIFICATE_VERIFY_FAILED`.

**Concrete blast radius:** `/v1/principals/csr` POST from `_bind_login_cert` errored silently every login, leaving `provisioning="deferred"`. Mastio never wrote the user TOFU pin to `local_user_principals.pubkey_thumbprint`, and every subsequent `/v1/llm/chat` call by the per-user cert path failed cert-pin check → 401.

## Fix

1. **`verify_arg_for`** (`cullis_connector/config.py`): pinned `ca-chain.pem` still wins (operator-controlled trust anchor never silently overridden); when absent, fall back to `CULLIS_FRONTDESK_CA_BUNDLE`, then `SSL_CERT_FILE`, then `REQUESTS_CA_BUNDLE` before returning `True` (system CA).
2. **`_build_user_client`** (`cullis_connector/ambassador/router.py`): defence-in-depth — read the same env CA bundle inline and pass it to `CullisClient.from_user_principal_pem(ca_chain_pem=...)` so short-lived per-user clients carry the trust anchor even if the profile-level pin is unavailable. SDK factory signature already accepts this — no SDK change needed.
3. **`tests/connector/test_config.py`**: 5 new tests pin the env-fallback semantics (env bundle picked when no pin; pin wins over env; all three env names honoured; missing env path skipped; `verify_tls=False` trumps env). Existing tests get a `_no_ca_env` fixture so they're deterministic regardless of host env.

## Order of precedence

```
verify_tls=False  →  False
      else
      ┌──────────────────────────────────────────────────────┐
      │ pinned ca-chain.pem exists → str(pinned)              │
      │ CULLIS_FRONTDESK_CA_BUNDLE exists → that path         │
      │ SSL_CERT_FILE exists → that path                      │
      │ REQUESTS_CA_BUNDLE exists → that path                 │
      │ else → True (httpx system CA store)                   │
      └──────────────────────────────────────────────────────┘
```

## Why an env fallback (and not just writing `ca-chain.pem` at bundle boot)

Per-profile `ca-chain.pem` is operator-controlled trust pin: writing it at bundle boot from a docker-mounted bundle file would conflate two semantics ("operator pinned the cert" vs "the deploy script knows where the cert lives"). The env fallback keeps pinning explicit while letting headless deploys still verify TLS end-to-end against the Org Root.

## Test plan

- [x] `pytest tests/connector/test_config.py` → 19 / 19 passed.
- [x] `pytest tests/connector/ tests/test_sdk_proxy_client_ca_pin.py -n auto` → 694 passed, 4 skipped.
- [x] Local customer-path smoke with `ANTHROPIC_API_KEY` set: login response flips from `provisioning="deferred"` to `provisioning="ok"`, `attribution="ok"`; Mastio `local_user_principals.pubkey_thumbprint` populated.
- [ ] CI customer-path will still skip the chat turn (`ANTHROPIC_API_KEY` secret not seeded); follow-up to populate that secret tracked separately.

## Related

- #761, #762 (L1 cookie + L2 ambassador install hook) — companion fixes already merged.
- #764 — base64url flake fix that unblocks this PR's CI.
- L3b residual (cert pubkey pin mismatch on `/v1/llm/chat` despite stored == SHA256(SPKI from cert)) — separate PR in flight.