### PR TITLE
diag(client-cert): expose SPKI thumbprints + cert serial + SAN on pin warnings

### DIFF
--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -204,6 +204,42 @@ def _pem_der_digest(pem: str) -> bytes | None:
         return None
 
 
+def _cert_serial_hex(cert: x509.Certificate) -> str:
+    """Return the cert's serial as lowercase hex, or ``"?"`` if unreadable.
+
+    Used only in warning logs for forensic correlation against the
+    ``/v1/principals/csr`` audit row that minted the cert — the serial
+    is a public identifier present in every X.509 leaf.
+    """
+    try:
+        return f"{cert.serial_number:x}"
+    except Exception:  # noqa: BLE001 — diagnostic only
+        return "?"
+
+
+def _cert_first_spiffe(cert: x509.Certificate) -> str:
+    """Return the first SPIFFE URI in the cert's SAN, or ``"?"``.
+
+    Used only in warning logs — :func:`_identity_from_cert` already
+    surfaces the parsed identity; this helper hands back the raw URI
+    so an operator can see whether the cert is missing the SAN
+    altogether or carrying an unexpected one.
+    """
+    try:
+        san_ext = cert.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName,
+        )
+        for uri in san_ext.value.get_values_for_type(
+            x509.UniformResourceIdentifier,
+        ):
+            return str(uri)
+    except x509.ExtensionNotFound:
+        pass
+    except Exception:  # noqa: BLE001 — diagnostic only
+        pass
+    return "?"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # FastAPI dependency
 # ─────────────────────────────────────────────────────────────────────────────
@@ -331,8 +367,13 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             # pin against. Refuse rather than admit on the strength of
             # the cert chain alone, otherwise CRIT-1 is back in play.
             _log.warning(
-                "client cert auth: typed principal has no pubkey pin: %s",
+                "client cert auth: typed principal has no pubkey pin: "
+                "principal=%s cert_serial=%s cert_san=%s — admin "
+                "pre-created the row but no /v1/principals/csr has been "
+                "signed yet for this principal.",
                 canonical_id,
+                _cert_serial_hex(cert),
+                _cert_first_spiffe(cert),
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -341,10 +382,26 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
         from mcp_proxy.registry.principals_csr import pubkey_thumbprint_sha256
         presented_pubkey = pubkey_thumbprint_sha256(cert.public_key())
         if not hmac.compare_digest(presented_pubkey, stored_pubkey):
+            # Both values are SHA-256 hex of the SubjectPublicKeyInfo DER
+            # — public identifiers, not secrets — log them in full so an
+            # operator can correlate against the on-disk Connector key
+            # (``cullis_connector/ambassador/shared/keystore.py``: hash
+            # the PEM at ``<config_dir>/user_keys/<sha256(principal_id)>.key.pem``
+            # and compare). Also log the cert serial + SPIFFE SAN so the
+            # mismatched cert can be traced back to the specific
+            # ``/v1/principals/csr`` mint it came from.
             _log.warning(
-                "client cert pubkey pin mismatch for %s — presented cert "
-                "is not bound to this principal's TOFU pubkey.",
+                "client cert pubkey pin mismatch: principal=%s "
+                "presented_spki_sha256=%s stored_spki_sha256=%s "
+                "cert_serial=%s cert_san=%s — presented cert is not "
+                "bound to this principal's TOFU pubkey. Compare "
+                "presented_spki_sha256 against "
+                "sha256(SPKI(<config_dir>/user_keys/sha256(principal_id))).",
                 canonical_id,
+                presented_pubkey,
+                stored_pubkey,
+                _cert_serial_hex(cert),
+                _cert_first_spiffe(cert),
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/test_client_cert_auth.py
+++ b/tests/test_client_cert_auth.py
@@ -381,6 +381,131 @@ async def test_typed_user_principal_pubkey_mismatch_rejected(proxy_app):
     assert "pubkey" in exc_info.value.detail.lower() or "bound" in exc_info.value.detail.lower()
 
 
+def _capture_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Patch ``mcp_proxy.auth.client_cert._log.warning`` and return the
+    captured rendered messages.
+
+    The ``mcp_proxy`` logger sets ``propagate=False`` (see
+    ``feedback_mcp_proxy_logger_caplog`` in personal memory), so
+    ``caplog`` never sees its records under pytest's default setup.
+    Patching the module-level ``_log.warning`` is the established
+    workaround across the rest of the test suite.
+    """
+    captured: list[str] = []
+    from mcp_proxy.auth import client_cert as _client_cert_mod
+
+    def _record(fmt: str, *args, **kwargs):  # noqa: ANN001
+        try:
+            captured.append(fmt % args if args else fmt)
+        except (TypeError, ValueError):
+            captured.append(fmt)
+
+    monkeypatch.setattr(_client_cert_mod._log, "warning", _record)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_pubkey_pin_mismatch_warning_carries_diagnostic_fields(
+    proxy_app, monkeypatch,
+):
+    """Diagnostic regression guard for L3b.
+
+    When the cert pubkey SPKI hash does not match the stored TOFU pin,
+    the ``WARNING`` log must carry enough forensic detail to identify
+    which cert was presented and which pin it failed against — without
+    requiring an in-container ``pdb`` session on the next dogfood. The
+    fields we lock in:
+
+      * ``principal=``: which typed principal the cert claims.
+      * ``presented_spki_sha256=``: full SHA-256 hex of the presented
+        cert's SubjectPublicKeyInfo DER.
+      * ``stored_spki_sha256=``: full SHA-256 hex of the pin row.
+      * ``cert_serial=``: lowercase hex of the cert's serial number
+        (cross-ref against ``/v1/principals/csr`` audit).
+      * ``cert_san=``: first SPIFFE URI in the cert's SAN.
+
+    Removing or renaming any of these fields breaks customer-path
+    incident response. If a future change really must rename one,
+    update this assert AND the corresponding ``imp/`` runbook entry.
+    """
+    from cryptography import x509
+
+    captured = _capture_warnings(monkeypatch)
+
+    legit_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::ceo")
+    await _provision_typed_principal(
+        "acme::user::ceo", cert_pem=legit_cert_pem,
+    )
+    attacker_cert_pem, _ = mint_agent_cert(
+        org_id="acme", agent_name="user::ceo",
+    )
+    attacker_cert = x509.load_pem_x509_certificate(
+        attacker_cert_pem.encode("utf-8"),
+    )
+    expected_serial_hex = f"{attacker_cert.serial_number:x}"
+
+    headers = mtls_headers(attacker_cert_pem)
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException):
+        await get_agent_from_client_cert(request)
+
+    mismatch_msgs = [m for m in captured if "pubkey pin mismatch" in m]
+    assert mismatch_msgs, (
+        "expected a WARNING containing 'pubkey pin mismatch' so operators "
+        "can grep the customer-path 401 in the next dogfood"
+    )
+    msg = mismatch_msgs[-1]
+    assert "principal=acme::user::ceo" in msg
+    assert "presented_spki_sha256=" in msg
+    assert "stored_spki_sha256=" in msg
+    # Different keypairs → different SPKI hashes. The full hashes appear
+    # in the message — assert they're DISTINCT to lock in that we log
+    # both sides (not e.g. presented twice).
+    presented = msg.split("presented_spki_sha256=", 1)[1].split(" ", 1)[0]
+    stored = msg.split("stored_spki_sha256=", 1)[1].split(" ", 1)[0]
+    assert len(presented) == 64 and len(stored) == 64
+    assert presented != stored
+    assert f"cert_serial={expected_serial_hex}" in msg
+    assert "cert_san=spiffe://" in msg
+
+
+@pytest.mark.asyncio
+async def test_pubkey_pin_unset_warning_carries_diagnostic_fields(
+    proxy_app, monkeypatch,
+):
+    """Sibling regression guard — the "no pin" warning is the other
+    arm of the diagnostic. An admin pre-created the principal row but
+    no /v1/principals/csr has been signed; the WARNING needs to name
+    that explicitly so the operator knows which retry to make."""
+    captured = _capture_warnings(monkeypatch)
+
+    cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::pending")
+    await _provision_typed_principal(
+        "acme::user::pending", pubkey_thumbprint=None,
+    )
+    headers = mtls_headers(cert_pem)
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException):
+        await get_agent_from_client_cert(request)
+
+    no_pin_msgs = [m for m in captured if "has no pubkey pin" in m]
+    assert no_pin_msgs
+    msg = no_pin_msgs[-1]
+    assert "principal=acme::user::pending" in msg
+    assert "cert_serial=" in msg
+    assert "cert_san=spiffe://" in msg
+
+
 @pytest.mark.asyncio
 async def test_typed_workload_principal_pubkey_pinned_authenticates(proxy_app):
     """Happy path workload — same contract as the user case via


### PR DESCRIPTION
## Summary

L3b investigation aid for the Cullis Chat customer-path 401 (see `session-2026-05-17-chat-401-deep-investigation` in personal memory).

The current `WARNING` log on pubkey-pin mismatch carries only the canonical principal id:

```
client cert pubkey pin mismatch for acme::user::ceo — presented
cert is not bound to this principal's TOFU pubkey.
```

That is exactly the information an operator already has from the 401's `detail` field. Anything actionable — which presented hash, which stored hash, which cert serial — needed an in-container `pdb` patch to extract, and the last attempt broke the Connector container with a syntax-error escape and forced a cleanup.

## What changes

Both diagnostic arms (mismatch + unset pin) now carry forensic fields:

| Field                      | Mismatch | Unset pin | Purpose                                                              |
|----------------------------|:--------:|:---------:|----------------------------------------------------------------------|
| `principal=`               | yes      | yes       | Typed principal canonical id (already carried, kept).                |
| `presented_spki_sha256=`   | yes      | —         | Full SHA-256 hex of the presented cert's `SubjectPublicKeyInfo` DER. |
| `stored_spki_sha256=`      | yes      | —         | Full SHA-256 hex of the `local_user_principals.pubkey_thumbprint` row. |
| `cert_serial=`             | yes      | yes       | Lowercase hex of the cert serial — cross-reference to `/v1/principals/csr` audit row. |
| `cert_san=`                | yes      | yes       | First SPIFFE URI in SAN — flags missing / unexpected SANs.            |

The two SPKI hashes are public identifiers (SHA-256 over the `SubjectPublicKeyInfo`), not secrets, and only appear on the failure path, so production noise stays bounded.

## Operator workflow it unlocks

On the next dogfood of `customer-path` chat:

1. Tail the Mastio warning, grep `pubkey pin mismatch`, read both hashes.
2. On the Connector side compute `sha256(SPKI($KEY_PEM))` where `$KEY_PEM = <config_dir>/user_keys/<sha256(principal_id)>.key.pem`.
3. Three branches in one step:
   - on-disk SPKI == `presented_spki_sha256` and == `stored_spki_sha256` → impossible (would not be a mismatch).
   - on-disk SPKI == `presented_spki_sha256` ≠ `stored_spki_sha256` → keystore rotated under a stale pin row; clear `local_user_principals.pubkey_thumbprint` + re-mint or invalidate keystore + re-enroll.
   - on-disk SPKI ≠ `presented_spki_sha256` → cert was minted from a different keypair than the one on disk now (cache pre-keystore retrofit?), or nginx mangled the `X-SSL-Client-Cert` header.
   - `cert_serial` lookup in the `/v1/principals/csr` audit timeline tells you exactly which sign call produced the presented cert.

## Non-changes

- 401 status and `detail` body are unchanged.
- No new public API.
- The `hmac.compare_digest` semantics are unchanged.

## Test plan

- [x] `pytest tests/test_client_cert_auth.py` → 17 / 17 passed (15 pre-existing + 2 new).
- [x] Two new regression tests lock the diagnostic field names:
  - `test_pubkey_pin_mismatch_warning_carries_diagnostic_fields`
  - `test_pubkey_pin_unset_warning_carries_diagnostic_fields`
- [x] Both tests `monkeypatch` `_log.warning` (the `mcp_proxy` logger has `propagate=False` so `caplog` would never see the records — established gotcha across the rest of the suite).

## Related

- #761, #762, #765 — L1 / L2 / L3a layers of the same chat-401 investigation.
- L3b root-cause work is intentionally out of scope here; this PR is the diagnostic layer that makes the root cause cheap to identify on the next dogfood.