### PR TITLE
chore(auth): post-merge nits on cert+trust paths (#765, #766 follow-up)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -86,15 +86,19 @@ def _build_user_client(request: Request, cred: Any):
     # to httpx's system CA store, which never carries the Org Root and
     # every ``/v1/principals/csr`` call collapsed to
     # ``provisioning="deferred"`` with ``CERTIFICATE_VERIFY_FAILED``.
-    # Same env precedence as ``config.verify_arg_for``.
+    # Shares :func:`cullis_connector.config._resolve_env_ca_path` with
+    # :func:`verify_arg_for` so the env precedence stays in one place.
+    #
+    # Sync I/O (``open(...).read()``) is intentional: this helper is a
+    # ``def`` (not ``async def``), invoked under a request that already
+    # pays three round-trip HTTPS calls inside
+    # :meth:`login_via_proxy_with_local_key`; the marginal file read is
+    # noise. If this is ever moved to ``async def``, wrap the read in
+    # ``await asyncio.to_thread(...)``.
+    from cullis_connector.config import _resolve_env_ca_path
     _ca_chain_pem: str | None = None
-    _ca_path = (
-        _os.environ.get("CULLIS_FRONTDESK_CA_BUNDLE")
-        or _os.environ.get("SSL_CERT_FILE")
-        or _os.environ.get("REQUESTS_CA_BUNDLE")
-        or ""
-    ).strip()
-    if _ca_path and _os.path.exists(_ca_path):
+    _ca_path = _resolve_env_ca_path()
+    if _ca_path is not None:
         try:
             with open(_ca_path, "r", encoding="utf-8") as _f:
                 _ca_chain_pem = _f.read()

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -23,10 +23,27 @@ A profile directory holds:
 """
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger("cullis_connector.config")
+
+# Trust-anchor env vars consulted by :func:`_resolve_env_ca_path` and,
+# indirectly, :func:`verify_arg_for` + :func:`_load_env_ca_pem`. Cullis-
+# specific name first so a deploy that intentionally splits the
+# Connector's trust anchor from the ambient Python ecosystem CA can do
+# it; the two standard names follow as ecosystem-compatible fallbacks.
+# Keeping the list in a module constant prevents drift between the two
+# callsites (config-level ``verify_arg_for`` and per-request defence-
+# in-depth in ``ambassador/router.py::_build_user_client``).
+_ENV_CA_BUNDLE_NAMES: tuple[str, ...] = (
+    "CULLIS_FRONTDESK_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+)
 
 # Optional dependency: PyYAML. Connector ships with it but degrades gracefully
 # if a user installs without it.
@@ -134,6 +151,38 @@ class ConnectorConfig:
         return verify_arg_for(self.verify_tls, self.ca_chain_path)
 
 
+def _resolve_env_ca_path() -> str | None:
+    """Return the first env-supplied CA bundle path that exists on disk.
+
+    Consults the same env var ordering as the rest of the Python
+    ecosystem so a Cullis Connector + Frontdesk bundle can carry a
+    trust anchor without manual ``/setup/pin-ca`` interaction. Single
+    source of truth: callers in :func:`verify_arg_for` and in
+    ``cullis_connector/ambassador/router.py::_build_user_client``
+    share this resolver so a future change to the env list (e.g.
+    adding ``XDG_CA_BUNDLE``) does not have to be made in two places
+    and risk drifting.
+
+    NOTE on TOCTOU: ``Path(...).exists()`` is checked, the path is
+    returned as a string, and httpx opens the file later. Between
+    those two events the file can in principle be swapped. The
+    Frontdesk bundle (`docker-compose.yml`) mounts the CA at
+    ``/etc/cullis/ca-bundle.pem`` read-only and the env value comes
+    from controlled boot env, not user input, so the race is not
+    exploitable in the supported deploy. Callers that rely on this
+    resolver outside the bundle must vouch for the env source.
+
+    Returns ``None`` when no env-supplied path exists. Callers decide
+    whether that maps to ``True`` (system CA store) or some other
+    fallback.
+    """
+    for env_name in _ENV_CA_BUNDLE_NAMES:
+        env_path = os.environ.get(env_name, "").strip()
+        if env_path and Path(env_path).exists():
+            return env_path
+    return None
+
+
 def verify_arg_for(verify_tls: bool, ca_chain_path: Path) -> bool | str:
     """Compute ``httpx.verify`` from a form-supplied ``verify_tls`` and a
     profile's ``ca-chain.pem`` path.
@@ -166,15 +215,10 @@ def verify_arg_for(verify_tls: bool, ca_chain_path: Path) -> bool | str:
         return False
     if ca_chain_path.exists():
         return str(ca_chain_path)
-    import os
-    for env_name in (
-        "CULLIS_FRONTDESK_CA_BUNDLE",
-        "SSL_CERT_FILE",
-        "REQUESTS_CA_BUNDLE",
-    ):
-        env_path = os.environ.get(env_name, "").strip()
-        if env_path and Path(env_path).exists():
-            return env_path
+    env_path = _resolve_env_ca_path()
+    if env_path is not None:
+        _log.debug("verify_arg_for using env CA bundle: %s", env_path)
+        return env_path
     return True
 
 

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -218,12 +218,25 @@ def _cert_serial_hex(cert: x509.Certificate) -> str:
 
 
 def _cert_first_spiffe(cert: x509.Certificate) -> str:
-    """Return the first SPIFFE URI in the cert's SAN, or ``"?"``.
+    """Return the first SAN URI in the cert (kept name for blame
+    history), or ``"?"`` when no URI SAN is present.
 
-    Used only in warning logs — :func:`_identity_from_cert` already
-    surfaces the parsed identity; this helper hands back the raw URI
-    so an operator can see whether the cert is missing the SAN
-    altogether or carrying an unexpected one.
+    Despite the legacy name this helper does NOT filter on the
+    ``spiffe://`` scheme — it returns the first
+    :class:`x509.UniformResourceIdentifier` value in the SAN regardless
+    of scheme. That is deliberate: when the diagnostic fires
+    (``client_cert.py`` pubkey-pin warnings) the operator wants to see
+    a wrong-scheme URI such as ``https://attacker.example`` rather
+    than ``"?"``. The :func:`_identity_from_cert` flow is the one that
+    enforces SPIFFE structure.
+
+    CR / LF / NUL in the returned value are escaped before logging so a
+    cert with an attacker-controlled SAN cannot inject extra newlines
+    into structured-log ingestion (Datadog / Sentry / Loki). nginx
+    validates the cert chain but does not sanitize SAN content, and
+    while most JSON-encoded loggers escape control chars defensively,
+    this strip is a low-cost belt-and-braces against any future
+    plain-text log sink.
     """
     try:
         san_ext = cert.extensions.get_extension_for_class(
@@ -232,12 +245,28 @@ def _cert_first_spiffe(cert: x509.Certificate) -> str:
         for uri in san_ext.value.get_values_for_type(
             x509.UniformResourceIdentifier,
         ):
-            return str(uri)
+            return _strip_log_controls(str(uri))
     except x509.ExtensionNotFound:
         pass
     except Exception:  # noqa: BLE001 — diagnostic only
         pass
     return "?"
+
+
+def _strip_log_controls(value: str) -> str:
+    """Escape control characters that could break structured log lines.
+
+    Used by :func:`_cert_first_spiffe`. Replaces CR / LF with their
+    escaped two-character form so a single log line stays single, and
+    drops NUL bytes outright (they terminate strings in some log
+    consumers and cannot be escaped safely).
+    """
+    return (
+        value
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\x00", "")
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_client_cert_auth.py
+++ b/tests/test_client_cert_auth.py
@@ -548,3 +548,84 @@ async def test_typed_workload_principal_unknown_rejected(proxy_app):
         await get_agent_from_client_cert(request)
     assert exc_info.value.status_code == 401
     assert "unknown" in exc_info.value.detail.lower()
+
+
+# ── Diagnostic helper unit tests ─────────────────────────────────────
+
+
+def test_strip_log_controls_escapes_cr_lf_drops_nul():
+    """Defence-in-depth for log-line spoofing: any CR / LF / NUL
+    sneaking through the cert SAN into a downstream plain-text log
+    sink must be neutralised before emission. Locks the exact
+    transformation so future tweaks (e.g. wider sanitisation) stay
+    intentional."""
+    from mcp_proxy.auth.client_cert import _strip_log_controls
+
+    raw = "spiffe://td/org/user/alice\r\nfake_field=evil\x00trailing"
+    assert _strip_log_controls(raw) == (
+        "spiffe://td/org/user/alice\\r\\nfake_field=eviltrailing"
+    )
+    # Idempotent on already-clean input.
+    clean = "spiffe://td/org/user/bob"
+    assert _strip_log_controls(clean) == clean
+    # Empty + "?" sentinel round-trip unchanged.
+    assert _strip_log_controls("") == ""
+    assert _strip_log_controls("?") == "?"
+
+
+def test_cert_first_spiffe_returns_non_spiffe_uri_unchanged():
+    """Docstring contract: the helper returns the FIRST URI in the
+    cert's SAN regardless of scheme — operators want to SEE a
+    wrong-scheme URI (``https://...``) rather than ``"?"`` so they
+    can spot a cert that was issued under the wrong identity model."""
+    from mcp_proxy.auth.client_cert import _cert_first_spiffe
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "weird"),
+        ]))
+        .issuer_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "weird"),
+        ]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier("https://attacker.example/"),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    assert _cert_first_spiffe(cert) == "https://attacker.example/"
+
+
+def test_cert_first_spiffe_no_san_returns_sentinel():
+    """A cert without a SAN extension returns ``"?"`` so the log line
+    stays structurally constant — downstream regex parsers can rely
+    on the field always being present."""
+    from mcp_proxy.auth.client_cert import _cert_first_spiffe
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "no-san"),
+        ]))
+        .issuer_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "no-san"),
+        ]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    assert _cert_first_spiffe(cert) == "?"


### PR DESCRIPTION
## Summary

Closes the crypto-review punch list on #765 (TLS verify env-CA fallback) and #766 (cert pubkey-pin diagnostic), both merged. Pure polish — no behaviour change.

## From #765 review

| Severity | Change |
|----------|--------|
| MINOR    | Extract `_resolve_env_ca_path()` in `cullis_connector/config.py`; share it with `ambassador/router.py::_build_user_client`. Prevents drift when a future change adds a new env name to one callsite and forgets the other. |
| NIT      | `_log.debug("verify_arg_for using env CA bundle: %s", ...)` when the env fallback fires — diagnostic breadcrumb for future Frontdesk path issues. |
| NIT      | Docstring note on the `Path(env_path).exists()` → `return str` → httpx-opens-later TOCTOU window. Not exploitable in the Frontdesk bundle (`:ro` mount, controlled boot env), but documented so out-of-bundle callers know the contract. |
| NIT      | Comment in `router.py::_build_user_client` flagging the intentional sync `open().read()` and the future async migration path. |

## From #766 review

| Severity | Change |
|----------|--------|
| NIT | Fix `_cert_first_spiffe` docstring drift. The helper returns the first SAN URI regardless of scheme (deliberate: operators want to SEE a wrong-scheme URI for diagnosis); old docstring claimed "first SPIFFE URI". Legacy name kept for blame continuity. |
| NIT | Defence-in-depth CR / LF / NUL sanitisation via new `_strip_log_controls()` helper. Most JSON loggers escape control chars defensively, but the contract is now explicit at the source. |

## Test coverage

Three new unit tests (all in `tests/test_client_cert_auth.py`):

- `test_strip_log_controls_escapes_cr_lf_drops_nul` — locks the exact escape transformation.
- `test_cert_first_spiffe_returns_non_spiffe_uri_unchanged` — documents the "return wrong-scheme URI for diagnosis" behaviour as contract.
- `test_cert_first_spiffe_no_san_returns_sentinel` — pins the `"?"` fallback so regex parsers can rely on the field always being present.

## Test plan

- [x] `pytest tests/connector/test_config.py tests/test_client_cert_auth.py` → 39 / 39 passed.
- [x] `pytest tests/connector/ tests/test_sdk_proxy_client_ca_pin.py tests/test_client_cert_auth.py -n auto` → 714 passed, 4 skipped.

## Related

- #765 — TLS verify env-CA fallback (merged).
- #766 — cert pubkey-pin diagnostic (merged).
- L3b root-cause work — separate, blocked on dogfood live trace (this PR enriches the diagnostic, doesn't replace it).