### PR TITLE
fix(bundle): nginx health-check uses loopback, not public URL (P3 MINOR-G)

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -273,12 +273,20 @@ services:
       - frontdesk_net
     restart: unless-stopped
     healthcheck:
+      # IPv4 literal on purpose: nginx:1.27-alpine ships musl libc, whose
+      # getaddrinfo prefers AAAA over A: ``localhost`` resolves to ``::1``
+      # first. Our ``listen 8443 ssl`` directive binds IPv4 only
+      # (``0.0.0.0:8443``), so a wget to ``localhost`` gets Connection
+      # refused on the IPv6 attempt and never falls back to IPv4 — the
+      # sidecar would serve traffic from the host fine but compose would
+      # report the container ``unhealthy`` for every probe (P3 MINOR-G).
+      # Same fix as the mastio-nginx sidecar above (PR #672 lineage).
       test:
         - CMD-SHELL
         - >-
           test -s /etc/nginx/certs/frontdesk-server.crt &&
           test -s /etc/nginx/certs/frontdesk-server.key &&
-          wget -q --no-check-certificate -O /dev/null https://localhost:8443/tls-health
+          wget -q --no-check-certificate -O /dev/null https://127.0.0.1:8443/tls-health
       interval: 30s
       timeout: 5s
       retries: 3

--- a/tests/test_bundle_healthchecks.py
+++ b/tests/test_bundle_healthchecks.py
@@ -1,0 +1,94 @@
+"""
+Regression guard for nginx sidecar healthchecks in the deploy bundles
+(P3 MINOR-G).
+
+The mastio-bundle and frontdesk-bundle ship nginx sidecars on
+``nginx:1.27-alpine``. Their healthchecks probe the TLS listener over
+loopback. Two failure modes have surfaced on dogfood and must stay fixed:
+
+1. ``host.docker.internal`` in a healthcheck — that hostname is the
+   PUBLIC URL the bundle advertises to siblings on the docker host. It
+   is NOT routable from inside the nginx container itself, so the probe
+   never reaches the listener and the container flaps ``unhealthy``
+   forever even though the host can reach it fine.
+
+2. ``localhost`` in a healthcheck — alpine ships musl libc, whose
+   ``getaddrinfo`` prefers AAAA over A. Our ``listen NNNN ssl`` directives
+   bind IPv4 only (``0.0.0.0:NNNN``), so wget on ``localhost`` tries
+   ``::1`` first, gets Connection refused, and never falls back to IPv4.
+   Use the ``127.0.0.1`` literal to skip the resolver entirely
+   (PR #672 lineage, ``feedback_musl_libc_localhost_ipv6_first``).
+"""
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# (compose path, service name) — every nginx sidecar with a healthcheck.
+NGINX_SIDECARS = [
+    ("packaging/mastio-bundle/docker-compose.yml", "mastio-nginx"),
+    ("packaging/mastio-enterprise-bundle/docker-compose.yml", "mastio-nginx"),
+    ("packaging/frontdesk-bundle/docker-compose.yml", "frontdesk-nginx"),
+]
+
+
+def _load_compose(rel_path: str) -> dict[str, Any]:
+    path = REPO_ROOT / rel_path
+    assert path.exists(), f"compose file missing: {rel_path}"
+    return yaml.safe_load(path.read_text())
+
+
+def _healthcheck_test_str(service: dict[str, Any]) -> str:
+    """Flatten the healthcheck ``test`` list/string into a single probe string."""
+    hc = service.get("healthcheck")
+    assert hc, "service has no healthcheck"
+    test = hc.get("test")
+    assert test, "healthcheck has no test"
+    if isinstance(test, list):
+        return " ".join(str(t) for t in test)
+    return str(test)
+
+
+@pytest.mark.parametrize("compose_rel,service_name", NGINX_SIDECARS)
+def test_nginx_sidecar_healthcheck_uses_loopback_literal(
+    compose_rel: str, service_name: str
+) -> None:
+    """nginx sidecar healthchecks must probe ``127.0.0.1`` over the
+    container's own TLS listener, never the public hostname and never
+    the ``localhost`` symbol (musl IPv6-first trap)."""
+    compose = _load_compose(compose_rel)
+    services = compose.get("services") or {}
+    service = services.get(service_name)
+    assert service, f"{compose_rel}: service {service_name!r} missing"
+
+    probe = _healthcheck_test_str(service)
+
+    # 1. Public hostname must never appear — unreachable from inside the
+    # container itself, causes permanent ``unhealthy`` in ``docker ps``.
+    assert "host.docker.internal" not in probe, (
+        f"{compose_rel}::{service_name}: healthcheck uses "
+        f"'host.docker.internal' — not routable from inside the container. "
+        f"Use 127.0.0.1 literal. Probe: {probe!r}"
+    )
+
+    # 2. Alpine/musl resolves ``localhost`` to ::1 first; our TLS listener
+    # binds IPv4 only. Use the literal to bypass the resolver entirely.
+    # We allow ``localhost`` ONLY if also paired with the v4 literal, but
+    # the canonical fix is to drop ``localhost`` outright.
+    assert "https://localhost" not in probe and "http://localhost" not in probe, (
+        f"{compose_rel}::{service_name}: healthcheck uses 'localhost' URL — "
+        f"musl libc prefers IPv6, but nginx binds IPv4 only. Use 127.0.0.1 "
+        f"literal. Probe: {probe!r}"
+    )
+
+    # 3. Positive assertion: the 127.0.0.1 literal must appear in the
+    # actual probe URL (not just in some comment-like fragment).
+    assert "127.0.0.1" in probe, (
+        f"{compose_rel}::{service_name}: healthcheck must probe via "
+        f"127.0.0.1 literal. Probe: {probe!r}"
+    )


### PR DESCRIPTION
## Summary

- The frontdesk-nginx TLS sidecar healthcheck probed `https://localhost:8443/tls-health`. On `nginx:1.27-alpine` (musl libc) `getaddrinfo` prefers AAAA over A, but our `listen 8443 ssl` binds IPv4 only, so wget tried `::1` first, got Connection refused, and never fell back to IPv4. Container served traffic from the host fine but `docker ps` reported it `unhealthy` forever (P3 MINOR-G dogfood 2026-05-17, customer support ticket risk on every fresh Frontdesk deploy).
- Same root cause + same fix as the mastio-nginx sidecar in PR #672: use the `127.0.0.1` literal to skip the resolver entirely. Mastio + Mastio Enterprise nginx sidecars already use `127.0.0.1` (PR #672 lineage); only Frontdesk TLS sidecar was still broken.
- Add `tests/test_bundle_healthchecks.py` as a parser-yaml regression guard. For every nginx sidecar healthcheck in `packaging/`, asserts: (1) no `host.docker.internal` in the probe (unroutable from inside the container), (2) no bare `https://localhost` (musl IPv6-first trap), (3) `127.0.0.1` literal is present. Catches both the original report (`host.docker.internal`) and the musl variant in one shot.

## Files touched

- `packaging/frontdesk-bundle/docker-compose.yml` (+9 / -1) — frontdesk-nginx healthcheck: `localhost` -> `127.0.0.1`, with comment explaining the musl rationale.
- `tests/test_bundle_healthchecks.py` (+94) — new regression guard, 3 parametrised cases (mastio-bundle, mastio-enterprise-bundle, frontdesk-bundle).

Total diff: 104 lines (well under the 150-line cap).

## Test plan

- [x] `pytest tests/test_bundle_healthchecks.py -v` — 3 passed (mastio-nginx, mastio-enterprise mastio-nginx, frontdesk-nginx).
- [x] In-memory regression simulation: injected `localhost` into mastio-bundle compose, confirmed the test's `https://localhost` assertion fires.
- [ ] Smoke verification on dogfood: `cd packaging/frontdesk-bundle && ./deploy.sh` then `docker ps | grep cullis-frontdesk-frontdesk-nginx-1` should show `Up (healthy)` within `start_period + 1 interval` (~40 s). Confirms the loopback probe terminates correctly through nginx TLS handshake.

## Scope notes

- Out of scope: nginx config files (`nginx-tls/default.conf`, `nginx/default.conf`) — `listen 8443 ssl` IPv4-only binding is intentional, the healthcheck is the side that needs to adapt.
- Out of scope: `mcp-proxy` python healthcheck on `http://localhost:9100/health` — runs on `python:3.11-slim` (Debian glibc), not affected by the musl resolver gotcha.
- The inner frontdesk `nginx` service (port 80) has no healthcheck; out of scope here, would be a separate add-healthcheck PR if wanted.

Refs: `feedback_musl_libc_localhost_ipv6_first`, PR #672 (mastio-nginx fix).