### PR TITLE
fix(bundle-mastio): refuse to start on orphan SQLite + Postgres URL (P3 MAJOR-A)

### DIFF
--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -122,6 +122,48 @@ PROXY_PUBLIC_URL=https://mastio.myorg.example.com \
 `MCP_PROXY_DASHBOARD_SIGNING_KEY` and refuses to run without
 `BROKER_URL` / `PROXY_PUBLIC_URL` env vars.
 
+## Database backend
+
+The default is SQLite at `./data/mcp_proxy.db`. A.1b stress test (May
+2026) confirmed SQLite WAL is ship-safe with 4 uvicorn workers — 0
+audit-chain integrity errors in 472k concurrent audit rows. For the
+Tier 2 throughput envelope (500+ concurrent agents under p99 1s), a
+hosted Postgres backend is on the roadmap.
+
+**Swapping `MCP_PROXY_DATABASE_URL` after first boot is NOT supported.**
+The Mastio derives its Org CA, `org_id`, and admin password hash from
+the active database on first boot (ADR-006). Pointing an already-
+enrolled Mastio at an empty Postgres causes the lifespan to mint a
+fresh Org CA — every Connector enrolled against the old CA will then
+fail TLS verification on `/v1/principals/csr` with no useful diagnostic
+on the client side.
+
+`./deploy.sh` refuses to start when it detects:
+
+  - `MCP_PROXY_DATABASE_URL` in `proxy.env` pointing at Postgres
+    (`postgresql+...`, `postgres://...`), AND
+  - a non-empty `./data/mcp_proxy.db` on the host bind mount.
+
+Pick one explicitly:
+
+  1. **Roll back to SQLite** (recommended for accidental swaps):
+     remove (or comment out) the Postgres line in `proxy.env` and
+     `./deploy.sh --pull`. Every previously enrolled Connector keeps
+     working.
+  2. **Wipe and re-enroll** (data-loss path): delete `./data/` and
+     `./nginx-certs/`, then `./deploy.sh`. The new Postgres-backed
+     Mastio mints a fresh Org CA; every agent must re-run the enroll
+     flow against the new CA.
+  3. **`--accept-data-loss`**: skip the guard. Same outcome as 2, but
+     the orphan SQLite file is left on disk for forensics. Use only
+     after backing up `./data/mcp_proxy.db` and confirming you have a
+     way to re-enroll every agent.
+
+A future bundle release will ship a `--migrate-db` flow that dumps the
+existing SQLite state and loads it into Postgres without re-deriving
+the Org CA. Until then, treat the SQLite → Postgres jump as
+"redeploy from scratch".
+
 ## What's in the bundle
 
 ```

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -116,6 +116,79 @@ _ensure_data_dirs() {
     fi
 }
 
+# P3 MAJOR-A — refuse to start when an orphan SQLite DB is sitting
+# alongside a Postgres ``MCP_PROXY_DATABASE_URL``.
+#
+# Failure mode this guards against (192.168.122.170 dogfood, 2026-05-17):
+#   1. Operator boots Mastio with the default SQLite URL. The lifespan
+#      generates an Org CA, derives org_id from it, and writes both into
+#      ``./data/mcp_proxy.db``. Connectors enroll, their certs are
+#      signed by that CA.
+#   2. Operator edits ``proxy.env`` to point ``MCP_PROXY_DATABASE_URL``
+#      at a Postgres instance and ``./deploy.sh``s again.
+#   3. Mastio boots against an empty Postgres → ``load_org_ca_from_config``
+#      finds nothing → ``generate_org_ca(derive_org_id=True)`` happily
+#      mints a BRAND NEW Org CA + org_id (the intended standalone
+#      bootstrap path, ADR-006). ``nginx-certs/org-ca.crt`` is rewritten.
+#   4. Every previously enrolled Connector now presents a cert signed by
+#      the orphaned CA. ``/v1/principals/csr`` fails with an opaque TLS
+#      verify error. The old SQLite DB stays on disk, 281 MB of data
+#      the operator no longer realises they have.
+#
+# Swapping ``DATABASE_URL`` is not a supported migration path — the
+# bundle has no automatic Postgres dump-and-load. Refuse to start
+# loudly rather than silently invalidate every enrolled agent.
+_check_sqlite_orphan_vs_postgres() {
+    local db_url data_dir sqlite_path size
+    db_url="$(_load_env MCP_PROXY_DATABASE_URL)"
+    # Nothing in proxy.env → compose default (SQLite) wins, no risk.
+    [[ -n "$db_url" ]] || return 0
+    # Only worry when the operator is asking for Postgres. SQLite swaps
+    # (file path changes) are a different gotcha and out of scope here.
+    case "$db_url" in
+        postgres://*|postgresql://*|postgresql+*|postgres+*) ;;
+        *) return 0 ;;
+    esac
+
+    data_dir="$(_data_dir_host)"
+    sqlite_path="$data_dir/mcp_proxy.db"
+    [[ -f "$sqlite_path" ]] || return 0
+    size="$(wc -c <"$sqlite_path" 2>/dev/null | tr -d ' ')"
+    [[ -n "$size" && "$size" -gt 0 ]] || return 0
+
+    if [[ "${ACCEPT_DATA_LOSS:-0}" -eq 1 ]]; then
+        warn "--accept-data-loss: orphan SQLite DB at ${sqlite_path#$SCRIPT_DIR/} (${size} bytes) ignored."
+        warn "    Every Connector previously enrolled against the Org CA in that DB"
+        warn "    will fail TLS verification at /v1/principals/csr until re-enrolled."
+        warn "    The old SQLite file is left on disk — delete by hand once you have"
+        warn "    confirmed the new Postgres-backed Mastio boots cleanly."
+        return 0
+    fi
+
+    echo ""
+    err "Orphan SQLite database found at ${sqlite_path#$SCRIPT_DIR/} while"
+    err "MCP_PROXY_DATABASE_URL points at Postgres (${db_url%%\?*})."
+    err ""
+    err "Starting the Mastio now would silently generate a NEW Org CA from"
+    err "the empty Postgres database. Every Connector enrolled against the"
+    err "old CA (the one persisted in ${sqlite_path#$SCRIPT_DIR/}) would fail"
+    err "TLS verification on /v1/principals/csr — there is no automatic"
+    err "SQLite→Postgres migration in the bundle."
+    err ""
+    err "Pick one of:"
+    err "  1. Roll back: edit proxy.env, remove (or comment out) the Postgres"
+    err "     MCP_PROXY_DATABASE_URL line, then ``./deploy.sh --pull``. The"
+    err "     Mastio comes back up against the existing SQLite DB and every"
+    err "     previously enrolled Connector keeps working."
+    err "  2. Accept the loss: delete ${sqlite_path#$SCRIPT_DIR/} (and"
+    err "     ./nginx-certs/) by hand if you are SURE you can re-enroll every"
+    err "     agent, then re-run. The new Postgres-backed Mastio will mint a"
+    err "     fresh Org CA on first boot."
+    err "  3. Skip this check with --accept-data-loss (same outcome as 2, but"
+    err "     the orphan SQLite file is left on disk for forensics)."
+    die "Refusing to start — pick a path explicitly."
+}
+
 # Rewrite (or append) a single VAR=value line in proxy.env. Same sed
 # pattern as the legacy --upgrade flow, extracted so --upgrade-bundle
 # and any future caller share the same trailing-newline-safe behaviour.
@@ -229,6 +302,11 @@ _cmd_upgrade_bundle() {
     local version="$1" tarball_url tarball_local backup_dir
     _validate_version "$version"
     _assert_bundle_pwd
+
+    # Same guard as the main ``up`` path: refuse to refresh the bundle
+    # if the operator has half-swapped to Postgres but left an orphan
+    # SQLite DB on disk. MAJOR-A.
+    _check_sqlite_orphan_vs_postgres
 
     step "Upgrading Cullis Mastio bundle to ${version}"
 
@@ -392,6 +470,17 @@ Options:
                               named-volume migration during --upgrade-
                               bundle. Used by the dashboard's update
                               banner one-liner.
+  --accept-data-loss          Skip the SQLite-orphan-vs-Postgres guard
+                              that refuses to start when proxy.env asks
+                              for Postgres but ./data/mcp_proxy.db is
+                              non-empty (the bundle has no automatic
+                              SQLite → Postgres migration, so swapping
+                              MCP_PROXY_DATABASE_URL silently re-derives
+                              a fresh Org CA and invalidates every
+                              previously enrolled Connector). Pass this
+                              flag ONLY after you have backed up the
+                              SQLite DB and are ready to re-enroll every
+                              agent against the new Postgres-backed CA.
   --help, -h                  Show this help and exit.
 
 Environment:
@@ -417,6 +506,7 @@ FORCE_PULL=0
 UPGRADE_TO=""
 UPGRADE_BUNDLE_TO=""
 FROM_BANNER=0
+ACCEPT_DATA_LOSS=0
 # Manual loop because ``--upgrade <version>`` needs to consume the
 # next positional arg. Keeps the existing single-token flags working
 # without pulling in getopt.
@@ -455,6 +545,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --migrate-volumes) ACTION="migrate_volumes"; shift ;;
         --from-banner)     FROM_BANNER=1; shift ;;
+        --accept-data-loss) ACCEPT_DATA_LOSS=1; shift ;;
         --help|-h)       print_help; exit 0 ;;
         *) die "Unknown argument: $arg (use --help)" ;;
     esac
@@ -580,6 +671,20 @@ if [[ "$MODE" == "production" ]]; then
         die "Fix the issues above and rerun. Aborting before compose up."
     fi
     ok "proxy.env validated for production"
+fi
+
+# ── MAJOR-A guard — SQLite orphan vs Postgres MCP_PROXY_DATABASE_URL ───────
+# Runs after the proxy.env wizard / validation so _load_env sees the
+# operator-edited values, and before docker pull/up so a Connector
+# population isn't silently invalidated mid-boot.
+_check_sqlite_orphan_vs_postgres
+
+# Test-only hook: exit after pre-flight checks so the bundle's bash
+# test harness can assert the guard's exit code without booting docker.
+# Not part of the public CLI — undocumented on purpose.
+if [[ "${CULLIS_DEPLOY_EXIT_AFTER_CHECKS:-0}" -eq 1 ]]; then
+    ok "CULLIS_DEPLOY_EXIT_AFTER_CHECKS=1 — stopping before docker pull/up"
+    exit 0
 fi
 
 # ── --upgrade: pin the requested version into proxy.env ────────────────────

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -108,6 +108,25 @@ MASTIO_WORKERS=4
 MASTIO_DATA_DIR=./data
 MASTIO_NGINX_CERTS_DIR=./nginx-certs
 
+# ─── Database backend ────────────────────────────────────────────────────────
+#
+# The default is SQLite at ``./data/mcp_proxy.db`` (compose-level
+# default — leave this line commented to keep it). A.1b stress test
+# (May 2026) confirmed SQLite WAL is ship-safe for ~4 worker processes;
+# for the Tier 2 throughput envelope (500+ concurrent agents under p99
+# 1s) a hosted Postgres is on the roadmap.
+#
+# IMPORTANT — swapping this URL is NOT a first-class migration path.
+# The bundle has no SQLite → Postgres dump-and-load. If you point an
+# already-enrolled Mastio at an empty Postgres, the lifespan finds no
+# Org CA and generates a BRAND NEW one (ADR-006 standalone bootstrap),
+# which silently invalidates every Connector enrolled against the old
+# CA. ``./deploy.sh`` refuses to start when it detects an orphan SQLite
+# DB alongside a Postgres URL — pass ``--accept-data-loss`` to override
+# (you will need to re-enroll every agent).
+#
+#MCP_PROXY_DATABASE_URL=postgresql+asyncpg://cullis:secret@db.internal:5432/cullis_mastio
+
 # ─── ADR-014 — nginx sidecar TLS ─────────────────────────────────────────────
 
 # Where the Mastio writes the Org CA + server cert + server key for the

--- a/tests/test_bundle_db_swap_guard.py
+++ b/tests/test_bundle_db_swap_guard.py
@@ -27,9 +27,6 @@ import pathlib
 import shutil
 import stat
 import subprocess
-import textwrap
-
-import pytest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 BUNDLE_SRC = REPO_ROOT / "packaging" / "mastio-bundle"

--- a/tests/test_bundle_db_swap_guard.py
+++ b/tests/test_bundle_db_swap_guard.py
@@ -1,0 +1,280 @@
+"""P3 MAJOR-A — packaging/mastio-bundle/deploy.sh refuses to start when
+the operator points ``MCP_PROXY_DATABASE_URL`` at Postgres but a
+non-empty ``./data/mcp_proxy.db`` is still on disk.
+
+Failure mode this pins (192.168.122.170 dogfood, 2026-05-17): an
+operator boots Mastio with the SQLite default, agents enroll against
+the Org CA persisted in ``mcp_proxy.db``. The operator then edits
+``proxy.env`` to point at Postgres and restarts. The Mastio lifespan
+finds an empty Postgres → ``generate_org_ca(derive_org_id=True)`` (the
+intended standalone bootstrap, ADR-006) mints a fresh CA. Every
+previously enrolled Connector now fails TLS verify on
+``/v1/principals/csr``. There is no automatic SQLite → Postgres
+migration in the bundle, so the only safe behaviour is to refuse to
+start and force the operator to pick a path explicitly.
+
+These tests drive ``deploy.sh`` directly in a tmp bundle dir with a
+PATH that has fake ``docker`` / ``ss`` binaries — the orphan check
+runs before any docker call, so the fake binaries are never invoked
+in the negative path. ``CULLIS_DEPLOY_EXIT_AFTER_CHECKS=1`` short-
+circuits the script after the pre-flight checks for the positive
+paths so we don't need to mock the full pull/up flow.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+import textwrap
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BUNDLE_SRC = REPO_ROOT / "packaging" / "mastio-bundle"
+COMMON_HELPERS = REPO_ROOT / "packaging" / "_common-deploy-helpers.sh"
+
+
+def _stage_bundle(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Mirror the bundle layout into ``tmp_path`` so ``deploy.sh`` sees
+    a real ``_common-deploy-helpers.sh`` next to its parent dir.
+
+    The source uses ``source "$SCRIPT_DIR/../_common-deploy-helpers.sh"``
+    so we reproduce the same parent/child layout the release tarball
+    has after extraction (``cullis-mastio-bundle/`` lives inside
+    ``packaging/``).
+    """
+    pkg = tmp_path / "packaging"
+    bundle = pkg / "mastio-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(BUNDLE_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(BUNDLE_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(BUNDLE_SRC / "proxy.env.example", bundle / "proxy.env.example")
+    shutil.copy2(COMMON_HELPERS, pkg / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    return bundle
+
+
+def _stub_path(tmp_path: pathlib.Path) -> str:
+    """A PATH stub directory shadowing ``docker`` and ``ss`` so the
+    script can survive even if it reaches the post-check steps. The
+    orphan guard exits BEFORE these are consulted in the failure cases;
+    the success cases use ``CULLIS_DEPLOY_EXIT_AFTER_CHECKS=1`` to bail
+    out before any docker call regardless.
+    """
+    stub = tmp_path / "stubpath"
+    stub.mkdir()
+    for name in ("docker", "ss", "curl"):
+        p = stub / name
+        p.write_text("#!/usr/bin/env bash\nexit 0\n")
+        p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # Compose v2 lookup: ``docker compose version`` must succeed.
+    # The simple stub above returns 0 for any subcommand, so this works.
+    real_path = os.environ.get("PATH", "")
+    return f"{stub}:{real_path}"
+
+
+def _write_proxy_env(bundle: pathlib.Path, **kv: str) -> None:
+    lines = [f"{k}={v}" for k, v in kv.items()]
+    (bundle / "proxy.env").write_text("\n".join(lines) + "\n")
+
+
+def _seed_sqlite(bundle: pathlib.Path, size_bytes: int = 4096) -> pathlib.Path:
+    data = bundle / "data"
+    data.mkdir(exist_ok=True)
+    db = data / "mcp_proxy.db"
+    db.write_bytes(b"SQLite format 3\x00" + b"\x00" * (size_bytes - 16))
+    return db
+
+
+def _run_deploy(
+    bundle: pathlib.Path,
+    *extra_args: str,
+    env_overrides: dict | None = None,
+    exit_after_checks: bool = True,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["PATH"] = _stub_path(bundle.parent.parent)
+    if exit_after_checks:
+        env["CULLIS_DEPLOY_EXIT_AFTER_CHECKS"] = "1"
+    # Force MODE=development so the prod validation block does not
+    # short-circuit the run on dev-default secrets. The MAJOR-A check
+    # is independent of MODE.
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), *extra_args],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ── deploy.sh syntax + flag plumbing ──────────────────────────────────────
+
+
+def test_deploy_sh_is_syntactically_valid():
+    """``bash -n`` must accept the script — guards against a stray edit
+    breaking the parser before any test exercises the runtime logic."""
+    result = subprocess.run(
+        ["bash", "-n", str(BUNDLE_SRC / "deploy.sh")],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_accept_data_loss_flag_is_advertised_in_help():
+    """``--help`` must mention the override so a stuck operator can find
+    the escape hatch without grepping the source."""
+    result = subprocess.run(
+        ["bash", str(BUNDLE_SRC / "deploy.sh"), "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    assert "--accept-data-loss" in result.stdout
+    # The help text should warn about Connector invalidation explicitly
+    # so the operator understands the blast radius before passing the
+    # flag.
+    assert "Connector" in result.stdout or "re-enroll" in result.stdout
+
+
+# ── MAJOR-A — orphan SQLite + Postgres URL ────────────────────────────────
+
+
+def test_orphan_sqlite_with_postgres_url_refuses_to_start(tmp_path):
+    """Test 1 — ./data/mcp_proxy.db non-empty AND
+    MCP_PROXY_DATABASE_URL=postgresql+... → deploy.sh exits 1 with a
+    clear, recoverable error."""
+    bundle = _stage_bundle(tmp_path)
+    _seed_sqlite(bundle)
+    _write_proxy_env(
+        bundle,
+        MCP_PROXY_DATABASE_URL="postgresql+asyncpg://u:p@db:5432/cullis",
+        MCP_PROXY_PROXY_PUBLIC_URL="https://host.docker.internal:9443",
+        MCP_PROXY_NGINX_SAN="host.docker.internal,localhost",
+    )
+    result = _run_deploy(bundle)
+    combined = result.stdout + result.stderr
+    assert result.returncode == 1, (
+        f"expected exit 1 (refuse-to-start), got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    # The error message must mention the orphan file path AND the
+    # Postgres URL so the operator immediately knows what to act on.
+    assert "Orphan SQLite database" in combined
+    assert "data/mcp_proxy.db" in combined
+    assert "Postgres" in combined or "postgresql" in combined
+    # All three recovery paths must be enumerated.
+    assert "Roll back" in combined or "rollback" in combined.lower()
+    assert "--accept-data-loss" in combined
+
+
+def test_no_sqlite_file_with_postgres_url_proceeds(tmp_path):
+    """Test 2 — ./data/mcp_proxy.db does not exist AND
+    MCP_PROXY_DATABASE_URL=postgresql+... → deploy.sh proceeds past
+    the guard (fresh Postgres bring-up, no enrolled agents to lose)."""
+    bundle = _stage_bundle(tmp_path)
+    # Intentionally do NOT seed ./data/mcp_proxy.db.
+    _write_proxy_env(
+        bundle,
+        MCP_PROXY_DATABASE_URL="postgresql+asyncpg://u:p@db:5432/cullis",
+        MCP_PROXY_PROXY_PUBLIC_URL="https://host.docker.internal:9443",
+        MCP_PROXY_NGINX_SAN="host.docker.internal,localhost",
+    )
+    result = _run_deploy(bundle)
+    assert result.returncode == 0, (
+        f"expected exit 0 (proceed), got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "Orphan SQLite database" not in (result.stdout + result.stderr)
+
+
+def test_sqlite_default_url_proceeds_even_with_db_file(tmp_path):
+    """Test 3 — ./data/mcp_proxy.db non-empty AND MCP_PROXY_DATABASE_URL
+    unset (compose default = SQLite) → deploy.sh proceeds. This is the
+    normal happy path on every restart of an already-initialized
+    Mastio."""
+    bundle = _stage_bundle(tmp_path)
+    _seed_sqlite(bundle)
+    _write_proxy_env(
+        bundle,
+        MCP_PROXY_PROXY_PUBLIC_URL="https://host.docker.internal:9443",
+        MCP_PROXY_NGINX_SAN="host.docker.internal,localhost",
+    )
+    result = _run_deploy(bundle)
+    assert result.returncode == 0, (
+        f"expected exit 0 (proceed, default SQLite), got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "Orphan SQLite database" not in (result.stdout + result.stderr)
+
+
+def test_orphan_sqlite_with_postgres_url_and_accept_data_loss_proceeds(tmp_path):
+    """Test 4 — ./data/mcp_proxy.db non-empty AND
+    MCP_PROXY_DATABASE_URL=postgresql+... AND --accept-data-loss →
+    deploy.sh proceeds with a loud warn (operator opted in to losing
+    every enrolled Connector)."""
+    bundle = _stage_bundle(tmp_path)
+    _seed_sqlite(bundle)
+    _write_proxy_env(
+        bundle,
+        MCP_PROXY_DATABASE_URL="postgresql+asyncpg://u:p@db:5432/cullis",
+        MCP_PROXY_PROXY_PUBLIC_URL="https://host.docker.internal:9443",
+        MCP_PROXY_NGINX_SAN="host.docker.internal,localhost",
+    )
+    result = _run_deploy(bundle, "--accept-data-loss")
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"expected exit 0 (proceed with override), got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    # Warn must mention the override AND the impact so the audit trail
+    # makes it obvious the operator opted in.
+    assert "--accept-data-loss" in combined
+    assert "Connector" in combined or "TLS verification" in combined
+
+
+def test_orphan_sqlite_with_short_postgres_url_scheme(tmp_path):
+    """Defensive — the short ``postgres://`` scheme (no driver suffix)
+    must trip the guard too. SQLAlchemy and lifecycle code accept both
+    spellings so a guard that only matches ``postgresql+`` would be
+    bypassed by a copy-paste from a libpq-style connection string."""
+    bundle = _stage_bundle(tmp_path)
+    _seed_sqlite(bundle)
+    _write_proxy_env(
+        bundle,
+        MCP_PROXY_DATABASE_URL="postgres://u:p@db:5432/cullis",
+        MCP_PROXY_PROXY_PUBLIC_URL="https://host.docker.internal:9443",
+        MCP_PROXY_NGINX_SAN="host.docker.internal,localhost",
+    )
+    result = _run_deploy(bundle)
+    assert result.returncode == 1, (
+        f"expected exit 1 on short postgres:// scheme, got {result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "Orphan SQLite database" in (result.stdout + result.stderr)
+
+
+# ── docs / customer-facing strings ────────────────────────────────────────
+
+
+def test_readme_documents_database_backend_section():
+    """README must surface the Postgres-swap gotcha at the section level
+    so a customer reading the bundle docs end-to-end cannot miss it."""
+    readme = (BUNDLE_SRC / "README.md").read_text()
+    assert "Database backend" in readme
+    assert "MCP_PROXY_DATABASE_URL" in readme
+    assert "--accept-data-loss" in readme
+
+
+def test_proxy_env_example_documents_database_url():
+    """proxy.env.example must mention the variable + the swap-is-not-a-
+    migration warning. Operators copy this file as the starting point;
+    burying the gotcha in README alone misses the cohort that edits
+    proxy.env without reading further docs."""
+    example = (BUNDLE_SRC / "proxy.env.example").read_text()
+    assert "MCP_PROXY_DATABASE_URL" in example
+    assert "migration" in example.lower() or "--accept-data-loss" in example


### PR DESCRIPTION
## Summary

P3 dogfood audit MAJOR-A. Swapping ``MCP_PROXY_DATABASE_URL`` from SQLite to Postgres after first boot silently re-derives a fresh Org CA (the ADR-006 standalone bootstrap path on an empty DB), invalidating every Connector enrolled against the old CA. The bundle has no automatic SQLite to Postgres migration, so this is a data-loss event masquerading as a config tweak. Reproduced on VM 192.168.122.170 during the 2026-05-17 dogfood: ``9d5c940c...`` CA in the orphan SQLite, ``70e44ddd...`` CA in the new Postgres, every ``/v1/principals/csr`` failing TLS verify on the Frontdesk Connector with no useful client-side diagnostic.

The fix is bundle UX: refuse to start with a clear, recoverable message, force the operator to pick a path explicitly.

- **deploy.sh**: new ``_check_sqlite_orphan_vs_postgres`` runs after ``proxy.env`` validation and before any docker call. Triggers when ``MCP_PROXY_DATABASE_URL`` matches ``postgres://`` / ``postgresql+...`` AND ``./data/mcp_proxy.db`` is non-empty. Error enumerates 3 paths: roll back to SQLite, wipe and re-enroll, or ``--accept-data-loss`` override.
- ``--accept-data-loss`` flag: skips the guard with a loud warn that every previously enrolled Connector will fail TLS verify on next ``/v1/principals/csr``. Leaves the orphan SQLite file on disk for forensics.
- Same guard runs at the top of ``_cmd_upgrade_bundle`` so ``--upgrade-bundle`` in a half-swapped state refuses before the tarball extract starts overwriting scripts.
- **proxy.env.example** + **README.md** document the variable + the swap-is-not-a-migration warning at section level.
- **tests/test_bundle_db_swap_guard.py** drives ``deploy.sh`` directly in a tmp bundle dir with a PATH stub for ``docker``/``ss``/``curl``. ``CULLIS_DEPLOY_EXIT_AFTER_CHECKS=1`` (test-only hook) short-circuits the script after pre-flight checks so the success paths don't have to mock the full pull/up flow.

## Test plan

- [x] ``bash -n packaging/mastio-bundle/deploy.sh`` clean
- [x] ``pytest tests/test_bundle_db_swap_guard.py -v`` — 9/9 passing (~6s)
- [x] ``pytest tests/test_deploy_scripts.py tests/test_mastio_version_check.py tests/test_bundle_db_swap_guard.py -v`` — 33/33 passing (no regression on adjacent suites)
- [x] ``deploy.sh --help`` advertises ``--accept-data-loss`` with the Connector-invalidation warning
- [x] ``deploy.sh --accept-data-loss --down`` works (flag plumbing doesn't break unrelated actions)
- [ ] Smoke pre-pilot dogfood: re-stage the original VM scenario (boot SQLite, enroll Connector, edit ``proxy.env`` to Postgres, ``./deploy.sh``) and confirm the refuse-to-start fires instead of silently re-deriving the Org CA

## Refs

- Runbook: ``imp/p3-dogfood-2026-05-17-mastio-state-corruption.md`` (MAJOR-A, gitignored — local-only)
- Out of scope: SQLite to Postgres automatic migration (separate ADR; ``--migrate-db`` flow is on roadmap, referenced from the new README section)
- Out of scope: same guard for ``packaging/mastio-enterprise-bundle/deploy.sh`` (private repo, separate PR if needed)