### PR TITLE
fix(mastio-lifespan): self-check org_id vs Org CA subject at boot (P3 MAJOR-B)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -162,16 +162,96 @@ class AgentManager:
         Key Vault, etc.) plug in via ``MCP_PROXY_KMS_BACKEND`` + the
         ``kms_factory`` plugin hook.
 
-        Returns True if loaded successfully, False otherwise.
+        P3 MAJOR-B (2026-05-17 dogfood) — after the load, cross-check
+        cert subject CN against ``proxy_config.org_id``. The Mastio CA
+        in :meth:`generate_org_ca` always carries CN ``"{org_id} CA"``;
+        a mismatch means a DB swap or stale pin, and every client cert
+        chain validation downstream silently 400/401's otherwise. We
+        also DER-compare the on-disk ``nginx_cert_dir/org-ca.crt`` to
+        the DB cert and WARN on divergence (advisory only —
+        ``ensure_nginx_server_cert`` re-syncs it later in the lifespan).
+
+        Returns True on successful load, False on missing-CA or mismatch.
         """
         from mcp_proxy.kms import get_kms_provider
         loaded = await get_kms_provider().load_org_ca()
-        if loaded is not None:
-            ca_key_pem, ca_cert_pem = loaded
-            await self.load_org_ca(ca_key_pem, ca_cert_pem)
-            return True
-        logger.warning("Org CA not found via KMS provider — agent cert issuance unavailable")
-        return False
+        if loaded is None:
+            logger.warning("Org CA not found via KMS provider — agent cert issuance unavailable")
+            return False
+
+        ca_key_pem, ca_cert_pem = loaded
+        await self.load_org_ca(ca_key_pem, ca_cert_pem)
+
+        # Primary check: CN vs proxy_config.org_id. Skip when org_id is
+        # env-pinned only (proxy_config row absent).
+        persisted_org_id = await get_config("org_id")
+        if persisted_org_id and self._org_ca_cert is not None:
+            try:
+                cn_attrs = self._org_ca_cert.subject.get_attributes_for_oid(
+                    NameOID.COMMON_NAME,
+                )
+                cert_cn = cn_attrs[0].value if cn_attrs else ""
+            except Exception:
+                cert_cn = ""
+            expected_cn = f"{persisted_org_id} CA"
+            if cert_cn != expected_cn:
+                logger.critical(
+                    "Org CA subject mismatch — refusing to load. "
+                    "proxy_config.org_id=%r expected CN=%r, loaded CN=%r "
+                    "(cert serial=%s). DB state inconsistent: either "
+                    "org_id was rewritten without re-issuing the Org CA, "
+                    "or a stale CA from a previous deploy is pinned. "
+                    "Agent cert issuance + mTLS will fail until resolved.",
+                    persisted_org_id, expected_cn, cert_cn,
+                    self._org_ca_cert.serial_number,
+                )
+                # Roll back so ca_loaded reports False — same degraded
+                # branch as the "no CA found" path above.
+                self._org_ca_key = None
+                self._org_ca_cert = None
+                return False
+
+        # Secondary check: nginx-certs bind mount DER. Advisory only.
+        await self._verify_nginx_cert_dir_matches_db(ca_cert_pem)
+
+        return True
+
+    async def _verify_nginx_cert_dir_matches_db(self, db_ca_cert_pem: str) -> None:
+        """DER-compare the on-disk ``org-ca.crt`` against the DB cert.
+
+        No-op when ``settings.nginx_cert_dir`` is unset (pytest in-
+        process lifespan) or the file doesn't exist yet (pre-first
+        ``ensure_nginx_server_cert`` write).
+        """
+        try:
+            cert_dir = get_settings().nginx_cert_dir
+            if not cert_dir:
+                return
+            from pathlib import Path
+            ca_path = Path(cert_dir) / "org-ca.crt"
+            if not ca_path.exists():
+                return
+            on_disk_der = x509.load_pem_x509_certificate(
+                ca_path.read_bytes(),
+            ).public_bytes(serialization.Encoding.DER)
+            db_der = x509.load_pem_x509_certificate(
+                db_ca_cert_pem.encode(),
+            ).public_bytes(serialization.Encoding.DER)
+            if on_disk_der != db_der:
+                logger.warning(
+                    "Org CA on-disk vs DB mismatch — %s differs from "
+                    "proxy_config.org_ca_cert. The nginx sidecar will "
+                    "serve a stale trust bundle until ensure_nginx_server_cert "
+                    "rewrites it. If divergence persists, re-run deploy.sh "
+                    "to re-export nginx-certs from the current DB state.",
+                    ca_path,
+                )
+        except Exception as exc:  # noqa: BLE001 — diagnostic only
+            logger.debug(
+                "nginx-certs DER check skipped (%s) — primary CN check "
+                "already gates the load, this is advisory only",
+                exc,
+            )
 
     async def generate_org_ca(
         self,

--- a/tests/test_mastio_org_ca_self_check.py
+++ b/tests/test_mastio_org_ca_self_check.py
@@ -1,0 +1,175 @@
+"""P3 MAJOR-B (2026-05-17 dogfood) — boot-time self-check that the Org
+CA loaded from ``proxy_config.org_ca_cert`` belongs to the
+``proxy_config.org_id`` row.
+
+The dogfood VM ``192.168.122.170`` had DB rows saying
+``org_id=70e44ddd5d7b5a76`` but a ``nginx-certs/org-ca.crt`` bind
+mount holding ``CN=9d5c940c49b8160f CA`` from a previous boot. Every
+Connector client cert chain validation 400/401'd silently. The fix
+makes :meth:`AgentManager.load_org_ca_from_config` log CRITICAL and
+refuse the load when the subject CN doesn't line up with the
+persisted ``org_id``.
+
+Logger capture uses :func:`monkeypatch.setattr` on ``logger.<level>``
+because ``mcp_proxy.logging_setup`` flips ``propagate=False`` and
+``caplog`` is fragile across NixOS / pytest configurations (memory
+``feedback_mcp_proxy_logger_caplog``).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from mcp_proxy.db import dispose_db, init_db, set_config
+from mcp_proxy.egress import agent_manager as agent_manager_module
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+def _mint_unrelated_ca_pem(cn: str) -> bytes:
+    """Self-signed CA cert in-memory only — used to stage a stale
+    on-disk file without overwriting ``proxy_config.org_ca_cert`` via
+    the KMS write path."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path):
+    db_file = tmp_path / "proxy.sqlite"
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+    yield
+    await dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_happy_path_cn_matches_persisted_org_id(fresh_db):
+    """Standard boot: generate-derive seeds matching ``org_id`` + CA,
+    second AgentManager reloads cleanly with ``ca_loaded=True``."""
+    mgr1 = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr1.generate_org_ca(derive_org_id=True)
+    org_id = mgr1.org_id
+    assert org_id
+
+    mgr2 = AgentManager(org_id=org_id, trust_domain="cullis.local")
+    ok = await mgr2.load_org_ca_from_config()
+
+    assert ok is True
+    assert mgr2.ca_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_mismatch_cn_refuses_load_and_logs_critical(fresh_db, monkeypatch):
+    """DB swap scenario: ``proxy_config.org_id`` was rewritten to A
+    while ``proxy_config.org_ca_cert`` still holds a CA with CN
+    ``B CA``. The load must return False, ``ca_loaded`` stays False,
+    and CRITICAL is emitted with both expected and actual CN."""
+    # Seed a CA whose CN is "{org_b} CA" (generate doesn't persist
+    # org_id when derive=False).
+    org_b = "bbbbbbbbbbbbbbbb"
+    mgr_b = AgentManager(org_id=org_b, trust_domain="cullis.local")
+    await mgr_b.generate_org_ca(derive_org_id=False)
+
+    # Simulate the DB drift the dogfood VM exhibited.
+    org_a = "aaaaaaaaaaaaaaaa"
+    await set_config("org_id", org_a)
+
+    captured: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        try:
+            captured.append(msg % args if args else msg)
+        except TypeError:
+            captured.append(str(msg))
+
+    monkeypatch.setattr(agent_manager_module.logger, "critical", _capture)
+
+    mgr_a = AgentManager(org_id=org_a, trust_domain="cullis.local")
+    ok = await mgr_a.load_org_ca_from_config()
+
+    assert ok is False, "mismatch path must return False"
+    assert mgr_a.ca_loaded is False, "in-memory CA must be cleared on mismatch"
+    assert any("Org CA subject mismatch" in m for m in captured), captured
+    joined = " | ".join(captured)
+    assert f"{org_a} CA" in joined
+    assert f"{org_b} CA" in joined
+
+
+@pytest.mark.asyncio
+async def test_no_persisted_org_id_skips_check(fresh_db, monkeypatch):
+    """Env-pinned org_id leaves ``proxy_config.org_id`` unset; the
+    self-check is then a no-op and load succeeds without CRITICAL."""
+    mgr_seed = AgentManager(org_id="env-pinned", trust_domain="cullis.local")
+    await mgr_seed.generate_org_ca(derive_org_id=False)
+
+    critical_calls: list[str] = []
+    monkeypatch.setattr(
+        agent_manager_module.logger,
+        "critical",
+        lambda msg, *a, **k: critical_calls.append(msg),
+    )
+
+    mgr2 = AgentManager(org_id="env-pinned", trust_domain="cullis.local")
+    ok = await mgr2.load_org_ca_from_config()
+
+    assert ok is True
+    assert mgr2.ca_loaded is True
+    assert critical_calls == [], critical_calls
+
+
+@pytest.mark.asyncio
+async def test_on_disk_ca_mismatch_logs_warning_but_loads(
+    fresh_db, tmp_path, monkeypatch,
+):
+    """Secondary check: when ``nginx_cert_dir/org-ca.crt`` differs from
+    the DB cert, log WARN but still return True —
+    ``ensure_nginx_server_cert`` will rewrite the file later in the
+    lifespan, so this is advisory only."""
+    mgr_seed = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr_seed.generate_org_ca(derive_org_id=True)
+
+    stale_pem = _mint_unrelated_ca_pem(cn="9d5c940c49b8160f CA")
+    nginx_dir = tmp_path / "nginx-certs"
+    nginx_dir.mkdir()
+    (nginx_dir / "org-ca.crt").write_bytes(stale_pem)
+
+    class _StubSettings:
+        nginx_cert_dir = str(nginx_dir)
+
+    monkeypatch.setattr(
+        agent_manager_module, "get_settings", lambda: _StubSettings(),
+    )
+
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        agent_manager_module.logger,
+        "warning",
+        lambda msg, *a, **k: warnings.append(msg % a if a else msg),
+    )
+
+    mgr_reload = AgentManager(org_id=mgr_seed.org_id, trust_domain="cullis.local")
+    ok = await mgr_reload.load_org_ca_from_config()
+
+    assert ok is True
+    assert mgr_reload.ca_loaded is True
+    assert any("on-disk vs DB mismatch" in w for w in warnings), warnings
+
+


### PR DESCRIPTION
## Summary

- Boot-time mismatch between `proxy_config.org_id` and the loaded Org CA subject CN now logs **CRITICAL** and refuses the load, rolling back `_org_ca_cert`/`_org_ca_key` so `ca_loaded=False`. The proxy degrades cleanly instead of silently issuing the wrong leaf certs and 400/401'ing every Connector handshake.
- Secondary advisory check: DER-compare `nginx_cert_dir/org-ca.crt` (the read-only bind mount the `mastio-nginx` sidecar serves) against the DB cert. Mismatch logs **WARN** only — `ensure_nginx_server_cert` later in the lifespan re-syncs the file from the just-loaded DB CA, so transient divergence at boot is benign.
- Scope strictly bounded to `load_org_ca_from_config`; no refactor of `LocalKMSProvider` or other call sites.

## Why now

The dogfood VM `192.168.122.170` (2026-05-17) had:

- `proxy_config.org_id` = `70e44ddd5d7b5a76`
- `proxy_config.org_ca_cert` subject = `CN=70e44ddd5d7b5a76 CA`
- `nginx-certs/org-ca.crt` bind mount = `CN=9d5c940c49b8160f CA` (stale, from a previous boot whose DB was wiped without re-exporting the directory)

Every Connector cert chain validation 400/401'd opaquely. Root cause was discovered only via manual `openssl x509` inspection of both the DB row and the file. This PR makes the proxy log loudly at lifespan start rather than degrading to silent customer-facing 401s.

## Test plan

- [x] `pytest tests/test_mastio_org_ca_self_check.py -v` — 4 new tests, all pass
- [x] `pytest tests/test_proxy_deterministic_org_id.py tests/test_proxy_mastio_rotation_concurrency.py tests/test_adr009_phase1_mastio_pubkey.py -n auto --dist=loadfile` — 25 existing tests, all still pass
- [x] `pytest tests/test_enrollment.py tests/test_enrollment_dashboard.py tests/test_admin_enroll_byoca.py tests/test_proxy_local_token.py tests/test_proxy_sign_assertion.py tests/test_kms_vault_provider.py tests/test_mastio_kms.py tests/test_updates_org_ca_pathlen_fix.py -n auto --dist=loadfile` — wider CA-touching sweep, 114 tests pass
- [ ] Manual: re-run a Mastio standalone boot with a deliberately drifted `proxy_config.org_id` row and confirm the CRITICAL log surfaces + `ca_loaded` reports False on `/health`

## Related

- `imp/p3-dogfood-2026-05-17-mastio-state-corruption.md` MAJOR-B
- Memory: `feedback_mcp_proxy_logger_caplog` (monkeypatch `logger.<level>` because `mcp_proxy.logging_setup` flips `propagate=False`)
- Memory: `feedback_h4_convergent_pattern_fallback_insecure_default` (fail-loud + refuse-to-load instead of silent fallback)