### PR TITLE
feat(auth): structured 401 detail on client cert auth failures (P3 MAJOR-C)

### DIFF
--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -70,6 +70,40 @@ _log = logging.getLogger("mcp_proxy")
 # we re-check.
 _VERIFY_SUCCESS = "SUCCESS"
 
+# P3 MAJOR-C — structured 401 detail bodies. Mirrors the
+# ``denied_reason_code`` token vocabulary from PR #751: SDK consumers,
+# dashboard banners, and admins reading raw 401 bodies all dispatch on
+# the stable ``reason`` token instead of substring-matching prose.
+# Only public-by-design fields (cert SAN, configured org_id) are
+# echoed back; cert PEM bytes / pubkey thumbprints / DB pins stay in
+# the warning log. See ``feedback_sqlalchemy_exc_leaks_bound_params``
+# for the controlled-disclosure principle.
+_REASON_CERT_NOT_VERIFIED = "client_cert_not_verified"
+_REASON_CERT_HEADER_MISSING = "client_cert_header_missing"
+_REASON_CERT_INVALID_PEM = "client_cert_invalid_pem"
+_REASON_CERT_NO_IDENTITY = "client_cert_no_parseable_identity"
+_REASON_ORG_MISMATCH = "client_cert_org_mismatch"
+_REASON_AGENT_UNKNOWN = "agent_unknown_or_inactive"
+_REASON_AGENT_PIN_UNAVAILABLE = "agent_cert_pin_unavailable"
+_REASON_CERT_PIN_MISMATCH = "client_cert_pin_mismatch"
+_REASON_TYPED_PRINCIPAL_UNKNOWN = "typed_principal_unknown"
+_REASON_TYPED_PRINCIPAL_NOT_ENROLLED = "typed_principal_not_yet_enrolled"
+_REASON_TYPED_PUBKEY_NOT_BOUND = "client_cert_pubkey_not_bound_to_principal"
+
+# Single docs anchor across all hints — one doc rewrite moves all
+# error messages without code churn.
+_DOCS_ANCHOR = "https://docs.cullis.io/runbook/mastio-mtls-auth"
+
+
+def _err(reason: str, hint: str, **extra: str) -> dict[str, str]:
+    """Build the structured ``HTTPException.detail`` body. Body shape:
+    ``{reason, hint, docs, **extra}``. ``extra`` is per-call-site
+    public context (expected_org, presented_org, principal_id, ...).
+    """
+    body: dict[str, str] = {"reason": reason, "hint": hint, "docs": _DOCS_ANCHOR}
+    body.update(extra)
+    return body
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PEM extraction + identity parsing
@@ -152,9 +186,11 @@ def _identity_from_cert(cert: x509.Certificate) -> tuple[str, str]:
          that pre-date the SAN URI extension. Same parsing rules as
          the canonical agent_id.
 
-    Raises 401 if neither yields a usable identity. The error
-    deliberately doesn't echo the cert bytes back — keeps the dep
-    diagnostic-quiet for would-be enumerators.
+    Raises 401 if neither yields a usable identity. The error body
+    includes the cert's first SAN URI + serial (both public-by-design
+    identifiers on every X.509 leaf) so an operator can match the
+    rejected cert against the ``/v1/principals/csr`` audit row, but
+    never echoes the cert DER / pubkey thumbprint / DB internals.
     """
     try:
         san_ext = cert.extensions.get_extension_for_class(
@@ -177,7 +213,13 @@ def _identity_from_cert(cert: x509.Certificate) -> tuple[str, str]:
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="client cert has no parseable SPIFFE SAN or CN identity",
+        detail=_err(
+            _REASON_CERT_NO_IDENTITY,
+            "Cert has no SPIFFE URI SAN and no '<org>::<agent>' CN; "
+            "re-mint via the Connector enroll wizard or /v1/principals/csr.",
+            cert_san=_cert_first_spiffe(cert),
+            cert_serial=_cert_serial_hex(cert),
+        ),
     )
 
 
@@ -309,14 +351,24 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
         # gate. Fail closed.
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="client cert not verified",
+            detail=_err(
+                _REASON_CERT_NOT_VERIFIED,
+                "nginx did not stamp X-SSL-Client-Verify=SUCCESS — "
+                "request bypassed the mTLS sidecar or the cert chain "
+                "failed validation; check the Mastio nginx access log.",
+                presented_verify=_strip_log_controls(verify) or "<empty>",
+            ),
         )
 
     escaped_pem = request.headers.get("X-SSL-Client-Cert") or ""
     if not escaped_pem:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="client cert header missing",
+            detail=_err(
+                _REASON_CERT_HEADER_MISSING,
+                "X-SSL-Client-Cert header is empty — request reached "
+                "mcp-proxy without traversing the mTLS sidecar.",
+            ),
         )
 
     pem = _decode_escaped_pem(escaped_pem)
@@ -325,7 +377,12 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="client cert is not valid PEM",
+            detail=_err(
+                _REASON_CERT_INVALID_PEM,
+                "X-SSL-Client-Cert payload is not a valid X.509 PEM — "
+                "check the nginx ``proxy_set_header $ssl_client_escaped_cert``"
+                " directive.",
+            ),
         )
 
     org_id_from_cert, agent_name = _identity_from_cert(cert)
@@ -342,7 +399,16 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="client cert org mismatch",
+            detail=_err(
+                _REASON_ORG_MISMATCH,
+                "The Connector cert was issued by a different Mastio "
+                "Org. Re-run the enroll wizard against the Mastio whose "
+                "org_id matches ``expected_org``, or correct "
+                "``MCP_PROXY_ORG_ID`` if the Mastio config drifted.",
+                expected_org=expected_org,
+                presented_org=org_id_from_cert,
+                agent_name=agent_name,
+            ),
         )
 
     canonical_id = f"{org_id_from_cert}::{agent_name}"
@@ -388,7 +454,15 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"{kind} principal unknown",
+                detail=_err(
+                    _REASON_TYPED_PRINCIPAL_UNKNOWN,
+                    f"No row exists for ``{canonical_id}`` in "
+                    f"``local_{kind}_principals``; pre-create via "
+                    f"``POST /v1/admin/{kind}s`` (admin dashboard) "
+                    "before the first /v1/principals/csr.",
+                    principal_id=canonical_id,
+                    principal_kind=kind,
+                ),
             )
         if stored_pubkey is None:
             # Row exists (e.g. admin pre-created via /v1/admin/users)
@@ -406,7 +480,15 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"{kind} principal not yet enrolled",
+                detail=_err(
+                    _REASON_TYPED_PRINCIPAL_NOT_ENROLLED,
+                    f"Principal ``{canonical_id}`` exists but no CSR has "
+                    "been signed yet (no pubkey to pin against); have "
+                    "the end-user complete the Connector enroll flow "
+                    "before retrying.",
+                    principal_id=canonical_id,
+                    principal_kind=kind,
+                ),
             )
         from mcp_proxy.registry.principals_csr import pubkey_thumbprint_sha256
         presented_pubkey = pubkey_thumbprint_sha256(cert.public_key())
@@ -434,7 +516,18 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="client cert pubkey not bound to principal",
+                detail=_err(
+                    _REASON_TYPED_PUBKEY_NOT_BOUND,
+                    "Cert's SPKI SHA-256 does not match the TOFU pin "
+                    f"stored for ``{canonical_id}``. Rotate the pin via "
+                    "the admin dashboard if the key rotation was "
+                    "legitimate; otherwise treat as a forged-cert "
+                    "incident.",
+                    principal_id=canonical_id,
+                    principal_kind=kind,
+                    cert_serial=_cert_serial_hex(cert),
+                    cert_san=_cert_first_spiffe(cert),
+                ),
             )
         agent_data = None
     else:
@@ -446,7 +539,13 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="agent unknown or inactive",
+                detail=_err(
+                    _REASON_AGENT_UNKNOWN,
+                    "No active ``internal_agents`` row for "
+                    f"``{canonical_id}``; re-enroll via the Connector "
+                    "or re-activate from the admin dashboard.",
+                    agent_id=canonical_id,
+                ),
             )
 
         # Pin the presented cert against the stored one. A renewal that
@@ -462,7 +561,13 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="agent cert pin unavailable",
+                detail=_err(
+                    _REASON_AGENT_PIN_UNAVAILABLE,
+                    f"Stored ``cert_pem`` for ``{canonical_id}`` is "
+                    "unparseable; inspect the row and re-issue the "
+                    "cert if the PEM is truncated.",
+                    agent_id=canonical_id,
+                ),
             )
         if not hmac.compare_digest(_cert_der_digest(cert), stored_digest):
             _log.warning(
@@ -472,7 +577,17 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             )
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="client cert does not match the registered identity",
+                detail=_err(
+                    _REASON_CERT_PIN_MISMATCH,
+                    "Presented cert's DER digest does not match the "
+                    f"one stored for ``{canonical_id}`` (likely a stale "
+                    "cert post-rotation); re-enroll the Connector, or "
+                    "treat as forged if the caller insists their cert "
+                    "is current.",
+                    agent_id=canonical_id,
+                    cert_serial=_cert_serial_hex(cert),
+                    cert_san=_cert_first_spiffe(cert),
+                ),
             )
 
     settings = get_settings()

--- a/tests/test_client_cert_auth.py
+++ b/tests/test_client_cert_auth.py
@@ -93,7 +93,9 @@ async def test_rejects_missing_verify_header(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
-    assert "verified" in resp.json()["detail"].lower()
+    body = resp.json()["detail"]
+    assert isinstance(body, dict)
+    assert body["reason"] == "client_cert_not_verified"
 
 
 @pytest.mark.asyncio
@@ -102,6 +104,7 @@ async def test_rejects_missing_cert_header(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
+    assert resp.json()["detail"]["reason"] == "client_cert_header_missing"
 
 
 @pytest.mark.asyncio
@@ -113,7 +116,7 @@ async def test_rejects_garbage_pem(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
-    assert "PEM" in resp.json()["detail"] or "valid" in resp.json()["detail"].lower()
+    assert resp.json()["detail"]["reason"] == "client_cert_invalid_pem"
 
 
 @pytest.mark.asyncio
@@ -124,7 +127,9 @@ async def test_rejects_unknown_agent(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
-    assert "unknown" in resp.json()["detail"].lower() or "inactive" in resp.json()["detail"].lower()
+    body = resp.json()["detail"]
+    assert body["reason"] == "agent_unknown_or_inactive"
+    assert body["agent_id"] == "acme::stranger"
 
 
 @pytest.mark.asyncio
@@ -145,6 +150,39 @@ async def test_rejects_org_mismatch(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_org_mismatch_response_detail_carries_expected_and_presented(
+    proxy_app,
+):
+    """P3 MAJOR-C — the org-mismatch 401 must surface both
+    ``expected_org`` (this Mastio's config) and ``presented_org``
+    (from the cert SAN) in a machine-readable JSON body so a
+    customer admin / dashboard banner / SPA dispatches on the stable
+    token instead of parsing prose. Both values are public-by-design
+    (cert SAN, admin-derivable config) — disclosure is safe per the
+    controlled-disclosure principle in
+    ``feedback_sqlalchemy_exc_leaks_bound_params``.
+    """
+    cert_pem, _ = mint_agent_cert(org_id="foreign", agent_name="alice")
+    headers = mtls_headers(cert_pem)
+    _, client = proxy_app
+    resp = await client.get("/v1/egress/peers", headers=headers)
+    assert resp.status_code == 401
+
+    body = resp.json()["detail"]
+    # MUST be parser-friendly JSON — not a bare string — otherwise
+    # customer admins fall back to substring matching.
+    assert isinstance(body, dict), (
+        f"expected dict body, got {type(body).__name__}: {body!r}"
+    )
+    assert body["reason"] == "client_cert_org_mismatch"
+    assert body["expected_org"] == "acme"
+    assert body["presented_org"] == "foreign"
+    assert body["agent_name"] == "alice"
+    assert body["hint"]
+    assert body["docs"].startswith("https://")
 
 
 @pytest.mark.asyncio
@@ -169,7 +207,11 @@ async def test_rejects_cert_pin_mismatch(proxy_app):
     _, client = proxy_app
     resp = await client.get("/v1/egress/peers", headers=headers)
     assert resp.status_code == 401
-    assert "match" in resp.json()["detail"].lower() or "registered" in resp.json()["detail"].lower()
+    body = resp.json()["detail"]
+    assert body["reason"] == "client_cert_pin_mismatch"
+    assert body["agent_id"] == "acme::alice"
+    assert "cert_serial" in body
+    assert "cert_san" in body
 
 
 @pytest.mark.asyncio
@@ -326,7 +368,9 @@ async def test_typed_user_principal_unknown_rejected(proxy_app):
     with pytest.raises(HTTPException) as exc_info:
         await get_agent_from_client_cert(request)
     assert exc_info.value.status_code == 401
-    assert "unknown" in exc_info.value.detail.lower()
+    assert exc_info.value.detail["reason"] == "typed_principal_unknown"
+    assert exc_info.value.detail["principal_kind"] == "user"
+    assert exc_info.value.detail["principal_id"] == "acme::user::nobody"
 
 
 @pytest.mark.asyncio
@@ -351,7 +395,8 @@ async def test_typed_user_principal_pubkey_unset_rejected(proxy_app):
     with pytest.raises(HTTPException) as exc_info:
         await get_agent_from_client_cert(request)
     assert exc_info.value.status_code == 401
-    assert "enrolled" in exc_info.value.detail.lower()
+    assert exc_info.value.detail["reason"] == "typed_principal_not_yet_enrolled"
+    assert exc_info.value.detail["principal_id"] == "acme::user::pending"
 
 
 @pytest.mark.asyncio
@@ -378,7 +423,8 @@ async def test_typed_user_principal_pubkey_mismatch_rejected(proxy_app):
     with pytest.raises(HTTPException) as exc_info:
         await get_agent_from_client_cert(request)
     assert exc_info.value.status_code == 401
-    assert "pubkey" in exc_info.value.detail.lower() or "bound" in exc_info.value.detail.lower()
+    assert exc_info.value.detail["reason"] == "client_cert_pubkey_not_bound_to_principal"
+    assert exc_info.value.detail["principal_id"] == "acme::user::ceo"
 
 
 def _capture_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
@@ -547,7 +593,8 @@ async def test_typed_workload_principal_unknown_rejected(proxy_app):
     with pytest.raises(HTTPException) as exc_info:
         await get_agent_from_client_cert(request)
     assert exc_info.value.status_code == 401
-    assert "unknown" in exc_info.value.detail.lower()
+    assert exc_info.value.detail["reason"] == "typed_principal_unknown"
+    assert exc_info.value.detail["principal_kind"] == "workload"
 
 
 # ── Diagnostic helper unit tests ─────────────────────────────────────

--- a/tests/test_proxy_challenge_response.py
+++ b/tests/test_proxy_challenge_response.py
@@ -281,11 +281,30 @@ async def test_cert_pin_mismatch_rejected(proxy_app):
         headers=bob_headers,
     )
     assert resp.status_code == 401
-    # ``unknown`` (bob row not provisioned) or ``match`` (bob row
-    # exists but DER doesn't match) are both valid pin-failure
-    # detail strings — both surface the same security boundary.
-    detail = resp.json()["detail"].lower()
-    assert "unknown" in detail or "match" in detail or "pin" in detail
+    # Post P3 MAJOR-C (#771): the detail body is a structured dict
+    # ``{"reason": "...", "hint": "...", ...}`` instead of a prose
+    # string. Both ``unknown`` (bob row not provisioned) and the
+    # cert-pin mismatch (bob row exists but DER doesn't match) surface
+    # via reason tokens — both are valid pin-failure outcomes and
+    # share the same security boundary, so accept either.
+    detail = resp.json()["detail"]
+    if isinstance(detail, dict):
+        reason = (detail.get("reason") or "").lower()
+        assert (
+            "unknown" in reason
+            or "pin" in reason
+            or "match" in reason
+            or "agent_unknown" in reason
+        ), f"unexpected reason token: {reason!r}"
+    else:
+        # Legacy prose-string path — keep coverage for any 401 raised
+        # outside the client_cert.py refactor surface.
+        detail_str = detail.lower()
+        assert (
+            "unknown" in detail_str
+            or "match" in detail_str
+            or "pin" in detail_str
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_mtls_only_send.py
+++ b/tests/test_proxy_mtls_only_send.py
@@ -216,7 +216,15 @@ async def test_mtls_only_sender_without_cert_is_rejected(proxy_app):
         },
     )
     assert resp.status_code == 401, resp.text
-    assert "cert" in resp.json()["detail"].lower()
+    # Post P3 MAJOR-C (#771): client_cert.py raises return structured
+    # ``detail = {"reason": "...", ...}``. Other endpoints still raise
+    # prose strings — accept both shapes.
+    detail = resp.json()["detail"]
+    if isinstance(detail, dict):
+        reason = (detail.get("reason") or "").lower()
+        assert "cert" in reason, f"unexpected reason token: {reason!r}"
+    else:
+        assert "cert" in detail.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Every 401 raised by ``get_agent_from_client_cert`` now returns a JSON dict ``detail`` body with a stable ``reason`` token, an operator-readable ``hint``, a ``docs`` link, and per-call-site public context fields. Replaces 10 opaque prose strings.
- Headline P3 MAJOR-C fix: ``client cert org mismatch`` now exposes ``expected_org`` (this Mastio's configured ``MCP_PROXY_ORG_ID``) and ``presented_org`` (cert SAN) — a customer admin without shell access can self-diagnose which enrollment side drifted, instead of escalating to Cullis to read the server-side warning log.
- Vocabulary mirrors the ``denied_reason_code`` tokens from #751 so SDK consumers and the dashboard banner dispatch on the same stable contract across the tool-execution path and the auth path.

## Why

From the P3 admin pre-pilot audit MAJOR-C: the org-mismatch 401 is the single most common ``cullis-mastio`` failure for first-time enrollers (Connector cert points at the wrong Mastio org). The body was an unactionable ``"client cert org mismatch"`` string — admin had to ssh into the Mastio, grep the WARNING log, find the line that names both orgs. Now the same forensic detail (both already public-by-cert) is in the 401 body itself.

## What changed

``mcp_proxy/auth/client_cert.py``:

- New ``_err(reason, hint, **extra)`` helper builds the structured body. ``reason`` is one of 11 stable snake_case tokens (constants at module top). Every callsite uses the helper.
- Disclosure boundary: only PUBLIC-by-cert (SPIFFE SAN, serial, CN) or admin-derivable (configured org_id) fields are echoed in the body. Cert PEM bytes, pubkey SPKI thumbprints, and DB-stored cert pins stay in the WARNING log (see ``feedback_sqlalchemy_exc_leaks_bound_params`` for the controlled-disclosure principle).
- Status codes (401) and timing-safe ``hmac.compare_digest`` pubkey compare are unchanged. Logging side is unchanged (#766 forensic fields preserved).

``tests/test_client_cert_auth.py``:

- 6 existing string-substring assertions migrated to dict-aware ``body["reason"] == "..."``.
- New ``test_org_mismatch_response_detail_carries_expected_and_presented`` locks the headline contract: body MUST be a JSON dict carrying ``expected_org`` + ``presented_org`` + ``agent_name`` + ``hint`` + ``docs``.

## Reason token vocabulary (stable across releases)

| Token | Trigger |
|---|---|
| ``client_cert_not_verified`` | ``X-SSL-Client-Verify`` not ``SUCCESS`` |
| ``client_cert_header_missing`` | ``X-SSL-Client-Cert`` empty |
| ``client_cert_invalid_pem`` | PEM parse fails |
| ``client_cert_no_parseable_identity`` | No SPIFFE SAN, no ``<org>::<agent>`` CN |
| ``client_cert_org_mismatch`` | Cert org_id ≠ ``MCP_PROXY_ORG_ID`` (**MAJOR-C**) |
| ``agent_unknown_or_inactive`` | ``internal_agents`` row missing or inactive |
| ``agent_cert_pin_unavailable`` | Stored ``cert_pem`` unparseable |
| ``client_cert_pin_mismatch`` | Leaf DER digest ≠ stored |
| ``typed_principal_unknown`` | ``local_{user,workload}_principals`` row missing |
| ``typed_principal_not_yet_enrolled`` | Row exists, ``pubkey_thumbprint`` NULL |
| ``client_cert_pubkey_not_bound_to_principal`` | SPKI SHA-256 ≠ TOFU pin |

## Test plan

- [x] ``pytest tests/test_client_cert_auth.py -v`` — 21/21 green in 37s (parallel)
- [x] ``pytest tests/ -k "client_cert or auth_egress"`` — 27 passed, 2 skipped
- [x] No string-substring assertions left in suite that hit the auth-401 path
- [ ] ``/security-review`` to be run pre-merge (mcp_proxy/auth/* touched — per ``feedback_security_review_per_pr``)

## Related

- #751 — ``denied_reason_code`` vocabulary this PR mirrors
- #766 — diagnostic fields on WARNING log (preserved; this PR adds the response-body half)
- #767 — post-merge nits on cert+trust paths

Diff size: 184 insertions / 22 deletions across 2 files.