### PR TITLE
fix(bundle-mastio): generate-proxy-env --defaults emits PROXY_PUBLIC_URL (P3 MINOR-F)

### DIFF
--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -137,14 +137,18 @@ case "$MODE" in
         ;;
     defaults)
         BROKER="${BROKER_URL:-http://broker:8000}"
-        # Empty by default → settings.py falls back to ``request.url`` for
-        # DPoP htu validation (auto-detect from the inbound Host header).
-        # Hardcoding ``localhost`` broke every non-localhost deploy
-        # (Docker, k8s, VM) because the agent's actual htu carried the
-        # service name / ingress hostname / VM IP. Operators who front
-        # the Mastio with a stable public hostname should still pass
-        # ``PROXY_PUBLIC_URL=https://mastio.example.com`` explicitly.
-        PUBLIC="${PROXY_PUBLIC_URL:-}"
+        # Default ``https://host.docker.internal:9443`` matches the
+        # docker-compose.yml fallback and the deploy.sh interactive
+        # prompt default. This is the same URL the interactive flow
+        # writes when the operator presses Enter at the public-URL
+        # prompt. Emitting it explicitly keeps ``--defaults`` self-
+        # contained for CI / Ansible / quick-laptop boot: the resulting
+        # proxy.env survives standalone (no extra deploy.sh post-fix)
+        # and the operator never hits 401 ``htu mismatch`` because the
+        # field was empty. Operators fronting the Mastio with a stable
+        # public hostname override via ``PROXY_PUBLIC_URL=...`` env or
+        # by editing proxy.env after generation.
+        PUBLIC="${PROXY_PUBLIC_URL:-https://host.docker.internal:9443}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
@@ -152,7 +156,14 @@ case "$MODE" in
         echo ""
         read -rp "  Broker URL [http://broker:8000]: " BROKER
         BROKER="${BROKER:-http://broker:8000}"
-        read -rp "  Proxy public URL [empty = auto-detect from Host header]: " PUBLIC
+        # Same default the deploy.sh interactive prompt offers (line ~611):
+        # covers host browser + sibling containers in the laptop / single
+        # VM scenario. Empty input → laptop default, never the empty
+        # string (MINOR-F: empty triggers 401 htu mismatch on every agent
+        # enrollment because the docker-compose ${VAR:-...} fallback does
+        # NOT apply uniformly across all consumers of proxy.env).
+        read -rp "  Proxy public URL [https://host.docker.internal:9443]: " PUBLIC
+        PUBLIC="${PUBLIC:-https://host.docker.internal:9443}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
@@ -164,7 +175,19 @@ sed -i "s|^MCP_PROXY_ADMIN_SECRET=.*|MCP_PROXY_ADMIN_SECRET=${ADMIN_SECRET}|"   
 sed -i "s|^MCP_PROXY_DASHBOARD_SIGNING_KEY=.*|MCP_PROXY_DASHBOARD_SIGNING_KEY=${SIGNING_KEY}|" "$OUT"
 sed -i "s|^MCP_PROXY_BROKER_URL=.*|MCP_PROXY_BROKER_URL=${BROKER}|"                  "$OUT"
 sed -i "s|^MCP_PROXY_BROKER_JWKS_URL=.*|MCP_PROXY_BROKER_JWKS_URL=${JWKS}|"          "$OUT"
-sed -i "s|^MCP_PROXY_PROXY_PUBLIC_URL=.*|MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}|"      "$OUT"
+
+# MCP_PROXY_PROXY_PUBLIC_URL ships COMMENTED in proxy.env.example (the
+# example carries a placeholder production hostname so operators see
+# the shape, not a usable default). A plain sed-substitution on
+# ``^MCP_PROXY_PROXY_PUBLIC_URL=`` therefore silently no-ops and the
+# generated proxy.env ends up without an uncommented line, exactly
+# the dogfood breakage MINOR-F pins (CI / Ansible / laptop boot with
+# --defaults then ./deploy.sh up: every agent enrollment fails 401
+# htu mismatch). Strip any pre-existing line (commented or not) and
+# append the resolved value so the field always lands uncommented.
+sed -i.bak '/^#*[[:space:]]*MCP_PROXY_PROXY_PUBLIC_URL=/d' "$OUT"
+rm -f "${OUT}.bak"
+echo "MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}" >> "$OUT"
 
 # ADR-030 — the bundle bind-mount paths default to ./data and ./nginx-certs.
 # proxy.env.example ships them already, so no sed required here. The block

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -48,19 +48,26 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # ─── Proxy identity ──────────────────────────────────────────────────────────
 
 # Public URL where the proxy itself is reachable. Used for DPoP HTU
-# validation on the ingress endpoints — MUST match the URL agents
+# validation on the ingress endpoints, MUST match the URL agents
 # actually use to address the Mastio. ADR-014: this points at the
 # mastio-nginx sidecar (TLS), not the in-network mcp-proxy listener.
 #
-# The compose file defaults this to ``https://localhost:9443`` for the
-# dev / quick-try path. **Production deploys MUST override** with the
-# public hostname agents resolve at, e.g.:
+# ``./generate-proxy-env.sh --defaults`` writes the laptop / single-VM
+# default ``https://host.docker.internal:9443`` here (covers host
+# browser AND sibling docker containers like the Frontdesk bundle in
+# the same host-gateway scenario). The interactive flow asks for the
+# value and falls back to the same laptop default on empty input.
+# **Production deploys MUST override** with the public hostname agents
+# resolve at, e.g.:
 #
 #   MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
 #
 # Mismatch → 401 ``Invalid DPoP proof: htu mismatch`` on every egress
-# call. Leaving this commented keeps the compose default; uncomment +
-# edit when fronting the Mastio with a stable public hostname.
+# call. Leaving the field empty (or commented) triggers the same 401
+# because compose's ``${VAR:-...}`` fallback does NOT apply uniformly
+# across every consumer of proxy.env (CI / Ansible / direct
+# python-dotenv readers see the empty literal). Always carry a real
+# uncommented value here in production.
 #MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy

--- a/tests/test_bundle_generate_proxy_env_defaults.py
+++ b/tests/test_bundle_generate_proxy_env_defaults.py
@@ -1,0 +1,234 @@
+"""P3 MINOR-F: packaging/mastio-bundle/generate-proxy-env.sh --defaults
+emits a real ``MCP_PROXY_PROXY_PUBLIC_URL`` value instead of leaving
+the field empty or commented out.
+
+Failure mode this pins (dogfood tabula rasa, 2026-05-17): an operator
+invokes ``./generate-proxy-env.sh --defaults`` from CI / Ansible / a
+quick laptop boot, then runs ``./deploy.sh up`` without going through
+the deploy.sh interactive prompt. The resulting proxy.env carries no
+uncommented ``MCP_PROXY_PROXY_PUBLIC_URL=`` line at all (the
+``proxy.env.example`` ships the field commented and the previous sed
+substitution silently no-oped on commented lines). Mastio boots, the
+docker-compose ``${VAR:-...}`` fallback does NOT apply uniformly to
+every consumer of proxy.env (CI smoke tests, Ansible plays, direct
+python-dotenv readers), and every agent enrollment fails 401
+``Invalid DPoP proof: htu mismatch`` against an empty htu.
+
+The fix: ``--defaults`` (and the interactive prompt's empty-input
+fallback) writes the laptop / single-VM default
+``https://host.docker.internal:9443``, which matches the
+docker-compose.yml fallback and the deploy.sh interactive prompt
+default. Operators with a stable public hostname override via the
+``PROXY_PUBLIC_URL`` env var or by editing proxy.env after generation.
+
+These tests drive ``generate-proxy-env.sh`` directly in a tmp bundle
+dir, parse the resulting proxy.env, and assert the public URL line is
+present and uncommented.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BUNDLE_SRC = REPO_ROOT / "packaging" / "mastio-bundle"
+
+
+def _stage_bundle(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Mirror the minimum bundle layout into ``tmp_path`` so
+    ``generate-proxy-env.sh`` finds its ``proxy.env.example`` sibling.
+    """
+    bundle = tmp_path / "mastio-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(BUNDLE_SRC / "generate-proxy-env.sh", bundle / "generate-proxy-env.sh")
+    shutil.copy2(BUNDLE_SRC / "proxy.env.example", bundle / "proxy.env.example")
+    (bundle / "generate-proxy-env.sh").chmod(0o755)
+    return bundle
+
+
+def _run_generate(
+    bundle: pathlib.Path,
+    *args: str,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PROJECT_DIR"] = str(bundle)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(bundle / "generate-proxy-env.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def _parse_env(env_path: pathlib.Path) -> dict[str, str]:
+    """Parse a proxy.env-style file into a dict, ignoring commented and
+    blank lines. Trailing newlines on values are stripped so the
+    assertion compares literal URL strings.
+    """
+    out: dict[str, str] = {}
+    for raw in env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# --defaults
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_defaults_emits_proxy_public_url_laptop_default(tmp_path: pathlib.Path) -> None:
+    """``--defaults`` writes the laptop / sibling-container URL so the
+    resulting proxy.env survives ``./deploy.sh up`` without the
+    interactive prompt and never produces 401 htu mismatch on agent
+    enrollment.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(bundle, "--defaults", "--force")
+    assert result.returncode == 0, f"generate-proxy-env.sh failed:\n{result.stderr}"
+
+    env = _parse_env(bundle / "proxy.env")
+    assert "MCP_PROXY_PROXY_PUBLIC_URL" in env, (
+        "MCP_PROXY_PROXY_PUBLIC_URL missing from proxy.env. "
+        "P3 MINOR-F regression: --defaults must emit an uncommented value."
+    )
+    assert env["MCP_PROXY_PROXY_PUBLIC_URL"] == "https://host.docker.internal:9443"
+
+
+def test_defaults_writes_single_uncommented_line(tmp_path: pathlib.Path) -> None:
+    """No duplicate ``MCP_PROXY_PROXY_PUBLIC_URL=`` line. Previous sed
+    silently no-oped on commented lines, so a careless ``echo >> $OUT``
+    fix would have left the original commented placeholder PLUS the
+    new uncommented line. Operators reading the file by hand would see
+    two values and pick the wrong one.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(bundle, "--defaults", "--force")
+    assert result.returncode == 0, result.stderr
+
+    lines = (bundle / "proxy.env").read_text().splitlines()
+    uncommented = [
+        ln for ln in lines if ln.startswith("MCP_PROXY_PROXY_PUBLIC_URL=")
+    ]
+    commented = [
+        ln for ln in lines
+        if ln.lstrip().startswith("#")
+        and "MCP_PROXY_PROXY_PUBLIC_URL=" in ln
+        and not ln.lstrip().startswith("# ")
+    ]
+    assert len(uncommented) == 1, (
+        f"expected exactly one uncommented MCP_PROXY_PROXY_PUBLIC_URL line, "
+        f"got {uncommented}"
+    )
+    # The commented placeholder from proxy.env.example must be stripped
+    # so an operator never sees two contradictory values in the same
+    # file when they open it to override the public URL.
+    assert commented == [], (
+        f"commented placeholder still present after --defaults: {commented}"
+    )
+
+
+def test_defaults_env_var_override_wins(tmp_path: pathlib.Path) -> None:
+    """An operator with a stable hostname exports
+    ``PROXY_PUBLIC_URL=...`` and runs ``--defaults``: the explicit
+    value wins over the laptop default. Same pattern as ``--prod``,
+    but available from the defaults path so CI / Ansible can pre-bake
+    a custom URL without flipping to ``--prod`` (which would also
+    require BROKER_URL).
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--defaults",
+        "--force",
+        env_overrides={"PROXY_PUBLIC_URL": "https://mastio.acme.local:9443"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "proxy.env")
+    assert env["MCP_PROXY_PROXY_PUBLIC_URL"] == "https://mastio.acme.local:9443"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# --prod
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_prod_emits_required_public_url(tmp_path: pathlib.Path) -> None:
+    """``--prod`` is the CI / production-rehearsal path: BROKER_URL +
+    PROXY_PUBLIC_URL are required env vars, the resulting proxy.env
+    must carry both as uncommented values. Regression guard for the
+    same sed-on-commented-line bug as --defaults.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--prod",
+        "--force",
+        env_overrides={
+            "BROKER_URL": "https://broker.example.com",
+            "PROXY_PUBLIC_URL": "https://mastio.acme.example.com",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "proxy.env")
+    assert env["MCP_PROXY_PROXY_PUBLIC_URL"] == "https://mastio.acme.example.com"
+    assert env["MCP_PROXY_BROKER_URL"] == "https://broker.example.com"
+    assert env["MCP_PROXY_ENVIRONMENT"] == "production"
+
+
+def test_prod_refuses_without_public_url(tmp_path: pathlib.Path) -> None:
+    """``--prod`` without PROXY_PUBLIC_URL must die loudly, never
+    silently fall back to the laptop default (which would put a
+    development URL into a production proxy.env).
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--prod",
+        "--force",
+        env_overrides={"BROKER_URL": "https://broker.example.com"},
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "PROXY_PUBLIC_URL" in combined
+
+
+# ──────────────────────────────────────────────────────────────────────
+# --defaults companion fields
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_defaults_emits_random_admin_secret_and_signing_key(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Sanity for the rest of the defaults block: the random-generated
+    secrets the script claims to write actually land in proxy.env and
+    are not the literal ``change-me-in-production`` placeholder.
+    Guards against a future refactor that reorders the sed block and
+    accidentally drops one of these alongside the public URL fix.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(bundle, "--defaults", "--force")
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "proxy.env")
+    assert env.get("MCP_PROXY_ADMIN_SECRET", "") != ""
+    assert env["MCP_PROXY_ADMIN_SECRET"] != "change-me-in-production"
+    assert env.get("MCP_PROXY_DASHBOARD_SIGNING_KEY", "") != ""
+    assert env["MCP_PROXY_ENVIRONMENT"] == "development"
+    # Broker stays at the same-docker-network default for the laptop
+    # path (an operator wiring a remote broker uses --prod).
+    assert env["MCP_PROXY_BROKER_URL"] == "http://broker:8000"


### PR DESCRIPTION
## Summary

- **Bug:** `./generate-proxy-env.sh --defaults` left `MCP_PROXY_PROXY_PUBLIC_URL` absent from the generated `proxy.env`. The example ships the field commented out, and the sed substitution on `^MCP_PROXY_PROXY_PUBLIC_URL=` silently no-oped on the commented placeholder. CI / Ansible / quick laptop boot that ran `--defaults` then `./deploy.sh up` (no interactive prompt) ended up with a Mastio that booted OK but 401'd every agent enrollment with `Invalid DPoP proof: htu mismatch`. The compose `${VAR:-...}` fallback does not apply uniformly across every consumer of `proxy.env` (python-dotenv readers, direct env-file mounts, Ansible reading the file).
- **Fix:** `--defaults` now resolves to `https://host.docker.internal:9443` (same value the `deploy.sh` interactive prompt offers and `docker-compose.yml` falls back to). `PROXY_PUBLIC_URL` env var still overrides for CI baking a custom hostname. The interactive prompt's empty-input path uses the same default so the field never lands empty regardless of mode. The substitution path was rewritten to strip the commented placeholder and append an uncommented value, so the field always lands in the generated `proxy.env`.
- **Scope:** Production diff is 46 lines across `packaging/mastio-bundle/generate-proxy-env.sh` (+ 19 doc lines in `proxy.env.example`). New pytest module `tests/test_bundle_generate_proxy_env_defaults.py` pins the contract.

## Files touched

| File | Change |
|---|---|
| `packaging/mastio-bundle/generate-proxy-env.sh` | `defaults` + `interactive` branches resolve PUBLIC to `https://host.docker.internal:9443` instead of empty string. Replace `sed` (which silently no-oped on the commented example line) with strip-and-append so the field always lands uncommented in `proxy.env`. |
| `packaging/mastio-bundle/proxy.env.example` | Doc block updated to flag `MCP_PROXY_PROXY_PUBLIC_URL` as auto-filled by `--defaults` with the laptop value, and to note empty / commented breaks every consumer (not just compose). |
| `tests/test_bundle_generate_proxy_env_defaults.py` | New, 6 tests: `--defaults` emits the laptop URL, single uncommented line (no duplicate commented placeholder), env-var override wins in defaults mode, `--prod` emits required URL, `--prod` refuses without `PROXY_PUBLIC_URL`, companion fields (admin secret + signing key) still random-generated. |

The `scripts/generate-proxy-env.sh` repo-side copy (last touched in #499) has diverged from the bundle copy and is not shipped in the bundle release. Left untouched to keep diff focused.

## Test plan

- [x] `pytest tests/test_bundle_generate_proxy_env_defaults.py -v` (6/6 pass, 5.45s)
- [x] `pytest tests/test_bundle_db_swap_guard.py tests/test_bundle_healthchecks.py` (12/12 pass, no regression on sibling bundle tests)
- [x] Manual: `./generate-proxy-env.sh --defaults --force` in a clean tmp dir, verify `grep -E "^MCP_PROXY_PROXY_PUBLIC_URL=" proxy.env` returns the laptop URL
- [x] Manual: `PROXY_PUBLIC_URL=https://mastio.acme.local:9443 ./generate-proxy-env.sh --defaults --force`, verify the env-var override wins
- [x] Manual: `BROKER_URL=... PROXY_PUBLIC_URL=... ./generate-proxy-env.sh --prod --force`, verify single uncommented line (regression guard for the same sed-on-commented-line bug)
- [x] Verified `deploy.sh` post-`generate-proxy-env.sh` strip-and-append still wins over the new default value (operator-chosen URL is preserved when the interactive prompt is followed)