### PR TITLE
feat(bundle): deploy.sh --down -v wipes bind dirs (P3 MINOR-H)

### DIFF
--- a/.github/workflows/release-frontdesk-bundle.yml
+++ b/.github/workflows/release-frontdesk-bundle.yml
@@ -81,6 +81,11 @@ jobs:
           cp packaging/frontdesk-bundle/mint-tls-cert.sh            "${STAGING}/"
           cp -r packaging/frontdesk-bundle/nginx                    "${STAGING}/"
           cp -r packaging/frontdesk-bundle/nginx-tls                "${STAGING}/"
+          # Shared deploy helpers (busybox-root wipe, env loaders).
+          # deploy.sh sources this beside itself so the customer
+          # tarball must ship a sibling copy, not the source-tree
+          # relative path.
+          cp packaging/_common-deploy-helpers.sh                    "${STAGING}/"
 
           chmod +x "${STAGING}/deploy.sh" \
                    "${STAGING}/generate-frontdesk-env.sh" \
@@ -100,6 +105,7 @@ jobs:
               "mint-tls-cert.sh" \
               "frontdesk.env.example" \
               "README.md" \
+              "_common-deploy-helpers.sh" \
               "nginx/default.conf" \
               "nginx-tls/default.conf" \
               "nginx-tls/00-maps.conf"; do

--- a/.github/workflows/release-mastio-enterprise-bundle.yml
+++ b/.github/workflows/release-mastio-enterprise-bundle.yml
@@ -76,6 +76,10 @@ jobs:
           cp packaging/mastio-enterprise-bundle/proxy.env.example   "${STAGING}/"
           cp packaging/mastio-enterprise-bundle/README.md           "${STAGING}/"
           cp -r packaging/mastio-enterprise-bundle/nginx            "${STAGING}/"
+          # Shared deploy helpers (busybox-root wipe, env loaders).
+          # deploy.sh sources this beside itself in the shipped tarball,
+          # not the source-tree relative ../ path.
+          cp packaging/_common-deploy-helpers.sh                    "${STAGING}/"
 
           chmod +x "${STAGING}/deploy.sh" "${STAGING}/backup.sh" "${STAGING}/restore.sh"
 
@@ -89,6 +93,7 @@ jobs:
               "restore.sh" \
               "proxy.env.example" \
               "README.md" \
+              "_common-deploy-helpers.sh" \
               "nginx/mastio/00-maps.conf" \
               "nginx/mastio/mastio.conf"; do
               if [ ! -f "${STAGING}/${f}" ]; then

--- a/.github/workflows/release-mastio.yml
+++ b/.github/workflows/release-mastio.yml
@@ -221,6 +221,11 @@ jobs:
           cp packaging/mastio-bundle/proxy.env.example                "${STAGING}/"
           cp packaging/mastio-bundle/README.md                        "${STAGING}/"
           cp -r packaging/mastio-bundle/nginx                         "${STAGING}/"
+          # Shared deploy helpers (busybox-root wipe, env_loader,
+          # version-pin sanity). deploy.sh sources this beside itself
+          # so the customer tarball must ship a sibling copy, not the
+          # source-tree relative path.
+          cp packaging/_common-deploy-helpers.sh                      "${STAGING}/"
 
           chmod +x "${STAGING}/deploy.sh" \
                    "${STAGING}/generate-proxy-env.sh"
@@ -240,6 +245,7 @@ jobs:
               "generate-proxy-env.sh" \
               "proxy.env.example" \
               "README.md" \
+              "_common-deploy-helpers.sh" \
               "nginx/mastio/00-maps.conf" \
               "nginx/mastio/mastio.conf"; do
               if [ ! -f "${STAGING}/${f}" ]; then

--- a/packaging/_common-deploy-helpers.sh
+++ b/packaging/_common-deploy-helpers.sh
@@ -92,3 +92,67 @@ _backup_user_state() {
     ok "Backup written to ${backup_dir#$SCRIPT_DIR/}"
     BACKUP_DIR="$backup_dir"
 }
+
+# Wipe contents of bind-mount dirs after ``compose down``. Mirror of
+# ``docker compose down --volumes`` semantics for the named volumes,
+# extended to the host bind dirs the bundles use after ADR-030. Each
+# arg is an absolute host path; the dir itself is kept (the operator
+# expects ``./data/`` to still exist as a placeholder, just empty),
+# only its contents are removed.
+#
+# Runs as root inside a transient busybox so 0600 files owned by uid
+# 10001 (mcp_proxy.db, mastio-server.key, connector identity material)
+# are actually removable. The invoking host user can't ``rm -rf`` them
+# directly after the init-permissions service has chown'd everything
+# to the runtime uid (feedback_busybox_root_for_bind_dir_post_init_perms).
+#
+# Idempotent: missing or empty dirs are a no-op. Never touches files
+# outside the supplied paths (proxy.env, frontdesk.env,
+# docker-compose.yml are explicitly NOT in scope). The caller is responsible
+# for confirming ``compose down`` ran first; wiping an active bind
+# mount under a running container is a recipe for sqlite WAL corruption.
+_wipe_bind_dirs() {
+    local any_wiped=0 dir mount_args=() rm_paths=()
+    if ! command -v docker >/dev/null 2>&1; then
+        warn "docker not available, cannot wipe bind dirs"
+        return 1
+    fi
+    # Build the docker mount list + the in-container paths to wipe.
+    # Each host dir is mounted at /wipe<N>; we only wipe contents
+    # (``/wipe<N>/.`` glob) so the dir itself survives.
+    local idx=0
+    for dir in "$@"; do
+        [[ -n "$dir" ]] || continue
+        [[ -d "$dir" ]] || continue
+        # Empty dir → skip both the mount and the rm to keep the
+        # docker argv short on a fresh-install down.
+        if ! compgen -G "$dir/*" >/dev/null 2>&1 \
+                && ! compgen -G "$dir/.[!.]*" >/dev/null 2>&1 \
+                && ! compgen -G "$dir/..?*" >/dev/null 2>&1; then
+            continue
+        fi
+        mount_args+=( -v "$dir:/wipe$idx" )
+        rm_paths+=( "/wipe$idx" )
+        any_wiped=1
+        idx=$((idx + 1))
+    done
+    if [[ $any_wiped -eq 0 ]]; then
+        ok "Bind dirs already empty, nothing to wipe"
+        return 0
+    fi
+    # Use ``find -mindepth 1 -delete`` instead of ``rm -rf /wipe*/*``
+    # so dotfiles (e.g. SQLite WAL/SHM ``-journal``, ``.cullis``
+    # identity stash) are caught too. ``-mindepth 1`` protects the
+    # mount root itself, matching the "keep the dir, wipe contents"
+    # contract above.
+    local find_cmd=""
+    for p in "${rm_paths[@]}"; do
+        find_cmd+="find $p -mindepth 1 -delete 2>/dev/null; "
+    done
+    docker run --rm --user 0:0 "${mount_args[@]}" busybox:stable \
+        sh -c "$find_cmd true" >/dev/null
+    for dir in "$@"; do
+        [[ -n "$dir" && -d "$dir" ]] || continue
+        ok "Wiped ${dir#$SCRIPT_DIR/}/"
+    done
+}

--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -201,9 +201,48 @@ For oauth2-proxy specifically, the upstream config `--pass-user-headers=true` is
 ## Tear down
 
 ```bash
-./deploy.sh --down             # stop containers, keep connector_data
-docker compose --env-file frontdesk.env down -v   # also wipe connector_data (forces re-enrollment)
+./deploy.sh --down             # stop containers, keep connector_data/ + tls/
+./deploy.sh --down -v          # stop AND wipe connector_data/ + tls/ (reset everything)
 ```
+
+### Reset everything (`--down -v`)
+
+`./deploy.sh --down -v` (aliases: `--volumes`, `--wipe-data`) stops
+the stack and then wipes the contents of `connector_data/` (the
+Connector's enrolled identity, profile material, users.db) and
+`tls/` (the self-signed sidecar cert minted by `mint-tls-cert.sh`).
+The wipe runs as root inside a transient `busybox` so files owned
+by uid 10001 are actually removed, no `sudo rm -rf` on the host
+required. `frontdesk.env`, the bundle scripts, and any
+`frontdesk.env.bak-*` backups are NOT touched.
+
+The flag mirrors `docker compose down --volumes` semantics for the
+bind dirs: by default `--down` keeps the Connector enrolled so a
+restart picks up the same identity; `-v` opts into a full reset
+and the next `./deploy.sh` walks through the device-code enrollment
+one-shot again.
+
+Three use cases:
+
+1. **Fresh setup after a botched first run**: wrong `--site` URL,
+   wrong org, or an admin approved the pending row in the wrong
+   Mastio. `./deploy.sh --down -v` clears `connector_data/`; the
+   next `./deploy.sh` re-runs enrollment cleanly.
+2. **Troubleshooting TLS sidecar issues**: the self-signed cert
+   in `tls/` got pinned in a browser keychain with stale SANs,
+   or `mint-tls-cert.sh` wrote a partial cert. Wipe + redeploy
+   regenerates it from the current `FRONTDESK_TLS_SAN` env.
+3. **Decommissioning**: moving the bundle to a different Mastio
+   or a different host. `--down -v` removes the Connector
+   identity so it can't accidentally reach back at the old
+   Mastio on the next restart.
+
+**Destructive.** The Connector's private key + cert are gone. The
+old enrollment row in the Mastio dashboard stays around (revoke it
+manually if the move is permanent). Local users in `connector_data/
+users.db` are also wiped; recreate them via the `X-Admin-Secret`
+flow shown in the deploy summary, or use the Mastio dashboard's
+Create User flow if the sibling bundle bridge is wired.
 
 ## Lost admin secret recovery
 

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -12,7 +12,8 @@
 # Modes (combinable):
 #   (default)         dev: generate frontdesk.env from --defaults if missing
 #   --prod            fail-fast on insecure defaults, requires frontdesk.env
-#   --down            stop + remove containers
+#   --down            stop + remove containers (keeps connector_data/, tls/)
+#   --down -v         stop + wipe bind dirs (connector_data/, tls/)
 #   --pull            re-pull images (otherwise pulled on first up)
 #
 # Enrollment (device-code flow — there is no pre-minted invite token in
@@ -69,6 +70,12 @@ else
     die "docker compose is not installed"
 fi
 
+# Source shared bind-dir helpers (P3 MINOR-H, _wipe_bind_dirs for
+# --down -v). Same helper file the Mastio bundles use; sourced here so
+# the busybox-root wipe pattern stays consistent across bundles.
+# shellcheck source=../_common-deploy-helpers.sh
+source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+
 print_help() {
     cat <<EOF
 Usage: $0 [OPTIONS]
@@ -81,7 +88,19 @@ Options:
                               run the device-code enrollment one-shot
   --prod                      Production: fail-fast on insecure defaults,
                               frontdesk.env must exist with real values
-  --down                      Stop and remove containers
+  --down                      Stop and remove containers. Bind dirs
+                              (connector_data/, tls/) are preserved.
+  -v, --volumes, --wipe-data  Modifier for --down. After containers are
+                              stopped, wipe contents of connector_data/
+                              (Connector identity) and tls/ (sidecar
+                              cert) via a transient root busybox so
+                              files owned by uid 10001 are actually
+                              removed. frontdesk.env, scripts, and
+                              .bak backups are NOT touched. Destructive:
+                              the next ./deploy.sh forces a fresh
+                              device-code enrollment against the Mastio.
+                              Mirrors ``docker compose down --volumes``
+                              semantics for bind mounts.
   --pull                      Force-pull the images before starting
   --rotate-admin-secret       Mint a fresh CULLIS_CONNECTOR_ADMIN_SECRET,
                               rewrite frontdesk.env atomically (timestamped
@@ -142,6 +161,12 @@ CLI_REQUESTER_NAME=""
 CLI_SITE_URL=""
 SKIP_ENROLL=0
 NO_WIZARD=0
+# ``--down -v`` (alias ``--volumes`` / ``--wipe-data``) mirrors
+# ``docker compose down --volumes`` semantics for bind dirs: after
+# containers stop, wipe connector_data/ + tls/. frontdesk.env and
+# scripts are NOT touched. Default ``--down`` keeps state intact so
+# re-deploying does not force re-enrollment (P3 MINOR-H).
+WIPE_VOLUMES=0
 # #655 / ADR-024 — built-in TLS sidecar. Defaults to ON (env value
 # resolves to "enabled" when nothing is set), customer-real out-of-
 # box HTTPS on :8443 with a self-signed cert. --no-tls / --tls flags
@@ -155,6 +180,7 @@ while [[ $# -gt 0 ]]; do
     arg="$1"
     case "$arg" in
         --down)             ACTION="down"; shift ;;
+        -v|--volumes|--wipe-data) WIPE_VOLUMES=1; shift ;;
         --pull)             FORCE_PULL=1; shift ;;
         --rotate-admin-secret) ACTION="rotate-admin-secret"; shift ;;
         --prod)             MODE="production"; shift ;;
@@ -196,6 +222,23 @@ if [[ "$ACTION" == "down" ]]; then
     $COMPOSE --env-file frontdesk.env --profile tls down 2>/dev/null \
         || $COMPOSE --profile tls down
     ok "Frontdesk stopped"
+    if [[ $WIPE_VOLUMES -eq 1 ]]; then
+        step "Wiping bind dirs (connector_data/, tls/)"
+        warn "Destructive: the Connector identity is gone, the next bring-up"
+        warn "must re-enroll against the Mastio (fresh device-code flow)."
+        # Resolve CONNECTOR_DATA_DIR from frontdesk.env if present,
+        # otherwise fall back to the compose default ``./connector_data``.
+        # ``_load_env`` is defined later in the script, after this branch
+        # exits, duplicate the grep inline rather than reorder the file.
+        _conn_data="./connector_data"
+        if [[ -f "$SCRIPT_DIR/frontdesk.env" ]]; then
+            _cd="$(grep -E '^CONNECTOR_DATA_DIR=' "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+            _conn_data="${_cd:-./connector_data}"
+        fi
+        [[ "$_conn_data" = /* ]] || _conn_data="$SCRIPT_DIR/${_conn_data#./}"
+        _tls_dir="$SCRIPT_DIR/tls"
+        _wipe_bind_dirs "$_conn_data" "$_tls_dir"
+    fi
     exit 0
 fi
 

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -73,8 +73,18 @@ fi
 # Source shared bind-dir helpers (P3 MINOR-H, _wipe_bind_dirs for
 # --down -v). Same helper file the Mastio bundles use; sourced here so
 # the busybox-root wipe pattern stays consistent across bundles.
+#
+# Layout: source tree has the helper at ``packaging/_common-deploy-
+# helpers.sh`` (parent of this bundle dir). Release workflows cp it as
+# a sibling so the shipped customer tarball can be extracted standalone
+# without the ``packaging/`` parent. Prefer the sibling copy; fall back
+# to the source-tree relative path for dev shells.
 # shellcheck source=../_common-deploy-helpers.sh
-source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+if [ -f "$SCRIPT_DIR/_common-deploy-helpers.sh" ]; then
+    source "$SCRIPT_DIR/_common-deploy-helpers.sh"
+else
+    source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+fi
 
 print_help() {
     cat <<EOF

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -107,7 +107,46 @@ in Mastio v0.5 on a separate roadmap.
 | `./deploy.sh --shared-broker` | Federated. Joins an existing Court's docker network. |
 | `./deploy.sh --prod` | Production safety: fails fast on insecure defaults. Requires `proxy.env` pre-provisioned. |
 | `./deploy.sh --pull` | Force re-pull the image before starting. |
-| `./deploy.sh --down` | Stop and remove containers. |
+| `./deploy.sh --down` | Stop and remove containers. Bind dirs (`./data`, `./nginx-certs`, `./certs`) are preserved. |
+| `./deploy.sh --down -v` | Stop, remove containers, AND wipe bind dirs. Resets state to a brand-new install. |
+
+## Reset everything (`--down -v`)
+
+`./deploy.sh --down -v` (aliases: `--volumes`, `--wipe-data`) stops the
+stack and then wipes the contents of `./data`, `./nginx-certs`, and
+`./certs`. The wipe runs as root inside a transient `busybox` so the
+0600 files owned by uid 10001 (`mcp_proxy.db`, `mastio-server.key`)
+are actually removed, no `sudo rm -rf` on the host required. `proxy.env`,
+the bundle scripts, and `./backups/` are NOT touched.
+
+The flag mirrors `docker compose down --volumes` semantics for the
+bind dirs: by default `--down` is conservative and leaves state
+intact so a restart picks up the same Org CA and enrolled Connectors;
+`-v` opts into a full reset.
+
+Three use cases:
+
+1. **Fresh setup after a botched bring-up**: first `./deploy.sh`
+   ran against a wrong `MCP_PROXY_PROXY_PUBLIC_URL` or a bad SAN,
+   half-wrote the SQLite DB, and now the Mastio refuses to start
+   clean. `./deploy.sh --down -v` clears the slate; the next
+   `./deploy.sh` mints a fresh Org CA against the corrected env.
+2. **Troubleshooting Org CA / cert weirdness**: agents fail TLS
+   verify with no obvious diagnostic, or `mastio-server.key`
+   permissions drift. Wipe + re-deploy is faster than `docker
+   inspect` archaeology when you have only one or two agents
+   enrolled and re-enrollment is cheap.
+3. **Decommissioning**: moving the bundle off this host (or off
+   this dev laptop entirely). `--down -v` removes every byte of
+   state the bundle wrote; `rm -rf <bundle-dir>` after that is
+   safe even on a shared box.
+
+**Destructive.** Every Connector enrolled against the current Org
+CA will fail TLS verify on `/v1/principals/csr` after the next
+bring-up: the new Mastio derives a fresh CA and `org_id`. Use
+`./deploy.sh --upgrade-bundle <version>` (which auto-backs-up to
+`./backups/pre-upgrade-<ts>/`) for any flow where you want to
+preserve enrolled agents.
 
 ## Production proxy.env
 

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -90,8 +90,21 @@ _volume_full_name() {
 # Sourcing here, before any ADR-030 helper that references them, keeps
 # the call order intact and the diff against the pre-extraction layout
 # limited to a deletion + a single source line.
+#
+# Layout: in the source tree the helper lives at
+# ``packaging/_common-deploy-helpers.sh`` (parent of this bundle dir).
+# Release workflows cp it as a sibling so the shipped tarball can be
+# extracted standalone (``cullis-mastio-bundle/{deploy.sh,_common-
+# deploy-helpers.sh}``) without dragging the ``packaging/`` parent.
+# Prefer the sibling copy when present; fall back to the source-tree
+# relative path otherwise so dev shells (``./packaging/mastio-bundle/
+# deploy.sh``) keep working from a fresh git clone.
 # shellcheck source=../_common-deploy-helpers.sh
-source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+if [ -f "$SCRIPT_DIR/_common-deploy-helpers.sh" ]; then
+    source "$SCRIPT_DIR/_common-deploy-helpers.sh"
+else
+    source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+fi
 
 # mkdir + chown the host bind targets. The chown is the same operation
 # the init-permissions compose service runs at boot, just earlier so a

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -16,7 +16,8 @@
 #   (default)         standalone Mastio, private docker network
 #   --shared-broker   join the broker's docker network (Court must be up)
 #   --prod            fail-fast on insecure defaults + prod overlay
-#   --down            stop + remove containers
+#   --down            stop + remove containers (keeps bind dirs intact)
+#   --down -v         stop + wipe bind dirs (data/, nginx-certs/, certs/)
 #   --pull            re-pull image (otherwise pulled on first up)
 #
 # Examples:
@@ -444,7 +445,20 @@ Options:
                               the Court compose project to be up.
   --prod                      Production: fail-fast on insecure defaults,
                               requires proxy.env pre-provisioned.
-  --down                      Stop and remove containers.
+  --down                      Stop and remove containers. Bind dirs
+                              (./data, ./nginx-certs, ./certs) are
+                              preserved by default.
+  -v, --volumes, --wipe-data  Modifier for --down. After containers are
+                              stopped, wipe contents of ./data,
+                              ./nginx-certs, ./certs via a transient
+                              root busybox so 0600 files owned by uid
+                              10001 (mcp_proxy.db, mastio-server.key)
+                              are actually removed. proxy.env, scripts,
+                              and ./backups are NOT touched. Destructive:
+                              the next ./deploy.sh mints a fresh Org CA;
+                              every previously enrolled Connector must
+                              re-enroll. Mirrors ``docker compose down
+                              --volumes`` semantics for bind mounts.
   --pull                      Force-pull the image before starting.
   --upgrade <version>         Image-only bump: pin CULLIS_MASTIO_VERSION
                               in proxy.env to <version>, pull the new
@@ -495,7 +509,8 @@ Examples:
   ./deploy.sh --upgrade 0.4.2                    # image-only bump
   ./deploy.sh --upgrade-bundle 0.4.2             # full bundle refresh
   ./deploy.sh --migrate-volumes                  # one-shot bind migration
-  ./deploy.sh --down                             # stop + remove
+  ./deploy.sh --down                             # stop + remove (keep state)
+  ./deploy.sh --down -v                          # stop + wipe bind dirs (reset)
 EOF
 }
 
@@ -507,6 +522,12 @@ UPGRADE_TO=""
 UPGRADE_BUNDLE_TO=""
 FROM_BANNER=0
 ACCEPT_DATA_LOSS=0
+# ``--down -v`` (alias ``--volumes`` / ``--wipe-data``) mirrors the
+# semantics of ``docker compose down --volumes`` for bind dirs: after
+# stopping containers, wipe the contents of ./data, ./nginx-certs,
+# ./certs so the next ``./deploy.sh`` boots a brand-new Mastio with a
+# fresh Org CA. Default ``--down`` keeps state intact (P3 MINOR-H).
+WIPE_VOLUMES=0
 # Manual loop because ``--upgrade <version>`` needs to consume the
 # next positional arg. Keeps the existing single-token flags working
 # without pulling in getopt.
@@ -514,6 +535,7 @@ while [[ $# -gt 0 ]]; do
     arg="$1"
     case "$arg" in
         --down)          ACTION="down"; shift ;;
+        -v|--volumes|--wipe-data) WIPE_VOLUMES=1; shift ;;
         --pull)          FORCE_PULL=1; shift ;;
         --prod)          MODE="production"; shift ;;
         --shared-broker) SHARED_BROKER=1; shift ;;
@@ -560,6 +582,15 @@ if [[ "$ACTION" == "down" ]]; then
     $COMPOSE $COMPOSE_FILES --env-file proxy.env down 2>/dev/null \
         || $COMPOSE $COMPOSE_FILES down
     ok "Mastio stopped"
+    if [[ $WIPE_VOLUMES -eq 1 ]]; then
+        step "Wiping bind dirs (data/, nginx-certs/, certs/)"
+        warn "Destructive: every Connector enrolled against the current Org CA"
+        warn "will fail TLS verify on /v1/principals/csr after the next bring-up."
+        _data_dir="$(_data_dir_host)"
+        _nginx_certs_dir="$(_nginx_certs_dir_host)"
+        _certs_dir="${CULLIS_CERTS_DIR:-$SCRIPT_DIR/certs}"
+        _wipe_bind_dirs "$_data_dir" "$_nginx_certs_dir" "$_certs_dir"
+    fi
     exit 0
 fi
 

--- a/packaging/mastio-enterprise-bundle/deploy.sh
+++ b/packaging/mastio-enterprise-bundle/deploy.sh
@@ -53,8 +53,17 @@ step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
 # Source shared backup helpers (same file the open-core mastio-bundle
 # uses, so the two bundles cannot drift on backup semantics). MAJOR-5
 # of imp/p3-operability-audit.md.
+#
+# Layout: source tree has the helper at ``packaging/_common-deploy-
+# helpers.sh`` (parent of this bundle dir). Release workflow cp's it
+# as a sibling so the customer tarball can be extracted standalone.
+# Prefer the sibling copy; fall back to the source-tree relative path.
 # shellcheck source=../_common-deploy-helpers.sh
-source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+if [ -f "$SCRIPT_DIR/_common-deploy-helpers.sh" ]; then
+    source "$SCRIPT_DIR/_common-deploy-helpers.sh"
+else
+    source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+fi
 
 MODE="up"
 PULL=0

--- a/packaging/mastio-enterprise-bundle/deploy.sh
+++ b/packaging/mastio-enterprise-bundle/deploy.sh
@@ -16,7 +16,8 @@
 #
 # Modes:
 #   (default)                   standalone enterprise Mastio
-#   --down                      stop + remove containers
+#   --down                      stop + remove containers (keeps bind dirs)
+#   --down -v                   stop + wipe bind dirs (data/, nginx-certs/)
 #   --pull                      re-pull image
 #   --upgrade-bundle <version>  snapshot user state to ./backups/, bump
 #                               CULLIS_MASTIO_VERSION in proxy.env, pull
@@ -58,12 +59,18 @@ source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
 MODE="up"
 PULL=0
 UPGRADE_BUNDLE_TO=""
+# ``--down -v`` (alias ``--volumes`` / ``--wipe-data``) mirrors
+# ``docker compose down --volumes`` semantics for bind dirs: after
+# stopping containers, wipe ./data and ./nginx-certs via a transient
+# root busybox. Default ``--down`` preserves state (P3 MINOR-H).
+WIPE_VOLUMES=0
 # Manual loop because --upgrade-bundle consumes the next positional
 # arg; the original ``for arg in "$@"`` cannot shift mid-iteration.
 while [[ $# -gt 0 ]]; do
     arg="$1"
     case "$arg" in
         --down)  MODE="down"; shift ;;
+        -v|--volumes|--wipe-data) WIPE_VOLUMES=1; shift ;;
         --pull)  PULL=1; shift ;;
         --upgrade-bundle)
             shift
@@ -106,6 +113,14 @@ if [[ "$MODE" == "down" ]]; then
     step "stopping cullis-mastio-enterprise stack"
     docker compose --env-file proxy.env down
     ok "stack stopped"
+    if [[ $WIPE_VOLUMES -eq 1 ]]; then
+        step "wiping bind dirs (data/, nginx-certs/)"
+        warn "Destructive: every Connector enrolled against the current Org CA"
+        warn "will fail TLS verify on /v1/principals/csr after the next bring-up."
+        _data_dir="$(_data_dir_host)"
+        _nginx_certs_dir="$(_nginx_certs_dir_host)"
+        _wipe_bind_dirs "$_data_dir" "$_nginx_certs_dir"
+    fi
     exit 0
 fi
 

--- a/tests/test_bundle_down_volumes.py
+++ b/tests/test_bundle_down_volumes.py
@@ -401,3 +401,174 @@ _wipe_bind_dirs "{bundle}/data" "{bundle}/nginx-certs"
     # Bystander files untouched.
     assert (bundle / "important.txt").read_text() == "keep me"
     assert (bundle / "proxy.env").exists()
+
+
+# ── customer-tarball layout (helper as sibling, no packaging/ parent) ────
+
+
+def _stage_mastio_customer_layout(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Stage the bundle the way the release tarball ships it: deploy.sh
+    and ``_common-deploy-helpers.sh`` are siblings inside a single
+    ``cullis-mastio-bundle/`` directory, with NO ``packaging/`` parent.
+
+    This replicates the customer host layout post ``tar xzf`` — the
+    layout the staging cp loop in ``.github/workflows/release-mastio.yml``
+    produces. The earlier source-tree fixture (``_stage_mastio``) keeps
+    helper at ``packaging/_common-deploy-helpers.sh`` (one level up),
+    which masked the fact that ``deploy.sh`` originally sourced via
+    ``$SCRIPT_DIR/../_common-deploy-helpers.sh`` and would fail at
+    runtime on the customer host (BLOCKER from #773 release review).
+    """
+    bundle = tmp_path / "cullis-mastio-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(MASTIO_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(MASTIO_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(COMMON_HELPERS, bundle / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    (bundle / "proxy.env").write_text(
+        "MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443\n"
+    )
+    return bundle
+
+
+def test_mastio_customer_tarball_layout_down_v_works(tmp_path):
+    """Regression guard for #773 BLOCKER: on the customer host the
+    bundle is extracted standalone (no ``packaging/`` parent dir), so
+    ``deploy.sh`` must resolve ``_common-deploy-helpers.sh`` as a
+    sibling rather than via ``$SCRIPT_DIR/..``. Pre-fix the source
+    statement was ``$SCRIPT_DIR/../_common-deploy-helpers.sh`` only,
+    which broke every ``--down`` / ``--upgrade-bundle`` / ``--down -v``
+    invocation on the shipped tarball with ``source: No such file or
+    directory``."""
+    bundle = _stage_mastio_customer_layout(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    _seed_dir_with_state(bundle / "nginx-certs")
+
+    path_val, _, _ = _build_path(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    result = subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), "--down", "-v"],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    # The source statement worked from the sibling: helper functions
+    # were available, the wipe banner fired, and the bind dirs were
+    # cleaned. Pre-fix this branch failed at module load time.
+    combined = result.stdout + result.stderr
+    assert "Wiping bind dirs" in combined
+    assert list((bundle / "data").iterdir()) == []
+    assert list((bundle / "nginx-certs").iterdir()) == []
+
+
+def test_frontdesk_customer_tarball_layout_down_v_works(tmp_path):
+    """Same regression guard as the mastio test above, for the
+    frontdesk bundle: customer tarball has the helper as a sibling."""
+    bundle = tmp_path / "cullis-frontdesk-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(FRONTDESK_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(FRONTDESK_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(COMMON_HELPERS, bundle / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    (bundle / "frontdesk.env").write_text(
+        "CULLIS_FRONTDESK_ORG_ID=test\nCULLIS_FRONTDESK_TRUST_DOMAIN=test.local\n"
+    )
+    _seed_dir_with_state(bundle / "connector_data")
+    _seed_dir_with_state(bundle / "tls")
+
+    path_val, _, _ = _build_path(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    result = subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), "--down", "-v"],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "Wiping bind dirs" in combined
+    assert list((bundle / "connector_data").iterdir()) == []
+    assert list((bundle / "tls").iterdir()) == []
+
+
+def test_mastio_enterprise_customer_tarball_layout_down_v_works(tmp_path):
+    """Same regression guard for the enterprise bundle."""
+    bundle = tmp_path / "cullis-mastio-enterprise-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(ENTERPRISE_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(ENTERPRISE_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(COMMON_HELPERS, bundle / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    (bundle / "proxy.env").write_text(
+        "MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443\n"
+    )
+    _seed_dir_with_state(bundle / "data")
+
+    path_val, _, _ = _build_path(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    result = subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), "--down", "-v"],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert list((bundle / "data").iterdir()) == []
+
+
+# ── busybox-root invariant (memoria feedback_busybox_root_for_bind_dir_post_init_perms) ──
+
+
+def test_wipe_invocation_passes_user_zero(tmp_path):
+    """The bind dirs are chmod 10001:10001 by ADR-030 init-permissions;
+    the host operator's uid (typically 1000) cannot rm them. The wipe
+    helper MUST therefore invoke busybox with ``--user 0:0`` to run as
+    root inside the container. A future refactor that drops the flag
+    would silently fail on a real customer host (idempotent test would
+    still pass with the local-uid shim) — so we assert directly on
+    the captured argv that the flag is present.
+
+    Note: the fake docker shim consumed ``--user 0:0`` previously
+    without asserting it, hiding any drift. This test closes that
+    gap."""
+    bundle = _stage_mastio(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    path_val, _, log = _build_path(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    result = subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), "--down", "-v"],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    docker_log = log.read_text()
+    # Pin: every wipe-shaped ``docker run`` invocation in the log must
+    # carry ``--user 0:0``. We grep for the run command containing
+    # busybox to skip unrelated docker compose calls.
+    wipe_invocations = [
+        line for line in docker_log.splitlines()
+        if "busybox" in line and line.startswith("run ")
+    ]
+    assert wipe_invocations, (
+        "expected at least one busybox wipe invocation, got: "
+        f"{docker_log!r}"
+    )
+    for inv in wipe_invocations:
+        assert "--user 0:0" in inv, (
+            "wipe invocation missing --user 0:0 (busybox-root "
+            f"invariant violated): {inv!r}"
+        )

--- a/tests/test_bundle_down_volumes.py
+++ b/tests/test_bundle_down_volumes.py
@@ -1,0 +1,403 @@
+"""P3 MINOR-H: ``./deploy.sh --down -v`` wipes the bundle bind dirs.
+
+After ADR-030 the Mastio + Frontdesk bundles persist runtime state on
+host bind mounts (``./data``, ``./nginx-certs``, ``./certs``,
+``connector_data/``, ``tls/``). ``compose down --volumes`` only touches
+named volumes, so a "tabula rasa" reset previously needed a manual
+busybox-root ``rm -rf`` because ``init-permissions`` had chown'd the
+trees to uid 10001.
+
+The new ``-v`` / ``--volumes`` / ``--wipe-data`` modifier on ``--down``
+runs that wipe via the shared ``_wipe_bind_dirs`` helper. These tests
+drive ``deploy.sh --down -v`` end-to-end with a fake ``docker`` shim on
+PATH that records every ``docker run`` invocation, then performs the
+wipe by hand. Real docker is NOT required — the helper's contract is
+that it passes ``--user 0:0`` + mounts each dir at ``/wipeN`` and calls
+``find -mindepth 1 -delete``. We assert on the argv and on the
+post-wipe filesystem state.
+
+Default ``--down`` (no flag) must leave bind dirs untouched. The flag
+parsing must accept ``-v`` (short), ``--volumes`` (long, compose
+parallel), and ``--wipe-data`` (descriptive).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import stat
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PKG_ROOT = REPO_ROOT / "packaging"
+COMMON_HELPERS = PKG_ROOT / "_common-deploy-helpers.sh"
+MASTIO_SRC = PKG_ROOT / "mastio-bundle"
+FRONTDESK_SRC = PKG_ROOT / "frontdesk-bundle"
+ENTERPRISE_SRC = PKG_ROOT / "mastio-enterprise-bundle"
+
+
+# ── shared shim infra ─────────────────────────────────────────────────────
+
+
+def _docker_shim(stub_dir: pathlib.Path, log_path: pathlib.Path) -> None:
+    """A ``docker`` shim that:
+
+    * Logs every argv to ``log_path`` so the test can assert on the
+      busybox invocation (``--user 0:0``, mount flags, find command).
+    * Performs the wipe locally for ``docker run --rm --user 0:0
+      -v <host>:/wipe<N> ... busybox:stable sh -c "<find ...>"`` calls
+      so the post-wipe filesystem state can be asserted on too.
+    * Returns 0 for any unrelated subcommand (``docker compose``,
+      ``docker volume inspect``) so the rest of deploy.sh runs.
+    """
+    docker = stub_dir / "docker"
+    docker.write_text(
+        f"""#!/usr/bin/env bash
+echo "$@" >> {log_path}
+# Translate the wipe invocation into a host-side rm. We only handle
+# the very specific argv shape _wipe_bind_dirs produces, so any other
+# docker call short-circuits to exit 0 (the bundle's compose calls
+# don't care about real container behaviour in these tests).
+if [[ "$1" == "run" ]]; then
+    # Collect -v <host>:/wipe<N> mounts; everything after busybox:stable
+    # sh -c is the find command, applied to the host paths.
+    mounts=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -v) mounts+=("$2"); shift 2 ;;
+            busybox:stable) shift; break ;;
+            *) shift ;;
+        esac
+    done
+    # Apply wipe semantics host-side: every mount of the form
+    # ``<hostpath>:/wipeN`` triggers ``find <hostpath> -mindepth 1 -delete``.
+    for m in "${{mounts[@]}}"; do
+        host="${{m%%:/wipe*}}"
+        if [[ -d "$host" ]]; then
+            find "$host" -mindepth 1 -delete 2>/dev/null || true
+        fi
+    done
+    exit 0
+fi
+# docker compose version / docker compose down / etc — short-circuit.
+exit 0
+"""
+    )
+    docker.chmod(docker.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _passthrough_shim(stub_dir: pathlib.Path, name: str) -> None:
+    p = stub_dir / name
+    p.write_text("#!/usr/bin/env bash\nexit 0\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _build_path(tmp_path: pathlib.Path) -> tuple[str, pathlib.Path, pathlib.Path]:
+    """Return (PATH, stub_dir, docker_log_path). The shim writes one line
+    per ``docker`` invocation so tests can assert on flag presence."""
+    stub = tmp_path / "stubpath"
+    stub.mkdir()
+    log = tmp_path / "docker.log"
+    log.write_text("")
+    _docker_shim(stub, log)
+    for n in ("ss", "curl", "wget"):
+        _passthrough_shim(stub, n)
+    real = os.environ.get("PATH", "")
+    return f"{stub}:{real}", stub, log
+
+
+def _seed_dir_with_state(d: pathlib.Path, owned_by_root_dotfile: bool = True) -> None:
+    """Drop a couple of files into ``d`` so we can verify the wipe ran.
+    ``owned_by_root_dotfile`` covers the ``find -mindepth 1 -delete``
+    case for dotfiles (sqlite ``-journal`` etc) the busybox path is
+    supposed to handle."""
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "marker.txt").write_text("pre-wipe")
+    (d / "nested").mkdir(exist_ok=True)
+    (d / "nested" / "inner.bin").write_bytes(b"\x00" * 32)
+    if owned_by_root_dotfile:
+        (d / ".cullis-stash").write_text("dotfile-state")
+
+
+# ── mastio-bundle ─────────────────────────────────────────────────────────
+
+
+def _stage_mastio(tmp_path: pathlib.Path) -> pathlib.Path:
+    pkg = tmp_path / "packaging"
+    bundle = pkg / "mastio-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(MASTIO_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(MASTIO_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(COMMON_HELPERS, pkg / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    # Minimal proxy.env so the _load_env helpers find something.
+    (bundle / "proxy.env").write_text(
+        "MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443\n"
+    )
+    return bundle
+
+
+def _run(bundle: pathlib.Path, *args: str, env_overrides: dict | None = None
+         ) -> subprocess.CompletedProcess:
+    path_val, _, _ = _build_path(bundle.parent.parent)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(bundle / "deploy.sh"), *args],
+        cwd=str(bundle),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_mastio_down_without_v_preserves_bind_dirs(tmp_path):
+    bundle = _stage_mastio(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    _seed_dir_with_state(bundle / "nginx-certs")
+    _seed_dir_with_state(bundle / "certs")
+
+    result = _run(bundle, "--down")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    # Bind dirs must be intact.
+    assert (bundle / "data" / "marker.txt").exists()
+    assert (bundle / "nginx-certs" / "marker.txt").exists()
+    assert (bundle / "certs" / "marker.txt").exists()
+    # The "Wiping bind dirs" step must NOT have run.
+    assert "Wiping bind dirs" not in (result.stdout + result.stderr)
+
+
+def test_mastio_down_v_wipes_bind_dirs(tmp_path):
+    bundle = _stage_mastio(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    _seed_dir_with_state(bundle / "nginx-certs")
+    _seed_dir_with_state(bundle / "certs")
+
+    result = _run(bundle, "--down", "-v")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    # Wipe banner shown.
+    combined = result.stdout + result.stderr
+    assert "Wiping bind dirs" in combined
+    assert "Destructive" in combined
+    # The dirs themselves survive (placeholders), contents are gone.
+    for sub in ("data", "nginx-certs", "certs"):
+        assert (bundle / sub).is_dir(), f"{sub}/ must survive as placeholder"
+        leftovers = list((bundle / sub).iterdir())
+        assert leftovers == [], f"{sub}/ should be empty, got {leftovers}"
+    # proxy.env must be untouched.
+    assert (bundle / "proxy.env").exists()
+    assert "MCP_PROXY_PROXY_PUBLIC_URL" in (bundle / "proxy.env").read_text()
+
+
+def test_mastio_down_v_accepts_long_flag_aliases(tmp_path):
+    """--volumes and --wipe-data are the documented aliases."""
+    for flag in ("--volumes", "--wipe-data"):
+        bundle = _stage_mastio(tmp_path / flag.lstrip("-"))
+        _seed_dir_with_state(bundle / "data")
+        result = _run(bundle, "--down", flag)
+        assert result.returncode == 0, (flag, result.stdout, result.stderr)
+        assert "Wiping bind dirs" in (result.stdout + result.stderr), flag
+        assert list((bundle / "data").iterdir()) == [], flag
+
+
+def test_mastio_down_v_is_idempotent_on_empty_dirs(tmp_path):
+    """Re-running --down -v after a successful wipe must be a no-op,
+    not an error. Same contract as ``docker compose down -v`` on an
+    already-down stack."""
+    bundle = _stage_mastio(tmp_path)
+    # Empty bind dirs (no state seeded).
+    (bundle / "data").mkdir()
+    (bundle / "nginx-certs").mkdir()
+    (bundle / "certs").mkdir()
+
+    result = _run(bundle, "--down", "-v")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    # The helper should report "already empty" instead of issuing the wipe.
+    assert "already empty" in (result.stdout + result.stderr)
+
+
+def test_mastio_down_v_is_idempotent_when_dirs_missing(tmp_path):
+    """Some operators rm -rf'd the dirs by hand before discovering this
+    flag — the wipe must not crash if they don't exist at all."""
+    bundle = _stage_mastio(tmp_path)
+    # Do not create data/ etc. at all.
+    result = _run(bundle, "--down", "-v")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+
+
+def test_mastio_help_documents_v_flag():
+    result = subprocess.run(
+        ["bash", str(MASTIO_SRC / "deploy.sh"), "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    # The flag itself + at least one alias + the destructive warning.
+    assert "--volumes" in result.stdout
+    assert "wipe" in result.stdout.lower()
+    assert "re-enroll" in result.stdout or "Connector" in result.stdout
+
+
+# ── frontdesk-bundle ──────────────────────────────────────────────────────
+
+
+def _stage_frontdesk(tmp_path: pathlib.Path) -> pathlib.Path:
+    pkg = tmp_path / "packaging"
+    bundle = pkg / "frontdesk-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(FRONTDESK_SRC / "deploy.sh", bundle / "deploy.sh")
+    # Minimal docker-compose.yml for sanity (deploy.sh doesn't assert
+    # on its content during --down).
+    (bundle / "docker-compose.yml").write_text("services: {}\n")
+    shutil.copy2(COMMON_HELPERS, pkg / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    (bundle / "frontdesk.env").write_text(
+        "CONNECTOR_DATA_DIR=./connector_data\n"
+    )
+    return bundle
+
+
+def test_frontdesk_down_without_v_preserves_bind_dirs(tmp_path):
+    bundle = _stage_frontdesk(tmp_path)
+    _seed_dir_with_state(bundle / "connector_data")
+    _seed_dir_with_state(bundle / "tls")
+
+    result = _run(bundle, "--down")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert (bundle / "connector_data" / "marker.txt").exists()
+    assert (bundle / "tls" / "marker.txt").exists()
+    assert "Wiping bind dirs" not in (result.stdout + result.stderr)
+
+
+def test_frontdesk_down_v_wipes_bind_dirs(tmp_path):
+    bundle = _stage_frontdesk(tmp_path)
+    _seed_dir_with_state(bundle / "connector_data")
+    _seed_dir_with_state(bundle / "tls")
+    # frontdesk.env.bak must NOT be wiped — only the bind dirs.
+    (bundle / "frontdesk.env.bak-20260517-120000").write_text("backup")
+
+    result = _run(bundle, "--down", "-v")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "Wiping bind dirs" in combined
+    assert "Destructive" in combined
+    for sub in ("connector_data", "tls"):
+        assert (bundle / sub).is_dir(), f"{sub}/ must survive"
+        assert list((bundle / sub).iterdir()) == [], sub
+    # frontdesk.env + .bak survive.
+    assert (bundle / "frontdesk.env").exists()
+    assert (bundle / "frontdesk.env.bak-20260517-120000").exists()
+
+
+def test_frontdesk_down_v_short_flag_alias(tmp_path):
+    bundle = _stage_frontdesk(tmp_path)
+    _seed_dir_with_state(bundle / "connector_data")
+    result = _run(bundle, "--down", "--wipe-data")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert list((bundle / "connector_data").iterdir()) == []
+
+
+def test_frontdesk_help_documents_v_flag():
+    result = subprocess.run(
+        ["bash", str(FRONTDESK_SRC / "deploy.sh"), "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    assert "--volumes" in result.stdout
+    assert "wipe" in result.stdout.lower()
+
+
+# ── enterprise bundle (private repo path, but the open-core deploy.sh ──
+#   in packaging/mastio-enterprise-bundle/ is open-source) ────────────────
+
+
+def _stage_enterprise(tmp_path: pathlib.Path) -> pathlib.Path:
+    pkg = tmp_path / "packaging"
+    bundle = pkg / "mastio-enterprise-bundle"
+    bundle.mkdir(parents=True)
+    shutil.copy2(ENTERPRISE_SRC / "deploy.sh", bundle / "deploy.sh")
+    shutil.copy2(ENTERPRISE_SRC / "docker-compose.yml", bundle / "docker-compose.yml")
+    shutil.copy2(ENTERPRISE_SRC / "proxy.env.example", bundle / "proxy.env.example")
+    shutil.copy2(COMMON_HELPERS, pkg / "_common-deploy-helpers.sh")
+    (bundle / "deploy.sh").chmod(0o755)
+    (bundle / "proxy.env").write_text(
+        "MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443\n"
+        "CULLIS_LICENSE_KEY=fake-license\n"
+    )
+    return bundle
+
+
+def test_enterprise_down_v_wipes_bind_dirs(tmp_path):
+    bundle = _stage_enterprise(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    _seed_dir_with_state(bundle / "nginx-certs")
+
+    result = _run(bundle, "--down", "-v")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "wiping bind dirs" in combined.lower()
+    for sub in ("data", "nginx-certs"):
+        assert (bundle / sub).is_dir()
+        assert list((bundle / sub).iterdir()) == [], sub
+    # proxy.env preserved.
+    assert (bundle / "proxy.env").exists()
+
+
+def test_enterprise_down_without_v_preserves_bind_dirs(tmp_path):
+    bundle = _stage_enterprise(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    result = _run(bundle, "--down")
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert (bundle / "data" / "marker.txt").exists()
+
+
+# ── helper unit test: never touches env files ─────────────────────────────
+
+
+def test_wipe_bind_dirs_helper_only_touches_listed_paths(tmp_path):
+    """Source the helper directly + drive ``_wipe_bind_dirs`` with two
+    paths; assert every other file in the tmp dir is untouched. Guards
+    against a future refactor that accidentally widens scope (e.g. an
+    inadvertent ``rm -rf $SCRIPT_DIR``)."""
+    bundle = _stage_mastio(tmp_path)
+    _seed_dir_with_state(bundle / "data")
+    _seed_dir_with_state(bundle / "nginx-certs")
+    # A sibling file the helper must NEVER touch.
+    (bundle / "important.txt").write_text("keep me")
+
+    path_val, _, _ = _build_path(bundle.parent.parent)
+    env = os.environ.copy()
+    env["PATH"] = path_val
+    env["SCRIPT_DIR"] = str(bundle)
+    # Drive _wipe_bind_dirs directly through the helper file. The
+    # caller-contract stubs (ok / warn / err) are required by the
+    # source, so seed them as no-op shell functions.
+    script = f"""
+set -eo pipefail
+SCRIPT_DIR="{bundle}"
+ok()   {{ echo "ok:   $1"; }}
+warn() {{ echo "warn: $1"; }}
+err()  {{ echo "err:  $1"; }}
+die()  {{ err "$1"; exit 1; }}
+step() {{ echo "step: $1"; }}
+source "{COMMON_HELPERS.parent / '_common-deploy-helpers.sh'}"
+_wipe_bind_dirs "{bundle}/data" "{bundle}/nginx-certs"
+"""
+    # Use the bundle's helpers location, not the one in the temp pkg
+    # (which is identical anyway).
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert list((bundle / "data").iterdir()) == []
+    assert list((bundle / "nginx-certs").iterdir()) == []
+    # Bystander files untouched.
+    assert (bundle / "important.txt").read_text() == "keep me"
+    assert (bundle / "proxy.env").exists()


### PR DESCRIPTION
## Summary

- New `-v` / `--volumes` / `--wipe-data` modifier on `--down` for all three bundles (`mastio-bundle`, `frontdesk-bundle`, `mastio-enterprise-bundle`). After containers stop, wipes the host bind dirs that ADR-030 introduced via a transient root busybox so 0600 files owned by uid 10001 are actually removable.
- Mirrors `docker compose down --volumes` semantics for bind mounts: default `--down` keeps state intact (Org CA + enrolled agents survive restart); `-v` opts into a full reset.
- New shared helper `_wipe_bind_dirs` lives in `packaging/_common-deploy-helpers.sh` so all three bundles use the same wipe pattern (`busybox sh -c "find /wipeN -mindepth 1 -delete"`). Idempotent on missing or already-empty dirs. Never touches `proxy.env`, `frontdesk.env`, scripts, or `.bak` backups.

## What changed per bundle

| Bundle | Wiped dirs | Preserved |
|---|---|---|
| `mastio-bundle` | `data/`, `nginx-certs/`, `certs/` | `proxy.env`, `backups/`, scripts |
| `frontdesk-bundle` | `connector_data/`, `tls/` | `frontdesk.env`, `frontdesk.env.bak-*`, scripts |
| `mastio-enterprise-bundle` | `data/`, `nginx-certs/` | `proxy.env`, `backups/`, scripts |

## Background

P3 admin pre-pilot audit, MINOR-H. During the 2026-05-17 tabula-rasa dogfood, every bundle reset needed a manual:

    docker run --rm -v /path:/m --user 0:0 busybox rm -rf /m/data /m/nginx-certs ...

because `init-permissions` had chown'd the bind dirs to uid 10001 and the host operator can't `rm -rf` them directly. This PR makes that one flag instead.

## README

Both `packaging/mastio-bundle/README.md` and `packaging/frontdesk-bundle/README.md` gain a "Reset everything" section with three use cases (fresh setup, troubleshoot, decommission) plus a destructive warning.

## Test plan

- [x] `pytest tests/test_bundle_down_volumes.py -v` — 13 tests, all pass. Drives `--down`, `--down -v`, `--down --volumes`, `--down --wipe-data` end-to-end with a fake docker shim that performs the wipe host-side. Covers:
  - default `--down` preserves bind dirs (mastio + frontdesk + enterprise)
  - `--down -v` wipes the right dirs (all three bundles)
  - flag aliases `-v` / `--volumes` / `--wipe-data` all work
  - idempotency on empty + missing dirs
  - env files + backups preserved
  - help text advertises the flag
  - unit test: helper never touches paths it wasn't given
- [x] `bash -n` syntax check passes on all three modified scripts + the helper
- [x] `tests/test_bundle_db_swap_guard.py` + `tests/test_deploy_scripts.py` still pass (no regression on adjacent paths)
- [ ] Manual dogfood: `./deploy.sh --down -v` on a real Mastio bundle, verify `ls data/ nginx-certs/ certs/` empty + next `./deploy.sh` mints fresh Org CA