### PR TITLE
feat(connector): forgot-password link on SPA login (P3 MAJOR-1-rest)

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -388,6 +388,7 @@ Tweaks via env on the dashboard process:
 |--------------------------------------|---------|----------------------------------------------------|
 | `CULLIS_CONNECTOR_NOTIFICATIONS=off` | `on`    | Disables the poller entirely (no popups, no badge) |
 | `CULLIS_CONNECTOR_POLL_S=30`         | `10`    | Poll interval, in seconds                          |
+| `CULLIS_FRONTDESK_SUPPORT_EMAIL`     | unset   | When set, the "Forgot password?" link on the login page renders a `mailto:` button pointing at this address (with the username pre-filled). When unset, the same link shows a CLI hint for the IT admin instead. Frontdesk bundle only. |
 
 Native notifications need the `dashboard` extra (which now pulls in
 `plyer`):

--- a/cullis_connector/auth/local_router.py
+++ b/cullis_connector/auth/local_router.py
@@ -239,6 +239,15 @@ class RuntimeInfoResponse(BaseModel):
     # decide before it has any cookie.
     setup_required: bool = False
     setup_url: str = "/api/auth/first-run-setup"
+    # P3 MAJOR-1-rest — IT-support email surfaced behind the
+    # "Forgot password?" affordance on the SPA login form. Empty
+    # string when ``CULLIS_FRONTDESK_SUPPORT_EMAIL`` is unset; the
+    # SPA then renders a CLI-hint fallback instead of a mailto link.
+    # No-auth is fine: this is the same kind of public hint as
+    # ``login_url`` (any visitor of the login page already sees the
+    # configured email rendered into a mailto by the server-side
+    # template).
+    support_email: str = ""
 
 
 class FirstRunSetupRequest(BaseModel):
@@ -617,9 +626,24 @@ def _cert_thumbprint(cert_pem: str) -> str:
 # ── Server-side fallback HTML ────────────────────────────────────────────
 
 
+# Cap on ``?user_name=`` echoed into the mailto subject — mirrors
+# ``LoginRequest`` so an attacker-controlled query cannot bloat the
+# rendered href. Jinja autoescape handles HTML; ``urlencode`` handles
+# CR/LF mailto-header-injection.
+_FORGOT_USER_NAME_MAX_LEN = 64
+
+
+def _support_email(env: dict[str, str] | None = None) -> str:
+    """``CULLIS_FRONTDESK_SUPPORT_EMAIL`` or empty string when unset."""
+    src = env if env is not None else os.environ
+    return (src.get("CULLIS_FRONTDESK_SUPPORT_EMAIL", "") or "").strip()
+
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request) -> Response:
     """Plain HTML form for non-SPA clients + ops debug."""
+    raw = request.query_params.get("user_name", "")
+    user_name_hint = raw.strip()[:_FORGOT_USER_NAME_MAX_LEN]
     return _templates.TemplateResponse(
         request,
         "login.html",
@@ -627,6 +651,8 @@ async def login_page(request: Request) -> Response:
             "connector_status": "offline",
             "connector_status_label": "Sign in",
             "error": None,
+            "support_email": _support_email(),
+            "user_name_hint": user_name_hint,
         },
     )
 
@@ -1031,6 +1057,7 @@ async def runtime_info(request: Request) -> RuntimeInfoResponse:
         login_url="/login",
         require_change_password_url="/change-password",
         setup_required=setup_required,
+        support_email=_support_email(),
     )
 
 

--- a/cullis_connector/static/style.css
+++ b/cullis_connector/static/style.css
@@ -504,6 +504,28 @@ body::after {
 
 .btn-row-end { justify-content: flex-end; }
 
+/* --- Forgot-password affordance (P3 MAJOR-1-rest) --------------------- */
+.form-footer { margin-top: 16px; text-align: center; font-size: 12px; }
+.link-muted {
+  color: var(--text-muted, #8b94a7); text-decoration: underline; text-underline-offset: 2px;
+}
+.link-muted:hover { color: var(--accent, #6aa8ff); }
+.forgot-panel {
+  margin-top: 18px; padding: 16px 18px;
+  background: var(--panel-bg, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-md, 8px); font-size: 13px; line-height: 1.5;
+}
+.forgot-panel[hidden] { display: none; }
+.forgot-panel-title { font-size: 14px; margin: 0 0 10px 0; }
+.forgot-panel-hint { color: var(--text-muted, #8b94a7); font-size: 12px; }
+.forgot-panel-code {
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 12px;
+  padding: 10px 12px; background: rgba(0, 0, 0, 0.25);
+  border-radius: var(--radius-sm); white-space: pre-wrap;
+  word-break: break-word; overflow-x: auto;
+}
+
 /* --- Alert / banner --------------------------------------------------- */
 
 .alert {

--- a/cullis_connector/templates/login.html
+++ b/cullis_connector/templates/login.html
@@ -46,10 +46,50 @@
             </button>
         </div>
     </form>
+
+    {# Forgot-password affordance (P3 MAJOR-1-rest). Panel content
+       branches on CULLIS_FRONTDESK_SUPPORT_EMAIL. #}
+    <p class="form-footer">
+        <a href="#" id="forgot-password-link" class="link-muted">Forgot password?</a>
+    </p>
+    <div id="forgot-password-panel" class="forgot-panel" hidden>
+        <h2 class="forgot-panel-title">Reset your password</h2>
+        {% if support_email %}
+        <p>Your account password is managed by your IT administrator. Send a short note and they will reset it for you.</p>
+        <p>
+            <a id="forgot-password-mailto" class="btn btn-secondary"
+               href="mailto:{{ support_email }}?subject={{ ('Password reset request' + (' - ' + user_name_hint if user_name_hint else '')) | urlencode }}&body={{ ('Hi,\n\nI cannot sign in to the Cullis Frontdesk workspace and would like my password reset.\n\nUsername: ' + (user_name_hint or '(please fill in)') + '\nConnector profile: frontdesk\nBrowser URL: (paste from the address bar)\n\nThanks.') | urlencode }}">Email IT support</a>
+        </p>
+        <p class="forgot-panel-hint">Or contact <a href="mailto:{{ support_email }}">{{ support_email }}</a> directly.</p>
+        {% else %}
+        <p>Contact your local IT administrator to reset your password. They can run the following on the Frontdesk host without taking the bundle offline:</p>
+        <pre class="forgot-panel-code"><code>docker exec -it cullis-frontdesk-connector \
+  cullis-connector users reset-password {{ user_name_hint or '&lt;your-username&gt;' }}</code></pre>
+        <p class="forgot-panel-hint">The IT admin can pre-configure a support contact by setting <code>CULLIS_FRONTDESK_SUPPORT_EMAIL</code> in the bundle's <code>frontdesk.env</code>.</p>
+        {% endif %}
+        <p><button type="button" id="forgot-password-close" class="btn btn-secondary">Close</button></p>
+    </div>
 </div>
 
 <script>
 (function() {
+    var fpLink = document.getElementById('forgot-password-link');
+    var fpPanel = document.getElementById('forgot-password-panel');
+    var fpClose = document.getElementById('forgot-password-close');
+    if (fpLink && fpPanel) {
+        fpLink.addEventListener('click', function(ev) {
+            ev.preventDefault();
+            fpPanel.hidden = false;
+            var first = fpPanel.querySelector('a, button');
+            if (first) { first.focus(); }
+        });
+    }
+    if (fpClose && fpPanel) {
+        fpClose.addEventListener('click', function() {
+            fpPanel.hidden = true;
+            if (fpLink) { fpLink.focus(); }
+        });
+    }
     var form = document.getElementById('login-form');
     if (!form) { return; }
     form.addEventListener('submit', function(ev) {

--- a/frontend/cullis-chat/src/components/auth/LoginForm.tsx
+++ b/frontend/cullis-chat/src/components/auth/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { LoginError, loginLocal } from '../../lib/auth';
+import { fetchRuntimeInfo, LoginError, loginLocal } from '../../lib/auth';
 
 /**
  * Local-mode sign-in form — ADR-025 Phase 5.
@@ -20,6 +20,12 @@ import { LoginError, loginLocal } from '../../lib/auth';
  * — Mastio CSR enrollment failed but the cookie was issued anyway),
  * we surface a one-line non-blocking warning before redirecting.
  */
+// Cap on the username we reflect back into the "Forgot password?"
+// mailto subject. Mirrors the server-side cap in
+// ``cullis_connector/auth/local_router.py::_FORGOT_USER_NAME_MAX_LEN``
+// so a malformed value from auto-fill cannot bloat the subject.
+const FORGOT_USER_NAME_MAX_LEN = 64;
+
 export default function LoginForm() {
   const [userName, setUserName] = useState('');
   const [password, setPassword] = useState('');
@@ -27,6 +33,24 @@ export default function LoginForm() {
   const [submitting, setSubmitting] = useState(false);
   const [retryAfter, setRetryAfter] = useState(0);
   const [provisioningWarn, setProvisioningWarn] = useState<string | null>(null);
+  const [supportEmail, setSupportEmail] = useState('');
+  const [forgotOpen, setForgotOpen] = useState(false);
+
+  // Pull the configured IT-support email from /api/auth/runtime-info so
+  // the "Forgot password?" panel can offer a one-click mailto. Falls
+  // back to the CLI-hint variant when the env var is unset on the
+  // bundle (or when this Connector is too old to surface it).
+  useEffect(() => {
+    let cancelled = false;
+    fetchRuntimeInfo().then((info) => {
+      if (cancelled) return;
+      const email = (info && info.support_email) || '';
+      setSupportEmail(email.trim());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // ADR-025 Phase 5 follow-up (bug N17, 2026-05-09 VM dogfood): if the
   // browser's password manager auto-fills both fields before React
@@ -173,9 +197,62 @@ export default function LoginForm() {
         </form>
 
         <p className="auth-footer">
-          Forgot your password? Contact your administrator.
+          <button
+            type="button"
+            className="auth-link"
+            onClick={() => setForgotOpen(true)}
+          >
+            Forgot password?
+          </button>
         </p>
+
+        {forgotOpen && (
+          <ForgotPasswordPanel
+            supportEmail={supportEmail}
+            userName={userName.trim().slice(0, FORGOT_USER_NAME_MAX_LEN)}
+            onClose={() => setForgotOpen(false)}
+          />
+        )}
       </div>
     </main>
+  );
+}
+
+/** "Forgot password?" panel. Mailto when CULLIS_FRONTDESK_SUPPORT_EMAIL
+ * is set, CLI hint for the IT admin otherwise. */
+function ForgotPasswordPanel(props: {
+  supportEmail: string;
+  userName: string;
+  onClose: () => void;
+}) {
+  const { supportEmail, userName, onClose } = props;
+  const subject = 'Password reset request' + (userName ? ` - ${userName}` : '');
+  const body =
+    `Hi,\n\nI cannot sign in to the Cullis Frontdesk workspace and would ` +
+    `like my password reset.\n\nUsername: ${userName || '(please fill in)'}\n` +
+    `Connector profile: frontdesk\nBrowser URL: (paste from the address bar)\n\nThanks.`;
+  const mailto = supportEmail
+    ? `mailto:${encodeURIComponent(supportEmail)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+    : '';
+  return (
+    <div className="auth-forgot-panel" role="dialog" aria-labelledby="forgot-title">
+      <h2 id="forgot-title" className="auth-forgot-title">Reset your password</h2>
+      {supportEmail ? (
+        <>
+          <p>Your account password is managed by your IT administrator. Send a short note and they will reset it for you.</p>
+          <p><a className="auth-button auth-button-secondary" href={mailto}>Email IT support</a></p>
+          <p className="auth-forgot-hint">Or contact <a href={`mailto:${encodeURIComponent(supportEmail)}`}>{supportEmail}</a> directly.</p>
+        </>
+      ) : (
+        <>
+          <p>Contact your local IT administrator to reset your password. They can run the following on the Frontdesk host without taking the bundle offline:</p>
+          <pre className="auth-forgot-code"><code>{`docker exec -it cullis-frontdesk-connector \\\n  cullis-connector users reset-password ${userName || '<your-username>'}`}</code></pre>
+          <p className="auth-forgot-hint">The IT admin can pre-configure a support contact by setting <code>CULLIS_FRONTDESK_SUPPORT_EMAIL</code> in the bundle&rsquo;s <code>frontdesk.env</code>.</p>
+        </>
+      )}
+      <p>
+        <button type="button" className="auth-button auth-button-secondary" onClick={onClose}>Close</button>
+      </p>
+    </div>
   );
 }

--- a/frontend/cullis-chat/src/lib/auth.ts
+++ b/frontend/cullis-chat/src/lib/auth.ts
@@ -68,6 +68,20 @@ export interface RuntimeInfo {
   auth_mode: 'local' | 'oidc' | string;
   login_url: string;
   require_change_password_url: string;
+  /**
+   * Optional setup-state hint used by the SPA bootstrap. Defaults to
+   * ``false`` on responses from older Connectors that did not return
+   * the field.
+   */
+  setup_required?: boolean;
+  setup_url?: string;
+  /**
+   * P3 MAJOR-1-rest — IT-support email behind the "Forgot password?"
+   * affordance. Empty string when the bundle operator has not set
+   * ``CULLIS_FRONTDESK_SUPPORT_EMAIL``; the LoginForm then renders a
+   * CLI-hint fallback instead of a mailto link.
+   */
+  support_email?: string;
 }
 
 /**

--- a/frontend/cullis-chat/src/styles/auth.css
+++ b/frontend/cullis-chat/src/styles/auth.css
@@ -245,6 +245,35 @@
   line-height: 1.5;
 }
 
+/* ── "Forgot password?" affordance (P3 MAJOR-1-rest) ───────────────── */
+.auth-link {
+  background: none; border: 0; padding: 0; font: inherit; color: inherit;
+  text-decoration: underline; text-underline-offset: 2px; cursor: pointer;
+}
+.auth-link:hover { color: var(--text-primary); }
+.auth-button-secondary {
+  background: var(--bg-elevated); color: var(--text-primary);
+  box-shadow: none; border: 1px solid var(--border-medium);
+}
+.auth-button-secondary:hover:not(:disabled) {
+  background: var(--bg-card-hover); border-color: var(--border-strong);
+}
+.auth-forgot-panel {
+  margin-top: 1rem; padding: 1rem 1.1rem;
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border-medium, rgba(255, 255, 255, 0.08));
+  border-radius: 6px; font-family: var(--font-mono);
+  font-size: 0.78rem; line-height: 1.55;
+}
+.auth-forgot-title { font-size: 0.9rem; margin: 0 0 0.6rem 0; color: var(--text-primary); }
+.auth-forgot-hint { color: var(--text-tertiary); font-size: 0.72rem; }
+.auth-forgot-code {
+  font-family: var(--font-mono); font-size: 0.72rem;
+  padding: 0.55rem 0.7rem; background: rgba(0, 0, 0, 0.25);
+  border-radius: 4px; white-space: pre-wrap;
+  word-break: break-word; overflow-x: auto;
+}
+
 /* ── password strength bar ────────────────────────────────────────── */
 
 .pw-strength {

--- a/frontend/cullis-chat/tests/unit/auth.test.ts
+++ b/frontend/cullis-chat/tests/unit/auth.test.ts
@@ -284,6 +284,22 @@ describe('fetchRuntimeInfo', () => {
     const info = await fetchRuntimeInfo();
     expect(info?.auth_mode).toBe('local');
   });
+
+  it('exposes support_email when the Connector reports it (P3 MAJOR-1-rest)', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({
+        status: 200,
+        body: {
+          auth_mode: 'local',
+          login_url: '/login',
+          require_change_password_url: '/change-password',
+          support_email: 'it-support@acme.com',
+        },
+      }),
+    );
+    const info = await fetchRuntimeInfo();
+    expect(info?.support_email).toBe('it-support@acme.com');
+  });
 });
 
 // ── admin endpoints ───────────────────────────────────────────────────

--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -160,9 +160,39 @@ If both rows show the same principal, the `X-Forwarded-User` header is not reach
 
 ## Lost end-user password recovery
 
-Un employee non riesce ad accedere alla SPA Frontdesk perché ha perso
-la password. L'IT manager può resettarla senza fermare il bundle e
-senza esportare l'`X-Admin-Secret`:
+When an employee cannot sign in to the Frontdesk SPA because they have
+lost their password, two complementary paths exist: an employee-facing
+self-serve affordance on the login page, and an IT-admin CLI on the
+host.
+
+### Self-serve link on the login page (employee)
+
+The Frontdesk login page renders a "Forgot password?" link below the
+Sign in button. Clicking it opens an in-page panel that either:
+
+- offers a one-click `mailto:` link pre-filled with the username and
+  bundle context (when `CULLIS_FRONTDESK_SUPPORT_EMAIL` is set in
+  `frontdesk.env`), so the employee can email IT support in two
+  clicks; or
+- shows the IT admin's `docker exec` command as a copy/paste hint
+  (when the env var is unset), so a colleague forwarding the message
+  to IT can paste the exact command.
+
+To enable the mailto variant, set in `frontdesk.env`:
+
+```text
+CULLIS_FRONTDESK_SUPPORT_EMAIL=it-support@acme.com
+```
+
+and run `./deploy.sh` again (or `docker compose --env-file
+frontdesk.env up -d --force-recreate connector`). The value is only
+ever rendered as a `mailto:` href, so it is safe to set even when the
+bundle is reached over the public internet.
+
+### CLI reset (IT admin)
+
+The IT manager can reset a password without taking the bundle offline
+and without exporting `X-Admin-Secret`:
 
 ```bash
 # Frontdesk container (no X-Admin-Secret needed):
@@ -170,11 +200,11 @@ docker exec -it cullis-frontdesk-connector \
   cullis-connector users reset-password alice
 ```
 
-L'output stampa una password temporanea generata (16 char URL-safe).
-Comunicala all'employee via canale sicuro. Al prossimo login alice
-sarà forzata a cambiarla.
+The output prints a generated temporary password (16 URL-safe chars).
+Share it with the employee over a secure channel. On the next sign-in
+alice is forced to change it.
 
-Per impostare un valore esplicito invece di generarlo:
+To set an explicit value instead of generating one:
 
 ```bash
 docker exec -it cullis-frontdesk-connector \
@@ -182,10 +212,10 @@ docker exec -it cullis-frontdesk-connector \
   --new-password "TempPass2026!"
 ```
 
-Il comando opera direttamente su `users.db` dentro il container — non
-richiede `CULLIS_CONNECTOR_ADMIN_SECRET` e non passa per la rete, per
-cui resta utilizzabile anche su deploy hardenati che non espongono
-l'admin secret all'host.
+The command writes directly to `users.db` inside the container, does
+not require `CULLIS_CONNECTOR_ADMIN_SECRET`, and never traverses the
+network. It therefore stays usable on hardened deployments that do
+not expose the admin secret to the host.
 
 ## Production: replace nginx with oauth2-proxy + IDP
 

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -137,6 +137,11 @@ services:
       # covers the bridge networks docker hands out (172.16.0.0/12).
       CULLIS_TRUSTED_PROXIES: ${CULLIS_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
       CULLIS_FRONTDESK_COOKIE_TTL_S: ${CULLIS_FRONTDESK_COOKIE_TTL_S:-3600}
+      # P3 MAJOR-1-rest — IT-support email surfaced behind the "Forgot
+      # password?" link on the login page. Empty by default, in which
+      # case the link renders a CLI-hint fallback for the IT admin
+      # instead of a mailto button for the employee.
+      CULLIS_FRONTDESK_SUPPORT_EMAIL: ${CULLIS_FRONTDESK_SUPPORT_EMAIL:-}
       # Where Mastio's CSR endpoint lives. Falls back to site_url when empty.
       CULLIS_FRONTDESK_MASTIO_URL: ${CULLIS_FRONTDESK_MASTIO_URL:-}
       CULLIS_SITE_URL: ${CULLIS_SITE_URL:-}

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -128,6 +128,18 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # chain belongs to the Mastio admin dashboard, not the end user surface.
 # PUBLIC_DEV_AUDIT_PANEL=0
 
+# -- Optional: end-user IT support contact ---------------------------------
+
+# IT-support email surfaced behind the "Forgot password?" link on the
+# Frontdesk SPA login page (P3 MAJOR-1-rest). When set, the login form
+# renders a one-click ``mailto:`` link pre-populated with the username
+# the employee typed (or arrived with via ``?user_name=alice``) plus a
+# short triage-friendly body. When unset, the same link shows a CLI
+# hint pointing the IT admin at the ``cullis-connector users
+# reset-password`` command instead. Leave blank if your org prefers
+# the CLI path.
+# CULLIS_FRONTDESK_SUPPORT_EMAIL=it-support@acme.com
+
 # ── ADR-029 tool-call PDP ────────────────────────────────────────────
 #
 # Off by default. Flip to ``true`` to make the Connector's

--- a/tests/connector/test_auth_local_router.py
+++ b/tests/connector/test_auth_local_router.py
@@ -385,6 +385,90 @@ def test_login_page_renders(client):
     assert "Sign in" in r.text
 
 
+# ── P3 MAJOR-1-rest: "Forgot password?" affordance ──────────────────────
+
+
+def _client_with_env(connector_config, monkeypatch, **extra: str) -> TestClient:
+    """Build a TestClient with optional extra env entries (e.g. the
+    support-email env var). Mirrors the ``client`` fixture wiring."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    for k, v in extra.items():
+        monkeypatch.setenv(k, v)
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
+def test_login_page_renders_forgot_password_cli_fallback(client):
+    """No CULLIS_FRONTDESK_SUPPORT_EMAIL → CLI hint variant rendered."""
+    r = client.get("/login")
+    assert r.status_code == 200
+    assert 'id="forgot-password-link"' in r.text
+    assert "Forgot password?" in r.text
+    assert "users reset-password" in r.text
+    assert "CULLIS_FRONTDESK_SUPPORT_EMAIL" in r.text
+    assert 'href="mailto:' not in r.text
+
+
+def test_login_page_renders_mailto_when_support_email_set(
+    connector_config, monkeypatch,
+):
+    """With env set, mailto button replaces the CLI hint."""
+    tc = _client_with_env(
+        connector_config, monkeypatch,
+        CULLIS_FRONTDESK_SUPPORT_EMAIL="it-support@acme.com",
+    )
+    r = tc.get("/login")
+    assert r.status_code == 200
+    assert "mailto:it-support@acme.com" in r.text
+    assert "users reset-password" not in r.text
+
+
+def test_login_page_user_name_query_is_url_escaped_in_mailto(
+    connector_config, monkeypatch,
+):
+    """``?user_name=`` reflected into mailto subject after url-encode,
+    blocks HTML break-out + mailto CR/LF header injection (RFC 6068)."""
+    tc = _client_with_env(
+        connector_config, monkeypatch,
+        CULLIS_FRONTDESK_SUPPORT_EMAIL="it@acme.com",
+    )
+    r = tc.get("/login?user_name=a%3Cb%26c%0Ax")
+    assert r.status_code == 200
+    assert "<b&c" not in r.text
+    href = r.text.split('href="mailto:', 1)[1].split('"', 1)[0]
+    assert "\n" not in href and "\r" not in href
+
+
+def test_login_page_user_name_hint_capped(connector_config, monkeypatch):
+    """Huge ``?user_name=`` is truncated before reaching the template."""
+    tc = _client_with_env(connector_config, monkeypatch)
+    r = tc.get("/login", params={"user_name": "a" * 500})
+    assert r.status_code == 200
+    assert ("a" * 200) not in r.text
+
+
+def test_runtime_info_exposes_support_email(connector_config, monkeypatch):
+    """The SPA reads support_email from /api/auth/runtime-info."""
+    tc = _client_with_env(
+        connector_config, monkeypatch,
+        CULLIS_FRONTDESK_SUPPORT_EMAIL="it-support@acme.com",
+    )
+    r = tc.get("/api/auth/runtime-info")
+    assert r.status_code == 200
+    assert r.json()["support_email"] == "it-support@acme.com"
+
+
+def test_runtime_info_support_email_empty_when_unset(client):
+    """Default support_email is empty string → SPA branches to CLI hint."""
+    r = client.get("/api/auth/runtime-info")
+    assert r.status_code == 200
+    assert r.json().get("support_email", "") == ""
+
+
 def test_change_password_page_renders(client):
     r = client.get("/change-password")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary

- Adds a "Forgot password?" affordance to both the server-side `/login` Jinja template and the SPA `LoginForm.tsx`. Clicking it opens an in-page panel.
- Panel branches on the new optional env var `CULLIS_FRONTDESK_SUPPORT_EMAIL`: when set, renders a one-click `mailto:` button pre-populated with the username + bundle context; when unset, renders a CLI hint pointing the IT admin at `cullis-connector users reset-password` (from #757).
- Wires `CULLIS_FRONTDESK_SUPPORT_EMAIL` through `packaging/frontdesk-bundle/docker-compose.yml`, documents it in the bundle README, `cullis_connector/README.md`, and `frontdesk.env.example`.

This closes the employee touchpoint for P3 MAJOR-1-rest in `imp/p3-operability-audit.md`. PR #757 added the IT-admin CLI reset path; this PR makes that path discoverable from the locked-out-employee moment without forcing the IT manager to write docs.

## Security notes

- The `?user_name=` query is reflected into the mailto subject so the employee does not retype it. The value is length-capped at 64 chars server-side (mirrors `LoginRequest`), then rendered through Jinja autoescape and `urlencode` so neither HTML break-out nor mailto CR/LF header injection (RFC 6068) survives.
- `CULLIS_FRONTDESK_SUPPORT_EMAIL` is rendered only as a `mailto:` href and as visible text, both under Jinja autoescape. Safe to set on internet-facing deployments.
- No new JS dependency. The SPA panel is a pure React inline component; the server template uses 18 lines of vanilla JS for show/hide.
- The SPA reads the email from `/api/auth/runtime-info`, which is already a no-auth public hint endpoint (same level as `login_url`).

## Test plan

- [x] `pytest tests/connector/test_auth_local_router.py` (38 tests, 6 new: link always present, mailto when email set, URL-escape of `?user_name=`, length cap, runtime-info exposes email, runtime-info default empty).
- [x] `pytest tests/connector/` (700 tests, no regression).
- [x] `vitest run tests/unit/auth.test.ts` on the SPA (18 tests, 1 new: `support_email` parsed from runtime-info).
- [x] `tsc --noEmit` clean.
- [ ] Manual: `./sandbox/demo.sh full`, open `https://localhost:8443/login`, click "Forgot password?", verify CLI-hint variant renders. Set `CULLIS_FRONTDESK_SUPPORT_EMAIL=it@example.com` in bundle env and verify mailto button works.

## Related

- Closes P3 MAJOR-1-rest in `imp/p3-operability-audit.md`.
- Builds on #757 (`feat(connector): add 'users reset-password' CLI subcommand`).
- Reuses the no-auth `/api/auth/runtime-info` contract already established in ADR-025 Phase 5.