### PR TITLE
fix(bundle-frontdesk): generate-frontdesk-env honors env var overrides (P3 MINOR-D)

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -123,10 +123,20 @@ The compose file pins sensible defaults via env vars:
 
 | Variable | Default | Image |
 |---|---|---|
-| `CONNECTOR_VERSION` | `0.4.0-rc1` | `ghcr.io/cullis-security/cullis-connector` |
-| `CHAT_VERSION`      | `0.1.0-rc1` | `ghcr.io/cullis-security/cullis-chat-frontdesk` |
+| `CONNECTOR_VERSION` | `0.4.6` | `ghcr.io/cullis-security/cullis-connector` |
+| `CHAT_VERSION`      | `0.4.1` | `ghcr.io/cullis-security/cullis-chat-frontdesk` |
 
 Pin both in production via `frontdesk.env` rather than relying on the defaults shipped with the bundle.
+
+`generate-frontdesk-env.sh` honors invoker-shell env vars in every mode (interactive, `--defaults`, `--prod`). Customer admins doing version pinning from CI / Ansible / a config-managed bash wrapper can preempt the file like so:
+
+```bash
+CONNECTOR_VERSION=0.4.5 CHAT_VERSION=0.4.0 ./deploy.sh --site https://mastio.acme.local:9443
+```
+
+The resulting `frontdesk.env` carries `CONNECTOR_VERSION=0.4.5` (not the hard-coded `0.4.6` default), and the next `docker compose up` picks the right tag. Same mechanism for `CULLIS_FRONTDESK_MASTIO_URL`, `CULLIS_SITE_URL`, `CULLIS_FRONTDESK_ORG_ID`, `CULLIS_FRONTDESK_TRUST_DOMAIN`, and `CULLIS_FRONTDESK_CA_BUNDLE_HOST`: invoker env wins over the in-template default. Re-runs are idempotent (no duplicate lines, no commented-out leftovers).
+
+Pre-fix the bundle silently ignored the invoker env vars because `docker compose --env-file frontdesk.env` only reads values from the file (parent shell env is NOT consulted for `${VAR:-default}` substitutions). Operators discovered the gap only when the wrong image tag landed in production. See P3 MINOR-D (#772 sibling, Mastio side).
 
 ## Smoke test (dev fake-SSO)
 

--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -16,9 +16,15 @@
 #   ./generate-frontdesk-env.sh --force      # Overwrite existing frontdesk.env
 #
 # Environment variables (used by --prod, optional elsewhere):
-#   CULLIS_FRONTDESK_ORG_ID           — org slug, e.g. ``acme``
-#   CULLIS_FRONTDESK_TRUST_DOMAIN     — SPIFFE TD, e.g. ``acme.prod``
-#   CULLIS_FRONTDESK_CA_BUNDLE_HOST   — host path to Mastio CA chain PEM
+#   CULLIS_FRONTDESK_ORG_ID           org slug, e.g. ``acme``
+#   CULLIS_FRONTDESK_TRUST_DOMAIN     SPIFFE TD, e.g. ``acme.prod``
+#   CULLIS_FRONTDESK_CA_BUNDLE_HOST   host path to Mastio CA chain PEM
+#
+# Optional version + URL overrides (honored in every mode, P3 MINOR-D):
+#   CONNECTOR_VERSION                 cullis-connector image tag
+#   CHAT_VERSION                      cullis-chat-frontdesk image tag
+#   CULLIS_FRONTDESK_MASTIO_URL       Mastio CSR endpoint URL
+#   CULLIS_SITE_URL                   Connector site_url (Mastio reverse proxy)
 #
 set -euo pipefail
 
@@ -189,6 +195,59 @@ cp "$SCRIPT_DIR/frontdesk.env.example" "$OUT"
 sed -i "s|^CULLIS_FRONTDESK_ORG_ID=.*|CULLIS_FRONTDESK_ORG_ID=${ORG_ID}|"               "$OUT"
 sed -i "s|^CULLIS_FRONTDESK_TRUST_DOMAIN=.*|CULLIS_FRONTDESK_TRUST_DOMAIN=${TRUST_DOMAIN}|" "$OUT"
 sed -i "s|^CULLIS_FRONTDESK_CA_BUNDLE_HOST=.*|CULLIS_FRONTDESK_CA_BUNDLE_HOST=${CA_BUNDLE}|" "$OUT"
+
+# ── env-var overrides for vars that ship COMMENTED in the example ────
+#
+# P3 MINOR-D (dogfood tabula rasa, 2026-05-17): customer admins doing
+# version pinning via CI / Ansible expect
+#
+#   CONNECTOR_VERSION=0.4.5 ./deploy.sh ...
+#
+# to land 0.4.5 into the running bundle. Pre-fix, the env var was
+# silently dropped: ``docker compose --env-file frontdesk.env`` only
+# reads values from the file (parent-shell env is NOT consulted for
+# ``${VAR:-default}`` substitutions), so the operator's intent never
+# reached the image: tag. Same trap as MINOR-F (#772) for
+# MCP_PROXY_PROXY_PUBLIC_URL on the Mastio side.
+#
+# Fix mirrors the #772 strip-and-append pattern: for each var that
+# ships COMMENTED in the example (no plain sed substitution would land
+# an uncommented value), resolve the invoker env var with a sane
+# default, strip any pre-existing line (commented or not), and append
+# the resolved value. Idempotent on rerun (--force).
+#
+# Defaults track the comments shipped in frontdesk.env.example so an
+# operator reading the generated env file sees the same values they
+# would have seen in the template.
+CONNECTOR_VERSION_VALUE="${CONNECTOR_VERSION:-0.4.6}"
+CHAT_VERSION_VALUE="${CHAT_VERSION:-0.4.1}"
+# The two Mastio URL fields ship commented in the example because the
+# right value depends on the deploy topology. Leave them empty when
+# unset so the downstream ``${VAR:-}`` fallback in docker-compose.yml
+# applies — first-boot wizard mode (CULLIS_SITE_URL empty) and
+# host.docker.internal probing for CULLIS_FRONTDESK_MASTIO_URL both
+# depend on the variable being unset rather than carrying a stale
+# default.
+CULLIS_FRONTDESK_MASTIO_URL_VALUE="${CULLIS_FRONTDESK_MASTIO_URL:-}"
+CULLIS_SITE_URL_VALUE="${CULLIS_SITE_URL:-}"
+
+_strip_and_append() {
+    # Usage: _strip_and_append VAR_NAME VALUE
+    # Skips the append when VALUE is empty so commented-out vars stay
+    # commented (preserves the in-template documentation).
+    local var="$1" value="$2"
+    sed -i.bak "/^#*[[:space:]]*${var}=/d" "$OUT"
+    rm -f "${OUT}.bak"
+    if [[ -n "$value" ]]; then
+        echo "${var}=${value}" >> "$OUT"
+    fi
+}
+
+_strip_and_append CONNECTOR_VERSION             "$CONNECTOR_VERSION_VALUE"
+_strip_and_append CHAT_VERSION                  "$CHAT_VERSION_VALUE"
+_strip_and_append CULLIS_FRONTDESK_MASTIO_URL   "$CULLIS_FRONTDESK_MASTIO_URL_VALUE"
+_strip_and_append CULLIS_SITE_URL               "$CULLIS_SITE_URL_VALUE"
+
 # The example file does not ship the secret line (we mint per-deploy); append.
 echo "CULLIS_CONNECTOR_ADMIN_SECRET=${ADMIN_SECRET}" >> "$OUT"
 
@@ -197,5 +256,7 @@ echo ""
 echo -e "  ${BOLD}CULLIS_FRONTDESK_ORG_ID${RESET}          ${GRAY}${ORG_ID}${RESET}"
 echo -e "  ${BOLD}CULLIS_FRONTDESK_TRUST_DOMAIN${RESET}    ${GRAY}${TRUST_DOMAIN}${RESET}"
 echo -e "  ${BOLD}CULLIS_FRONTDESK_CA_BUNDLE_HOST${RESET}  ${GRAY}${CA_BUNDLE}${RESET}"
+echo -e "  ${BOLD}CONNECTOR_VERSION${RESET}                ${GRAY}${CONNECTOR_VERSION_VALUE}${RESET}"
+echo -e "  ${BOLD}CHAT_VERSION${RESET}                     ${GRAY}${CHAT_VERSION_VALUE}${RESET}"
 echo -e "  ${BOLD}CULLIS_CONNECTOR_ADMIN_SECRET${RESET}    ${GRAY}${ADMIN_SECRET:0:8}…${RESET} (provision users via X-Admin-Secret)"
 echo ""

--- a/tests/test_bundle_frontdesk_env_override.py
+++ b/tests/test_bundle_frontdesk_env_override.py
@@ -1,0 +1,343 @@
+"""P3 MINOR-D: packaging/frontdesk-bundle/generate-frontdesk-env.sh
+honors invoker-shell env vars for fields that ship COMMENTED in
+``frontdesk.env.example`` (``CONNECTOR_VERSION``, ``CHAT_VERSION``,
+``CULLIS_FRONTDESK_MASTIO_URL``, ``CULLIS_SITE_URL``).
+
+Failure mode this pins (dogfood tabula rasa, 2026-05-17): a customer
+admin doing version pinning via CI / Ansible runs
+
+    CONNECTOR_VERSION=l3a-fix ./deploy.sh ...
+
+expecting the bundle to pull the ``l3a-fix`` tag. Pre-fix, the env
+var was silently dropped: ``docker compose --env-file frontdesk.env``
+only reads values FROM the file, the parent shell env is not consulted
+for ``${VAR:-default}`` substitutions. The generated ``frontdesk.env``
+left ``CONNECTOR_VERSION`` commented (or sed-substituted the wrong
+hard-coded default), and the next ``docker compose up`` ran an image
+tag the operator never asked for.
+
+The fix mirrors the #772 strip-and-append pattern: every env var that
+ships COMMENTED in the example is resolved from invoker shell env
+(with a sane default for unset), any pre-existing line (commented or
+not) is stripped, and the resolved value is appended.
+
+These tests drive ``generate-frontdesk-env.sh`` directly in a tmp
+bundle dir, parse the resulting ``frontdesk.env``, and assert the env
+var overrides survive into the file.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BUNDLE_SRC = REPO_ROOT / "packaging" / "frontdesk-bundle"
+
+
+def _stage_bundle(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Mirror the minimum bundle layout into ``tmp_path`` so
+    ``generate-frontdesk-env.sh`` finds its siblings
+    (``frontdesk.env.example``, ``_lib-admin-secret.sh``).
+    """
+    bundle = tmp_path / "frontdesk-bundle"
+    bundle.mkdir(parents=True)
+    for fname in (
+        "generate-frontdesk-env.sh",
+        "frontdesk.env.example",
+        "_lib-admin-secret.sh",
+    ):
+        shutil.copy2(BUNDLE_SRC / fname, bundle / fname)
+    (bundle / "generate-frontdesk-env.sh").chmod(0o755)
+    return bundle
+
+
+def _run_generate(
+    bundle: pathlib.Path,
+    *args: str,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    # Strip parent-process inherited values for the vars under test so
+    # the test does not pick up the running user's shell state.
+    for k in (
+        "CONNECTOR_VERSION",
+        "CHAT_VERSION",
+        "CULLIS_FRONTDESK_MASTIO_URL",
+        "CULLIS_SITE_URL",
+        "CULLIS_FRONTDESK_ORG_ID",
+        "CULLIS_FRONTDESK_TRUST_DOMAIN",
+        "CULLIS_FRONTDESK_CA_BUNDLE_HOST",
+        "CULLIS_CONNECTOR_ADMIN_SECRET",
+    ):
+        env.pop(k, None)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(bundle / "generate-frontdesk-env.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        cwd=str(bundle),
+    )
+
+
+def _parse_env(env_path: pathlib.Path) -> dict[str, str]:
+    """Parse a frontdesk.env-style file into a dict, ignoring commented
+    and blank lines. Trailing newlines on values are stripped so the
+    assertion compares literal strings.
+    """
+    out: dict[str, str] = {}
+    for raw in env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def _count_lines(env_path: pathlib.Path, prefix: str) -> int:
+    """Count how many lines (uncommented or commented) match
+    ``^#*[[:space:]]*<prefix>=``. Used to assert idempotency: no
+    duplicate lines on rerun.
+    """
+    count = 0
+    for raw in env_path.read_text().splitlines():
+        stripped = raw.lstrip("# \t")
+        if stripped.startswith(f"{prefix}="):
+            count += 1
+    return count
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CONNECTOR_VERSION env override
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_connector_version_env_override_honored(tmp_path: pathlib.Path) -> None:
+    """``CONNECTOR_VERSION=l3a-fix ./generate-frontdesk-env.sh`` lands
+    ``l3a-fix`` in frontdesk.env, not the hard-coded default.
+
+    Customer admin scenario: version pinning via CI / Ansible. Pre-fix,
+    deploy.sh silently dropped the invoker env var because
+    ``docker compose --env-file`` does not propagate parent shell env.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--defaults",
+        "--force",
+        env_overrides={"CONNECTOR_VERSION": "l3a-fix"},
+    )
+    assert result.returncode == 0, (
+        f"generate-frontdesk-env.sh failed:\n{result.stderr}"
+    )
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert env.get("CONNECTOR_VERSION") == "l3a-fix", (
+        f"expected CONNECTOR_VERSION=l3a-fix, got {env.get('CONNECTOR_VERSION')!r}. "
+        "P3 MINOR-D regression: invoker env var must override the in-template default."
+    )
+
+
+def test_connector_version_default_when_unset(tmp_path: pathlib.Path) -> None:
+    """No CONNECTOR_VERSION env var set: frontdesk.env carries the sane
+    default (the same value the bundle README documents).
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(bundle, "--defaults", "--force")
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    # The exact default tracks the comment shipped in frontdesk.env.example.
+    # Asserting non-empty + non-placeholder is enough to pin the regression:
+    # the bug was "field missing", not "field has the wrong number".
+    assert env.get("CONNECTOR_VERSION", "") != "", (
+        "CONNECTOR_VERSION missing from frontdesk.env when unset; "
+        "must fall back to a sane default."
+    )
+    # Sanity: the value looks like a version string, not a placeholder.
+    assert env["CONNECTOR_VERSION"] not in ("", "TODO", "change-me")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CHAT_VERSION env override
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_chat_version_env_override_honored(tmp_path: pathlib.Path) -> None:
+    """Same shape as CONNECTOR_VERSION: the Cullis Chat image tag is
+    overridable from the invoker shell. Regression guard against future
+    refactors that touch one var and forget the symmetric one.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--defaults",
+        "--force",
+        env_overrides={"CHAT_VERSION": "0.4.2-rc1"},
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert env.get("CHAT_VERSION") == "0.4.2-rc1"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CULLIS_SITE_URL + CULLIS_FRONTDESK_MASTIO_URL env override
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_mastio_url_env_overrides_honored(tmp_path: pathlib.Path) -> None:
+    """Two Mastio URL fields ship commented in the example. The
+    invoker can pin either or both via env. Empty (unset) leaves the
+    line commented so the in-template documentation survives and the
+    downstream first-boot wizard mode (CULLIS_SITE_URL empty triggers
+    the in-browser /setup/discover path) keeps working.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--defaults",
+        "--force",
+        env_overrides={
+            "CULLIS_SITE_URL": "https://mastio.acme.local:9443",
+            "CULLIS_FRONTDESK_MASTIO_URL": "https://mastio.acme.local:9443",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert env.get("CULLIS_SITE_URL") == "https://mastio.acme.local:9443"
+    assert env.get("CULLIS_FRONTDESK_MASTIO_URL") == "https://mastio.acme.local:9443"
+
+
+def test_mastio_urls_stay_commented_when_unset(tmp_path: pathlib.Path) -> None:
+    """When CULLIS_SITE_URL / CULLIS_FRONTDESK_MASTIO_URL are not set
+    in the invoker env, generate-frontdesk-env.sh does NOT write
+    an empty uncommented line.
+
+    First-boot wizard mode (ADR-019 Phase 8c) keys off
+    ``CULLIS_SITE_URL`` being EMPTY (not set, or commented). Writing
+    ``CULLIS_SITE_URL=`` uncommented would still be empty-string in
+    practice (docker-compose ``${VAR:-}`` resolves identically), but
+    the deploy.sh wizard detection grep would mis-classify a literal
+    empty value differently from a missing line and the wizard branch
+    would never fire. Keep them commented.
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(bundle, "--defaults", "--force")
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert "CULLIS_SITE_URL" not in env, (
+        f"CULLIS_SITE_URL must stay commented when invoker env is unset; "
+        f"got {env.get('CULLIS_SITE_URL')!r}"
+    )
+    assert "CULLIS_FRONTDESK_MASTIO_URL" not in env, (
+        f"CULLIS_FRONTDESK_MASTIO_URL must stay commented when invoker env is unset; "
+        f"got {env.get('CULLIS_FRONTDESK_MASTIO_URL')!r}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Idempotency
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_rerun_is_idempotent_no_duplicate_lines(tmp_path: pathlib.Path) -> None:
+    """Rerunning ``--defaults --force`` with the same env produces
+    exactly the same field set: no duplicate
+    ``CONNECTOR_VERSION=`` / ``CHAT_VERSION=`` lines piling up on each
+    invocation. The strip-and-append pattern must own the line; the
+    sed-on-commented-line bug from #772 would have left a commented
+    placeholder PLUS the new uncommented line on rerun.
+    """
+    bundle = _stage_bundle(tmp_path)
+    env_overrides = {"CONNECTOR_VERSION": "0.4.7", "CHAT_VERSION": "0.4.2"}
+
+    for _ in range(3):
+        result = _run_generate(
+            bundle, "--defaults", "--force", env_overrides=env_overrides
+        )
+        assert result.returncode == 0, result.stderr
+
+    out = bundle / "frontdesk.env"
+    assert _count_lines(out, "CONNECTOR_VERSION") == 1, (
+        f"expected exactly one CONNECTOR_VERSION= line, got "
+        f"{_count_lines(out, 'CONNECTOR_VERSION')}"
+    )
+    assert _count_lines(out, "CHAT_VERSION") == 1
+    # And the value is the latest one.
+    env = _parse_env(out)
+    assert env["CONNECTOR_VERSION"] == "0.4.7"
+    assert env["CHAT_VERSION"] == "0.4.2"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Multiple vars set simultaneously
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_multiple_env_vars_all_honored(tmp_path: pathlib.Path) -> None:
+    """Full CI-style invocation: 4 env vars at once. All four land in
+    frontdesk.env. Guards against a future refactor that drops one
+    var while preserving the others (the test_*_env_override_honored
+    tests assert each var in isolation, this one asserts the
+    combination).
+    """
+    bundle = _stage_bundle(tmp_path)
+    result = _run_generate(
+        bundle,
+        "--defaults",
+        "--force",
+        env_overrides={
+            "CONNECTOR_VERSION": "0.4.7",
+            "CHAT_VERSION": "0.4.2",
+            "CULLIS_SITE_URL": "https://mastio.acme.local:9443",
+            "CULLIS_FRONTDESK_MASTIO_URL": "https://mastio.acme.local:9443",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert env.get("CONNECTOR_VERSION") == "0.4.7"
+    assert env.get("CHAT_VERSION") == "0.4.2"
+    assert env.get("CULLIS_SITE_URL") == "https://mastio.acme.local:9443"
+    assert env.get("CULLIS_FRONTDESK_MASTIO_URL") == "https://mastio.acme.local:9443"
+
+
+def test_prod_mode_honors_env_overrides_too(tmp_path: pathlib.Path) -> None:
+    """``--prod`` is the CI / production-rehearsal path. Same env-var
+    plumbing must work there: requirement comes from the same customer
+    admin scenario (Ansible play, scripted deploy).
+    """
+    bundle = _stage_bundle(tmp_path)
+    # Stage a fake CA bundle so --prod's existence check passes.
+    fake_ca = bundle / "fake-ca.pem"
+    fake_ca.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+
+    result = _run_generate(
+        bundle,
+        "--prod",
+        "--force",
+        env_overrides={
+            "CULLIS_FRONTDESK_ORG_ID": "acme",
+            "CULLIS_FRONTDESK_TRUST_DOMAIN": "acme.prod",
+            "CULLIS_FRONTDESK_CA_BUNDLE_HOST": str(fake_ca),
+            "CONNECTOR_VERSION": "0.4.7",
+            "CHAT_VERSION": "0.4.2",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+
+    env = _parse_env(bundle / "frontdesk.env")
+    assert env.get("CONNECTOR_VERSION") == "0.4.7"
+    assert env.get("CHAT_VERSION") == "0.4.2"
+    assert env.get("CULLIS_FRONTDESK_ORG_ID") == "acme"
+    assert env.get("CULLIS_FRONTDESK_TRUST_DOMAIN") == "acme.prod"


### PR DESCRIPTION
## Summary

- Customer admin scenario from dogfood tabula rasa 2026-05-17: ``CONNECTOR_VERSION=l3a-fix ./deploy.sh ...`` silently dropped the invoker env var. ``docker compose --env-file frontdesk.env`` only reads values FROM the file (parent shell env is NOT consulted for ``${VAR:-default}`` substitutions), so the wrong image tag landed in production.
- Sibling of MINOR-F (#772) for ``MCP_PROXY_PROXY_PUBLIC_URL`` on the Mastio side. Same strip-and-append pattern: every env var that ships COMMENTED in ``frontdesk.env.example`` (``CONNECTOR_VERSION``, ``CHAT_VERSION``, ``CULLIS_FRONTDESK_MASTIO_URL``, ``CULLIS_SITE_URL``) is resolved from invoker shell env with a sane default, any pre-existing line is stripped, the resolved value is appended. Empty values stay commented so first-boot wizard mode (``CULLIS_SITE_URL`` detection) keeps working.
- README ``Image versions`` section documents the new behavior with the exact CI/Ansible invocation shape; existing ``CULLIS_FRONTDESK_ORG_ID`` / ``TRUST_DOMAIN`` / ``CA_BUNDLE_HOST`` env-override paths already worked and are unchanged.

## Test plan

- [x] ``pytest tests/test_bundle_frontdesk_env_override.py -v`` (8/8 pass)
- [x] Sibling regression check: ``pytest tests/test_bundle_generate_proxy_env_defaults.py tests/test_bundle_down_volumes.py tests/test_bundle_db_swap_guard.py tests/test_bundle_healthchecks.py -v`` (35/35 pass)
- [x] Dogfood-shape smoke: ``CONNECTOR_VERSION=l3a-fix bash generate-frontdesk-env.sh --defaults --force`` writes ``CONNECTOR_VERSION=l3a-fix`` to ``frontdesk.env`` (verified manually)
- [x] Idempotency: 3 reruns produce exactly one ``CONNECTOR_VERSION=`` and one ``CHAT_VERSION=`` line each

Coverage in the new test file:

- Env override honored: ``CONNECTOR_VERSION``, ``CHAT_VERSION``, ``CULLIS_SITE_URL``, ``CULLIS_FRONTDESK_MASTIO_URL``, multiple at once, ``--prod`` mode
- Default fallback when env unset
- Commented-out vars stay commented when invoker env unset (preserves wizard-mode trigger)
- Idempotency across reruns (no duplicate lines)