### PR TITLE
ci(circleci): add CircleCI config alongside GH Actions (Phase 1 migration)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,492 @@
+version: 2.1
+
+# CircleCI gate per Cullis. Sostituisce 5 workflow GitHub Actions:
+#   ci.yml                  -> test-shard (3-way split) + security
+#   smoke.yml               -> smoke-{rsa, ec, rsa-postgres, standalone}
+#   helm-test.yml           -> helm-test-{cullis, cullis-mastio}
+#   customer-path-smoke.yml -> customer-path-smoke
+#   cullis-chat.yml         -> cullis-chat-e2e
+#
+# Restano su GH Actions:
+#   dco.yml                 -> commit-signature check, zero docker / zero pytest
+#   release-*.yml           -> tag-triggered, native GHCR/PyPI publish path
+#
+# Resource class: medium ovunque (free tier).
+# Note operative:
+#   - COMPOSE_PROJECT_NAME parametrizzato con CIRCLE_BUILD_NUM per evitare
+#     collisioni docker-network/nome-container quando piu' job girano in
+#     parallelo sullo stesso runner pool.
+#   - kind cluster_name parametrizzato per la stessa ragione.
+
+executors:
+  python-node:
+    docker:
+      - image: cimg/python:3.11-node
+    resource_class: medium
+
+  node-browsers:
+    docker:
+      - image: cimg/node:20-browsers
+    resource_class: medium
+
+  ubuntu-machine:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: medium
+
+jobs:
+  # ─── Unit tests (ci.yml: test-shard) ─────────────────────────────────
+  test-shard:
+    executor: python-node
+    parallelism: 3
+    environment:
+      ADMIN_SECRET: "test-secret-not-default"
+      OTEL_ENABLED: "false"
+      DATABASE_URL: "sqlite+aiosqlite://"
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-pip-{{ checksum "requirements.txt" }}
+            - v1-pip-
+
+      - run:
+          name: Install Python dependencies
+          command: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install ruff pytest-repeat pytest-split
+
+      - save_cache:
+          key: v1-pip-{{ checksum "requirements.txt" }}
+          paths:
+            - ~/.cache/pip
+
+      - restore_cache:
+          keys:
+            - v1-npm-sdk-ts-{{ checksum "sdk-ts/package-lock.json" }}
+            - v1-npm-sdk-ts-
+
+      - run:
+          name: Build TypeScript SDK (for cross-language interop test)
+          working_directory: sdk-ts
+          command: |
+            npm ci
+            npx tsc || true
+
+      - save_cache:
+          key: v1-npm-sdk-ts-{{ checksum "sdk-ts/package-lock.json" }}
+          paths:
+            - sdk-ts/node_modules
+
+      - run:
+          name: Lint with ruff (shard 0 only)
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" = "0" ]; then
+              ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402
+            else
+              echo "Lint skipped on shard $CIRCLE_NODE_INDEX (pinned to shard 0)."
+            fi
+
+      - run:
+          name: Verify Alembic migrations (shard 0 only)
+          environment:
+            DATABASE_URL: "sqlite+aiosqlite:///./test_migrations.db"
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" = "0" ]; then
+              alembic upgrade head
+              python -c "import sqlite3; c=sqlite3.connect('test_migrations.db'); tables=c.execute(\"SELECT name FROM sqlite_master WHERE type='table'\").fetchall(); print(f'{len(tables)} tables created'); assert len(tables) >= 10, f'Expected >=10 tables, got {len(tables)}'"
+              rm -f test_migrations.db
+            else
+              echo "Alembic check skipped on shard $CIRCLE_NODE_INDEX (pinned to shard 0)."
+            fi
+
+      - run:
+          name: Run tests (pytest-split shard $((CIRCLE_NODE_INDEX + 1))/3)
+          # CIRCLE_NODE_INDEX is 0-based; pytest-split --group is 1-based.
+          # tests/test_e2e.py is order-dependent (module-level _state shared
+          # across step1..step10), excluded here and re-run as a single
+          # block on shard 0.
+          command: |
+            GROUP=$((CIRCLE_NODE_INDEX + 1))
+            pytest tests/ \
+                --tb=short \
+                --ignore=tests/test_postgres_integration.py \
+                --ignore=tests/test_e2e.py \
+                --splits 3 --group $GROUP
+
+      - run:
+          name: Run tests/test_e2e.py (shard 0 only, order-dependent)
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" = "0" ]; then
+              pytest tests/test_e2e.py --tb=short
+            else
+              echo "test_e2e.py skipped on shard $CIRCLE_NODE_INDEX (pinned to shard 0)."
+            fi
+
+      - run:
+          name: Anti-flaky concurrency gate (shard 0 only, 10x rotation race)
+          # Issue #281 — pinned to shard 0 instead of every shard so the
+          # ~100s overhead is paid once.
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" = "0" ]; then
+              pytest tests/test_proxy_mastio_rotation_concurrency.py \
+                  --count=10 -n auto --dist=loadfile --tb=short -q
+            else
+              echo "Concurrency gate skipped on shard $CIRCLE_NODE_INDEX (pinned to shard 0)."
+            fi
+
+  # ─── Dependency audit + insecure TLS guard (ci.yml: security) ───────
+  security:
+    executor: python-node
+    steps:
+      - checkout
+      - run:
+          name: Install pip-audit
+          command: |
+            python -m pip install --upgrade pip
+            pip install pip-audit
+      - run:
+          name: Audit dependencies
+          # ``pip-audit`` without args scans the whole venv (incl. pip/setuptools
+          # which we don't deploy). Scoping to requirements.txt audits exactly
+          # what the broker image ships.
+          command: |
+            pip install -r requirements.txt
+            pip-audit -r requirements.txt
+      - run:
+          name: Ban insecure TLS opt-outs in production code
+          # F-E-01/F-E-02 audit class: blanket verify=False / rejectUnauthorized:
+          # false buried in runtime code (EUDI wallet MITM-wide-open URLSession
+          # pattern). Allow-list: tests/, sandbox/, demo/, demo_network/.
+          command: |
+            set -e
+            py_hits=$(grep -rn --include='*.py' \
+              -E 'verify\s*=\s*False[\s,)]' \
+              app/ mcp_proxy/ cullis_sdk/ cullis_connector/ agents/ \
+              | grep -vE '^[^:]+:[0-9]+:\s*#' \
+              || true)
+            ts_hits=$(grep -rn --include='*.ts' --include='*.tsx' \
+              -E 'rejectUnauthorized\s*:\s*false|process\.env\.NODE_TLS_REJECT_UNAUTHORIZED\s*=' \
+              sdk-ts/src/ cullis_connector/ \
+              | grep -vE '^[^:]+:[0-9]+:\s*//' \
+              || true)
+            if [ -n "$py_hits" ] || [ -n "$ts_hits" ]; then
+              echo "::error::Insecure TLS opt-out detected in production code."
+              echo "$py_hits"
+              echo "$ts_hits"
+              exit 1
+            fi
+
+  # ─── Smoke (smoke.yml: 4-entry matrix) ──────────────────────────────
+  smoke:
+    parameters:
+      key_type:
+        type: string
+      proxy_db:
+        type: string
+      script:
+        type: string
+    executor: ubuntu-machine
+    environment:
+      PKI_KEY_TYPE: << parameters.key_type >>
+      PROXY_DB: << parameters.proxy_db >>
+    steps:
+      - checkout
+      - run:
+          name: Docker + Compose version
+          command: |
+            docker --version
+            docker compose version
+      - run:
+          name: Run smoke (<< parameters.script >>)
+          working_directory: demo_network
+          no_output_timeout: 20m
+          # COMPOSE_PROJECT_NAME pinned per matrix entry + build num to keep
+          # parallel runs isolated (duplicate-key on ix_federation_events_org_seq
+          # was the original race when rsa+ec+postgres entries shared compose
+          # project name).
+          command: |
+            export COMPOSE_PROJECT_NAME="cullis-smoke-<< parameters.key_type >>-<< parameters.proxy_db >>-${CIRCLE_BUILD_NUM}"
+            << parameters.script >>
+      - run:
+          name: Collect logs on failure
+          working_directory: demo_network
+          when: on_fail
+          command: |
+            export COMPOSE_PROJECT_NAME="cullis-smoke-<< parameters.key_type >>-<< parameters.proxy_db >>-${CIRCLE_BUILD_NUM}"
+            docker compose ps -a || true
+            for svc in ca-init broker-init broker bootstrap proxy-a-init proxy-a proxy-b-init proxy-b sender checker traefik prober; do
+              echo "=== logs $svc ==="
+              docker compose logs "$svc" 2>&1 || true
+            done
+      - run:
+          name: Teardown (defensive)
+          working_directory: demo_network
+          when: always
+          command: |
+            export COMPOSE_PROJECT_NAME="cullis-smoke-<< parameters.key_type >>-<< parameters.proxy_db >>-${CIRCLE_BUILD_NUM}"
+            ./smoke.sh down || true
+            ./standalone_smoke.sh down || true
+
+  # ─── Helm chart deployment gate (helm-test.yml: 2-chart matrix) ─────
+  helm-test:
+    parameters:
+      chart:
+        type: string
+    executor: ubuntu-machine
+    steps:
+      - checkout
+      - run:
+          name: Install Helm v3.16.2
+          command: |
+            curl -L https://get.helm.sh/helm-v3.16.2-linux-amd64.tar.gz | tar -xz
+            sudo mv linux-amd64/helm /usr/local/bin/helm
+            helm version
+      - run:
+          name: Helm lint
+          command: helm lint deploy/helm/<< parameters.chart >>/
+      - run:
+          name: Helm template (default values)
+          command: helm template << parameters.chart >> deploy/helm/<< parameters.chart >>/ > /tmp/template-default.yaml
+      - run:
+          name: Helm template (dev values)
+          command: |
+            if [ -f deploy/helm/<< parameters.chart >>/values-dev.yaml ]; then
+              helm template << parameters.chart >> deploy/helm/<< parameters.chart >>/ \
+                -f deploy/helm/<< parameters.chart >>/values-dev.yaml \
+                > /tmp/template-dev.yaml
+            else
+              echo "No values-dev.yaml for << parameters.chart >>, skipping dev template."
+            fi
+      - run:
+          name: Install kind v0.26.0
+          command: |
+            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+            chmod +x ./kind
+            sudo mv ./kind /usr/local/bin/kind
+            kind --version
+      - run:
+          name: Install kubectl v1.31.4
+          command: |
+            curl -LO "https://dl.k8s.io/release/v1.31.4/bin/linux/amd64/kubectl"
+            chmod +x kubectl
+            sudo mv kubectl /usr/local/bin/
+            kubectl version --client
+      - run:
+          name: Create kind cluster
+          # Unique cluster_name per chart + build num so parallel matrix entries
+          # don't fight on the default "chart-testing" name.
+          command: |
+            CLUSTER_NAME=cullis-helm-<< parameters.chart >>-${CIRCLE_BUILD_NUM}
+            echo "export CLUSTER_NAME=$CLUSTER_NAME" >> $BASH_ENV
+            kind create cluster --name $CLUSTER_NAME \
+              --image kindest/node:v1.31.4 \
+              --wait 5m
+      - run:
+          name: Build chart image
+          # values.yaml defaults point at ghcr.io/... images not yet published;
+          # build locally and kind-load until release workflow ships them.
+          command: |
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              docker build -t cullis-broker:ci-local -f Dockerfile .
+            else
+              docker build -t cullis-mastio:ci-local -f mcp_proxy/Dockerfile .
+            fi
+      - run:
+          name: Load image into kind
+          command: |
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              kind load docker-image cullis-broker:ci-local --name $CLUSTER_NAME
+            else
+              kind load docker-image cullis-mastio:ci-local --name $CLUSTER_NAME
+            fi
+      - run:
+          name: Helm install << parameters.chart >>
+          # cullis-mastio runs with nginx.enabled=false here (ADR-014). The
+          # sidecar K8s pod lifecycle (lifespan stall post-cert-mint, suspected
+          # fsGroup x emptyDir) needs its own kind-local debug session.
+          command: |
+            kubectl create namespace cullis-test --dry-run=client -o yaml | kubectl apply -f -
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              helm install << parameters.chart >> deploy/helm/<< parameters.chart >>/ \
+                -n cullis-test \
+                -f deploy/helm/<< parameters.chart >>/values-dev.yaml \
+                --set broker.image.repository=cullis-broker \
+                --set broker.image.tag=ci-local \
+                --set broker.image.pullPolicy=Never \
+                --wait --timeout 8m
+            else
+              helm install << parameters.chart >> deploy/helm/<< parameters.chart >>/ \
+                -n cullis-test \
+                -f deploy/helm/<< parameters.chart >>/values-dev.yaml \
+                --set proxy.image.repository=cullis-mastio \
+                --set proxy.image.tag=ci-local \
+                --set proxy.image.pullPolicy=Never \
+                --set nginx.enabled=false \
+                --wait --timeout 5m
+            fi
+      - run:
+          name: Assert /healthz 200
+          command: |
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              SVC=cullis-broker PORT=8000
+            else
+              SVC=cullis-mastio PORT=9100
+            fi
+            kubectl -n cullis-test run curl-healthz --rm -i --restart=Never \
+              --image=curlimages/curl:8.10.1 -- \
+              curl -sf --max-time 10 http://$SVC:$PORT/healthz
+      - run:
+          name: Assert /readyz 200
+          command: |
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              SVC=cullis-broker PORT=8000
+            else
+              SVC=cullis-mastio PORT=9100
+            fi
+            kubectl -n cullis-test run curl-readyz --rm -i --restart=Never \
+              --image=curlimages/curl:8.10.1 -- \
+              curl -sf --max-time 10 http://$SVC:$PORT/readyz
+      - run:
+          name: Dump /readyz body on failure
+          when: on_fail
+          command: |
+            if [ "<< parameters.chart >>" = "cullis" ]; then
+              SVC=cullis-broker PORT=8000
+            else
+              SVC=cullis-mastio PORT=9100
+            fi
+            kubectl -n cullis-test run curl-readyz-dump --rm -i --restart=Never \
+              --image=curlimages/curl:8.10.1 -- \
+              curl -s --max-time 10 "http://$SVC:$PORT/readyz" || true
+      - run:
+          name: Dump pod logs on failure
+          when: on_fail
+          command: |
+            kubectl -n cullis-test get pods -o wide || true
+            kubectl -n cullis-test get events --sort-by='.lastTimestamp' || true
+            for pod in $(kubectl -n cullis-test get pods -o name); do
+              echo "=== $pod (current) ==="
+              kubectl -n cullis-test logs "$pod" --tail=500 || true
+              echo "=== $pod (previous) ==="
+              kubectl -n cullis-test logs "$pod" --tail=500 --previous || true
+              echo "=== $pod (describe) ==="
+              kubectl -n cullis-test describe "$pod" || true
+            done
+      - run:
+          name: Teardown kind cluster
+          when: always
+          command: |
+            kind delete cluster --name $CLUSTER_NAME || true
+
+  # ─── Customer-path smoke (customer-path-smoke.yml) ──────────────────
+  customer-path-smoke:
+    executor: ubuntu-machine
+    steps:
+      - checkout
+      - run:
+          name: Tooling versions
+          command: |
+            docker --version
+            docker compose version
+            python3 --version
+      - run:
+          name: Run customer-path smoke
+          no_output_timeout: 25m
+          # ANTHROPIC_API_KEY is a CircleCI project env var (Project Settings ->
+          # Environment Variables). The smoke script asserts it is set when
+          # SKIP_CHAT_TURN is not set.
+          command: |
+            ./packaging/smoke-customer-path.sh
+      - run:
+          name: Collect logs on failure
+          when: on_fail
+          command: |
+            docker ps -a || true
+            for ctr in $(docker ps -aq 2>/dev/null); do
+              name=$(docker inspect --format '{{.Name}}' "$ctr" | sed 's|^/||')
+              echo "=== logs $name ==="
+              docker logs --tail 200 "$ctr" 2>&1 || true
+            done
+            echo "=== mastio deploy log ==="
+            cat /tmp/mastio-deploy.log 2>/dev/null || true
+            echo "=== frontdesk deploy log ==="
+            cat /tmp/frontdesk-deploy.log 2>/dev/null || true
+      - run:
+          name: Teardown (defensive)
+          when: always
+          command: |
+            cd packaging/frontdesk-bundle && ./deploy.sh --down >/dev/null 2>&1 || true
+            cd packaging/mastio-bundle && ./deploy.sh --down >/dev/null 2>&1 || true
+
+  # ─── Cullis Chat Playwright e2e (cullis-chat.yml) ───────────────────
+  cullis-chat-e2e:
+    executor: node-browsers
+    working_directory: ~/project/frontend/cullis-chat
+    steps:
+      - checkout:
+          path: ~/project
+      - restore_cache:
+          keys:
+            - v1-npm-cullis-chat-{{ checksum "package-lock.json" }}
+            - v1-npm-cullis-chat-
+      - run:
+          name: Install dependencies
+          command: npm ci
+      - save_cache:
+          key: v1-npm-cullis-chat-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Build
+          command: npm run build
+      - run:
+          name: Install Playwright Chromium
+          command: npx playwright install --with-deps chromium
+      - run:
+          name: Run e2e suite
+          environment:
+            CI: "true"
+          command: npm run test:e2e
+      - store_artifacts:
+          path: playwright-report
+          destination: playwright-report
+      - store_artifacts:
+          path: test-results
+          destination: test-results
+
+workflows:
+  pr-gate:
+    jobs:
+      - test-shard
+      - security
+      - smoke:
+          name: smoke-rsa
+          key_type: rsa
+          proxy_db: sqlite
+          script: "./smoke.sh full"
+      - smoke:
+          name: smoke-ec
+          key_type: ec
+          proxy_db: sqlite
+          script: "./smoke.sh full"
+      - smoke:
+          name: smoke-rsa-postgres
+          key_type: rsa
+          proxy_db: postgres
+          script: "./smoke.sh full"
+      - smoke:
+          name: smoke-standalone
+          key_type: rsa
+          proxy_db: sqlite
+          script: "./standalone_smoke.sh full"
+      - helm-test:
+          name: helm-test-cullis
+          chart: cullis
+      - helm-test:
+          name: helm-test-cullis-mastio
+          chart: cullis-mastio
+      - customer-path-smoke
+      - cullis-chat-e2e


### PR DESCRIPTION
## Summary

Phase 1 of GH Actions → CircleCI migration. Adds `.circleci/config.yml` covering 5 PR-time workflows:

- `ci.yml` → `test-shard` (3-way pytest-split) + `security` (pip-audit + insecure TLS guard)
- `smoke.yml` → 4-entry matrix (rsa, ec, rsa-postgres, standalone)
- `helm-test.yml` → 2-chart matrix (cullis, cullis-mastio)
- `customer-path-smoke.yml` → single job
- `cullis-chat.yml` → Playwright e2e

Keeps the existing GH workflows untouched so branch-protection required-checks keep reporting and there's a fallback if CircleCI is mid-rollout.

**Stays on GH Actions**: `dco.yml` (zero docker / zero pytest cost) + all `release-*.yml` (native GHCR/PyPI publish path).

## Motivation

GH Actions metered usage May 1-17 hit $123 (~20,170 Linux minutes in 17 days, ~35k min/mo run rate). Free quota saturated, downstream PRs blocked unless spending limit bumped. Migration to CircleCI Performance plan ($15/mo, 80k min/mo) restores predictable CI cost while leaving headroom for stress/dogfood iterations.

## Operational notes baked in

- `parallelism: 3` on test-shard with pytest-split (`CIRCLE_NODE_INDEX` → `--group + 1` mapping). `test_e2e.py` + concurrency-gate + lint + alembic pinned to shard 0 (order-dependent / one-shot work).
- `COMPOSE_PROJECT_NAME` parametrized with `CIRCLE_BUILD_NUM` on smoke entries (avoids the `ix_federation_events_org_seq` race documented in the self-hosted runner attempt).
- `kind` `cluster_name` parametrized per chart for the same reason.
- `medium` resource class everywhere (free tier compatible). Upgrade to `large` via $15 Performance plan if min budget pinch surfaces.

## Phase 2 (next PR after CircleCI green)

- Remove migrated GH workflows: `ci.yml`, `smoke.yml`, `helm-test.yml`, `customer-path-smoke.yml`, `cullis-chat.yml`
- Update branch-protection required-checks: rename to `ci/circleci: <job-name>` format
- (Optional) Add `path-filtering` orb to skip irrelevant jobs per-PR

## Test plan

- [ ] CircleCI auto-triggers on this PR open (verifies webhook)
- [ ] All 5 job types start and complete (1× test-shard parallelism=3, 1× security, 4× smoke matrix, 2× helm-test matrix, 1× customer-path, 1× cullis-chat-e2e)
- [ ] `customer-path-smoke` job may fail on first run if `ANTHROPIC_API_KEY` env var not yet set in CircleCI Project Settings — that's expected, set + re-run
- [ ] Existing GH Actions checks continue to report green (no regression)
- [ ] Compare CircleCI per-job duration vs GH Actions counterparts for future budget tuning