### PR TITLE
feat(multiworker): leader-elect 6 lifespan tasks (PR #759 follow-up)

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -613,24 +613,44 @@ async def lifespan(app: FastAPI):
                 "— subscriber not started. Set one before app startup.",
             )
         else:
+            from mcp_proxy.lifespan import get_leader as _sub_get_leader
             from mcp_proxy.sync.subscriber import (
                 SubscriberConfig,
                 run_subscriber,
             )
-            sub_cfg = SubscriberConfig(
-                broker_url=broker_url,
-                org_id=org_id,
-                client_factory=factory,
-            )
-            sub_stop = asyncio.Event()
-            sub_task = asyncio.create_task(
-                run_subscriber(sub_cfg, stop_event=sub_stop),
-                name="federation_subscriber",
-            )
-            app.state.federation_subscriber_stop = sub_stop
-            app.state.federation_subscriber_task = sub_task
-            app.state.federation_subscriber_stats = sub_cfg.stats
-            _log.info("federation subscriber started (org=%s)", org_id)
+
+            # Bug 3 follow-up to PR #759. Without leader gating, four
+            # uvicorn workers each open their own SSE connection to
+            # the Court (4x persistent HTTP streams) and re-apply the
+            # same events. apply_event() is idempotent per
+            # ``(org_id, seq)`` so correctness holds, but the bandwidth
+            # + Court-side compute is 4x per worker and the SSE
+            # connection count surfaces in Court dashboards as
+            # "phantom subscribers".
+            subscriber_leader = _sub_get_leader("federation_subscriber")
+            if await subscriber_leader.acquire():
+                sub_cfg = SubscriberConfig(
+                    broker_url=broker_url,
+                    org_id=org_id,
+                    client_factory=factory,
+                )
+                sub_stop = asyncio.Event()
+                sub_task = asyncio.create_task(
+                    run_subscriber(sub_cfg, stop_event=sub_stop),
+                    name="federation_subscriber",
+                )
+                app.state.federation_subscriber_stop = sub_stop
+                app.state.federation_subscriber_task = sub_task
+                app.state.federation_subscriber_stats = sub_cfg.stats
+                app.state.federation_subscriber_leader = subscriber_leader
+                _log.info("federation subscriber started (org=%s)", org_id)
+            else:
+                _log.info(
+                    "federation_subscriber: another worker holds the "
+                    "leader lock — skipping (SSE bandwidth saved, "
+                    "org=%s)",
+                    org_id,
+                )
 
     # ADR-010 Phase 3 — federation publisher loop. Only makes sense when
     # the proxy is federated (broker_url set) and the mastio identity
@@ -669,14 +689,28 @@ async def lifespan(app: FastAPI):
         # Aggregate-stats publisher — fleet-size counters for the Court
         # dashboard. Separate task so a slow stats push never delays the
         # per-agent revision loop above.
-        stats_stop = asyncio.Event()
-        stats_task = asyncio.create_task(
-            run_stats_publisher(app.state, stop_event=stats_stop),
-            name="federation_stats_publisher",
-        )
-        app.state.federation_stats_stop = stats_stop
-        app.state.federation_stats_task = stats_task
-        _log.info("federation stats publisher started (org=%s)", org_id)
+        #
+        # Bug 3 follow-up to PR #759 — same anti-pattern as the agent
+        # publisher above (4 workers, 4 redundant POSTs). Lowest
+        # priority of the federation trio, but the leader scaffolding
+        # cost is identical so wire it for consistency.
+        stats_leader = _fed_get_leader("federation_stats_publisher")
+        if await stats_leader.acquire():
+            stats_stop = asyncio.Event()
+            stats_task = asyncio.create_task(
+                run_stats_publisher(app.state, stop_event=stats_stop),
+                name="federation_stats_publisher",
+            )
+            app.state.federation_stats_stop = stats_stop
+            app.state.federation_stats_task = stats_task
+            app.state.federation_stats_publisher_leader = stats_leader
+            _log.info("federation stats publisher started (org=%s)", org_id)
+        else:
+            _log.info(
+                "federation_stats_publisher: another worker holds the "
+                "leader lock — skipping (org=%s)",
+                org_id,
+            )
 
         # Wave B PR8 / D1 — Mastio audit replication. Pushes
         # local_audit rows to the Court (mastio_audit_replica) so
@@ -1020,6 +1054,16 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("federation subscriber teardown loop mismatch (xdist): %s", exc)
+    subscriber_leader = getattr(
+        app.state, "federation_subscriber_leader", None,
+    )
+    if subscriber_leader is not None:
+        try:
+            await subscriber_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug(
+                "federation_subscriber leader release failed: %s", exc,
+            )
 
     stats_stop = getattr(app.state, "federation_stats_stop", None)
     stats_task = getattr(app.state, "federation_stats_task", None)
@@ -1036,6 +1080,16 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("federation stats teardown loop mismatch (xdist): %s", exc)
+    stats_publisher_leader = getattr(
+        app.state, "federation_stats_publisher_leader", None,
+    )
+    if stats_publisher_leader is not None:
+        try:
+            await stats_publisher_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug(
+                "federation_stats_publisher leader release failed: %s", exc,
+            )
 
     pub_stop = getattr(app.state, "federation_publisher_stop", None)
     pub_task = getattr(app.state, "federation_publisher_task", None)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -682,15 +682,34 @@ async def lifespan(app: FastAPI):
         # local_audit rows to the Court (mastio_audit_replica) so
         # cross-org disputes have a Mastio-attested source of truth
         # alongside the Court's broker-observed audit_log.
+        #
+        # Bug 3 follow-up to PR #759 — without leader gating, four
+        # uvicorn workers each read ``last_replicated_local_audit_id``,
+        # batch the same rows, POST four times and race on
+        # ``_write_cursor``. The Court enforces
+        # ``UNIQUE(mastio_org_id, chain_seq)`` so dupes are dropped,
+        # but the customer's Court quota burns 4x. Separate lock from
+        # the agent publisher: audit replication has a tighter
+        # freshness SLA so it should be free to land on a different
+        # worker if scheduling pins the publisher elsewhere.
         from mcp_proxy.federation.audit_publisher import run_audit_publisher
-        audit_stop = asyncio.Event()
-        audit_task = asyncio.create_task(
-            run_audit_publisher(app.state, stop_event=audit_stop),
-            name="federation_audit_publisher",
-        )
-        app.state.federation_audit_stop = audit_stop
-        app.state.federation_audit_task = audit_task
-        _log.info("federation audit publisher started (org=%s)", org_id)
+        audit_leader = _fed_get_leader("federation_audit_publisher")
+        if await audit_leader.acquire():
+            audit_stop = asyncio.Event()
+            audit_task = asyncio.create_task(
+                run_audit_publisher(app.state, stop_event=audit_stop),
+                name="federation_audit_publisher",
+            )
+            app.state.federation_audit_stop = audit_stop
+            app.state.federation_audit_task = audit_task
+            app.state.federation_audit_publisher_leader = audit_leader
+            _log.info("federation audit publisher started (org=%s)", org_id)
+        else:
+            _log.info(
+                "federation_audit_publisher: another worker holds the "
+                "leader lock — skipping (Court quota saved, org=%s)",
+                org_id,
+            )
 
     # ADR-013 layer 6 — DB latency tracker + circuit breaker state.
     # Started after init_db (need the engine) and after the federation
@@ -1056,6 +1075,16 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("audit publisher teardown loop mismatch (xdist): %s", exc)
+    audit_publisher_leader = getattr(
+        app.state, "federation_audit_publisher_leader", None,
+    )
+    if audit_publisher_leader is not None:
+        try:
+            await audit_publisher_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug(
+                "federation_audit_publisher leader release failed: %s", exc,
+            )
 
     ws_manager = getattr(app.state, "local_ws_manager", None)
     if ws_manager is not None:

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -726,6 +726,8 @@ async def lifespan(app: FastAPI):
     from mcp_proxy.observability.traffic_recorder import TrafficRecorder
 
     if settings.anomaly_quarantine_mode != "off":
+        from mcp_proxy.lifespan import get_leader
+
         engine = _require_engine()
 
         traffic_recorder = TrafficRecorder(engine)
@@ -739,26 +741,55 @@ async def lifespan(app: FastAPI):
         await baseline_rollup.start()
         app.state.baseline_rollup = baseline_rollup
 
-        anomaly_evaluator = AnomalyEvaluator(
-            engine,
-            mode=settings.anomaly_quarantine_mode,
-            ratio_threshold=settings.anomaly_ratio_threshold,
-            abs_threshold_rps=settings.anomaly_absolute_threshold_rps,
-            abs_threshold_rps_soft=settings.anomaly_absolute_threshold_rps_soft,
-            sustained_ticks_required=settings.anomaly_sustained_ticks_required,
-            interval_s=settings.anomaly_evaluation_interval_s,
-            ceiling_per_min=settings.anomaly_ceiling_per_min,
-            baseline_min_days=settings.anomaly_baseline_min_days,
-            apply_hook=make_quarantine_apply_hook(
-                engine, ttl_hours=settings.anomaly_quarantine_ttl_hours
-            ),
-        )
-        await anomaly_evaluator.start()
-        app.state.anomaly_evaluator = anomaly_evaluator
+        # Multi-worker leader election — Bug 3 follow-up to PR #759.
+        # Without gating, every uvicorn worker runs its own evaluator
+        # loop. Four workers see the same traffic baseline, four
+        # independent ``apply_hook`` calls run on the same agent, four
+        # rows land in ``agent_quarantine_events`` and four
+        # ``is_active = 0`` UPDATEs fire for one logical anomaly. The
+        # downstream symptom is audit-chain inflation and operator
+        # confusion ("why are there four quarantine events for the
+        # same agent in the same second?"). Lock per task name so the
+        # expiry scheduler can still run on a different worker than
+        # the evaluator if scheduling lands that way.
+        anomaly_leader = get_leader("anomaly_evaluator")
+        if await anomaly_leader.acquire():
+            anomaly_evaluator = AnomalyEvaluator(
+                engine,
+                mode=settings.anomaly_quarantine_mode,
+                ratio_threshold=settings.anomaly_ratio_threshold,
+                abs_threshold_rps=settings.anomaly_absolute_threshold_rps,
+                abs_threshold_rps_soft=settings.anomaly_absolute_threshold_rps_soft,
+                sustained_ticks_required=settings.anomaly_sustained_ticks_required,
+                interval_s=settings.anomaly_evaluation_interval_s,
+                ceiling_per_min=settings.anomaly_ceiling_per_min,
+                baseline_min_days=settings.anomaly_baseline_min_days,
+                apply_hook=make_quarantine_apply_hook(
+                    engine, ttl_hours=settings.anomaly_quarantine_ttl_hours
+                ),
+            )
+            await anomaly_evaluator.start()
+            app.state.anomaly_evaluator = anomaly_evaluator
+            app.state.anomaly_evaluator_leader = anomaly_leader
+            _log.info("anomaly_evaluator: leader acquired, loop spawned")
+        else:
+            _log.info(
+                "anomaly_evaluator: another worker holds the leader "
+                "lock — skipping (audit storm prevention)"
+            )
 
-        quarantine_expiry = QuarantineExpiryScheduler(engine)
-        await quarantine_expiry.start()
-        app.state.quarantine_expiry = quarantine_expiry
+        quarantine_leader = get_leader("quarantine_expiry")
+        if await quarantine_leader.acquire():
+            quarantine_expiry = QuarantineExpiryScheduler(engine)
+            await quarantine_expiry.start()
+            app.state.quarantine_expiry = quarantine_expiry
+            app.state.quarantine_expiry_leader = quarantine_leader
+            _log.info("quarantine_expiry: leader acquired, loop spawned")
+        else:
+            _log.info(
+                "quarantine_expiry: another worker holds the leader "
+                "lock — skipping"
+            )
 
         _log.info(
             "anomaly detector: mode=%s ratio>%.1fx abs>%.0frps "
@@ -832,6 +863,27 @@ async def lifespan(app: FastAPI):
                 _log.warning("%s.stop raised: %s", attr_name, exc)
             try:
                 delattr(app.state, attr_name)
+            except AttributeError:
+                pass
+
+    # Release leader locks for anomaly_evaluator + quarantine_expiry
+    # (Bug 3 follow-up to PR #759). Release after .stop() above so the
+    # held connection / flock fd outlives any in-flight cycle that
+    # ``stop()`` is draining.
+    for leader_attr in (
+        "anomaly_evaluator_leader",
+        "quarantine_expiry_leader",
+    ):
+        leader_obj = getattr(app.state, leader_attr, None)
+        if leader_obj is not None:
+            try:
+                await leader_obj.release()
+            except Exception as exc:  # noqa: BLE001 — best-effort
+                _log.debug(
+                    "%s release failed: %s", leader_attr, exc,
+                )
+            try:
+                delattr(app.state, leader_attr)
             except AttributeError:
                 pass
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -638,14 +638,33 @@ async def lifespan(app: FastAPI):
     # succeeds). Standalone proxies skip entirely.
     if broker_url and getattr(agent_mgr, "mastio_loaded", False):
         from mcp_proxy.federation.publisher import run_publisher, run_stats_publisher
-        pub_stop = asyncio.Event()
-        pub_task = asyncio.create_task(
-            run_publisher(app.state, stop_event=pub_stop),
-            name="federation_publisher",
-        )
-        app.state.federation_publisher_stop = pub_stop
-        app.state.federation_publisher_task = pub_task
-        _log.info("federation publisher started (org=%s)", org_id)
+        from mcp_proxy.lifespan import get_leader as _fed_get_leader
+
+        # Multi-worker leader election — Bug 3 follow-up to PR #759.
+        # Without gating, every uvicorn worker reads
+        # ``federation_revision > last_pushed_revision`` and POSTs the
+        # same revision to the Court. The Court de-duplicates
+        # (already_present), but the wasted bandwidth + Court-side
+        # compute is 4x per tick on a 4-worker bundle. The publisher
+        # body itself is correct when only one caller runs it — keep
+        # it untouched and gate the loop spawn.
+        publisher_leader = _fed_get_leader("federation_publisher")
+        if await publisher_leader.acquire():
+            pub_stop = asyncio.Event()
+            pub_task = asyncio.create_task(
+                run_publisher(app.state, stop_event=pub_stop),
+                name="federation_publisher",
+            )
+            app.state.federation_publisher_stop = pub_stop
+            app.state.federation_publisher_task = pub_task
+            app.state.federation_publisher_leader = publisher_leader
+            _log.info("federation publisher started (org=%s)", org_id)
+        else:
+            _log.info(
+                "federation_publisher: another worker holds the leader "
+                "lock — skipping (Court bandwidth saved, org=%s)",
+                org_id,
+            )
 
         # Aggregate-stats publisher — fleet-size counters for the Court
         # dashboard. Separate task so a slow stats push never delays the
@@ -1014,6 +1033,12 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("federation publisher teardown loop mismatch (xdist): %s", exc)
+    publisher_leader = getattr(app.state, "federation_publisher_leader", None)
+    if publisher_leader is not None:
+        try:
+            await publisher_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug("federation_publisher leader release failed: %s", exc)
 
     # Wave B PR8 / D1 — audit replication publisher teardown.
     audit_stop = getattr(app.state, "federation_audit_stop", None)

--- a/tests/test_multiworker_leader_extension.py
+++ b/tests/test_multiworker_leader_extension.py
@@ -1,0 +1,198 @@
+"""Multi-worker leader gating for 6 background tasks (Bug 3 / PR #759
+follow-up).
+
+PR #759 (a.k.a. "Cluster A wave 2b") shipped ``get_leader()`` and
+wired it on three tasks: ``local_sweeper``, ``mdm_intune_poller``,
+``attestation_stale_watcher``. The remaining six lifespan-spawned
+loops still ran on every uvicorn worker, causing:
+
+* ``anomaly_evaluator`` + ``quarantine_expiry``: audit-chain inflation
+  (4x quarantine events per logical anomaly) — CRITICAL.
+* ``federation_publisher`` + ``federation_audit_publisher``: 4x
+  outbound bandwidth to the Court and 4x compute Court-side.
+* ``federation_subscriber``: 4x concurrent SSE connections per worker.
+* ``federation_stats_publisher``: 4x stats push per tick.
+
+These tests pin the gating contract at the unit level. They do not
+exercise the full lifespan (those paths land in the integration smoke
++ ``./sandbox/smoke.sh full``); they pin that ``get_leader(task_name)``
+is consulted for each of the six tasks before the loop body runs and
+that the held leader is released cleanly at shutdown.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+
+
+# Six task names that PR follow-up wires. Keep this list in sync with
+# the task_name string literals used at the ``get_leader(...)`` call
+# sites in ``mcp_proxy/main.py``. If a task is renamed, this fixture
+# is the single source of truth that catches the drift.
+_BUG3_TASK_NAMES = (
+    "anomaly_evaluator",
+    "quarantine_expiry",
+    "federation_publisher",
+    "federation_audit_publisher",
+    "federation_subscriber",
+    "federation_stats_publisher",
+)
+
+
+# ── leader factory dispatch on real task names ──────────────────────
+
+
+def test_all_bug3_task_names_get_distinct_postgres_keys():
+    """``pg_try_advisory_lock`` collisions across tasks would mean
+    two unrelated loops fight for the same lock and only one runs.
+    The factory uses crc32 ^ salt under the hood, so distinctness is
+    de facto guaranteed for non-pathological names, but we pin it
+    here so a future rename can't silently break leader independence.
+    """
+    from mcp_proxy.lifespan.leader_election import PostgresAdvisoryLeader
+
+    keys = {name: PostgresAdvisoryLeader._key_for(name) for name in _BUG3_TASK_NAMES}
+    assert len(set(keys.values())) == len(_BUG3_TASK_NAMES), keys
+
+
+def test_all_bug3_tasks_get_distinct_sqlite_lockfiles(tmp_path):
+    """Distinct task names map to distinct sidecar lockfiles, so on
+    a SQLite deployment six tasks can be held by up to six workers
+    concurrently (no false serialization)."""
+    from mcp_proxy.lifespan.leader_election import get_leader
+
+    db = tmp_path / "bug3.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db}"
+    leaders = [get_leader(name, db_url=db_url) for name in _BUG3_TASK_NAMES]
+    lock_paths = {leader._lock_path for leader in leaders}  # type: ignore[attr-defined]
+    assert len(lock_paths) == len(_BUG3_TASK_NAMES)
+
+
+# ── leader-gated lifespan-loop contract (the body of the fix) ────────
+
+
+class _FakeLeader:
+    """Records ``acquire()`` / ``release()`` and decides if the loop
+    body runs. Mirrors the ``LeaderElection`` contract closely enough
+    that swapping it in via monkeypatch on ``mcp_proxy.lifespan.
+    get_leader`` exercises the gating logic without needing real
+    flock / postgres infra.
+    """
+
+    def __init__(self, task_name: str, *, wins: bool = True) -> None:
+        self.task_name = task_name
+        self._wins = wins
+        self.acquired = False
+        self.released = False
+        self.held = False
+
+    async def acquire(self) -> bool:
+        self.acquired = True
+        if self._wins:
+            self.held = True
+        return self._wins
+
+    async def release(self) -> None:
+        self.released = True
+        self.held = False
+
+
+def _make_leader_factory(wins_for: set[str]):
+    """Return a ``get_leader`` replacement that yields a winning
+    ``_FakeLeader`` for tasks in ``wins_for`` and a losing one
+    otherwise. Records each instance for post-hoc assertions."""
+    created: dict[str, _FakeLeader] = {}
+
+    def factory(task_name: str, db_url: str | None = None) -> _FakeLeader:
+        leader = _FakeLeader(task_name, wins=task_name in wins_for)
+        created[task_name] = leader
+        return leader
+
+    return factory, created
+
+
+@pytest.mark.asyncio
+async def test_leader_loses_skips_loop_spawn():
+    """Pattern reference: when ``leader.acquire()`` returns False, the
+    follower path must NOT spawn the background task. This pins the
+    branch all six lifespan call sites take when another worker
+    already holds the lock — preventing the duplicate work that Bug
+    3 set out to fix."""
+    leader = _FakeLeader("anomaly_evaluator", wins=False)
+    spawned = []
+
+    async def fake_loop() -> None:
+        spawned.append("ran")
+
+    # Mirror the call-site shape exactly: if acquired, spawn; else,
+    # skip with an INFO log (omitted here — pinned in main.py).
+    if await leader.acquire():
+        await fake_loop()
+
+    assert leader.acquired is True
+    assert leader.held is False
+    assert spawned == []  # loop body must NOT run on the follower
+
+
+@pytest.mark.asyncio
+async def test_leader_wins_runs_loop_and_releases_at_shutdown():
+    """Pattern reference: winning leader runs the loop, holds for the
+    lifetime of the worker, and releases at lifespan shutdown."""
+    leader = _FakeLeader("federation_publisher", wins=True)
+    spawned = []
+
+    async def fake_loop() -> None:
+        spawned.append("ran")
+
+    if await leader.acquire():
+        await fake_loop()
+        # ... lifespan yields, worker serves traffic ...
+        await leader.release()
+
+    assert leader.acquired is True
+    assert leader.released is True
+    assert leader.held is False
+    assert spawned == ["ran"]
+
+
+@pytest.mark.asyncio
+async def test_factory_called_once_per_task_at_startup():
+    """The lifespan hook must call ``get_leader(name)`` exactly once
+    per task at startup — duplicate calls would imply two leader
+    instances, which on SQLite would race on the same flock and on
+    Postgres would open a second long-lived connection."""
+    factory, created = _make_leader_factory(wins_for=set(_BUG3_TASK_NAMES))
+    for name in _BUG3_TASK_NAMES:
+        leader = factory(name)
+        assert await leader.acquire() is True
+
+    assert set(created.keys()) == set(_BUG3_TASK_NAMES)
+    for name, leader in created.items():
+        assert leader.acquired is True, name
+        assert leader.held is True, name
+
+
+# ── pin the lifespan code path imports the helper ────────────────────
+
+
+def test_main_py_imports_get_leader_for_each_bug3_task():
+    """Smoke check: every Bug 3 task name appears next to a
+    ``get_leader("…")`` call in ``mcp_proxy/main.py``. Cheap textual
+    check, but catches the "someone refactored and dropped the gating"
+    regression with no infra dependency."""
+    from pathlib import Path
+
+    main_py = Path(__file__).resolve().parents[1] / "mcp_proxy" / "main.py"
+    src = main_py.read_text()
+    for task in _BUG3_TASK_NAMES:
+        needle = f'get_leader("{task}")'
+        assert needle in src, f"missing leader gating for task {task!r}"


### PR DESCRIPTION
## Summary

PR #759 follow-up. Extends `get_leader(task_name)` gating to the six lifespan background loops that still spawned on every uvicorn worker.

## Why

- **anomaly_evaluator + quarantine_expiry (CRITICAL)** — 4 workers spawn evaluators on same agent baseline, 4 INSERT in `agent_quarantine_events` per logical anomaly. Audit-chain inflation, auditor trust regression
- **federation_publisher (MEDIUM)** — 4x outbound bandwidth to Court per tick
- **federation_audit_publisher (MEDIUM)** — 4x Court POST + cursor-write race
- **federation_subscriber (MEDIUM)** — 4 concurrent SSE streams
- **federation_stats_publisher (MEDIUM)** — 4x stats push per tick

## What

Wraps each lifespan task spawn in `get_leader("<task_name>").acquire()` with distinct lock per task. Loop bodies untouched. Leaders released on shutdown.

## Test plan

- [x] pytest tests/test_multiworker_leader_extension.py (6/6 PASS, new file)
- [x] pytest tests/ -n auto (3953 pass; 4 failures pre-existing on origin/main, see test_dashboard_approvals_nav + test_audit_race_safety parallel-only flake)
- [x] ./sandbox/smoke.sh full → PASS=25 FAIL=0 SKIP=1
- [ ] Multi-worker manual: uvicorn --workers 4, each task name appears as "leader acquired" exactly once

No API break, no config flag, no schema change.