### PR TITLE
feat(frontdesk): threat model ADR + shared-mode audit warning baseline (Phase 1 of 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ The `release-*.yml` workflows extract the section for the released
 version from this file via `awk` matching `## [v<version>]`; bodies
 flow until the next `## ` heading.
 
+## [Unreleased]
+
+### Security
+
+- **Frontdesk shared-mode audit warning (ADR-033 Phase 1).** When the
+  Frontdesk Connector forwards a user session to the Mastio without a
+  cryptographic assertion from the user (the current state pre-Phase-2
+  WebAuthn), the Mastio now emits a structured WARNING log entry and an
+  audit chain row of type
+  `frontdesk_shared_unauthenticated_user_session_warning`. This gives
+  operators a baseline metric for alerting on anomalous impersonation
+  patterns before the Phase 2 cryptographic fix ships.
+  Opt-out for dev/test: `MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED=false`.
+
+### Documentation
+
+- **Frontdesk shared-mode security hardening runbook** added at
+  `docs/runbooks/frontdesk-shared-hardening.md`. Covers container
+  security configuration, network isolation, monitoring, update cadence,
+  compromise response procedure, and the Phase 2 WebAuthn roadmap.
+
+---
+
 ## [v0.4.4] — Mastio multi-worker default — 2026-05-16
 
 First Mastio release that uses this file for release notes (the

--- a/docs/runbooks/frontdesk-shared-hardening.md
+++ b/docs/runbooks/frontdesk-shared-hardening.md
@@ -1,0 +1,171 @@
+# Frontdesk Shared-Mode Security Hardening
+
+**Audience:** IT/security administrators deploying the Cullis Frontdesk container bundle in shared mode (multiple users on a single container instance).
+
+**Applies to:** Frontdesk bundle v0.4.x and later (`cullis-frontdesk-bundle`).
+
+---
+
+## Threat Overview
+
+Frontdesk shared mode runs a single Connector container that handles authentication on behalf of multiple users. When a user logs in via SSO, the Connector issues a short-lived session token and forwards requests to the Mastio with an `X-Cullis-On-Behalf-Of-User` header identifying the user.
+
+This design gives the Connector container a high level of inherent trust: it is the authoritative source of user identity claims toward the Mastio. If the container is compromised (for example, via a supply-chain attack on a dependency, a container escape, or a misconfigured volume mount), an attacker who controls the container can issue requests attributed to any user in the organisation.
+
+Container hardening reduces the probability of compromise, but does not eliminate it by design. This runbook documents the operational controls that bring the residual risk to an acceptable level for production deployments.
+
+A cryptographic fix (WebAuthn-bound session tokens) is in the roadmap as Phase 2 and is the target state for regulated-industry customers. See "Roadmap" below.
+
+---
+
+## Operational Mitigations
+
+### 1. Container Security Hardening
+
+Run the Frontdesk container with the following Docker configuration:
+
+```yaml
+# docker-compose.yml (relevant security settings)
+services:
+  cullis-connector:
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+      - seccomp:unconfined    # replace with a custom profile in production
+    cap_drop:
+      - ALL
+    tmpfs:
+      - /tmp
+      - /run
+    volumes:
+      # Bind-mount only the data directory; no docker.sock mount.
+      - ./connector_data:/app/data:rw
+```
+
+Key requirements:
+
+- **Read-only root filesystem.** Prevents an attacker from modifying the container image on disk.
+- **No `docker.sock` mount.** Mounting the Docker socket grants effective root on the host. Never mount it inside the Frontdesk container.
+- **Drop all capabilities.** The Connector process does not need any Linux capabilities.
+- **No `--privileged` flag.** Never run the Frontdesk container in privileged mode.
+- **Custom seccomp profile.** The default Docker seccomp profile is a good baseline. For production, apply a custom profile that blocks `ptrace`, `process_vm_readv`, and other memory-introspection syscalls.
+
+### 2. Network Isolation
+
+The Frontdesk container should only be able to reach the Mastio on your LAN. It should have no direct internet egress.
+
+```yaml
+services:
+  cullis-connector:
+    networks:
+      - internal
+    # Do NOT attach to a network with internet access.
+
+networks:
+  internal:
+    internal: true
+```
+
+Firewall rules (apply at the host or on a dedicated security group):
+
+| Direction | Source | Destination | Port | Rule |
+|---|---|---|---|---|
+| Inbound | User browsers | Frontdesk container | 4321/TCP | Allow |
+| Outbound | Frontdesk container | Mastio | 9443/TCP | Allow |
+| Outbound | Frontdesk container | IdP (OIDC only) | 443/TCP | Allow |
+| Outbound | Frontdesk container | `*` (internet) | any | Deny |
+
+### 3. Monitoring and Alerting
+
+The Mastio emits a structured audit event every time the Frontdesk uses a session token that lacks a user cryptographic signature:
+
+```
+action: frontdesk_shared_unauthenticated_user_session_warning
+```
+
+This event fires on every authenticated request today (pre-Phase-2). Use it as a baseline metric, then alert on anomalous patterns:
+
+- **Volume spike.** More than 10 events per minute from a single `connector_agent_id` when the expected concurrency is lower suggests automated exploitation.
+- **Off-hours access.** Requests attributed to users outside business hours may indicate stolen sessions.
+- **User enumeration.** A rapid sequence of requests attributed to many distinct users in a short window is a strong signal of automated impersonation.
+
+Example Grafana alert (pseudo-query):
+
+```
+count_over_time(
+  {action="frontdesk_shared_unauthenticated_user_session_warning"}[1m]
+) > 10
+```
+
+You can disable the audit warning in non-production environments by setting `MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED=false` in `proxy.env`. Do not disable this in production.
+
+### 4. Update Cadence
+
+Keep the Frontdesk container up to date. Container images are published on each Mastio release at `ghcr.io/cullis-security/cullis-chat-frontdesk`. Enable automated image pulls on a schedule that matches your organisation's vulnerability remediation SLA.
+
+To upgrade the bundle:
+
+```bash
+./deploy.sh --pull
+```
+
+Do not run `docker compose up -d` directly; it derives the wrong project name and creates an orphaned parallel stack. Always use `deploy.sh`.
+
+### 5. Compromise Response
+
+If you suspect the Frontdesk container has been compromised, follow these steps immediately:
+
+**Step 1: Revoke the Connector certificate.**
+
+```bash
+# Find the Connector agent ID in the Mastio dashboard under Agents.
+curl -X POST https://<mastio-host>:9443/v1/admin/agents/<connector-agent-id>/revoke \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+After revocation, the Mastio rejects all DPoP-authenticated requests from the Connector. Existing user sessions are invalidated because they depend on the Connector's cert thumbprint for pinning.
+
+**Step 2: Revoke all user sessions.**
+
+```bash
+# Force all user sessions issued by this Connector to expire.
+curl -X POST https://<mastio-host>:9443/v1/admin/agents/<connector-agent-id>/revoke-all-sessions \
+  -H "Authorization: Bearer <admin-token>"
+```
+
+**Step 3: Take the container offline.**
+
+```bash
+docker compose -p cullis-frontdesk down
+```
+
+**Step 4: Audit the access log.**
+
+Review the audit chain for the period from the suspected compromise to the revocation. Focus on entries with `on_behalf_of_user_id` populated — these show which users were potentially impersonated.
+
+**Step 5: Re-enroll after investigation.**
+
+After verifying the container image and configuration are clean, bring the bundle back up with `./deploy.sh` and re-approve the Connector enrollment in the Mastio dashboard. All users will need to log in again.
+
+---
+
+## Roadmap: Cryptographic Fix (Phase 2)
+
+Phase 2, planned for the first Frontdesk shared customer engagement, adds WebAuthn-bound session tokens:
+
+1. At login, the user's browser signs a challenge using a FIDO2 authenticator (platform authenticator or YubiKey).
+2. The signature is included in the session token as a `user_signed_assertion` field.
+3. The Mastio verifies the assertion against the user's registered public key before accepting the session.
+
+After Phase 2, compromising the Connector container alone is not sufficient to impersonate users. The attacker also needs access to each user's authenticator device. The `frontdesk_shared_unauthenticated_user_session_warning` audit events will stop appearing once users have enrolled a WebAuthn credential.
+
+Phase 3 (long term) adds TPM-bound device attestation for regulated-industry deployments where the threat model extends to compromised user devices.
+
+---
+
+## References
+
+- ADR-019: Cullis Frontdesk architecture and distribution channels (`imp/adrs/adr-019-cullis-frontdesk.md`)
+- ADR-020: User principal and request quadrants (`imp/adrs/adr-020-user-principal-and-quadrants.md`)
+- ADR-033: Frontdesk shared-mode threat model and remediation roadmap (`imp/adrs/adr-033-frontdesk-threat-model-shared-mode.md`, internal)
+- Mastio bundle deploy guide: `packaging/frontdesk-bundle/README.md`

--- a/mcp_proxy/auth/user_session.py
+++ b/mcp_proxy/auth/user_session.py
@@ -19,6 +19,15 @@ leave the contextvar at None. Rationale: the agent identity is the
 primary credential — the user binding is optional dual-attribution.
 If the user wants strict enforcement they can run with
 ``CULLIS_REQUIRE_USER_SESSION=true`` (config flag added in a follow-up).
+
+ADR-033 Phase 1 audit warning:
+When a session token is accepted but the stored row lacks a
+``user_signed_assertion`` field (no cryptographic proof from the user),
+:func:`maybe_stamp_user_session` emits a WARNING log and writes an
+audit chain row of type
+``frontdesk_shared_unauthenticated_user_session_warning``. This
+visibility is the Phase 1 baseline; Phase 2 (WebAuthn-bound session
+tokens) will add the assertion and the warning will cease.
 """
 from __future__ import annotations
 
@@ -33,6 +42,10 @@ from mcp_proxy.db import get_user_session
 
 _log = logging.getLogger("mcp_proxy.auth.user_session")
 
+# Action constant for the ADR-033 Phase 1 audit entry.
+ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION = (
+    "frontdesk_shared_unauthenticated_user_session_warning"
+)
 
 SESSION_HEADER = "X-Cullis-Session-Token"
 PRINCIPAL_HEADER = "X-Cullis-On-Behalf-Of-User"
@@ -48,6 +61,11 @@ async def maybe_stamp_user_session(
 
     Returns the verified ``principal_id`` on success, ``None`` otherwise.
     Never raises — failure is logged and the contextvar stays at None.
+
+    ADR-033 Phase 1: when the session is accepted but lacks a
+    ``user_signed_assertion``, emits an audit chain row and a WARNING log
+    so operators can alert on unauthenticated-to-user sessions in
+    Frontdesk shared mode.
     """
     session_token = request.headers.get(SESSION_HEADER)
     claimed_principal = request.headers.get(PRINCIPAL_HEADER)
@@ -110,4 +128,81 @@ async def maybe_stamp_user_session(
         "user-session: stamped on_behalf_of_user=%s (agent=%s)",
         stored_principal, caller_agent_id,
     )
+
+    # ADR-033 Phase 1 — emit audit warning when no user-signed assertion is
+    # present. Today this fires on every accepted session because Phase 2
+    # (WebAuthn-bound tokens) is not yet implemented. The warning enables
+    # SOC alerting on anomalous on_behalf_of volume before Phase 2 lands.
+    await _emit_unauthenticated_session_warning_if_needed(
+        caller_agent_id=caller_agent_id,
+        claimed_principal=stored_principal,
+        session_id=session_token,
+        row=row,
+    )
+
     return stored_principal
+
+
+async def _emit_unauthenticated_session_warning_if_needed(
+    *,
+    caller_agent_id: str,
+    claimed_principal: str,
+    session_id: str,
+    row: dict,
+) -> None:
+    """Emit WARNING log + audit chain entry for sessions lacking user assertion.
+
+    Checks ``MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED`` before acting.
+    Never raises — audit warning failures must not break the auth flow.
+    The audit entry is awaited inline (not fire-and-forget) to ensure
+    correctness: the write is cheap (same DB connection pool) and the
+    latency added is below the DPoP proof window.
+    """
+    try:
+        from mcp_proxy.config import get_settings
+        if not get_settings().frontdesk_audit_warning_enabled:
+            return
+    except Exception:
+        return
+
+    # Check whether the session row carries a user-signed assertion (Phase 2).
+    # The field does not exist yet; any truthy value would suppress the warning.
+    has_user_assertion = bool(row.get("user_signed_assertion"))
+    if has_user_assertion:
+        return
+
+    ts = datetime.now(timezone.utc).isoformat()
+
+    _log.warning(
+        "frontdesk-shared: session accepted without user cryptographic assertion "
+        "(agent=%s claimed_user=%s session=%s). "
+        "This is expected pre-Phase-2 (ADR-033). "
+        "Alert if rate exceeds 10/min per container.",
+        caller_agent_id,
+        claimed_principal,
+        session_id[:12] + "...",  # truncate for log hygiene
+    )
+
+    from mcp_proxy.db import log_audit
+
+    try:
+        await log_audit(
+            caller_agent_id,
+            ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION,
+            "warning",
+            details={
+                "connector_agent_id": caller_agent_id,
+                "claimed_user_principal_id": claimed_principal,
+                "session_id": session_id[:12] + "...",
+                "timestamp": ts,
+                "note": (
+                    "No user_signed_assertion field present. "
+                    "Phase 2 WebAuthn-bound sessions will add this. "
+                    "See ADR-033."
+                ),
+            },
+        )
+    except Exception as exc:
+        _log.debug(
+            "frontdesk-shared: audit warning entry failed (non-critical): %s", exc,
+        )

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -412,6 +412,19 @@ class ProxySettings(BaseSettings):
     # Operators tune via ``MCP_PROXY_USER_SESSION_TTL_SECONDS``.
     user_session_ttl_seconds: int = 3600
 
+    # ADR-033 Phase 1 — Frontdesk shared-mode audit warning.
+    # When true (default), ``maybe_stamp_user_session`` emits a
+    # WARNING log entry and an audit chain row of type
+    # ``frontdesk_shared_unauthenticated_user_session_warning``
+    # whenever a Connector presents a session token that lacks a
+    # ``user_signed_assertion`` field (i.e. no cryptographic proof
+    # that the user authorised this specific session). This is every
+    # session today because Phase 2 (WebAuthn-bound session tokens)
+    # is not yet implemented.
+    # Set to false only in dev/test environments where the warning
+    # volume would obscure other signal. Never disable in production.
+    frontdesk_audit_warning_enabled: bool = True
+
     # ADR-017 native AI gateway on Mastio. When the Mastio runs litellm
     # in-process (default: ``litellm_embedded``), every chat completion
     # is dispatched without a Court round trip. Set ``backend=portkey``

--- a/tests/test_frontdesk_audit_warning.py
+++ b/tests/test_frontdesk_audit_warning.py
@@ -1,0 +1,364 @@
+"""ADR-033 Phase 1 — Frontdesk shared-mode audit warning.
+
+Verifies that ``maybe_stamp_user_session`` emits:
+  (a) a WARNING log entry, and
+  (b) an audit chain row of type
+      ``frontdesk_shared_unauthenticated_user_session_warning``
+
+whenever a session is accepted but lacks a ``user_signed_assertion``
+field (i.e. every session today, pre-Phase-2).
+
+Also verifies that setting ``MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED=false``
+suppresses both the log entry and the audit row (opt-out for dev/test).
+
+Note: ``mcp_proxy`` loggers set ``propagate=False`` at configure time so
+pytest caplog does not capture them by default. We use ``monkeypatch`` on
+``_log.warning`` to intercept calls — the same pattern used across the
+suite (see memory ``feedback_mcp_proxy_logger_caplog``).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from starlette.requests import Request
+
+from mcp_proxy.auth.user_context import (
+    reset_on_behalf_of_user,
+    set_on_behalf_of_user,
+)
+from mcp_proxy.auth.user_session import (
+    ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION,
+    maybe_stamp_user_session,
+)
+from mcp_proxy.db import create_user_session, dispose_db, get_db, init_db
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "frontdesk_warn.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_contextvar():
+    tok = set_on_behalf_of_user(None)
+    yield
+    reset_on_behalf_of_user(tok)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(headers: dict[str, str]) -> Request:
+    raw = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in headers.items()
+    ]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/egress/anything",
+        "headers": raw,
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+async def _seed_session(
+    *,
+    session_id: str,
+    principal_id: str = "acme::user::daniele",
+    thumbprint: str = "a" * 64,
+) -> None:
+    await create_user_session(
+        session_id=session_id,
+        principal_id=principal_id,
+        agent_cert_thumbprint=thumbprint,
+        sso_subject="daniele@acme.com",
+        idp_issuer="https://idp.acme.com",
+        display_name="Daniele",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+async def _count_audit_rows_by_action(action: str) -> int:
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT COUNT(*) FROM audit_log WHERE action = :action"),
+            {"action": action},
+        )).first()
+    return int(row[0]) if row else 0
+
+
+async def _flush_pending_tasks() -> None:
+    """Let any fire-and-forget asyncio.Tasks spawned by the helper complete."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: warning emitted
+# ---------------------------------------------------------------------------
+
+
+async def test_warning_log_emitted_for_session_without_user_assertion(
+    proxy_db, monkeypatch,
+):
+    """A valid session (no user_signed_assertion in the row) triggers WARNING.
+
+    Uses monkeypatch on ``_log.warning`` because the mcp_proxy logger
+    hierarchy sets ``propagate=False``, which prevents pytest caplog from
+    capturing these records.
+    """
+    await _seed_session(session_id="warn-sess-001")
+
+    import mcp_proxy.auth.user_session as _us_mod
+
+    warning_calls: list[str] = []
+    original_warn = _us_mod._log.warning
+
+    def _capture_warning(msg, *args, **kwargs):
+        warning_calls.append(msg % args if args else msg)
+        original_warn(msg, *args, **kwargs)
+
+    monkeypatch.setattr(_us_mod._log, "warning", _capture_warning)
+
+    req = _make_request({
+        "X-Cullis-Session-Token": "warn-sess-001",
+        "X-Cullis-On-Behalf-Of-User": "acme::user::daniele",
+    })
+
+    result = await maybe_stamp_user_session(
+        req,
+        caller_agent_id="acme::frontdesk-connector",
+    )
+
+    assert result == "acme::user::daniele", "session should still be accepted"
+    assert any(
+        "frontdesk-shared" in m and "without user cryptographic assertion" in m
+        for m in warning_calls
+    ), f"expected frontdesk warning in log, got: {warning_calls}"
+
+
+async def test_audit_chain_row_written_for_session_without_user_assertion(proxy_db):
+    """The audit chain row with the correct action type is written."""
+    await _seed_session(session_id="warn-sess-002")
+
+    req = _make_request({
+        "X-Cullis-Session-Token": "warn-sess-002",
+        "X-Cullis-On-Behalf-Of-User": "acme::user::daniele",
+    })
+
+    await maybe_stamp_user_session(
+        req,
+        caller_agent_id="acme::frontdesk-connector",
+    )
+
+    # Allow the fire-and-forget Task to complete.
+    await _flush_pending_tasks()
+
+    count = await _count_audit_rows_by_action(
+        ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION,
+    )
+    assert count >= 1, (
+        f"expected at least 1 audit row with action="
+        f"'{ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION}', got {count}"
+    )
+
+
+async def test_audit_row_contains_correct_agent_and_user_fields(proxy_db):
+    """The audit row detail JSON carries connector_agent_id and claimed_user_principal_id."""
+    import json
+
+    await _seed_session(
+        session_id="warn-sess-003",
+        principal_id="acme::user::alice",
+    )
+
+    req = _make_request({
+        "X-Cullis-Session-Token": "warn-sess-003",
+        "X-Cullis-On-Behalf-Of-User": "acme::user::alice",
+    })
+
+    await maybe_stamp_user_session(
+        req,
+        caller_agent_id="acme::frontdesk-node-1",
+    )
+    await _flush_pending_tasks()
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT agent_id, action, detail FROM audit_log "
+                "WHERE action = :action ORDER BY id DESC LIMIT 1"
+            ),
+            {"action": ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION},
+        )).mappings().first()
+
+    assert row is not None
+    assert row["agent_id"] == "acme::frontdesk-node-1"
+
+    detail = json.loads(row["detail"])
+    assert detail["connector_agent_id"] == "acme::frontdesk-node-1"
+    assert detail["claimed_user_principal_id"] == "acme::user::alice"
+    assert "timestamp" in detail
+
+
+# ---------------------------------------------------------------------------
+# Tests: opt-out via env var
+# ---------------------------------------------------------------------------
+
+
+async def test_warning_suppressed_when_env_var_disabled(
+    tmp_path, monkeypatch,
+):
+    """When FRONTDESK_AUDIT_WARNING_ENABLED=false, no WARNING and no audit row."""
+    db_file = tmp_path / "frontdesk_optout.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED", "false")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+
+    try:
+        await _seed_session(session_id="optout-sess-001")
+
+        import mcp_proxy.auth.user_session as _us_mod
+
+        warning_calls: list[str] = []
+        original_warn = _us_mod._log.warning
+
+        def _capture_warning(msg, *args, **kwargs):
+            warning_calls.append(msg % args if args else msg)
+            original_warn(msg, *args, **kwargs)
+
+        monkeypatch.setattr(_us_mod._log, "warning", _capture_warning)
+
+        req = _make_request({
+            "X-Cullis-Session-Token": "optout-sess-001",
+            "X-Cullis-On-Behalf-Of-User": "acme::user::daniele",
+        })
+
+        result = await maybe_stamp_user_session(
+            req,
+            caller_agent_id="acme::frontdesk-connector",
+        )
+
+        await _flush_pending_tasks()
+
+        # Session still accepted.
+        assert result == "acme::user::daniele"
+
+        # No frontdesk warning log.
+        frontdesk_warnings = [m for m in warning_calls if "frontdesk-shared" in m]
+        assert frontdesk_warnings == [], (
+            f"expected no frontdesk warning log when disabled, got: {frontdesk_warnings}"
+        )
+
+        # No audit row for the warning action.
+        count = await _count_audit_rows_by_action(
+            ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION,
+        )
+        assert count == 0, (
+            f"expected 0 audit rows for warning action when disabled, got {count}"
+        )
+
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests: sessions that are rejected do not emit the warning
+# ---------------------------------------------------------------------------
+
+
+async def test_no_warning_when_session_token_absent(proxy_db, monkeypatch):
+    """No warning when X-Cullis-Session-Token header is absent."""
+    import mcp_proxy.auth.user_session as _us_mod
+
+    warning_calls: list[str] = []
+    monkeypatch.setattr(
+        _us_mod._log, "warning",
+        lambda msg, *a, **kw: warning_calls.append(msg % a if a else msg),
+    )
+
+    req = _make_request({})
+
+    result = await maybe_stamp_user_session(
+        req,
+        caller_agent_id="acme::frontdesk-connector",
+    )
+
+    assert result is None
+    frontdesk_warnings = [m for m in warning_calls if "frontdesk-shared" in m]
+    assert frontdesk_warnings == []
+
+
+async def test_no_warning_when_session_is_rejected_due_to_mismatch(
+    proxy_db, monkeypatch,
+):
+    """No warning when principal_id header mismatches the stored row."""
+    await _seed_session(session_id="warn-mismatch-001", principal_id="acme::user::alice")
+
+    warning_calls: list[str] = []
+    import mcp_proxy.auth.user_session as _us_mod
+    monkeypatch.setattr(
+        _us_mod._log, "warning",
+        lambda msg, *a, **kw: warning_calls.append(msg % a if a else msg),
+    )
+
+    req = _make_request({
+        "X-Cullis-Session-Token": "warn-mismatch-001",
+        # Claims a different user than the session row has.
+        "X-Cullis-On-Behalf-Of-User": "acme::user::eve",
+    })
+
+    result = await maybe_stamp_user_session(
+        req,
+        caller_agent_id="acme::frontdesk-connector",
+    )
+    await _flush_pending_tasks()
+
+    assert result is None
+    # No audit warning row should be written for a rejected session.
+    count = await _count_audit_rows_by_action(
+        ACTION_FRONTDESK_SHARED_UNAUTHENTICATED_SESSION,
+    )
+    assert count == 0


### PR DESCRIPTION
## Discovery (Step 0)

Pre-verify findings before writing a line of code:

- `mcp_proxy/auth/user_session.py`: `maybe_stamp_user_session` already verifies session token + cert thumbprint pinning (ADR-032 Layer 2). No partial implementation of the warning existed.
- `user_signed_assertion` field: absent from the `user_sessions` schema (as expected — Phase 2 placeholder).
- `ambassador_mode=shared` detection: lives in `enrollment/service.py` for the auto-binding skip, not in the auth path. The auth path does not check ambassador mode, which means the trust gap applies to any accepted session.
- Next ADR ID: 033 (032 was the device attestation ADR, 033 existed in the Alembic migration `0033_audit_dpop_jkt` but not as an ADR doc — used 033 for the ADR doc).
- `docs/runbooks/`: contained only `postgres-pilot.md`. New file is the second entry.

## Threat Summary

Frontdesk shared mode (ADR-019 + ADR-020): a single Connector container acts as the authoritative source of user identity claims for all users in the org. Every request to the Mastio carries `X-Cullis-On-Behalf-Of-User: <org>::user::<username>` from the Connector. Mastio trusts this claim entirely.

**If the Connector container is compromised, an attacker can impersonate every registered user with zero cryptographic friction.** Container hardening is a probability-reducing operational control, not a cryptographic guarantee. A single container serving 50 users is a 50x impersonation amplifier.

ADR-033 (internal-only, `imp/adrs/adr-033-frontdesk-threat-model-shared-mode.md`) documents the full threat model, current mitigations, and the Phase 2 WebAuthn roadmap.

## What This PR Does

**Phase 1: Audit visibility baseline.**

- `mcp_proxy/auth/user_session.py`: when `maybe_stamp_user_session` accepts a session that lacks `user_signed_assertion`, emits a structured WARNING log and an audit chain row:
  ```
  action: frontdesk_shared_unauthenticated_user_session_warning
  detail: {connector_agent_id, claimed_user_principal_id, session_id, timestamp, note}
  ```
  This fires on every accepted session today (pre-Phase-2). Enables SOC alerting on anomalous volume.

- `mcp_proxy/config.py`: new `MCP_PROXY_FRONTDESK_AUDIT_WARNING_ENABLED` (default `true`). Opt-out for dev/test; never disable in production.

- `tests/test_frontdesk_audit_warning.py`: 6 tests covering warning emission, audit row content, env var opt-out, and non-emission on rejected sessions.

- `docs/runbooks/frontdesk-shared-hardening.md`: customer-facing runbook with container hardening config, network isolation rules, monitoring alert patterns, update cadence, and compromise response procedure.

- `CHANGELOG.md`: `[Unreleased]` entry for Security and Documentation.

## What Is Left for Phase 2 (WebAuthn)

Phase 2 (executor E, separate Wave 1 PR) will:
1. Add `user_signed_assertion` to the `user_sessions` table schema (Alembic migration).
2. Connector: at login, request a WebAuthn signature from the user's browser/FIDO2 device, include it in the session token payload.
3. Mastio `maybe_stamp_user_session`: verify the assertion against `local_user_principals.user_pubkey_thumbprint` before accepting the session.
4. When `user_signed_assertion` is valid, the `frontdesk_shared_unauthenticated_user_session_warning` audit entries stop. Phase 2 is blocking for first Frontdesk-shared customer engagement.

## Test Plan

- [x] 6 new tests in `test_frontdesk_audit_warning.py` — all pass
- [x] Existing `test_user_session_pinning.py` (5 tests) — all pass with new code
- [x] Existing `test_audit_on_behalf_of_user.py` (4 tests) — all pass
- [x] Broader test suite (`pytest tests/ -n auto`) — green
- [ ] Smoke (`./sandbox/smoke.sh full`) — to run pre-merge