### PR TITLE
fix(enrollment): make pop_signature mandatory (drop backward-compat grace period)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Breaking change
+
+- **`POST /v1/enrollment/start` now requires `pop_signature`** (H-csr-pop
+  audit fix). The `pop_signature` field on `StartEnrollmentRequest` was
+  Optional during the transition window: a Connector that did not sign
+  `"enrollment-pop:v1|<pubkey-sha256-hex>"` still enrolled, with the
+  server logging a WARNING. The transition window is closed and the
+  field is now mandatory. Pre-v0.4.4 Connectors that don't ship a PoP
+  signature fail enrollment with HTTP 400 and a structured detail.
+- **Why**: without proof-of-possession the server could not distinguish
+  the legitimate keypair owner from an attacker submitting an intercepted
+  or observed public key, the only defense was admin fingerprint
+  cross-check (out-of-band, human, non-cryptographic). Making
+  `pop_signature` mandatory closes the impersonation vector at the
+  protocol layer.
+- **Migration**: Connectors v0.4.4+ already ship `_build_pop_signature`
+  and sign by default. SDK callers building their own request body must
+  add a `pop_signature` over `"enrollment-pop:v1|<pubkey-sha256-hex>"`
+  (RSA-PSS or ECDSA-P256, base64url).
+
 ### Security
 
 - **Frontdesk shared-mode audit warning (ADR-033 Phase 1).** When the

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -51,20 +51,19 @@ class EnrollmentStartRequest(BaseModel):
             " endpoint (#206) or re-enrolls (audit F-B-11 Phase 3b)."
         ),
     )
-    pop_signature: str | None = Field(
-        None,
+    pop_signature: str = Field(
+        ...,
         max_length=2048,
         description=(
-            "H-csr-pop audit fix — base64url proof of possession over"
+            "H-csr-pop audit fix, base64url proof of possession over"
             " the keypair whose public half is in ``pubkey_pem``. The"
             " Connector signs ``\"enrollment-pop:v1|<pubkey-sha256-hex>\"``"
             " (RSA-PSS or ECDSA, dispatched by key type) and submits"
             " the signature here. The server verifies before persisting,"
-            " so an attacker cannot enroll a stolen / observed public"
-            " key whose private half they don't control. Optional for"
-            " a transition window — pre-fix Connectors still enroll"
-            " but the server logs a WARNING. Will become required in"
-            " a follow-up release."
+            " so an attacker cannot enroll a stolen or observed public"
+            " key whose private half they don't control. Required since"
+            " v0.5; pre-v0.4.4 Connectors that don't ship this field"
+            " fail enrollment with HTTP 400."
         ),
     )
     # ── ADR-032 F3: TPM attestation (optional) ────────────────────────

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -220,12 +220,12 @@ async def start_enrollment(
     conn: AsyncConnection,
     *,
     pubkey_pem: str,
+    pop_signature: str,
     requester_name: str,
     requester_email: str,
     reason: str | None,
     device_info: str | None,
     dpop_jwk: dict | None = None,
-    pop_signature: str | None = None,
     attestation_nonce_id: str | None = None,
     tpm_quote_b64: str | None = None,
     tpm_manufacturer: str | None = None,
@@ -255,27 +255,25 @@ async def start_enrollment(
 
     fingerprint = _pubkey_fingerprint(pubkey_pem)
 
-    # H-csr-pop audit fix — verify proof-of-possession over the
-    # submitted public key. A pre-fix Connector that doesn't ship
-    # ``pop_signature`` is allowed through with a WARNING during the
-    # transition window so existing fleets keep working; a follow-up
-    # PR makes it required once Connector rollout is confirmed.
-    if pop_signature:
-        if not _verify_pop_signature(pubkey_pem, fingerprint, pop_signature):
-            raise EnrollmentError(
-                "pop_signature does not verify against pubkey_pem — "
-                "the submitter does not control the corresponding "
-                "private key (H-csr-pop audit).",
-                http_status=400,
-            )
-    else:
-        import logging
-        logging.getLogger("mcp_proxy.enrollment").warning(
-            "start_enrollment: legacy Connector submitted pubkey_pem "
-            "without pop_signature (fingerprint=%s). Accepted under "
-            "the transition window; a future release will make the "
-            "PoP signature required.",
-            fingerprint,
+    # H-csr-pop audit, verify proof-of-possession over the submitted
+    # public key. Required since v0.5 (transition window dropped):
+    # a pre-fix Connector that doesn't ship pop_signature fails enroll
+    # with HTTP 400, an attacker cannot enroll a stolen or observed
+    # public key whose private half they don't control.
+    if not pop_signature:
+        raise EnrollmentError(
+            "pop_signature is required. Connectors must sign "
+            "'enrollment-pop:v1|<pubkey-sha256-hex>' with the "
+            "enrollment private key. Pre-v0.4.4 Connectors are "
+            "unsupported.",
+            http_status=400,
+        )
+    if not _verify_pop_signature(pubkey_pem, fingerprint, pop_signature):
+        raise EnrollmentError(
+            "pop_signature does not verify against pubkey_pem, "
+            "the submitter does not control the corresponding "
+            "private key (H-csr-pop audit).",
+            http_status=400,
         )
 
     # ADR-032 F3 Phase 1: verify the optional TPM attestation half.

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -9,13 +9,15 @@ Covers:
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
 from cryptography import x509
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from httpx import ASGITransport, AsyncClient
 
 from mcp_proxy.db import dispose_db, get_db, init_db
@@ -26,20 +28,69 @@ from mcp_proxy.enrollment.service import EnrollmentError
 # ── Helpers ────────────────────────────────────────────────────────
 
 
-def _rsa_pubkey_pem() -> str:
+def _rsa_keypair() -> tuple[rsa.RSAPrivateKey, str]:
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    return key.public_key().public_bytes(
+    pem = key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
+    return key, pem
+
+
+def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return key, pem
+
+
+def _rsa_pubkey_pem() -> str:
+    return _rsa_keypair()[1]
 
 
 def _ec_pubkey_pem() -> str:
-    key = ec.generate_private_key(ec.SECP256R1())
-    return key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
+    return _ec_keypair()[1]
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    """Build a valid H-csr-pop signature over ``enrollment-pop:v1|<fp>``.
+
+    Mirrors ``cullis_connector/enrollment.py:_build_pop_signature`` so
+    the test calls match what the server's ``_verify_pop_signature``
+    accepts.
+    """
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+def _rsa_pop_kwargs() -> dict[str, str]:
+    """Returns ``{pubkey_pem, pop_signature}`` ready to splat into a call."""
+    priv, pem = _rsa_keypair()
+    return {"pubkey_pem": pem, "pop_signature": _sign_pop(priv, pem)}
+
+
+def _ec_pop_kwargs() -> dict[str, str]:
+    priv, pem = _ec_keypair()
+    return {"pubkey_pem": pem, "pop_signature": _sign_pop(priv, pem)}
 
 
 # ── Service layer tests (SQLite-backed, no HTTP) ───────────────────
@@ -62,11 +113,12 @@ async def db_engine(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_start_enrollment_persists_row(db_engine):
-    pubkey = _ec_pubkey_pem()
+    _priv, pubkey = _ec_keypair()
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="Mario Rossi",
             requester_email="mario@acme.com",
             reason="Procurement Q2 project",
@@ -89,6 +141,7 @@ async def test_start_rejects_malformed_pubkey(db_engine):
             await service.start_enrollment(
                 conn,
                 pubkey_pem="not a real pem",
+                pop_signature="noise",
                 requester_name="Mario",
                 requester_email="m@x.com",
                 reason=None,
@@ -107,11 +160,12 @@ async def test_get_record_not_found_raises_404(db_engine):
 
 @pytest.mark.asyncio
 async def test_expired_record_flips_on_read(db_engine):
-    pubkey = _rsa_pubkey_pem()
+    _priv, pubkey = _rsa_keypair()
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="N",
             requester_email="n@x.com",
             reason=None,
@@ -137,7 +191,7 @@ async def test_list_pending_skips_expired(db_engine):
     async with get_db() as conn:
         alive = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Alive",
             requester_email="alive@x.com",
             reason=None,
@@ -145,7 +199,7 @@ async def test_list_pending_skips_expired(db_engine):
         )
         stale = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Stale",
             requester_email="stale@x.com",
             reason=None,
@@ -172,7 +226,7 @@ async def test_reject_sets_status_and_reason(db_engine):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="R",
             requester_email="r@x.com",
             reason=None,
@@ -208,11 +262,12 @@ async def test_approve_signs_cert_and_marks_approved(db_engine):
     ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
     await manager.load_org_ca(ca_key, ca_cert_pem)
 
-    pubkey = _rsa_pubkey_pem()
+    _priv, pubkey = _rsa_keypair()
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="A",
             requester_email="a@x.com",
             reason=None,
@@ -261,11 +316,12 @@ async def test_approve_registers_agent_in_internal_registry(db_engine):
     ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
     await manager.load_org_ca(ca_key, ca_cert_pem)
 
-    pubkey = _rsa_pubkey_pem()
+    _priv, pubkey = _rsa_keypair()
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="A",
             requester_email="a@x.com",
             reason=None,
@@ -334,11 +390,12 @@ async def test_approve_re_enroll_same_agent_id_updates_cert(db_engine):
     await manager.load_org_ca(ca_key, ca_cert_pem)
 
     # First enrollment + approval — establishes the baseline row.
-    pubkey_1 = _rsa_pubkey_pem()
+    _priv_1, pubkey_1 = _rsa_keypair()
     async with get_db() as conn:
         s1 = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey_1,
+            pop_signature=_sign_pop(_priv_1, pubkey_1),
             requester_name="A",
             requester_email="a@x.com",
             reason=None,
@@ -360,12 +417,13 @@ async def test_approve_re_enroll_same_agent_id_updates_cert(db_engine):
     # recovery flow). The admin's ``capabilities`` arg here is a stand-in
     # for a re-approval ritual; it should NOT overwrite the first
     # approval's stored caps because admin state is preserved.
-    pubkey_2 = _rsa_pubkey_pem()
+    _priv_2, pubkey_2 = _rsa_keypair()
     assert pubkey_2 != pubkey_1, "test fixture sanity"
     async with get_db() as conn:
         s2 = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey_2,
+            pop_signature=_sign_pop(_priv_2, pubkey_2),
             requester_name="A",
             requester_email="a@x.com",
             reason="reinstall",
@@ -436,7 +494,7 @@ async def test_approve_shared_mode_skips_auto_baseline_binding(
     ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
     await manager.load_org_ca(ca_key, ca_cert_pem)
 
-    pubkey = _rsa_pubkey_pem()
+    _priv, pubkey = _rsa_keypair()
 
     # Spy on the auto-baseline-binding scheduler so we can assert no task
     # is created for shared-mode enrollments. ``approve()`` calls
@@ -453,6 +511,7 @@ async def test_approve_shared_mode_skips_auto_baseline_binding(
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="Frontdesk",
             requester_email="frontdesk@acme.com",
             reason=None,
@@ -488,7 +547,7 @@ async def test_approve_single_mode_still_schedules_auto_baseline_binding(
     ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
     await manager.load_org_ca(ca_key, ca_cert_pem)
 
-    pubkey = _rsa_pubkey_pem()
+    _priv, pubkey = _rsa_keypair()
 
     called: list[dict] = []
 
@@ -501,6 +560,7 @@ async def test_approve_single_mode_still_schedules_auto_baseline_binding(
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey,
+            pop_signature=_sign_pop(_priv, pubkey),
             requester_name="Daniele",
             requester_email="d@acme.com",
             reason=None,
@@ -567,7 +627,7 @@ async def test_http_start_returns_201_and_poll_url(proxy_app):
     resp = await client.post(
         "/v1/enrollment/start",
         json={
-            "pubkey_pem": _ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             "requester_name": "Mario",
             "requester_email": "mario@acme.com",
             "reason": "Onboarding",
@@ -586,7 +646,7 @@ async def test_http_status_pending_then_not_found(proxy_app):
     start = await client.post(
         "/v1/enrollment/start",
         json={
-            "pubkey_pem": _ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             "requester_name": "X",
             "requester_email": "x@x.com",
         },
@@ -694,7 +754,7 @@ async def test_http_start_rate_limits_after_budget(proxy_app, monkeypatch):
         resp = await client.post(
             "/v1/enrollment/start",
             json={
-                "pubkey_pem": _ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 "requester_name": "Mario",
                 "requester_email": "mario@acme.com",
             },
@@ -704,7 +764,7 @@ async def test_http_start_rate_limits_after_budget(proxy_app, monkeypatch):
     blocked = await client.post(
         "/v1/enrollment/start",
         json={
-            "pubkey_pem": _ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             "requester_name": "Mario",
             "requester_email": "mario@acme.com",
         },
@@ -729,7 +789,7 @@ async def test_http_status_rate_limits_after_budget(proxy_app, monkeypatch):
     started = await client.post(
         "/v1/enrollment/start",
         json={
-            "pubkey_pem": _ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             "requester_name": "X",
             "requester_email": "x@x.com",
         },

--- a/tests/test_enrollment_attestation_injection.py
+++ b/tests/test_enrollment_attestation_injection.py
@@ -10,13 +10,15 @@ matches, and verify:
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding
 from sqlalchemy import text
 
 from mcp_proxy.db import dispose_db, get_db, init_db
@@ -24,12 +26,35 @@ from mcp_proxy.enrollment import service
 from mcp_proxy.mdm.poller import upsert_device_rows
 
 
-def _ec_pubkey_pem() -> str:
+def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
     key = ec.generate_private_key(ec.SECP256R1())
-    return key.public_key().public_bytes(
+    pem = key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
+    return key, pem
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
 
 
 @pytest_asyncio.fixture
@@ -65,11 +90,14 @@ class _FakeAgentManager:
         return f"-----BEGIN CERTIFICATE-----\nFAKE-{agent_name}\n-----END CERTIFICATE-----\n"
 
 
-async def _seed_pending(pubkey_pem: str, device_info_json: str) -> str:
+async def _seed_pending(
+    priv, pubkey_pem: str, device_info_json: str,
+) -> str:
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pubkey_pem,
+            pop_signature=_sign_pop(priv, pubkey_pem),
             requester_name="Alice Tester",
             requester_email="alice@example.com",
             reason="attestation test",
@@ -94,12 +122,12 @@ async def test_enrollment_with_matching_intune_device_stamps_claim(db_engine):
         now=now,
     )
 
-    pubkey = _ec_pubkey_pem()
+    _priv, pubkey = _ec_keypair()
     device_info = json.dumps({
         "os": "linux",
         "azure_ad_device_id": "aad-1",
     })
-    session_id = await _seed_pending(pubkey, device_info)
+    session_id = await _seed_pending(_priv, pubkey, device_info)
 
     # 2. Approve.
     async with get_db() as conn:
@@ -150,9 +178,9 @@ async def test_enrollment_with_matching_intune_device_stamps_claim(db_engine):
 @pytest.mark.asyncio
 async def test_enrollment_without_mdm_match_completes_without_stamping(db_engine):
     """No cache match → no last_attestation, no audit, no error."""
-    pubkey = _ec_pubkey_pem()
+    _priv, pubkey = _ec_keypair()
     device_info = json.dumps({"os": "linux", "azure_ad_device_id": "unknown-aad"})
-    session_id = await _seed_pending(pubkey, device_info)
+    session_id = await _seed_pending(_priv, pubkey, device_info)
 
     async with get_db() as conn:
         record = await service.approve(
@@ -195,9 +223,9 @@ async def test_non_compliant_match_stamps_byod_attested_or_untrusted(db_engine):
         now=now,
     )
 
-    pubkey = _ec_pubkey_pem()
+    _priv, pubkey = _ec_keypair()
     device_info = json.dumps({"azure_ad_device_id": "aad-2"})
-    session_id = await _seed_pending(pubkey, device_info)
+    session_id = await _seed_pending(_priv, pubkey, device_info)
 
     async with get_db() as conn:
         record = await service.approve(
@@ -237,8 +265,8 @@ async def test_enrollment_hook_failure_does_not_break_approve(db_engine, monkeyp
         _boom,
     )
 
-    pubkey = _ec_pubkey_pem()
-    session_id = await _seed_pending(pubkey, "{}")
+    _priv, pubkey = _ec_keypair()
+    session_id = await _seed_pending(_priv, pubkey, "{}")
 
     async with get_db() as conn:
         record = await service.approve(

--- a/tests/test_enrollment_dashboard.py
+++ b/tests/test_enrollment_dashboard.py
@@ -12,6 +12,8 @@ Complements ``tests/test_enrollment.py`` which exercises the JSON API.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
 import json as _json
 import time as _time
 from datetime import datetime, timedelta, timezone
@@ -20,7 +22,7 @@ import pytest
 import pytest_asyncio
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from cryptography.x509.oid import NameOID
 from httpx import ASGITransport, AsyncClient
 
@@ -28,12 +30,40 @@ from httpx import ASGITransport, AsyncClient
 # ── Helpers ──────────────────────────────────────────────────────
 
 
-def _ec_pubkey_pem() -> str:
+def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
     key = ec.generate_private_key(ec.SECP256R1())
-    return key.public_key().public_bytes(
+    pem = key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
+    return key, pem
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+def _ec_pop_kwargs() -> dict[str, str]:
+    priv, pem = _ec_keypair()
+    return {"pubkey_pem": pem, "pop_signature": _sign_pop(priv, pem)}
 
 
 def _generate_self_signed_ca(org_id: str) -> tuple[str, str]:
@@ -115,7 +145,7 @@ async def _start_enrollment(client: AsyncClient, name: str = "Mario Rossi") -> s
     resp = await client.post(
         "/v1/enrollment/start",
         json={
-            "pubkey_pem": _ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             "requester_name": name,
             "requester_email": "mario@acme.com",
             "reason": "Onboarding via dashboard test",

--- a/tests/test_enrollment_dpop_jkt.py
+++ b/tests/test_enrollment_dpop_jkt.py
@@ -13,11 +13,12 @@ Covers the service layer and the HTTP path:
 from __future__ import annotations
 
 import base64
+import hashlib
 
 import pytest
 import pytest_asyncio
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from sqlalchemy import text
 
 from mcp_proxy.db import dispose_db, get_db, init_db
@@ -27,12 +28,44 @@ from mcp_proxy.enrollment.service import EnrollmentError
 
 # ── Helpers ────────────────────────────────────────────────────────
 
-def _ec_pubkey_pem() -> str:
+def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
     key = ec.generate_private_key(ec.SECP256R1())
-    return key.public_key().public_bytes(
+    pem = key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
+    return key, pem
+
+
+def _ec_pubkey_pem() -> str:
+    return _ec_keypair()[1]
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+def _ec_pop_kwargs() -> dict[str, str]:
+    priv, pem = _ec_keypair()
+    return {"pubkey_pem": pem, "pop_signature": _sign_pop(priv, pem)}
 
 
 def _ec_public_jwk() -> dict:
@@ -81,7 +114,7 @@ async def test_start_with_valid_ec_jwk_stores_thumbprint(db_engine):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Alice",
             requester_email="alice@example.com",
             reason="test",
@@ -106,7 +139,7 @@ async def test_start_with_valid_rsa_jwk_stores_thumbprint(db_engine):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Bob",
             requester_email="bob@example.com",
             reason=None,
@@ -129,7 +162,7 @@ async def test_start_without_jwk_keeps_dpop_jkt_null(db_engine):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Carol",
             requester_email="carol@example.com",
             reason=None,
@@ -153,7 +186,7 @@ async def test_start_rejects_jwk_with_private_material(db_engine):
         with pytest.raises(EnrollmentError) as exc:
             await service.start_enrollment(
                 conn,
-                pubkey_pem=_ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 requester_name="Dave",
                 requester_email="dave@example.com",
                 reason=None,
@@ -170,7 +203,7 @@ async def test_start_rejects_unsupported_kty(db_engine):
         with pytest.raises(EnrollmentError) as exc:
             await service.start_enrollment(
                 conn,
-                pubkey_pem=_ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 requester_name="Erin",
                 requester_email="erin@example.com",
                 reason=None,
@@ -187,7 +220,7 @@ async def test_start_rejects_malformed_jwk(db_engine):
         with pytest.raises(EnrollmentError) as exc:
             await service.start_enrollment(
                 conn,
-                pubkey_pem=_ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 requester_name="Fred",
                 requester_email="fred@example.com",
                 reason=None,
@@ -203,7 +236,7 @@ async def test_start_rejects_empty_jwk(db_engine):
         with pytest.raises(EnrollmentError) as exc:
             await service.start_enrollment(
                 conn,
-                pubkey_pem=_ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 requester_name="Gina",
                 requester_email="gina@example.com",
                 reason=None,
@@ -232,7 +265,7 @@ async def test_approve_copies_jkt_to_internal_agents(agent_manager):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Helen",
             requester_email="helen@example.com",
             reason=None,
@@ -266,7 +299,7 @@ async def test_approve_without_jwk_leaves_agent_dpop_jkt_null(agent_manager):
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
-            pubkey_pem=_ec_pubkey_pem(),
+            **_ec_pop_kwargs(),
             requester_name="Iris",
             requester_email="iris@example.com",
             reason=None,
@@ -319,7 +352,7 @@ async def test_http_start_with_dpop_jwk_returns_201(http_app):
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with http_app.router.lifespan_context(http_app):
             body = {
-                "pubkey_pem": _ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 "requester_name": "Jack",
                 "requester_email": "jack@example.com",
                 "dpop_jwk": _ec_public_jwk(),
@@ -335,7 +368,7 @@ async def test_http_start_rejects_malformed_dpop_jwk(http_app):
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with http_app.router.lifespan_context(http_app):
             body = {
-                "pubkey_pem": _ec_pubkey_pem(),
+                **_ec_pop_kwargs(),
                 "requester_name": "Kate",
                 "requester_email": "kate@example.com",
                 "dpop_jwk": {"kty": "oct", "k": "bad"},

--- a/tests/test_enrollment_tpm_flow.py
+++ b/tests/test_enrollment_tpm_flow.py
@@ -19,7 +19,7 @@ import secrets
 import pytest
 import pytest_asyncio
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from sqlalchemy import text
 
@@ -51,6 +51,28 @@ def _ec_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
     return key, pem
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
 
 
 def _build_quote_b64(nonce: bytes, key: ec.EllipticCurvePrivateKey) -> str:
@@ -88,6 +110,7 @@ async def test_start_enrollment_with_valid_tpm_quote_persists_claim(db_engine):
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pem,
+            pop_signature=_sign_pop(key, pem),
             requester_name="Hardware Hannah",
             requester_email="hh@acme.com",
             reason="tpm-pilot",
@@ -127,6 +150,7 @@ async def test_start_enrollment_audit_row_written_on_verified_quote(db_engine):
         await service.start_enrollment(
             conn,
             pubkey_pem=pem,
+            pop_signature=_sign_pop(key, pem),
             requester_name="Hannah",
             requester_email="h@acme.com",
             reason=None,
@@ -150,11 +174,12 @@ async def test_start_enrollment_audit_row_written_on_verified_quote(db_engine):
 
 @pytest.mark.asyncio
 async def test_start_enrollment_without_tpm_fields_skips_attestation(db_engine):
-    _, pem = _ec_keypair()
+    key, pem = _ec_keypair()
     async with get_db() as conn:
         started = await service.start_enrollment(
             conn,
             pubkey_pem=pem,
+            pop_signature=_sign_pop(key, pem),
             requester_name="Soft Sam",
             requester_email="s@acme.com",
             reason=None,
@@ -183,6 +208,7 @@ async def test_start_enrollment_rejects_quote_without_nonce_id(db_engine):
             await service.start_enrollment(
                 conn,
                 pubkey_pem=pem,
+                pop_signature=_sign_pop(key, pem),
                 requester_name="Half",
                 requester_email="h@acme.com",
                 reason=None,
@@ -208,6 +234,7 @@ async def test_start_enrollment_rejects_expired_or_unknown_nonce(db_engine):
             await service.start_enrollment(
                 conn,
                 pubkey_pem=pem,
+                pop_signature=_sign_pop(key, pem),
                 requester_name="Stale",
                 requester_email="x@acme.com",
                 reason=None,
@@ -234,6 +261,7 @@ async def test_start_enrollment_rejects_tampered_quote(db_engine):
             await service.start_enrollment(
                 conn,
                 pubkey_pem=pem,
+                pop_signature=_sign_pop(key, pem),
                 requester_name="Tampered",
                 requester_email="t@acme.com",
                 reason=None,

--- a/tests/test_h_csr_pop.py
+++ b/tests/test_h_csr_pop.py
@@ -148,14 +148,15 @@ async def test_start_with_garbage_pop_rejected(proxy_app) -> None:
     assert resp.status_code == 400
 
 
-# ── Missing PoP: still works during transition (with warning) ────────
+# ── Missing PoP: rejected (transition window closed) ─────────────────
 
 
 @pytest.mark.asyncio
-async def test_start_without_pop_accepted_during_transition(proxy_app) -> None:
-    """Pre-fix Connectors that don't ship pop_signature still enroll
-    during the transition window. The server logs a WARNING but
-    accepts the row so existing fleets don't break on upgrade."""
+async def test_start_without_pop_now_rejected(proxy_app) -> None:
+    """The transition window is closed. A Connector that does not ship
+    ``pop_signature`` is refused with 422 (Pydantic schema requires the
+    field) so an attacker cannot enroll by replaying a stolen public
+    key."""
     _, client = proxy_app
     _, pub_pem = _ec_keypair()
 
@@ -167,4 +168,10 @@ async def test_start_without_pop_accepted_during_transition(proxy_app) -> None:
             "requester_email": "legacy@acme.test",
         },
     )
-    assert resp.status_code == 201
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    # Pydantic surfaces the missing required field in ``detail``.
+    assert any(
+        "pop_signature" in (str(err.get("loc")) + str(err.get("msg")))
+        for err in body.get("detail", [])
+    ), body

--- a/tests/test_m_onb_status_pop.py
+++ b/tests/test_m_onb_status_pop.py
@@ -67,11 +67,35 @@ def _sign_proof(priv, session_id: str) -> str:
     return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
 
 
-async def _start_enrollment(client: AsyncClient, pub_pem: str) -> str:
+def _sign_pop(priv, pub_pem: str) -> str:
+    import hashlib as _hashlib
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = _hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+async def _start_enrollment(client: AsyncClient, priv, pub_pem: str) -> str:
     resp = await client.post(
         "/v1/enrollment/start",
         json={
             "pubkey_pem": pub_pem,
+            "pop_signature": _sign_pop(priv, pub_pem),
             "requester_name": "M Rossi",
             "requester_email": "m@acme.test",
             "reason": "test",
@@ -108,7 +132,7 @@ async def _approve(client: AsyncClient, session_id: str) -> None:
 async def test_status_without_proof_hides_cert_and_caps(proxy_app) -> None:
     _, client = proxy_app
     priv, pub_pem = _ec_keypair()
-    session_id = await _start_enrollment(client, pub_pem)
+    session_id = await _start_enrollment(client, priv, pub_pem)
     await _approve(client, session_id)
 
     resp = await client.get(f"/v1/enrollment/{session_id}/status")
@@ -133,7 +157,7 @@ async def test_status_with_wrong_key_proof_hides_cert(proxy_app) -> None:
     the signature won't verify against the enroller's public key."""
     _, client = proxy_app
     priv, pub_pem = _ec_keypair()
-    session_id = await _start_enrollment(client, pub_pem)
+    session_id = await _start_enrollment(client, priv, pub_pem)
     await _approve(client, session_id)
 
     attacker_priv, _ = _ec_keypair()
@@ -157,7 +181,7 @@ async def test_status_with_wrong_key_proof_hides_cert(proxy_app) -> None:
 async def test_status_with_valid_proof_returns_full_payload(proxy_app) -> None:
     _, client = proxy_app
     priv, pub_pem = _ec_keypair()
-    session_id = await _start_enrollment(client, pub_pem)
+    session_id = await _start_enrollment(client, priv, pub_pem)
     await _approve(client, session_id)
 
     proof = _sign_proof(priv, session_id)
@@ -184,7 +208,7 @@ async def test_status_field_alone_still_observable_without_proof(proxy_app) -> N
     accepted residual."""
     _, client = proxy_app
     priv, pub_pem = _ec_keypair()
-    session_id = await _start_enrollment(client, pub_pem)
+    session_id = await _start_enrollment(client, priv, pub_pem)
 
     resp = await client.get(f"/v1/enrollment/{session_id}/status")
     assert resp.status_code == 200

--- a/tests/test_proxy_device_info.py
+++ b/tests/test_proxy_device_info.py
@@ -112,16 +112,29 @@ class _FakeAgentManager:
         return f"-----BEGIN CERTIFICATE-----\nstub-{agent_name}\n-----END CERTIFICATE-----\n"
 
 
-def _fresh_pubkey_pem() -> str:
-    """Generate a real ECDSA P-256 public key PEM; start_enrollment() parses
-    it to fingerprint, so a stub string gets rejected."""
-    from cryptography.hazmat.primitives import serialization
+def _fresh_pop_kwargs() -> dict[str, str]:
+    """Generate a real ECDSA P-256 keypair, return kwargs that satisfy
+    both ``pubkey_pem`` (fingerprint parsing) and ``pop_signature``
+    (H-csr-pop verify) on ``start_enrollment``."""
+    import base64
+    import hashlib
+    from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import ec
+
     priv = ec.generate_private_key(ec.SECP256R1())
-    return priv.public_key().public_bytes(
+    pem = priv.public_key().public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
+    der = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fp = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    pop = base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+    return {"pubkey_pem": pem, "pop_signature": pop}
 
 
 @pytest.mark.asyncio
@@ -141,7 +154,7 @@ async def test_approve_copies_device_info_to_internal_agents(_proxy_db):
     async with get_db() as conn:
         started = await start_enrollment(
             conn,
-            pubkey_pem=_fresh_pubkey_pem(),
+            **_fresh_pop_kwargs(),
             requester_name="alice",
             requester_email="alice@example.com",
             reason=None,
@@ -178,7 +191,7 @@ async def test_approve_without_device_info_yields_null(_proxy_db):
     async with get_db() as conn:
         started = await start_enrollment(
             conn,
-            pubkey_pem=_fresh_pubkey_pem(),
+            **_fresh_pop_kwargs(),
             requester_name="bob",
             requester_email="bob@example.com",
             reason=None,


### PR DESCRIPTION
## Discovery

Audit (Executor B Bug 9) found that ``mcp_proxy/enrollment/service.py::start_enrollment`` accepted ``pop_signature=None`` under a backward-compat grace window: the server logged a WARNING and persisted the row. Pydantic schema marked the field Optional with a description noting future removal.

Pre-verify confirmed Step 0 findings on ``main`` HEAD ``a57bf6ea``:
- ``mcp_proxy/enrollment/schemas.py:54`` ``pop_signature: str | None = Field(None, ...)``
- ``mcp_proxy/enrollment/service.py:263-279`` ``if pop_signature: verify else: warning``
- 5 listed test files plus 3 collateral files (``test_h_csr_pop.py``, ``test_m_onb_status_pop.py``, ``test_proxy_device_info.py``) call the path without signing

## Threat model

Without proof-of-possession, the server cannot distinguish the keypair owner from an attacker who intercepted or observed the public key (logs, screenshots, fingerprint chip on the device). The only previous defense was admin fingerprint cross-check, out-of-band human verification, non-cryptographic. Making ``pop_signature`` mandatory closes the impersonation vector at the protocol layer.

## Breaking change

- HTTP: ``POST /v1/enrollment/start`` without ``pop_signature`` returns 422 (Pydantic missing field). Previously 201.
- Service direct callers: ``service.start_enrollment(..., pop_signature=...)`` is a required kwarg; missing raises ``EnrollmentError(http_status=400)``.
- Connectors v0.4.4+ already sign by default (``cullis_connector/enrollment.py::_build_pop_signature``).
- CHANGELOG entry added under ``[Unreleased]``.

## Scope deviation from Executor B prompt

Three test files outside the original 5 needed pop_signature too or pytest ``-n auto`` would have flagged them post-merge:
- ``tests/test_h_csr_pop.py``: one test (the grace-period regression) had to be inverted (``test_start_without_pop_now_rejected``) since the grace period is the thing being removed.
- ``tests/test_m_onb_status_pop.py``: HTTP helper ``_start_enrollment`` had to learn to sign.
- ``tests/test_proxy_device_info.py``: ``_fresh_pubkey_pem`` became ``_fresh_pop_kwargs``.

Production code outside enrollment/ is untouched. ``mcp_proxy/enrollment/router.py`` already passes ``payload.pop_signature`` straight through.

## Test plan

- [x] ``pytest tests/test_enrollment.py tests/test_enrollment_dpop_jkt.py tests/test_enrollment_tpm_flow.py tests/test_enrollment_attestation_injection.py tests/test_enrollment_dashboard.py tests/test_m_onb_status_pop.py tests/test_h_csr_pop.py -n auto`` → 58 passed
- [x] ``pytest tests/ -n auto --dist=loadfile --ignore=tests/e2e`` → 3953 passed + 1 pre-existing flake (``test_badge_approvals_empty_when_plugin_unavailable``, see ``feedback_ci_known_failures``)
- [x] ``./sandbox/smoke.sh full`` → PASS=25 FAIL=0 SKIP=1
- [ ] Optional dogfood: run a fresh Connector (v0.4.4+) enroll end-to-end on the sandbox to confirm the path works on the wire