### PR TITLE
fix(auth): agent cert rotation grace period + DPoP pinning fallback

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -447,29 +447,86 @@ async def register_agent_dpop_jwk(
             detail="malformed JWK",
         ) from exc
 
+    # Wave 2 fix 7+8 — stash the previous ``dpop_jkt`` so the DPoP
+    # pinning dep can fall back to the old jkt during a bounded grace
+    # window (``MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS``, default 48h).
+    # Without this, every in-flight DPoP-proof signed by the old key
+    # 401s the instant the row flips — kills long-running MCP
+    # connections + streaming chat completions.
+    from mcp_proxy.auth.cert_grace import compute_grace_expiry
+    from mcp_proxy.config import get_settings as _grace_settings
+
+    grace_hours = _grace_settings().agent_cert_grace_period_hours
+    grace_expiry = compute_grace_expiry(grace_hours)
+
     async with get_db() as conn:
-        result = await conn.execute(
+        prev_row = (await conn.execute(
             text(
-                """
-                UPDATE internal_agents
-                   SET dpop_jkt = :jkt
-                 WHERE agent_id = :aid AND is_active = 1
-                """
+                "SELECT dpop_jkt FROM internal_agents "
+                "WHERE agent_id = :aid AND is_active = 1"
             ),
-            {"jkt": jkt, "aid": agent_id},
-        )
+            {"aid": agent_id},
+        )).mappings().first()
+        old_jkt = prev_row["dpop_jkt"] if prev_row else None
+        # Skip the previous-stash when the row already carried the same
+        # jkt (idempotent set: operator re-POSTed the same JWK to fix a
+        # botched API call). Otherwise a same-key replay would clear
+        # the previous-stash on the next legitimate rotation by setting
+        # previous = current.
+        same_jkt = bool(old_jkt) and old_jkt == jkt
+
+        if same_jkt:
+            result = await conn.execute(
+                text(
+                    "UPDATE internal_agents SET dpop_jkt = :jkt "
+                    "WHERE agent_id = :aid AND is_active = 1"
+                ),
+                {"jkt": jkt, "aid": agent_id},
+            )
+        else:
+            result = await conn.execute(
+                text(
+                    """
+                    UPDATE internal_agents
+                       SET dpop_jkt = :jkt,
+                           previous_dpop_jkt = :prev_jkt,
+                           previous_grace_period_expires_at = :grace_expiry
+                     WHERE agent_id = :aid AND is_active = 1
+                    """
+                ),
+                {
+                    "jkt": jkt,
+                    "aid": agent_id,
+                    "prev_jkt": old_jkt,
+                    "grace_expiry": grace_expiry,
+                },
+            )
         if result.rowcount == 0:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="agent not found or inactive",
             )
 
-    await log_audit(
-        agent_id="admin",
-        action="agent.dpop_jwk_set",
-        status="success",
-        detail=f"agent_id={agent_id} jkt={jkt}",
-    )
+    if same_jkt:
+        await log_audit(
+            agent_id="admin",
+            action="agent.dpop_jwk_set",
+            status="success",
+            detail=f"agent_id={agent_id} jkt={jkt} idempotent=1",
+        )
+    else:
+        await log_audit(
+            agent_id="admin",
+            action="agent.dpop_jwk_rotated",
+            status="success",
+            detail=json.dumps({
+                "agent_id": agent_id,
+                "previous_dpop_jkt": old_jkt,
+                "new_dpop_jkt": jkt,
+                "grace_period_expires_at": grace_expiry,
+                "grace_period_hours": grace_hours,
+            }),
+        )
     return DpopJwkResponse(agent_id=agent_id, dpop_jkt=jkt)
 
 

--- a/mcp_proxy/alembic/versions/0039_agent_cert_grace.py
+++ b/mcp_proxy/alembic/versions/0039_agent_cert_grace.py
@@ -1,0 +1,100 @@
+"""``internal_agents`` — previous cert + dpop_jkt grace period columns.
+
+Revision ID: 0039_agent_cert_grace
+Revises: 0038_pki_key_store
+Create Date: 2026-05-18 14:00:00.000000
+
+Wave 2 fix 7+8 — agent leaf cert rotation grace period + DPoP pinning
+fallback. Pre-fix, rotating ``internal_agents.cert_pem`` (re-enrollment
+flow in ``mcp_proxy/enrollment/service.py``) or ``dpop_jkt`` (admin
+endpoint ``POST /v1/admin/agents/{id}/dpop-jwk``) cuts mid-flight
+requests instantly: any in-progress connection signed with the OLD
+keypair sees a 401 ``client_cert_pin_mismatch`` (or DPoP jkt mismatch)
+the moment the row flips. With agents that maintain long-lived MCP
+connections or stream chat completions, that is an SLA hole.
+
+The columns introduced here let the rotate writer stash the old
+credentials before overwriting, and let the pinning verifier accept
+the previous values during a bounded grace window
+(``MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS`` default 48h). A background
+cleanup task (``mcp_proxy.lifespan.agent_cert_grace_cleanup``) sweeps
+expired rows and clears the previous fields so the grace surface stays
+bounded.
+
+Columns added:
+
+* ``previous_cert_pem TEXT NULL`` — stashed x509 PEM the verifier
+  falls back to on pin mismatch.
+* ``previous_dpop_jkt TEXT NULL`` — stashed RFC 7638 JWK thumbprint
+  the DPoP dep falls back to on jkt mismatch.
+* ``previous_grace_period_expires_at TEXT NULL`` — ISO-8601 UTC. The
+  fallback applies only when ``now() < this``. Stored as text to match
+  the rest of the timestamp columns on this table (``created_at``,
+  ``enrolled_at``) and stay portable across SQLite + Postgres without
+  a TIMESTAMP-vs-TIMESTAMPTZ binding gotcha (see
+  ``feedback_postgres_type_binding``).
+
+Indexed on ``previous_grace_period_expires_at`` so the cleanup sweep
+can range-scan instead of full-tabling — keeps the weekly tick cheap
+even on a 10k-agent registry.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0039_agent_cert_grace"
+down_revision: Union[str, Sequence[str], None] = "0038_pki_key_store"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_cols = {col["name"] for col in inspector.get_columns("internal_agents")}
+
+    if "previous_cert_pem" not in existing_cols:
+        op.add_column(
+            "internal_agents",
+            sa.Column("previous_cert_pem", sa.Text(), nullable=True),
+        )
+    if "previous_dpop_jkt" not in existing_cols:
+        op.add_column(
+            "internal_agents",
+            sa.Column("previous_dpop_jkt", sa.Text(), nullable=True),
+        )
+    if "previous_grace_period_expires_at" not in existing_cols:
+        op.add_column(
+            "internal_agents",
+            sa.Column("previous_grace_period_expires_at", sa.Text(), nullable=True),
+        )
+
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("internal_agents")}
+    if "idx_internal_agents_grace_expiry" not in existing_indexes:
+        op.create_index(
+            "idx_internal_agents_grace_expiry",
+            "internal_agents",
+            ["previous_grace_period_expires_at"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("internal_agents")}
+    if "idx_internal_agents_grace_expiry" in existing_indexes:
+        op.drop_index(
+            "idx_internal_agents_grace_expiry",
+            table_name="internal_agents",
+        )
+    existing_cols = {col["name"] for col in inspector.get_columns("internal_agents")}
+    if "previous_grace_period_expires_at" in existing_cols:
+        op.drop_column("internal_agents", "previous_grace_period_expires_at")
+    if "previous_dpop_jkt" in existing_cols:
+        op.drop_column("internal_agents", "previous_dpop_jkt")
+    if "previous_cert_pem" in existing_cols:
+        op.drop_column("internal_agents", "previous_cert_pem")

--- a/mcp_proxy/auth/cert_grace.py
+++ b/mcp_proxy/auth/cert_grace.py
@@ -1,0 +1,105 @@
+"""Grace-period helpers for agent leaf cert + DPoP jkt rotation.
+
+Wave 2 fix 7+8. Shared by:
+
+* ``mcp_proxy.enrollment.service.approve_enrollment`` (re-enrollment
+  flow that overwrites ``internal_agents.cert_pem`` + ``dpop_jkt``).
+* ``mcp_proxy.admin.agents.register_agent_dpop_jwk`` (admin endpoint
+  that rotates ``dpop_jkt`` alone).
+* ``mcp_proxy.auth.client_cert.get_agent_from_client_cert`` (fall back
+  to ``previous_cert_pem`` on pin mismatch during the grace window).
+* ``mcp_proxy.auth.dpop_client_cert.get_agent_from_dpop_client_cert``
+  (fall back to ``previous_dpop_jkt`` on jkt mismatch during the
+  grace window).
+* ``mcp_proxy.lifespan.agent_cert_grace_cleanup`` (sweep expired rows).
+
+Kept here (not inlined into each call site) so changing the grace
+window or the thumbprint format is a single-file edit and the
+verifier-vs-writer surfaces never drift.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+_log = logging.getLogger("mcp_proxy.auth.cert_grace")
+
+
+def now_utc_iso() -> str:
+    """ISO-8601 UTC timestamp matching the format the rest of the
+    Mastio writes into ``internal_agents.created_at`` /
+    ``enrolled_at``. Centralised so the rotation writer + the cleanup
+    task use exactly the same shape (string comparison vs the cleanup
+    SQL ``WHERE previous_grace_period_expires_at < :now``)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def compute_grace_expiry(grace_hours: int) -> str:
+    """``now() + grace_hours`` as an ISO-8601 UTC string.
+
+    ``grace_hours`` <= 0 returns ``now()``, which the verifier reads
+    as "grace expired the instant we set it" — i.e. effectively
+    disables grace. The writers still stash the previous values so
+    operators can inspect a recently-rotated row, but the pinning
+    fallback never activates.
+    """
+    expiry = datetime.now(timezone.utc) + timedelta(hours=max(grace_hours, 0))
+    return expiry.isoformat()
+
+
+def is_grace_active(expires_at: Optional[str]) -> bool:
+    """Return True iff ``expires_at`` is in the future.
+
+    Tolerates ``None`` / empty string (no grace window active) and
+    malformed timestamps (logs at debug, returns False — fail closed
+    so a corrupted DB row can't widen the trust boundary).
+    """
+    if not expires_at:
+        return False
+    try:
+        expiry = datetime.fromisoformat(expires_at)
+    except (TypeError, ValueError) as exc:
+        _log.debug(
+            "agent_cert_grace: unparseable previous_grace_period_expires_at "
+            "%r (%s) — treating as expired",
+            expires_at, exc,
+        )
+        return False
+    if expiry.tzinfo is None:
+        # The writers always emit ``isoformat()`` on tz-aware datetimes,
+        # but legacy rows / hand-seeded fixtures may carry naive values.
+        # Treat them as UTC to match the writer contract.
+        expiry = expiry.replace(tzinfo=timezone.utc)
+    return expiry > datetime.now(timezone.utc)
+
+
+def cert_thumbprint_hex(pem: Optional[str]) -> Optional[str]:
+    """SHA-256 hex digest of the cert DER, or ``None`` on parse error.
+
+    Mirrors the ``_pem_der_digest`` helper in
+    :mod:`mcp_proxy.auth.client_cert` but returns hex (string) instead
+    of bytes so audit rows + log lines can embed it directly. Used in
+    audit detail bodies so operators can correlate
+    ``agent.cert_rotated`` rows to specific certs.
+    """
+    if not pem:
+        return None
+    try:
+        cert = x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    except (ValueError, TypeError, UnicodeEncodeError):
+        return None
+    der = cert.public_bytes(encoding=serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
+__all__ = [
+    "now_utc_iso",
+    "compute_grace_expiry",
+    "is_grace_active",
+    "cert_thumbprint_hex",
+]

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -638,4 +638,9 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
         cert_pem=agent_data.get("cert_pem"),
         dpop_jkt=agent_data.get("dpop_jkt"),
         reach=agent_data.get("reach") or "both",
+        previous_cert_pem=agent_data.get("previous_cert_pem"),
+        previous_dpop_jkt=agent_data.get("previous_dpop_jkt"),
+        previous_grace_period_expires_at=agent_data.get(
+            "previous_grace_period_expires_at"
+        ),
     )

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -569,26 +569,76 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
                     agent_id=canonical_id,
                 ),
             )
-        if not hmac.compare_digest(_cert_der_digest(cert), stored_digest):
-            _log.warning(
-                "client cert pin mismatch for %s — presented cert is not "
-                "the one this Mastio issued.",
-                canonical_id,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=_err(
-                    _REASON_CERT_PIN_MISMATCH,
-                    "Presented cert's DER digest does not match the "
-                    f"one stored for ``{canonical_id}`` (likely a stale "
-                    "cert post-rotation); re-enroll the Connector, or "
-                    "treat as forged if the caller insists their cert "
-                    "is current.",
-                    agent_id=canonical_id,
-                    cert_serial=_cert_serial_hex(cert),
-                    cert_san=_cert_first_spiffe(cert),
-                ),
-            )
+        presented_digest = _cert_der_digest(cert)
+        if not hmac.compare_digest(presented_digest, stored_digest):
+            # Wave 2 fix 7+8 — fall back to ``previous_cert_pem`` when
+            # the row carries an active grace window. Pre-fix, the
+            # rotation writers swapped ``cert_pem`` in place and every
+            # mid-flight request signed with the OLD keypair 401'd
+            # against the fresh pin. Now, requests signed with the
+            # previous cert keep working until
+            # ``previous_grace_period_expires_at`` passes. Logged as a
+            # warning + audited so operators can see how many
+            # rotations land mid-flight and tune the grace window.
+            from mcp_proxy.auth.cert_grace import is_grace_active
+            prev_pem = agent_data.get("previous_cert_pem")
+            grace_expires = agent_data.get("previous_grace_period_expires_at")
+            prev_digest = _pem_der_digest(prev_pem) if prev_pem else None
+            if (
+                prev_digest is not None
+                and is_grace_active(grace_expires)
+                and hmac.compare_digest(presented_digest, prev_digest)
+            ):
+                _log.warning(
+                    "client cert pin grace match for %s — presented the "
+                    "PREVIOUS cert (post-rotation grace, expires=%s). "
+                    "Connector should re-enroll to pick up the new cert "
+                    "before the grace window closes.",
+                    canonical_id, grace_expires,
+                )
+                # Best-effort audit; mirror the writer's audit shape so
+                # ``agent.cert_rotated`` + ``agent.cert_pinning_grace_match``
+                # join cleanly on agent_id + thumbprint in forensic queries.
+                try:
+                    from mcp_proxy.db import log_audit
+                    await log_audit(
+                        agent_id=canonical_id,
+                        action="agent.cert_pinning_grace_match",
+                        status="success",
+                        detail=(
+                            f"grace_expires_at={grace_expires} "
+                            f"presented_thumbprint={presented_digest.hex()}"
+                        ),
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    _log.debug(
+                        "agent.cert_pinning_grace_match audit emit failed: %s",
+                        exc,
+                    )
+                # Drop through to the rate-limit + traffic-recorder steps
+                # below as if the pin matched. ``agent_data`` already
+                # carries the active credentials for the InternalAgent
+                # envelope returned to the caller.
+            else:
+                _log.warning(
+                    "client cert pin mismatch for %s — presented cert is not "
+                    "the one this Mastio issued.",
+                    canonical_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=_err(
+                        _REASON_CERT_PIN_MISMATCH,
+                        "Presented cert's DER digest does not match the "
+                        f"one stored for ``{canonical_id}`` (likely a stale "
+                        "cert post-rotation); re-enroll the Connector, or "
+                        "treat as forged if the caller insists their cert "
+                        "is current.",
+                        agent_id=canonical_id,
+                        cert_serial=_cert_serial_hex(cert),
+                        cert_san=_cert_first_spiffe(cert),
+                    ),
+                )
 
     settings = get_settings()
     if not await get_agent_rate_limiter().check(

--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -144,16 +144,58 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
     stored_jkt = getattr(agent, "dpop_jkt", None)
     if stored_jkt:
         if not hmac.compare_digest(proof_jkt, stored_jkt):
-            _log.warning(
-                "DPoP proof jkt mismatch (agent=%s, proof_jkt=%s, "
-                "stored_jkt=%s)",
-                agent.agent_id, proof_jkt, stored_jkt,
+            # Wave 2 fix 7+8 — fall back to ``previous_dpop_jkt`` when
+            # the row carries an active grace window. Pre-fix, the
+            # admin DPoP rotation endpoint (or the re-enrollment flow)
+            # swapped ``dpop_jkt`` in place and every mid-flight proof
+            # signed by the OLD key 401'd against the fresh jkt. With
+            # grace, proofs signed by the previous key keep working
+            # until ``previous_grace_period_expires_at`` passes.
+            from mcp_proxy.auth.cert_grace import is_grace_active
+            prev_jkt = getattr(agent, "previous_dpop_jkt", None)
+            grace_expires = getattr(
+                agent, "previous_grace_period_expires_at", None,
             )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="DPoP proof was signed by a key not registered "
-                       "for this agent.",
-            )
+            if (
+                prev_jkt
+                and is_grace_active(grace_expires)
+                and hmac.compare_digest(proof_jkt, prev_jkt)
+            ):
+                _log.warning(
+                    "DPoP proof jkt grace match (agent=%s, proof_jkt=%s, "
+                    "previous_jkt=%s, grace_expires=%s) — Connector "
+                    "should re-issue its DPoP keypair before the grace "
+                    "window closes.",
+                    agent.agent_id, proof_jkt, prev_jkt, grace_expires,
+                )
+                try:
+                    from mcp_proxy.db import log_audit
+                    await log_audit(
+                        agent_id=agent.agent_id,
+                        action="agent.dpop_pinning_grace_match",
+                        status="success",
+                        detail=(
+                            f"grace_expires_at={grace_expires} "
+                            f"presented_jkt={proof_jkt}"
+                        ),
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    _log.debug(
+                        "agent.dpop_pinning_grace_match audit emit failed: %s",
+                        exc,
+                    )
+                # Fall through: same shape as a current-jkt match.
+            else:
+                _log.warning(
+                    "DPoP proof jkt mismatch (agent=%s, proof_jkt=%s, "
+                    "stored_jkt=%s)",
+                    agent.agent_id, proof_jkt, stored_jkt,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="DPoP proof was signed by a key not registered "
+                           "for this agent.",
+                )
     elif mode == "required":
         _log.warning(
             "DPoP required but agent %s has no registered dpop_jkt — "

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -591,6 +591,24 @@ class ProxySettings(BaseSettings):
     cert_expiry_warn_days_agent: int = 90
     cert_expiry_warn_days_nginx: int = 30
 
+    # Wave 2 fix 7+8. Agent leaf cert rotation grace period. When the
+    # re-enrollment flow or the admin DPoP endpoint rotates
+    # ``internal_agents.cert_pem`` / ``dpop_jkt``, the previous values
+    # stay valid for ``agent_cert_grace_period_hours`` hours so
+    # mid-flight requests signed with the OLD keypair don't 401 at the
+    # instant the row flips. After expiry the cleanup task sweeps the
+    # row back to a single-pin state. 48h matches the typical SDK retry
+    # / Connector re-enroll-on-401 budget; tighten to 1h+ for
+    # short-window operators, widen for batch workloads with multi-day
+    # checkpoints.
+    agent_cert_grace_period_hours: int = 48
+    # Tick cadence for the grace-period cleanup loop. Default 1h gives
+    # the operator a worst-case "old pin valid up to grace + 1h"
+    # surface, which keeps the bounded window predictable without
+    # burning sleeping wakeups on a typical fleet.
+    agent_cert_grace_cleanup_interval_seconds: int = 3600
+    agent_cert_grace_cleanup_enabled: bool = True
+
     # Docker compose ``${VAR:-}`` substitutes to the empty string when
     # the operator has not set the var in proxy.env. Pydantic v2's bool
     # parser rejects "" with ``bool_parsing`` ValidationError, which

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1534,6 +1534,19 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
     # as "untrusted".
     if "last_attestation" in row.keys():
         out["last_attestation"] = row["last_attestation"]
+    # Wave 2 fix 7+8 migration 0039 — agent cert rotation grace period.
+    # Optional at read time so unit tests / fixtures that hand-build
+    # ``internal_agents`` rows pre-migration don't blow up. The
+    # rotation writers (re-enrollment, admin DPoP) and the pinning
+    # verifiers both treat NULL / absent identically as "no grace
+    # window active".
+    for key in (
+        "previous_cert_pem",
+        "previous_dpop_jkt",
+        "previous_grace_period_expires_at",
+    ):
+        if key in row.keys():
+            out[key] = row[key]
     return out
 
 

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -82,6 +82,18 @@ class InternalAgent(Base):
     # written there too; not declared on the ORM model because the
     # writers use raw SQL via ``conn.execute(text(...))``.
 
+    # Wave 2 fix 7+8 (migration 0039) — agent leaf cert rotation grace
+    # period. When the re-enrollment flow or admin DPoP endpoint
+    # rotates ``cert_pem`` / ``dpop_jkt``, the old values are stashed
+    # here so the pinning verifier (``client_cert.py`` /
+    # ``dpop_client_cert.py``) can fall back during a bounded window
+    # (``MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS`` default 48h). The
+    # cleanup task in ``mcp_proxy/lifespan/agent_cert_grace_cleanup.py``
+    # sweeps rows past expiry and resets all three to NULL.
+    previous_cert_pem = Column(Text, nullable=True)
+    previous_dpop_jkt = Column(Text, nullable=True)
+    previous_grace_period_expires_at = Column(Text, nullable=True)
+
 
 class AuditLogEntry(Base):
     __tablename__ = "audit_log"

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -581,6 +581,33 @@ async def approve(
         # re-enroll cannot reset operator decisions, and bump the
         # revision so the federation publisher republishes the new cert
         # to the Court.
+        #
+        # Wave 2 fix 7+8 — instead of clobbering the previous
+        # ``cert_pem`` / ``dpop_jkt`` we stash them into the
+        # ``previous_*`` columns so the pinning verifiers can fall back
+        # to the OLD credentials for a bounded grace window (default
+        # 48h, see ``MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS``).
+        # Mid-flight requests signed with the old keypair survive the
+        # rotation instead of 401-ing the instant the row flips.
+        from mcp_proxy.auth.cert_grace import (
+            cert_thumbprint_hex,
+            compute_grace_expiry,
+        )
+        from mcp_proxy.config import get_settings as _grace_settings
+
+        prev_row = (await conn.execute(
+            text(
+                "SELECT cert_pem, dpop_jkt FROM internal_agents "
+                "WHERE agent_id = :aid"
+            ),
+            {"aid": canonical_id},
+        )).mappings().first()
+        old_cert_pem = prev_row["cert_pem"] if prev_row else None
+        old_dpop_jkt = prev_row["dpop_jkt"] if prev_row else None
+
+        grace_hours = _grace_settings().agent_cert_grace_period_hours
+        grace_expiry = compute_grace_expiry(grace_hours)
+
         await conn.execute(
             text(
                 """UPDATE internal_agents
@@ -590,7 +617,10 @@ async def approve(
                        spiffe_id = :spiffe_id,
                        enrolled_at = :now,
                        is_active = 1,
-                       federation_revision = COALESCE(federation_revision, 0) + 1
+                       federation_revision = COALESCE(federation_revision, 0) + 1,
+                       previous_cert_pem = :prev_cert,
+                       previous_dpop_jkt = :prev_jkt,
+                       previous_grace_period_expires_at = :grace_expiry
                    WHERE agent_id = :aid"""
             ),
             {
@@ -600,13 +630,16 @@ async def approve(
                 "spiffe_id": spiffe_id,
                 "now": now,
                 "aid": canonical_id,
+                "prev_cert": old_cert_pem,
+                "prev_jkt": old_dpop_jkt,
+                "grace_expiry": grace_expiry,
             },
         )
         await conn.execute(
             text(
                 """INSERT INTO audit_log
                    (timestamp, agent_id, action, status, detail)
-                   VALUES (:ts, :aid, 'agent.cert_renewed', 'success', :detail)"""
+                   VALUES (:ts, :aid, 'agent.cert_rotated', 'success', :detail)"""
             ),
             {
                 "ts": now,
@@ -616,6 +649,12 @@ async def approve(
                     "session_id": session_id,
                     "admin": admin_name,
                     "reason": "re-enrollment of existing agent_id",
+                    "previous_cert_thumbprint": cert_thumbprint_hex(old_cert_pem),
+                    "new_cert_thumbprint": cert_thumbprint_hex(cert_pem),
+                    "previous_dpop_jkt": old_dpop_jkt,
+                    "new_dpop_jkt": record.get("dpop_jkt"),
+                    "grace_period_expires_at": grace_expiry,
+                    "grace_period_hours": grace_hours,
                 }),
             },
         )

--- a/mcp_proxy/lifespan/agent_cert_grace_cleanup.py
+++ b/mcp_proxy/lifespan/agent_cert_grace_cleanup.py
@@ -1,0 +1,152 @@
+"""Background sweep that clears expired agent-cert grace rows.
+
+Wave 2 fix 7+8, Phase 4. The rotation writers stash the old
+``cert_pem`` / ``dpop_jkt`` into ``internal_agents.previous_*`` so the
+pinning verifiers can fall back during a bounded window. After
+``previous_grace_period_expires_at`` passes, those values must be
+cleared, otherwise:
+
+* the pinning dep keeps a stale cert / jkt in the "fall back to this"
+  pool indefinitely, widening the trust surface beyond the configured
+  ``MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS``;
+* a future incident response can't tell "freshly rotated, in grace" from
+  "rotated a year ago, just never cleaned up".
+
+This loop ticks hourly by default and runs a single UPDATE that resets
+all three previous_* columns to NULL where the grace expiry is in the
+past. Leader-elected via :func:`mcp_proxy.lifespan.get_leader` so only
+one worker runs the sweep in a multi-worker deployment — pattern from
+PR #784 (six lifespan tasks leader-elected).
+
+Audit row ``agent.cert_grace_period_expired`` lands once per agent
+cleared, so the audit chain records the trust-surface collapse from
+"two pins (current + previous)" back to "one pin".
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from sqlalchemy import text
+
+logger = logging.getLogger("mcp_proxy.lifespan.agent_cert_grace_cleanup")
+
+# Match the cadence ``mcp_proxy.config.ProxySettings`` exposes so the
+# loop body and the default Settings stay in lock-step. The settings
+# field is read at task spawn (lifespan), this constant is only the
+# fallback when the task is spawned without an explicit interval.
+_DEFAULT_TICK_SECONDS = 3600
+
+
+async def agent_cert_grace_cleanup_loop(
+    *,
+    tick_seconds: int = _DEFAULT_TICK_SECONDS,
+    stop_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Loop body. Runs ``_sweep_once`` every ``tick_seconds``.
+
+    ``stop_event`` lets the lifespan tear-down signal a prompt return
+    so SIGTERM does not have to wait a full hour for the loop to wake
+    up. Mirrors the contract of
+    :func:`mcp_proxy.lifespan.intermediate_ca_watcher.intermediate_ca_watcher_loop`.
+    """
+    stop_event = stop_event or asyncio.Event()
+    logger.info(
+        "agent_cert_grace_cleanup loop starting (tick=%ds)", tick_seconds,
+    )
+
+    while not stop_event.is_set():
+        try:
+            await _sweep_once()
+        except Exception as exc:  # noqa: BLE001 — defensive long-running loop
+            logger.error(
+                "agent_cert_grace_cleanup tick raised %s — continuing",
+                exc,
+            )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=tick_seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("agent_cert_grace_cleanup loop stopped")
+
+
+async def _sweep_once() -> int:
+    """Single-tick sweep. Returns the number of rows cleared.
+
+    Two-step inside one transaction:
+
+      1. SELECT the agent_ids with an expired ``previous_grace_period_expires_at``
+         so the audit log can name them.
+      2. UPDATE those rows, setting all three previous_* columns back
+         to NULL.
+
+    Idempotent: a tick that fires twice in a row with no expirations
+    in-between updates zero rows and emits zero audit. The
+    ``previous_grace_period_expires_at IS NOT NULL`` guard prevents
+    cleaning up rows that never had a previous-stash to begin with.
+    """
+    from mcp_proxy.auth.cert_grace import now_utc_iso
+    from mcp_proxy.db import get_db, log_audit
+
+    now = now_utc_iso()
+
+    async with get_db() as conn:
+        expired_rows = (await conn.execute(
+            text(
+                """SELECT agent_id, previous_grace_period_expires_at
+                     FROM internal_agents
+                    WHERE previous_grace_period_expires_at IS NOT NULL
+                      AND previous_grace_period_expires_at < :now"""
+            ),
+            {"now": now},
+        )).mappings().all()
+
+        if not expired_rows:
+            return 0
+
+        await conn.execute(
+            text(
+                """UPDATE internal_agents
+                      SET previous_cert_pem = NULL,
+                          previous_dpop_jkt = NULL,
+                          previous_grace_period_expires_at = NULL
+                    WHERE previous_grace_period_expires_at IS NOT NULL
+                      AND previous_grace_period_expires_at < :now"""
+            ),
+            {"now": now},
+        )
+
+    # Audit each cleared row outside the cleanup transaction so a
+    # downstream audit-chain hiccup doesn't block the sweep. The
+    # ordering is "row cleared, then audit emitted" — for a forensic
+    # operator, the absence of the audit row + presence of NULL columns
+    # is recoverable; the inverse (audit fired, columns still pinned
+    # in grace) would be a confusing trust-surface lie.
+    for row in expired_rows:
+        try:
+            await log_audit(
+                agent_id=row["agent_id"],
+                action="agent.cert_grace_period_expired",
+                status="success",
+                detail=(
+                    f"grace_expired_at={row['previous_grace_period_expires_at']} "
+                    f"cleared_at={now}"
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "agent.cert_grace_period_expired audit emit failed for "
+                "agent=%s: %s",
+                row["agent_id"], exc,
+            )
+
+    logger.info(
+        "agent_cert_grace_cleanup: swept %d expired rows", len(expired_rows),
+    )
+    return len(expired_rows)
+
+
+__all__ = ["agent_cert_grace_cleanup_loop", "_sweep_once"]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -458,6 +458,47 @@ async def lifespan(app: FastAPI):
                 exc,
             )
 
+    # Wave 2 fix 7+8 — agent cert + DPoP jkt rotation grace period
+    # cleanup. Hourly leader-elected sweep clears expired previous_*
+    # columns on internal_agents so the trust surface collapses back
+    # to "one pin" after MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS. Same
+    # leader-election pattern as the Intermediate watcher above.
+    if getattr(settings, "agent_cert_grace_cleanup_enabled", True):
+        try:
+            from mcp_proxy.lifespan import get_leader as _grace_get_leader
+            from mcp_proxy.lifespan.agent_cert_grace_cleanup import (
+                agent_cert_grace_cleanup_loop,
+            )
+            grace_cleanup_leader = _grace_get_leader(
+                "agent_cert_grace_cleanup",
+            )
+            if await grace_cleanup_leader.acquire():
+                grace_cleanup_stop = asyncio.Event()
+                grace_cleanup_task = asyncio.create_task(
+                    agent_cert_grace_cleanup_loop(
+                        tick_seconds=settings.agent_cert_grace_cleanup_interval_seconds,
+                        stop_event=grace_cleanup_stop,
+                    ),
+                    name="agent_cert_grace_cleanup",
+                )
+                app.state.agent_cert_grace_cleanup_task = grace_cleanup_task
+                app.state.agent_cert_grace_cleanup_stop = grace_cleanup_stop
+                app.state.agent_cert_grace_cleanup_leader = grace_cleanup_leader
+                _log.info(
+                    "agent_cert_grace_cleanup: leader acquired, loop spawned",
+                )
+            else:
+                _log.info(
+                    "agent_cert_grace_cleanup: another worker holds the "
+                    "leader lock — skipping",
+                )
+        except Exception as exc:
+            _log.warning(
+                "agent_cert_grace_cleanup startup failed: %s — expired "
+                "previous_* columns will linger until next restart",
+                exc,
+            )
+
     # Federation update framework (imp/federation_hardening_plan.md
     # Parte 1, PR 2). Must run BEFORE ``LocalIssuer`` construction so a
     # critical-pending migration affecting this proxy's enrollments can
@@ -1113,7 +1154,7 @@ async def lifespan(app: FastAPI):
                 "mastio_ca_rotation_watcher leader release failed: %s", exc,
             )
 
-    # Wave 2 fix 5 — stop the cert expiry watcher.
+    # Wave 2 fix 5. Stop the cert expiry watcher.
     cert_expiry_stop = getattr(app.state, "cert_expiry_watcher_stop", None)
     cert_expiry_task = getattr(app.state, "cert_expiry_watcher_task", None)
     if cert_expiry_stop is not None:
@@ -1135,9 +1176,37 @@ async def lifespan(app: FastAPI):
     if cert_expiry_leader is not None:
         try:
             await cert_expiry_leader.release()
-        except Exception as exc:  # noqa: BLE001 — best-effort
+        except Exception as exc:  # noqa: BLE001 best-effort
             _log.debug(
                 "cert_expiry_watcher leader release failed: %s", exc,
+            )
+
+    # Wave 2 fix 7+8. Stop the agent cert grace cleanup sweep.
+    grace_stop = getattr(app.state, "agent_cert_grace_cleanup_stop", None)
+    grace_task = getattr(app.state, "agent_cert_grace_cleanup_task", None)
+    if grace_stop is not None:
+        grace_stop.set()
+    if grace_task is not None:
+        try:
+            await asyncio.wait_for(grace_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            grace_task.cancel()
+            try:
+                await grace_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug(
+                "agent_cert_grace_cleanup teardown loop mismatch (xdist): %s",
+                exc,
+            )
+    grace_leader = getattr(app.state, "agent_cert_grace_cleanup_leader", None)
+    if grace_leader is not None:
+        try:
+            await grace_leader.release()
+        except Exception as exc:  # noqa: BLE001 best-effort
+            _log.debug(
+                "agent_cert_grace_cleanup leader release failed: %s", exc,
             )
 
     # ADR-032 F6 — stop the stale-watcher.

--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -93,6 +93,17 @@ class InternalAgent(BaseModel):
     # unless the operator widens it explicitly.
     scope_providers: list[str] | None = None
     scope_paths: list[str] | None = None
+    # Wave 2 fix 7+8 — rotation grace period. Populated by the
+    # rotation writers (re-enrollment, admin DPoP) when the previous
+    # cert / jkt is still inside the configured grace window. Pinning
+    # verifiers in ``mcp_proxy/auth/client_cert.py`` and
+    # ``mcp_proxy/auth/dpop_client_cert.py`` fall back to these when
+    # the current pin mismatches and ``previous_grace_period_expires_at``
+    # is in the future. Cleaned by
+    # ``mcp_proxy/lifespan/agent_cert_grace_cleanup.py`` on expiry.
+    previous_cert_pem: str | None = None
+    previous_dpop_jkt: str | None = None
+    previous_grace_period_expires_at: str | None = None
 
 
 class AuditEntry(BaseModel):

--- a/tests/test_agent_cert_rotation_grace.py
+++ b/tests/test_agent_cert_rotation_grace.py
@@ -1,0 +1,307 @@
+"""Wave 2 fix 7+8 — agent leaf cert rotation grace period tests.
+
+Validates the four phases end-to-end:
+
+1. Schema: new ``previous_*`` columns are nullable + indexable.
+2. Pinning fallback: ``get_agent_from_client_cert`` accepts the
+   previous cert during an active grace window, rejects after expiry,
+   rejects when the cert matches neither.
+3. Cleanup sweep: ``agent_cert_grace_cleanup._sweep_once`` clears
+   expired rows back to NULL and emits one audit row per agent.
+4. Helper coverage: ``cert_grace.is_grace_active`` /
+   ``compute_grace_expiry`` / ``cert_thumbprint_hex`` edge cases.
+
+Tests hit the FastAPI ASGI app directly via ``ASGITransport`` (same
+pattern as ``test_client_cert_auth.py``); nginx is synthesized by
+``tests._mtls_helpers.mtls_headers``.
+"""
+from __future__ import annotations
+
+import urllib.parse
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from tests._mtls_helpers import (
+    mint_agent_cert,
+    mtls_headers,
+    provision_internal_agent,
+)
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "false")
+    monkeypatch.setenv("MCP_PROXY_AGENT_CERT_GRACE_CLEANUP_ENABLED", "false")
+    monkeypatch.delenv("PROXY_TRANSPORT_INTRA_ORG", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _set_grace_columns(
+    *,
+    agent_id: str,
+    previous_cert_pem: str | None,
+    previous_dpop_jkt: str | None,
+    grace_expiry_iso: str | None,
+) -> None:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "UPDATE internal_agents "
+                "  SET previous_cert_pem = :pcp, "
+                "      previous_dpop_jkt = :pjk, "
+                "      previous_grace_period_expires_at = :pge "
+                "WHERE agent_id = :aid"
+            ),
+            {
+                "pcp": previous_cert_pem,
+                "pjk": previous_dpop_jkt,
+                "pge": grace_expiry_iso,
+                "aid": agent_id,
+            },
+        )
+
+
+async def _swap_current_cert(*, agent_id: str, cert_pem: str) -> None:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "UPDATE internal_agents SET cert_pem = :cert WHERE agent_id = :aid"
+            ),
+            {"cert": cert_pem, "aid": agent_id},
+        )
+
+
+async def _read_audit_rows(*, action: str, agent_id: str) -> list[dict]:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT timestamp, action, status, detail FROM audit_log "
+                " WHERE action = :action AND agent_id = :aid "
+                " ORDER BY id DESC"
+            ),
+            {"action": action, "aid": agent_id},
+        )).mappings().all()
+    return [dict(r) for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_cert_pin_falls_back_to_previous_during_grace(proxy_app):
+    _, client = proxy_app
+    old_headers = await provision_internal_agent("rotor-bot")
+    new_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="rotor-bot")
+    old_cert_pem = urllib.parse.unquote(old_headers["X-SSL-Client-Cert"])
+
+    await _swap_current_cert(agent_id="acme::rotor-bot", cert_pem=new_cert_pem)
+    grace_expiry = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    await _set_grace_columns(
+        agent_id="acme::rotor-bot",
+        previous_cert_pem=old_cert_pem,
+        previous_dpop_jkt=None,
+        grace_expiry_iso=grace_expiry,
+    )
+
+    resp = await client.get("/v1/egress/peers", headers=old_headers)
+    assert resp.status_code == 200, resp.text
+
+    audit = await _read_audit_rows(
+        action="agent.cert_pinning_grace_match",
+        agent_id="acme::rotor-bot",
+    )
+    assert audit, "grace match audit row should be present"
+    assert grace_expiry in audit[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_cert_pin_rejects_after_grace_expiry(proxy_app):
+    _, client = proxy_app
+    old_headers = await provision_internal_agent("ex-rotor")
+    new_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="ex-rotor")
+    old_cert_pem = urllib.parse.unquote(old_headers["X-SSL-Client-Cert"])
+
+    await _swap_current_cert(agent_id="acme::ex-rotor", cert_pem=new_cert_pem)
+    expired = (
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    ).isoformat()
+    await _set_grace_columns(
+        agent_id="acme::ex-rotor",
+        previous_cert_pem=old_cert_pem,
+        previous_dpop_jkt=None,
+        grace_expiry_iso=expired,
+    )
+
+    resp = await client.get("/v1/egress/peers", headers=old_headers)
+    assert resp.status_code == 401
+    body = resp.json()["detail"]
+    assert body["reason"] == "client_cert_pin_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_cert_pin_rejects_third_party_cert_during_grace(proxy_app):
+    _, client = proxy_app
+    await provision_internal_agent("strict-rotor")
+    new_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="strict-rotor")
+    await _swap_current_cert(agent_id="acme::strict-rotor", cert_pem=new_cert_pem)
+    other_pem, _ = mint_agent_cert(org_id="acme", agent_name="strict-rotor")
+    forged_pem, _ = mint_agent_cert(org_id="acme", agent_name="strict-rotor")
+    grace_expiry = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    await _set_grace_columns(
+        agent_id="acme::strict-rotor",
+        previous_cert_pem=other_pem,
+        previous_dpop_jkt=None,
+        grace_expiry_iso=grace_expiry,
+    )
+
+    resp = await client.get(
+        "/v1/egress/peers", headers=mtls_headers(forged_pem),
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["reason"] == "client_cert_pin_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_sweep_clears_expired_grace_rows(proxy_app):
+    from mcp_proxy.db import get_db
+    from mcp_proxy.lifespan.agent_cert_grace_cleanup import _sweep_once
+
+    _, _client = proxy_app
+    await provision_internal_agent("expired-bot")
+    await provision_internal_agent("active-bot")
+
+    expired = (
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    ).isoformat()
+    future = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    await _set_grace_columns(
+        agent_id="acme::expired-bot",
+        previous_cert_pem="-----BEGIN CERTIFICATE-----\nold\n-----END CERTIFICATE-----",
+        previous_dpop_jkt="old-jkt",
+        grace_expiry_iso=expired,
+    )
+    await _set_grace_columns(
+        agent_id="acme::active-bot",
+        previous_cert_pem="-----BEGIN CERTIFICATE-----\nactive\n-----END CERTIFICATE-----",
+        previous_dpop_jkt="active-jkt",
+        grace_expiry_iso=future,
+    )
+
+    cleared = await _sweep_once()
+    assert cleared == 1
+
+    async with get_db() as conn:
+        expired_row = (await conn.execute(
+            text(
+                "SELECT previous_cert_pem, previous_dpop_jkt, "
+                "       previous_grace_period_expires_at "
+                "  FROM internal_agents WHERE agent_id = :aid"
+            ),
+            {"aid": "acme::expired-bot"},
+        )).mappings().first()
+        active_row = (await conn.execute(
+            text(
+                "SELECT previous_cert_pem, previous_dpop_jkt, "
+                "       previous_grace_period_expires_at "
+                "  FROM internal_agents WHERE agent_id = :aid"
+            ),
+            {"aid": "acme::active-bot"},
+        )).mappings().first()
+
+    assert expired_row["previous_cert_pem"] is None
+    assert expired_row["previous_dpop_jkt"] is None
+    assert expired_row["previous_grace_period_expires_at"] is None
+    assert active_row["previous_cert_pem"] is not None
+    assert active_row["previous_dpop_jkt"] == "active-jkt"
+    assert active_row["previous_grace_period_expires_at"] == future
+
+    audit = await _read_audit_rows(
+        action="agent.cert_grace_period_expired",
+        agent_id="acme::expired-bot",
+    )
+    assert audit, "cleanup must audit each cleared row"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_sweep_empty_case_is_noop(proxy_app):
+    from mcp_proxy.lifespan.agent_cert_grace_cleanup import _sweep_once
+
+    _, _client = proxy_app
+    await provision_internal_agent("nogrease-bot")
+    cleared = await _sweep_once()
+    assert cleared == 0
+
+    audit = await _read_audit_rows(
+        action="agent.cert_grace_period_expired",
+        agent_id="acme::nogrease-bot",
+    )
+    assert audit == []
+
+
+@pytest.mark.asyncio
+async def test_cert_grace_helper_now_and_active():
+    from mcp_proxy.auth.cert_grace import (
+        compute_grace_expiry,
+        is_grace_active,
+        cert_thumbprint_hex,
+    )
+
+    assert is_grace_active(None) is False
+    assert is_grace_active("") is False
+    assert is_grace_active("not-a-date") is False
+
+    future = (
+        datetime.now(timezone.utc) + timedelta(hours=1)
+    ).isoformat()
+    past = (
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    ).isoformat()
+    assert is_grace_active(future) is True
+    assert is_grace_active(past) is False
+
+    naive_future = (
+        datetime.utcnow() + timedelta(hours=1)
+    ).isoformat()
+    assert is_grace_active(naive_future) is True
+
+    expiry = compute_grace_expiry(24)
+    assert is_grace_active(expiry) is True
+
+    instant = compute_grace_expiry(0)
+    parsed = datetime.fromisoformat(instant)
+    assert parsed <= datetime.now(timezone.utc)
+
+    assert cert_thumbprint_hex(None) is None
+    assert cert_thumbprint_hex("") is None
+    assert cert_thumbprint_hex("not-a-pem") is None
+    real_pem, _ = mint_agent_cert(org_id="acme", agent_name="thumb-test")
+    thumb = cert_thumbprint_hex(real_pem)
+    assert thumb is not None
+    assert len(thumb) == 64

--- a/tests/test_dpop_pinning_grace.py
+++ b/tests/test_dpop_pinning_grace.py
@@ -1,0 +1,178 @@
+"""Wave 2 fix 7+8 — DPoP jkt pinning grace fallback tests."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.models import InternalAgent
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "false")
+    monkeypatch.setenv("MCP_PROXY_AGENT_CERT_GRACE_CLEANUP_ENABLED", "false")
+    monkeypatch.delenv("PROXY_TRANSPORT_INTRA_ORG", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as _client:
+        async with app.router.lifespan_context(app):
+            yield app
+    get_settings.cache_clear()
+
+
+def _build_agent(*, dpop_jkt: str, previous_jkt: str | None, grace_expiry: str | None) -> InternalAgent:
+    return InternalAgent(
+        agent_id="acme::rotor-bot",
+        display_name="rotor-bot",
+        capabilities=[],
+        created_at="2026-05-15T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt=dpop_jkt,
+        reach="both",
+        previous_dpop_jkt=previous_jkt,
+        previous_grace_period_expires_at=grace_expiry,
+    )
+
+
+def _patch_dpop_chain(monkeypatch, *, fake_agent: InternalAgent, proof_jkt: str) -> None:
+    from mcp_proxy.auth import dpop_client_cert
+    import mcp_proxy.auth.api_token as _api_token_mod
+    import mcp_proxy.auth.local_agent_dep as _lad
+    import mcp_proxy.auth.dpop as _dpop_mod
+
+    async def _noop_api_token(_req):
+        return None
+
+    async def _noop_local_agent(_req):
+        return None
+
+    async def _fake_cert(_req):
+        return fake_agent
+
+    async def _fake_verify(*_a, **_kw):
+        return proof_jkt
+
+    monkeypatch.setattr(_api_token_mod, "_maybe_api_token_principal", _noop_api_token)
+    monkeypatch.setattr(_lad, "_maybe_local_internal_agent", _noop_local_agent)
+    monkeypatch.setattr(dpop_client_cert, "get_agent_from_client_cert", _fake_cert)
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "optional")
+    monkeypatch.setattr(_dpop_mod, "verify_dpop_proof", _fake_verify)
+
+
+def _stub_request() -> MagicMock:
+    req = MagicMock()
+    req.method = "POST"
+    req.headers = {"DPoP": "proof.proof.proof"}
+    req.url = MagicMock()
+    req.url.path = "/v1/llm/chat"
+    return req
+
+
+@pytest.mark.asyncio
+async def test_dpop_grace_accepts_previous_jkt_during_window(monkeypatch, proxy_app):
+    from mcp_proxy.auth import dpop_client_cert
+
+    future = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    fake_agent = _build_agent(
+        dpop_jkt="NEW" + "0" * 60,
+        previous_jkt="OLD" + "0" * 60,
+        grace_expiry=future,
+    )
+    _patch_dpop_chain(monkeypatch, fake_agent=fake_agent, proof_jkt="OLD" + "0" * 60)
+
+    agent = await dpop_client_cert.get_agent_from_dpop_client_cert(_stub_request())
+    assert agent.agent_id == "acme::rotor-bot"
+
+
+@pytest.mark.asyncio
+async def test_dpop_grace_rejects_after_expiry(monkeypatch, proxy_app):
+    from mcp_proxy.auth import dpop_client_cert
+
+    expired = (
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    ).isoformat()
+    fake_agent = _build_agent(
+        dpop_jkt="NEW" + "0" * 60,
+        previous_jkt="OLD" + "0" * 60,
+        grace_expiry=expired,
+    )
+    _patch_dpop_chain(monkeypatch, fake_agent=fake_agent, proof_jkt="OLD" + "0" * 60)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await dpop_client_cert.get_agent_from_dpop_client_cert(_stub_request())
+    assert excinfo.value.status_code == 401
+    assert "not registered" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_dpop_grace_rejects_third_party_jkt(monkeypatch, proxy_app):
+    from mcp_proxy.auth import dpop_client_cert
+
+    future = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    fake_agent = _build_agent(
+        dpop_jkt="NEW" + "0" * 60,
+        previous_jkt="OLD" + "0" * 60,
+        grace_expiry=future,
+    )
+    _patch_dpop_chain(monkeypatch, fake_agent=fake_agent, proof_jkt="FORGED" + "0" * 57)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await dpop_client_cert.get_agent_from_dpop_client_cert(_stub_request())
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dpop_no_previous_means_strict_mismatch(monkeypatch, proxy_app):
+    from mcp_proxy.auth import dpop_client_cert
+
+    fake_agent = _build_agent(
+        dpop_jkt="NEW" + "0" * 60,
+        previous_jkt=None,
+        grace_expiry=None,
+    )
+    _patch_dpop_chain(monkeypatch, fake_agent=fake_agent, proof_jkt="OTHER" + "0" * 58)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await dpop_client_cert.get_agent_from_dpop_client_cert(_stub_request())
+    assert excinfo.value.status_code == 401
+    assert "not registered" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_dpop_current_jkt_match_is_unchanged(monkeypatch, proxy_app):
+    from mcp_proxy.auth import dpop_client_cert
+
+    future = (
+        datetime.now(timezone.utc) + timedelta(hours=24)
+    ).isoformat()
+    fake_agent = _build_agent(
+        dpop_jkt="NEW" + "0" * 60,
+        previous_jkt="OLD" + "0" * 60,
+        grace_expiry=future,
+    )
+    _patch_dpop_chain(monkeypatch, fake_agent=fake_agent, proof_jkt="NEW" + "0" * 60)
+
+    agent = await dpop_client_cert.get_agent_from_dpop_client_cert(_stub_request())
+    assert agent.agent_id == "acme::rotor-bot"


### PR DESCRIPTION
## Discovery (STEP 0 pre-verify)

L'endpoint `/v1/registry/agents/{id}/rotate-cert` lato Mastio non esiste: rimosso ADR-010 Phase 6a-4 (vedi `tests/test_auth.py:467`). Lato Mastio la rotation di `internal_agents.cert_pem` / `dpop_jkt` avviene in due punti:

1. **Re-enrollment** (`mcp_proxy/enrollment/service.py:584-621`): UPDATE in place quando il device-code flow ri-approva un `agent_id` esistente. Audit pre-fix: `agent.cert_renewed`.
2. **Admin DPoP rotation** (`mcp_proxy/admin/agents.py:387-473`): `POST /v1/admin/agents/{id}/dpop-jwk` UPDATE `dpop_jkt`. Audit pre-fix: `agent.dpop_jwk_set`.

Pre-fix entrambi gli endpoint clobberano la pin corrente. Mid-flight: ogni request in volo con il vecchio cert/jkt si becca 401 (`client_cert_pin_mismatch` su `client_cert.py:556-591`, jkt mismatch su `dpop_client_cert.py:144-156`). Per Connector che mantengono streaming chat o long-running MCP connections, e' un buco SLA.

## Threat model coperto

**Buco chiuso**: mid-flight breakage post-rotation. Un Connector che ha aperto una streaming chat 10s prima della rotation non vede piu' 401 al primo proof successivo.

**Threat model invariato**: la grace window allarga il set di pin accettati solo per la singola row che l'operatore ha appena ruotato. Un attaccante che aveva rubato la vecchia keypair PRE-rotation ha la stessa exposure di prima, piu' la finestra bounded (default 48h, configurabile via `MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS`).

**Cleanup hard bound**: il cleanup task hourly sweep tutte le row dove `previous_grace_period_expires_at < now()` e azzera previous_*. Trust surface collassa back a "one pin" entro `grace_hours + 1h` (default 49h max).

## Le 4 fasi (1 commit per fase + 1 commit di test)

### Phase 1 — Schema (commit cb163d64)

- Alembic `0039_agent_cert_grace` (21 char, <= 32 ok)
- `internal_agents` += `previous_cert_pem`, `previous_dpop_jkt`, `previous_grace_period_expires_at`
- Index su `previous_grace_period_expires_at` per range-scan del cleanup
- ORM in `db_models.py`, row mapper in `db.py:_agent_row_to_dict`, Pydantic in `models.InternalAgent`, propagated by `get_agent_from_client_cert`
- 3 env vars in `mcp_proxy/config.py`: `MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS` (48), `MCP_PROXY_AGENT_CERT_GRACE_CLEANUP_INTERVAL_SECONDS` (3600), `MCP_PROXY_AGENT_CERT_GRACE_CLEANUP_ENABLED` (true)

### Phase 2 — Rotation writers (commit 77890bf2)

- Nuovo helper `mcp_proxy/auth/cert_grace.py`: `compute_grace_expiry`, `is_grace_active`, `cert_thumbprint_hex`, `now_utc_iso`. Tutti i caller derivano il window da una singola sorgente.
- `enrollment/service.py` re-enrollment branch: SELECT corrente, stash in `previous_*`, set `previous_grace_period_expires_at = now + grace_hours`. Audit `agent.cert_renewed` -> `agent.cert_rotated` con detail body strutturato.
- `admin/agents.py` DPoP endpoint: stesso pattern per il solo `dpop_jkt`. Nuovo audit `agent.dpop_jwk_rotated` (cambio reale). Legacy `agent.dpop_jwk_set` mantenuto per il caso idempotent.

### Phase 3 — Pinning fallback (commit b059094b)

- `client_cert.py:get_agent_from_client_cert`: post strict-mismatch ricalcola digest di `previous_cert_pem`, accetta se `is_grace_active`. WARN + audit `agent.cert_pinning_grace_match`.
- `dpop_client_cert.py:get_agent_from_dpop_client_cert`: stesso shape per `previous_dpop_jkt`. WARN + audit `agent.dpop_pinning_grace_match`.
- 401 `client_cert_pin_mismatch` invariato quando ne' corrente ne' previous match, o grace scaduto.

### Phase 4 — Cleanup sweep (commit bec74dac)

- `mcp_proxy/lifespan/agent_cert_grace_cleanup.py`: `_sweep_once` SELECT poi UPDATE delle row scadute back a NULL. Audit `agent.cert_grace_period_expired` per ogni row pulita.
- Loop ticka su `MCP_PROXY_AGENT_CERT_GRACE_CLEANUP_INTERVAL_SECONDS` (default 1h).
- Leader-elected via `get_leader('agent_cert_grace_cleanup')`, stesso pattern PR #784.
- Registered + teardown wired in `main.py` dopo `intermediate_ca_watcher`.

### Phase 5 — Tests (commit c40ebe1b)

- `tests/test_agent_cert_rotation_grace.py`: cert pinning grace match, post-expiry rejection, third-party cert rejection within window, cleanup sweep (expired/active/empty case), helper edge cases.
- `tests/test_dpop_pinning_grace.py`: DPoP jkt grace match, post-expiry rejection, third-party jkt rejection, no-previous strict mismatch unchanged, current-jkt happy path unchanged.

## Test plan

- [x] `pytest tests/test_agent_cert_rotation_grace.py tests/test_dpop_pinning_grace.py` -- 11 passed locale (xdist parallel)
- [x] `alembic upgrade head` esercitato via la lifespan dei test fixture (sqlite tmp_path) -- 0039 applica clean
- [ ] `./sandbox/smoke.sh full` (gate pre-merge per modifiche a `mcp_proxy/`)
- [ ] Suite globale: `pytest tests/ -n auto --dist=loadfile`
- [ ] Dogfood manuale: enroll Connector contro Mastio, rotate (re-enroll), tentare richiesta con vecchio cert entro grace -> 200 + audit `agent.cert_pinning_grace_match`, dopo 48h -> 401 + audit `agent.cert_grace_period_expired`

## File toccati

```
mcp_proxy/alembic/versions/0039_agent_cert_grace.py  (new)
mcp_proxy/auth/cert_grace.py                          (new)
mcp_proxy/lifespan/agent_cert_grace_cleanup.py        (new)
mcp_proxy/db_models.py                                (+3 columns)
mcp_proxy/db.py                                       (row mapper)
mcp_proxy/config.py                                   (+3 env vars)
mcp_proxy/models.py                                   (+3 optional fields)
mcp_proxy/auth/client_cert.py                         (grace fallback)
mcp_proxy/auth/dpop_client_cert.py                    (grace fallback)
mcp_proxy/enrollment/service.py                       (rotation writer)
mcp_proxy/admin/agents.py                             (rotation writer)
mcp_proxy/main.py                                     (lifespan reg + teardown)
tests/test_agent_cert_rotation_grace.py               (new, 6 tests)
tests/test_dpop_pinning_grace.py                      (new, 5 tests)
```

## Note operatori

- Default 48h ragionevole per Connector + agent fleets con re-enroll automatico al 401. Operatori con budget di retry piu' stretti possono settare `MCP_PROXY_AGENT_CERT_GRACE_PERIOD_HOURS=1` (grace effettivamente off oltre lo stash di forensic).
- `agent.cert_pinning_grace_match` audit chip e' il segnale operativo: se ne vedi tanti per agent_id specifico, quel Connector non sta vedendo il nuovo cert (re-enroll loop rotto).
- `agent.cert_grace_period_expired` chiude il ciclo della rotation in audit log.

DRAFT, no auto-merge. `/security-review` da lanciare separatamente prima del merge (regola progetto).