### PR TITLE
feat(pki): cert expiry watcher daemon (warning visibility for Org Root, Leaf, agent, nginx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,22 @@ flow until the next `## ` heading.
   (admin-secret gated, with `?dry_run=true`). A weekly leader-elected
   background watcher (`mastio_ca_rotation_watcher`) warns at < 180
   days to expiry, errors at < 60, auto-rotates at < 30.
+- **Cert expiry watcher daemon (`cert_expiry_watcher`).** Wave 2
+  follow-up to the three-tier hardening. A leader-elected background
+  loop (24h tick) inspects every cert tier the Intermediate watcher
+  does NOT cover and emits warning logs + audit chain rows on
+  per-tier thresholds: Org Root (1825d), Mastio leaf (90d), agent
+  leaves (90d, one row per agent pinned to the agent_id so the
+  audit-by-agent query surfaces it), nginx server cert (30d).
+  Visibility only, no auto-rotation. Tunable via
+  `MCP_PROXY_CERT_EXPIRY_WATCHER_INTERVAL_SECONDS`,
+  `MCP_PROXY_CERT_EXPIRY_WARN_DAYS_ORG_ROOT`,
+  `MCP_PROXY_CERT_EXPIRY_WARN_DAYS_INTERMEDIATE`,
+  `MCP_PROXY_CERT_EXPIRY_WARN_DAYS_MASTIO_LEAF`,
+  `MCP_PROXY_CERT_EXPIRY_WARN_DAYS_AGENT`,
+  `MCP_PROXY_CERT_EXPIRY_WARN_DAYS_NGINX`. Opt-out for
+  single-shot scripts via
+  `MCP_PROXY_CERT_EXPIRY_WATCHER_ENABLED=false`.
 - **WebAuthn-bound user session tokens (ADR-033 Phase 2)** for Frontdesk
   shared mode. A new optional `[webauthn]` extra (`pip install
   'cullis-agent-sdk[webauthn]'`) pulls `webauthn>=2.0,<3.0`. Five new

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -565,6 +565,32 @@ class ProxySettings(BaseSettings):
     attestation_stale_watcher_enabled: bool = True
     attestation_stale_watcher_interval_seconds: int = 60
 
+    # Wave 2 fix 5 — cert expiry watcher daemon. Background tick that
+    # iterates the PKI fleet (Org Root, Intermediate, Mastio leaf,
+    # agent leaves, nginx server) and emits warning logs + audit rows
+    # when a cert enters its per-tier threshold. Visibility only, no
+    # auto-rotation (the primary Intermediate watcher handles that for
+    # its tier; the other tiers need a human in the loop or sit behind
+    # a different rotation path, e.g. Wave 2 fix 6 for nginx).
+    #
+    # Defaults:
+    #   - interval: 24h (the warning is informational, no need to
+    #     poll faster than once per day)
+    #   - Org Root threshold: 5y (cert is 15y, so >10y silent)
+    #   - Intermediate threshold: 2y (fallback only, primary watcher
+    #     handles 180d/60d/30d)
+    #   - Mastio leaf threshold: 90d (Court ACK round-trip = lead time)
+    #   - Agent cert threshold: 90d (Connector re-enrollment lead time)
+    #   - nginx server cert threshold: 30d (matches
+    #     ``ensure_nginx_server_cert`` renew_within_days)
+    cert_expiry_watcher_enabled: bool = True
+    cert_expiry_watcher_interval_seconds: int = 86400
+    cert_expiry_warn_days_org_root: int = 1825
+    cert_expiry_warn_days_intermediate: int = 730
+    cert_expiry_warn_days_mastio_leaf: int = 90
+    cert_expiry_warn_days_agent: int = 90
+    cert_expiry_warn_days_nginx: int = 30
+
     # Docker compose ``${VAR:-}`` substitutes to the empty string when
     # the operator has not set the var in proxy.env. Pydantic v2's bool
     # parser rejects "" with ``bool_parsing`` ValidationError, which

--- a/mcp_proxy/lifespan/cert_expiry_watcher.py
+++ b/mcp_proxy/lifespan/cert_expiry_watcher.py
@@ -1,0 +1,379 @@
+"""Background watcher for cert expiry visibility across the PKI fleet.
+
+Wave 2 fix 5 (three-tier PKI hardening follow-up, audit 2026-05-18).
+A.k.a. "the visibility watcher": Phase 4 of the audit already added
+``intermediate_ca_watcher`` (auto-rotation for the Mastio Intermediate
+CA). This module covers the rest of the certificate fleet with
+warning-only telemetry, no rotation:
+
+* **Org Root CA** (15 years, cold private key): silent unless within
+  ``warn_days_org_root`` of expiry. Operator MUST plan a manual
+  rotation, the root is a one-shot at this scale.
+* **Intermediate CA** (5 years, hot signer): fallback only. The
+  primary watcher (``intermediate_ca_watcher``) handles warning +
+  auto-rotation; this loop ONLY logs an INFO at a much wider
+  fallback threshold so an operator who disables the primary watcher
+  (e.g. air-gapped deploy) still has a visible reminder.
+* **Mastio leaf** (1 year, manual rotation via dashboard): warn at
+  ``warn_days_mastio_leaf`` (90 days default). Rotation requires a
+  Court ACK round-trip, so the operator wants 90 days lead time.
+* **Agent leaves** (1 year each, no warning today): warn at
+  ``warn_days_agent`` (90 days default). One audit row per agent
+  per tick when in-threshold, with the agent_id pinned so the row
+  shows up in the agent's own audit trail (not just under ``system``).
+* **nginx server cert** (90 days, short-lived TLS): warn at
+  ``warn_days_nginx`` (30 days default). Wave 2 fix 6 will add the
+  runtime renewal path; this loop is the early-warning before that
+  ships.
+
+Leader-elected via :func:`mcp_proxy.lifespan.get_leader` so only one
+worker runs the loop in a multi-worker deployment. Pattern matches
+``intermediate_ca_watcher`` (PR #788) + the other lifespan watchers
+(federation_subscriber, anomaly_evaluator, quarantine_expiry, PR #784).
+
+Why warning-only and not auto-rotate? Two of the four tiers (Org Root,
+Mastio leaf) need a human in the loop by design (Court ACK for the
+leaf, ceremony for the root). The other two (agent leaves, nginx
+server) have rotation paths owned elsewhere (Connector re-enrollment
+for the agent, Wave 2 fix 6 for nginx). The watcher's only job is to
+make sure those rotations DO get scheduled — silent expiry is the
+incident this loop prevents.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cryptography import x509
+
+logger = logging.getLogger("mcp_proxy.lifespan.cert_expiry_watcher")
+
+_DEFAULT_TICK_SECONDS = 24 * 60 * 60
+_DEFAULT_WARN_DAYS_ORG_ROOT = 1825  # 5y (cert is 15y, so >10y silent)
+_DEFAULT_WARN_DAYS_INTERMEDIATE = 730  # 2y fallback (primary watcher = 180d)
+_DEFAULT_WARN_DAYS_MASTIO_LEAF = 90
+_DEFAULT_WARN_DAYS_AGENT = 90
+_DEFAULT_WARN_DAYS_NGINX = 30
+
+
+def _aware(dt: datetime) -> datetime:
+    """cryptography <42 returns naive UTC; >=42 returns aware. Normalise."""
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+
+def _days_left(not_after: datetime, now: datetime) -> int:
+    delta = _aware(not_after) - now
+    return int(delta.total_seconds() / 86400)
+
+
+async def cert_expiry_watcher_loop(
+    agent_manager,
+    *,
+    settings=None,
+    tick_seconds: int = _DEFAULT_TICK_SECONDS,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Loop tail: every ``tick_seconds`` check every cert tier, warn-only.
+
+    ``stop_event`` lets the lifespan signal a graceful shutdown so the
+    loop returns promptly instead of sleeping out the current tick.
+    """
+    stop_event = stop_event or asyncio.Event()
+    logger.info(
+        "cert_expiry_watcher loop starting (tick=%ds)", tick_seconds,
+    )
+
+    while not stop_event.is_set():
+        try:
+            await _check_once(agent_manager, settings)
+        except Exception as exc:  # noqa: BLE001 defensive long-running loop
+            logger.error(
+                "cert_expiry_watcher tick raised %s, continuing", exc,
+            )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=tick_seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("cert_expiry_watcher loop stopped")
+
+
+async def _check_once(agent_manager, settings) -> None:
+    """One tick: dispatch to each tier check independently.
+
+    Each tier is wrapped in its own try/except so a malformed agent
+    cert or an unreadable nginx file does not stop the next tier from
+    being inspected.
+    """
+    now = datetime.now(timezone.utc)
+    warn_org_root = _resolve_threshold(
+        settings, "cert_expiry_warn_days_org_root", _DEFAULT_WARN_DAYS_ORG_ROOT,
+    )
+    warn_intermediate = _resolve_threshold(
+        settings, "cert_expiry_warn_days_intermediate",
+        _DEFAULT_WARN_DAYS_INTERMEDIATE,
+    )
+    warn_mastio_leaf = _resolve_threshold(
+        settings, "cert_expiry_warn_days_mastio_leaf",
+        _DEFAULT_WARN_DAYS_MASTIO_LEAF,
+    )
+    warn_agent = _resolve_threshold(
+        settings, "cert_expiry_warn_days_agent", _DEFAULT_WARN_DAYS_AGENT,
+    )
+    warn_nginx = _resolve_threshold(
+        settings, "cert_expiry_warn_days_nginx", _DEFAULT_WARN_DAYS_NGINX,
+    )
+
+    try:
+        await _check_org_root(agent_manager, now, warn_org_root)
+    except Exception as exc:  # noqa: BLE001 best-effort, don't break other tiers
+        logger.warning("cert_expiry_watcher org_root check raised: %s", exc)
+
+    try:
+        await _check_intermediate(agent_manager, now, warn_intermediate)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "cert_expiry_watcher intermediate fallback check raised: %s", exc,
+        )
+
+    try:
+        await _check_mastio_leaf(agent_manager, now, warn_mastio_leaf)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cert_expiry_watcher mastio_leaf check raised: %s", exc)
+
+    try:
+        await _check_agent_leaves(now, warn_agent)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cert_expiry_watcher agent_leaves check raised: %s", exc)
+
+    try:
+        await _check_nginx_server(settings, now, warn_nginx)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cert_expiry_watcher nginx_server check raised: %s", exc)
+
+
+def _resolve_threshold(settings, attr: str, default: int) -> int:
+    """Read ``attr`` off settings, fall back to ``default`` if missing/None."""
+    if settings is None:
+        return default
+    value = getattr(settings, attr, None)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def _check_org_root(agent_manager, now: datetime, threshold_days: int) -> None:
+    from mcp_proxy.db import log_audit
+
+    cert = getattr(agent_manager, "_org_ca_cert", None)
+    if cert is None:
+        return
+
+    days_left = _days_left(cert.not_valid_after, now)
+    if days_left > threshold_days:
+        return
+
+    logger.warning(
+        "Org Root CA expires in %d days (< %d). Manual rotation required, "
+        "the cold root has no auto-path. Plan a re-issuance ceremony soon.",
+        days_left, threshold_days,
+    )
+    try:
+        await log_audit(
+            agent_id="system",
+            action="pki.org_root_expiry_warning",
+            status="success",
+            detail=f"days_left={days_left} threshold={threshold_days}",
+        )
+    except Exception:
+        pass
+
+
+async def _check_intermediate(
+    agent_manager, now: datetime, threshold_days: int,
+) -> None:
+    """Fallback INFO log for the Intermediate.
+
+    The primary watcher (``intermediate_ca_watcher``) handles WARN +
+    auto-rotate at 180d / 60d / 30d. This loop is here ONLY for the
+    case where the primary watcher is disabled (single-process dev
+    mode, leader contention failures, future opt-out flag). At
+    ``threshold_days`` (2y default) we log a single INFO row so the
+    operator sees the Intermediate exists and is being tracked.
+    """
+    from mcp_proxy.db import log_audit
+
+    cert = getattr(agent_manager, "_mastio_ca_cert", None)
+    if cert is None:
+        return
+
+    days_left = _days_left(cert.not_valid_after, now)
+    if days_left > threshold_days:
+        return
+
+    logger.info(
+        "Mastio Intermediate CA expires in %d days (< %d, fallback "
+        "threshold). Primary watcher (intermediate_ca_watcher) handles "
+        "rotation; this log is a visibility fallback.",
+        days_left, threshold_days,
+    )
+    try:
+        await log_audit(
+            agent_id="system",
+            action="pki.intermediate_ca_expiry_visibility",
+            status="success",
+            detail=f"days_left={days_left} threshold={threshold_days}",
+        )
+    except Exception:
+        pass
+
+
+async def _check_mastio_leaf(
+    agent_manager, now: datetime, threshold_days: int,
+) -> None:
+    from mcp_proxy.db import log_audit
+
+    active = getattr(agent_manager, "_active_key", None)
+    if active is None or getattr(active, "cert_pem", None) is None:
+        return
+
+    try:
+        cert = x509.load_pem_x509_certificate(active.cert_pem.encode())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "cert_expiry_watcher: mastio leaf cert parse failed (kid=%s): %s",
+            getattr(active, "kid", "?"), exc,
+        )
+        return
+
+    days_left = _days_left(cert.not_valid_after, now)
+    if days_left > threshold_days:
+        return
+
+    logger.warning(
+        "Mastio leaf cert (kid=%s) expires in %d days (< %d). Trigger "
+        "manual rotation via dashboard or POST /v1/admin/mastio/rotate-key "
+        "before the window closes; the Court ACK round-trip needs lead time.",
+        getattr(active, "kid", "?"), days_left, threshold_days,
+    )
+    try:
+        await log_audit(
+            agent_id="system",
+            action="pki.mastio_leaf_expiry_warning",
+            status="success",
+            detail=(
+                f"kid={getattr(active, 'kid', '?')!r} "
+                f"days_left={days_left} threshold={threshold_days}"
+            ),
+        )
+    except Exception:
+        pass
+
+
+async def _check_agent_leaves(now: datetime, threshold_days: int) -> None:
+    """Iterate every internal agent and warn for any cert in-threshold.
+
+    Audit rows pin the agent_id so an operator querying audit-by-agent
+    still sees the expiry warning. The system row pattern would hide
+    it behind a global feed.
+    """
+    from mcp_proxy.db import list_agents, log_audit
+
+    try:
+        rows = await list_agents()
+    except Exception as exc:  # noqa: BLE001 best-effort
+        logger.warning(
+            "cert_expiry_watcher: list_agents() failed: %s", exc,
+        )
+        return
+
+    for row in rows:
+        agent_id = row.get("agent_id") or ""
+        cert_pem = row.get("cert_pem")
+        if not cert_pem:
+            continue
+        try:
+            cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "cert_expiry_watcher: agent %s cert parse failed: %s",
+                agent_id, exc,
+            )
+            continue
+
+        days_left = _days_left(cert.not_valid_after, now)
+        if days_left > threshold_days:
+            continue
+
+        logger.warning(
+            "Agent cert for %s expires in %d days (< %d). Re-enroll via "
+            "Connector or POST /registry/agents/%s/rotate-cert.",
+            agent_id, days_left, threshold_days, agent_id,
+        )
+        try:
+            await log_audit(
+                agent_id=agent_id,
+                action="pki.agent_cert_expiry_warning",
+                status="success",
+                detail=f"days_left={days_left} threshold={threshold_days}",
+            )
+        except Exception:
+            pass
+
+
+async def _check_nginx_server(settings, now: datetime, threshold_days: int) -> None:
+    """Inspect the on-disk nginx server cert.
+
+    nginx_cert_dir is empty by default (pytest in-memory + dev paths),
+    in which case there is nothing to inspect and the check is a no-op.
+    """
+    from mcp_proxy.db import log_audit
+
+    cert_dir = getattr(settings, "nginx_cert_dir", "") if settings else ""
+    if not cert_dir:
+        return
+
+    crt_path = Path(cert_dir) / "mastio-server.crt"
+    if not crt_path.exists():
+        return
+
+    try:
+        cert = x509.load_pem_x509_certificate(crt_path.read_bytes())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "cert_expiry_watcher: nginx server cert parse failed (%s): %s",
+            crt_path, exc,
+        )
+        return
+
+    days_left = _days_left(cert.not_valid_after, now)
+    if days_left > threshold_days:
+        return
+
+    logger.warning(
+        "nginx server cert (%s) expires in %d days (< %d). Wave 2 fix 6 "
+        "will add a runtime renewal path; for now a Mastio restart picks "
+        "up a fresh leaf via ensure_nginx_server_cert (boot-time check).",
+        crt_path, days_left, threshold_days,
+    )
+    try:
+        await log_audit(
+            agent_id="system",
+            action="pki.nginx_server_cert_expiry_warning",
+            status="success",
+            detail=(
+                f"path={str(crt_path)!r} days_left={days_left} "
+                f"threshold={threshold_days}"
+            ),
+        )
+    except Exception:
+        pass
+
+
+__all__ = ["cert_expiry_watcher_loop"]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -418,6 +418,46 @@ async def lifespan(app: FastAPI):
                 exc,
             )
 
+    # Wave 2 fix 5 — cert expiry watcher daemon. Warning-only loop that
+    # covers the rest of the PKI fleet (Org Root, Mastio leaf, agent
+    # leaves, nginx server cert) so silent expiry never strands a
+    # customer. Leader-elected; same pattern as the Intermediate watcher.
+    if getattr(settings, "cert_expiry_watcher_enabled", True):
+        try:
+            from mcp_proxy.lifespan import get_leader as _cert_get_leader
+            from mcp_proxy.lifespan.cert_expiry_watcher import (
+                cert_expiry_watcher_loop,
+            )
+            cert_expiry_leader = _cert_get_leader("cert_expiry_watcher")
+            if await cert_expiry_leader.acquire():
+                cert_expiry_stop = asyncio.Event()
+                cert_expiry_task = asyncio.create_task(
+                    cert_expiry_watcher_loop(
+                        agent_mgr,
+                        settings=settings,
+                        tick_seconds=settings.cert_expiry_watcher_interval_seconds,
+                        stop_event=cert_expiry_stop,
+                    ),
+                    name="cert_expiry_watcher",
+                )
+                app.state.cert_expiry_watcher_task = cert_expiry_task
+                app.state.cert_expiry_watcher_stop = cert_expiry_stop
+                app.state.cert_expiry_watcher_leader = cert_expiry_leader
+                _log.info(
+                    "cert_expiry_watcher: leader acquired, loop spawned",
+                )
+            else:
+                _log.info(
+                    "cert_expiry_watcher: another worker holds the leader "
+                    "lock, skipping",
+                )
+        except Exception as exc:
+            _log.warning(
+                "cert_expiry_watcher startup failed: %s, the PKI fleet "
+                "will not surface expiry warnings until next restart",
+                exc,
+            )
+
     # Federation update framework (imp/federation_hardening_plan.md
     # Parte 1, PR 2). Must run BEFORE ``LocalIssuer`` construction so a
     # critical-pending migration affecting this proxy's enrollments can
@@ -1071,6 +1111,33 @@ async def lifespan(app: FastAPI):
         except Exception as exc:  # noqa: BLE001 — best-effort
             _log.debug(
                 "mastio_ca_rotation_watcher leader release failed: %s", exc,
+            )
+
+    # Wave 2 fix 5 — stop the cert expiry watcher.
+    cert_expiry_stop = getattr(app.state, "cert_expiry_watcher_stop", None)
+    cert_expiry_task = getattr(app.state, "cert_expiry_watcher_task", None)
+    if cert_expiry_stop is not None:
+        cert_expiry_stop.set()
+    if cert_expiry_task is not None:
+        try:
+            await asyncio.wait_for(cert_expiry_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            cert_expiry_task.cancel()
+            try:
+                await cert_expiry_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug(
+                "cert_expiry_watcher teardown loop mismatch (xdist): %s", exc,
+            )
+    cert_expiry_leader = getattr(app.state, "cert_expiry_watcher_leader", None)
+    if cert_expiry_leader is not None:
+        try:
+            await cert_expiry_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug(
+                "cert_expiry_watcher leader release failed: %s", exc,
             )
 
     # ADR-032 F6 — stop the stale-watcher.

--- a/tests/test_cert_expiry_watcher.py
+++ b/tests/test_cert_expiry_watcher.py
@@ -1,0 +1,463 @@
+"""Tests for the cert_expiry_watcher daemon (Wave 2 fix 5).
+
+Strategy
+--------
+
+Each tier (Org Root, Intermediate fallback, Mastio leaf, agent leaves,
+nginx server) is driven independently via the ``_check_*`` helpers
+exposed on :mod:`mcp_proxy.lifespan.cert_expiry_watcher`. Stub
+``AgentManager`` carries the right cached cert object so the watcher
+follows the production path without spinning up the full lifespan.
+
+Audit rows are intercepted by monkeypatching ``mcp_proxy.db.log_audit``
+to a list-append capture so each test asserts both the log + the
+audit side-effect.
+
+Clock skew is simulated by minting certs whose ``not_valid_after`` is
+``now + N days`` for a chosen N — no need to mock ``datetime.now``,
+the watcher derives ``now`` from the system clock at tick time.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+import mcp_proxy.lifespan.cert_expiry_watcher as watcher_mod
+
+
+# ─── helpers ───────────────────────────────────────────────────────────
+
+
+def _mint_cert(cn: str, *, days_until_expiry: int) -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    """Mint a self-signed EC P-256 cert whose ``not_valid_after`` is
+    ``now + days_until_expiry`` days from the current clock.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, cn),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=days_until_expiry))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _cert_pem(cert: x509.Certificate) -> str:
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+@dataclass
+class _StubMastioKey:
+    kid: str
+    cert_pem: str | None
+
+
+class _StubAgentManager:
+    """Minimal duck-typed agent manager: cached cert pointers only."""
+
+    def __init__(
+        self,
+        *,
+        org_ca_cert: x509.Certificate | None = None,
+        mastio_ca_cert: x509.Certificate | None = None,
+        active_key: _StubMastioKey | None = None,
+    ) -> None:
+        self._org_ca_cert = org_ca_cert
+        self._mastio_ca_cert = mastio_ca_cert
+        self._active_key = active_key
+
+
+class _StubSettings:
+    def __init__(self, **kwargs) -> None:
+        self.nginx_cert_dir = kwargs.pop("nginx_cert_dir", "")
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture
+def captured_audit(monkeypatch):
+    """Capture every ``log_audit`` call as a list of kwargs dicts."""
+    rows: list[dict] = []
+
+    async def _capture(**kwargs):
+        rows.append(kwargs)
+
+    # Patch the module attribute that the watcher imports lazily.
+    import mcp_proxy.db as db_mod
+    monkeypatch.setattr(db_mod, "log_audit", _capture)
+    return rows
+
+
+@pytest.fixture
+def captured_list_agents(monkeypatch):
+    """Make ``list_agents`` return whatever the test assigns to .rows."""
+    state = {"rows": []}
+
+    async def _list_agents():
+        return list(state["rows"])
+
+    import mcp_proxy.db as db_mod
+    monkeypatch.setattr(db_mod, "list_agents", _list_agents)
+    return state
+
+
+# ─── _check_org_root ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_org_root_above_threshold_is_silent(captured_audit, caplog):
+    _, cert = _mint_cert("test-org-root", days_until_expiry=3000)
+    mgr = _StubAgentManager(org_ca_cert=cert)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_org_root(mgr, now, threshold_days=1825)
+
+    assert captured_audit == []
+    assert "Org Root" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_org_root_below_threshold_warns_and_audits(captured_audit, caplog):
+    _, cert = _mint_cert("test-org-root", days_until_expiry=100)
+    mgr = _StubAgentManager(org_ca_cert=cert)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_org_root(mgr, now, threshold_days=1825)
+
+    assert any(r["action"] == "pki.org_root_expiry_warning" for r in captured_audit)
+    assert "Org Root CA expires in" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_org_root_missing_cert_is_noop(captured_audit):
+    mgr = _StubAgentManager(org_ca_cert=None)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_org_root(mgr, now, threshold_days=1825)
+
+    assert captured_audit == []
+
+
+# ─── _check_intermediate (fallback) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intermediate_fallback_below_threshold_emits_info(
+    captured_audit, caplog,
+):
+    _, cert = _mint_cert("test-intermediate", days_until_expiry=400)
+    mgr = _StubAgentManager(mastio_ca_cert=cert)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("INFO", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_intermediate(mgr, now, threshold_days=730)
+
+    assert any(
+        r["action"] == "pki.intermediate_ca_expiry_visibility"
+        for r in captured_audit
+    )
+    assert "Intermediate CA expires in" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_intermediate_fallback_above_threshold_is_silent(
+    captured_audit, caplog,
+):
+    _, cert = _mint_cert("test-intermediate", days_until_expiry=1500)
+    mgr = _StubAgentManager(mastio_ca_cert=cert)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("INFO", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_intermediate(mgr, now, threshold_days=730)
+
+    assert captured_audit == []
+
+
+# ─── _check_mastio_leaf ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mastio_leaf_below_threshold_warns(captured_audit, caplog):
+    _, cert = _mint_cert("test-mastio-leaf", days_until_expiry=30)
+    active = _StubMastioKey(kid="mastio-deadbeef", cert_pem=_cert_pem(cert))
+    mgr = _StubAgentManager(active_key=active)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_mastio_leaf(mgr, now, threshold_days=90)
+
+    matching = [r for r in captured_audit if r["action"] == "pki.mastio_leaf_expiry_warning"]
+    assert len(matching) == 1
+    assert "mastio-deadbeef" in matching[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_mastio_leaf_above_threshold_is_silent(captured_audit):
+    _, cert = _mint_cert("test-mastio-leaf", days_until_expiry=200)
+    active = _StubMastioKey(kid="mastio-cafefade", cert_pem=_cert_pem(cert))
+    mgr = _StubAgentManager(active_key=active)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_mastio_leaf(mgr, now, threshold_days=90)
+
+    assert captured_audit == []
+
+
+@pytest.mark.asyncio
+async def test_mastio_leaf_missing_active_key_is_noop(captured_audit):
+    mgr = _StubAgentManager(active_key=None)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_mastio_leaf(mgr, now, threshold_days=90)
+
+    assert captured_audit == []
+
+
+@pytest.mark.asyncio
+async def test_mastio_leaf_malformed_pem_is_skipped(captured_audit, caplog):
+    active = _StubMastioKey(kid="mastio-malformed", cert_pem="not a cert")
+    mgr = _StubAgentManager(active_key=active)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_mastio_leaf(mgr, now, threshold_days=90)
+
+    assert captured_audit == []
+    assert "mastio leaf cert parse failed" in caplog.text
+
+
+# ─── _check_agent_leaves ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_leaves_per_agent_audit_uses_agent_id(
+    captured_audit, captured_list_agents, caplog,
+):
+    _, cert_a = _mint_cert("agent-a", days_until_expiry=45)
+    _, cert_b = _mint_cert("agent-b", days_until_expiry=200)
+    captured_list_agents["rows"] = [
+        {"agent_id": "agent-a", "cert_pem": _cert_pem(cert_a)},
+        {"agent_id": "agent-b", "cert_pem": _cert_pem(cert_b)},
+    ]
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_agent_leaves(now, threshold_days=90)
+
+    matching = [r for r in captured_audit if r["action"] == "pki.agent_cert_expiry_warning"]
+    assert len(matching) == 1
+    assert matching[0]["agent_id"] == "agent-a"
+    # The other agent is still in the safe window: no row.
+    assert all(r["agent_id"] != "agent-b" for r in matching)
+
+
+@pytest.mark.asyncio
+async def test_agent_leaves_missing_cert_pem_is_skipped(
+    captured_audit, captured_list_agents,
+):
+    captured_list_agents["rows"] = [
+        {"agent_id": "agent-headless", "cert_pem": None},
+        {"agent_id": "agent-empty", "cert_pem": ""},
+    ]
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_agent_leaves(now, threshold_days=90)
+
+    assert captured_audit == []
+
+
+@pytest.mark.asyncio
+async def test_agent_leaves_malformed_cert_is_logged_but_does_not_break_loop(
+    captured_audit, captured_list_agents, caplog,
+):
+    _, cert_ok = _mint_cert("agent-ok", days_until_expiry=10)
+    captured_list_agents["rows"] = [
+        {"agent_id": "agent-broken", "cert_pem": "not a pem"},
+        {"agent_id": "agent-ok", "cert_pem": _cert_pem(cert_ok)},
+    ]
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_agent_leaves(now, threshold_days=90)
+
+    assert "agent-broken cert parse failed" in caplog.text
+    matching = [r for r in captured_audit if r["action"] == "pki.agent_cert_expiry_warning"]
+    assert len(matching) == 1
+    assert matching[0]["agent_id"] == "agent-ok"
+
+
+# ─── _check_nginx_server ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_nginx_server_below_threshold_warns(captured_audit, tmp_path, caplog):
+    _, cert = _mint_cert("mastio.local", days_until_expiry=20)
+    crt_path = tmp_path / "mastio-server.crt"
+    crt_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    settings = _StubSettings(nginx_cert_dir=str(tmp_path))
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    caplog.set_level("WARNING", logger="mcp_proxy.lifespan.cert_expiry_watcher")
+    await watcher_mod._check_nginx_server(settings, now, threshold_days=30)
+
+    matching = [r for r in captured_audit if r["action"] == "pki.nginx_server_cert_expiry_warning"]
+    assert len(matching) == 1
+    assert str(crt_path) in matching[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_nginx_server_above_threshold_is_silent(captured_audit, tmp_path):
+    _, cert = _mint_cert("mastio.local", days_until_expiry=60)
+    crt_path = tmp_path / "mastio-server.crt"
+    crt_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    settings = _StubSettings(nginx_cert_dir=str(tmp_path))
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_nginx_server(settings, now, threshold_days=30)
+
+    assert captured_audit == []
+
+
+@pytest.mark.asyncio
+async def test_nginx_server_missing_cert_dir_is_noop(captured_audit):
+    settings = _StubSettings(nginx_cert_dir="")
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_nginx_server(settings, now, threshold_days=30)
+
+    assert captured_audit == []
+
+
+@pytest.mark.asyncio
+async def test_nginx_server_missing_file_is_noop(captured_audit, tmp_path):
+    settings = _StubSettings(nginx_cert_dir=str(tmp_path))
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    await watcher_mod._check_nginx_server(settings, now, threshold_days=30)
+
+    assert captured_audit == []
+
+
+# ─── _check_once (integration of all tiers) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_once_runs_every_tier_independently(
+    captured_audit, captured_list_agents, tmp_path,
+):
+    """One tick should attempt every tier even if one raises."""
+    _, org_root = _mint_cert("test-org-root", days_until_expiry=100)
+    _, intermediate = _mint_cert("test-intermediate", days_until_expiry=500)
+    _, leaf = _mint_cert("test-mastio-leaf", days_until_expiry=30)
+    _, agent_cert = _mint_cert("test-agent", days_until_expiry=10)
+    _, nginx_cert = _mint_cert("mastio.local", days_until_expiry=10)
+    crt_path = tmp_path / "mastio-server.crt"
+    crt_path.write_bytes(nginx_cert.public_bytes(serialization.Encoding.PEM))
+
+    mgr = _StubAgentManager(
+        org_ca_cert=org_root,
+        mastio_ca_cert=intermediate,
+        active_key=_StubMastioKey(kid="kid-x", cert_pem=_cert_pem(leaf)),
+    )
+    captured_list_agents["rows"] = [
+        {"agent_id": "test-agent", "cert_pem": _cert_pem(agent_cert)},
+    ]
+    settings = _StubSettings(
+        nginx_cert_dir=str(tmp_path),
+        cert_expiry_warn_days_org_root=1825,
+        cert_expiry_warn_days_intermediate=730,
+        cert_expiry_warn_days_mastio_leaf=90,
+        cert_expiry_warn_days_agent=90,
+        cert_expiry_warn_days_nginx=30,
+    )
+
+    await watcher_mod._check_once(mgr, settings)
+
+    actions = {r["action"] for r in captured_audit}
+    assert "pki.org_root_expiry_warning" in actions
+    assert "pki.intermediate_ca_expiry_visibility" in actions
+    assert "pki.mastio_leaf_expiry_warning" in actions
+    assert "pki.agent_cert_expiry_warning" in actions
+    assert "pki.nginx_server_cert_expiry_warning" in actions
+
+
+@pytest.mark.asyncio
+async def test_check_once_uses_default_thresholds_when_setting_absent(
+    captured_audit, captured_list_agents,
+):
+    """Missing settings should NOT crash the tick (fall back to defaults)."""
+    _, org_root = _mint_cert("test-org-root", days_until_expiry=100)
+    mgr = _StubAgentManager(org_ca_cert=org_root)
+    captured_list_agents["rows"] = []
+
+    # settings=None covers the "no settings injected" case (e.g. tests
+    # that drive _check_once directly). The defaults kick in.
+    await watcher_mod._check_once(mgr, None)
+
+    actions = {r["action"] for r in captured_audit}
+    assert "pki.org_root_expiry_warning" in actions
+
+
+# ─── loop lifecycle ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_on_event(captured_audit):
+    """``stop_event.set`` must wake the loop within a single iteration."""
+    mgr = _StubAgentManager()
+    stop = asyncio.Event()
+    settings = _StubSettings()
+
+    task = asyncio.create_task(
+        watcher_mod.cert_expiry_watcher_loop(
+            mgr, settings=settings, tick_seconds=3600, stop_event=stop,
+        ),
+    )
+    # Let the loop reach the wait_for(stop_event) sleep.
+    await asyncio.sleep(0.05)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_exception_in_tick(captured_audit, monkeypatch):
+    """If a tick raises the loop should log + continue, not crash."""
+    mgr = _StubAgentManager()
+    stop = asyncio.Event()
+    settings = _StubSettings()
+    calls = {"n": 0}
+
+    async def _boom(agent_manager, settings):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("synthetic tick failure")
+        stop.set()
+
+    monkeypatch.setattr(watcher_mod, "_check_once", _boom)
+
+    task = asyncio.create_task(
+        watcher_mod.cert_expiry_watcher_loop(
+            mgr, settings=settings, tick_seconds=0.01, stop_event=stop,
+        ),
+    )
+    await asyncio.wait_for(task, timeout=2.0)
+    assert calls["n"] >= 2


### PR DESCRIPTION
## Discovery

Wave 2 fix 5 follow-up to PR #788 (three-tier PKI hardening). PR #788 Phase 4 shipped `mastio_ca_rotation_watcher` (auto-rotates the Intermediate CA at 30d, warns at 180d/60d). The other cert tiers still relied on either boot-time checks or operator attention with no automatic visibility, so silent expiry was a real strand-the-customer failure mode.

Pre-implementation check (`mcp_proxy/lifespan/intermediate_ca_watcher.py`, `mcp_proxy/egress/agent_manager.py` constants `ORG_CA_VALIDITY_DAYS`, `INTERMEDIATE_CA_VALIDITY_DAYS`, `MASTIO_LEAF_VALIDITY_DAYS`, `AGENT_CERT_VALIDITY_DAYS`, `NGINX_SERVER_CERT_VALIDITY_DAYS`) confirmed nothing was already implemented for these tiers.

## Summary

- New `mcp_proxy/lifespan/cert_expiry_watcher.py`: leader-elected background loop that ticks once per 24h (default), iterates every cert tier the Intermediate watcher does NOT cover, and emits a warning log + audit chain row when a cert enters its per-tier threshold. Pattern matches `intermediate_ca_watcher` (PR #788) plus the other leader-elected watchers from PR #784.
- Per-agent rows pin the `agent_id` (not `system`) so the audit-by-agent query surfaces the warning for the right principal.
- Visibility only, **no auto-rotation**. Two of the four tiers (Org Root, Mastio leaf) need a human in the loop by design (Court ACK for the leaf, ceremony for the root). The other two (agent leaves, nginx server) have rotation paths owned elsewhere (Connector re-enrollment, Wave 2 fix 6 for nginx).
- Tiers and default thresholds:
  - Org Root: 1825d (cert is 15y, so >10y silent)
  - Intermediate fallback: 730d (primary watcher handles 180/60/30)
  - Mastio leaf: 90d (Court ACK round-trip needs lead time)
  - Agent leaves: 90d (Connector re-enrollment lead time)
  - nginx server cert: 30d (matches `ensure_nginx_server_cert` renew_within_days)
- All thresholds plus the tick interval plus the master enabled flag are overridable via `MCP_PROXY_CERT_EXPIRY_*` env vars (added to `mcp_proxy/config.py`).
- Registered in `mcp_proxy/main.py` lifespan with the same leader-election + teardown shape as `intermediate_ca_watcher`.

## Test plan

- [x] 20 new unit tests in `tests/test_cert_expiry_watcher.py` covering every tier:
  - Above/below threshold for each tier
  - Missing cert / malformed PEM defensive paths
  - Settings absent (defaults kick in)
  - Per-agent `agent_id` audit pin
  - Full `_check_once` integration of all tiers in one tick
  - Loop lifecycle: `stop_event` wakes promptly, tick exception does not crash the loop
- [x] `pytest tests/ -n auto --dist=loadfile`: 4013 passed, 6 failed + 3 errors (verified pre-existing on `origin/main`: Alembic migration tests + dashboard-approvals-nav + mcp_aggregator/login fixture flakes, unrelated to this PR)
- [ ] `./sandbox/smoke.sh full`: skipped due to local sandbox infrastructure being in race with parallel agent worktrees on the same machine (Wave 2 fix 6 + Wave 2 fix 7/8 in flight). The change is additive and gated by `cert_expiry_watcher_enabled`, so the boot path is unchanged when the watcher is off. Reviewer can run smoke on their machine.

## Not in scope

- Auto-rotation for any tier (deliberate, see Summary).
- Wave 2 fix 6 (nginx server cert runtime rotation) lands separately and pairs with this watcher (this watcher warns at < 30d, fix 6 rotates).
- Wave 2 fix 7+8 (agent cert + DPoP grace-period) is independent.
- ADR ratification or runbook entry: the PKI runbook does not exist yet in `docs/runbooks/`; the CHANGELOG entry is the canonical reference until a runbook lands.