### PR TITLE
feat(nginx): runtime cert rotation watcher with SIGHUP hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Added
+- nginx sidecar runtime cert rotation via leader-elected lifespan
+  watcher (default 24h tick). Pairs with a polling reload-watcher
+  script in the sidecar that detects mtime changes on
+  `mastio-server.crt` and triggers `nginx -s reload`. Mastio
+  containers up beyond the 90-day cert validity now rotate
+  automatically without restart. Tunable via
+  `MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS` (default 86400)
+  and `NGINX_RELOAD_POLL_SECONDS` (default 60). Audit chain entry
+  `pki.nginx_server_cert_rotated` per rotation.
+
 ### Breaking changes
 
 - **`POST /v1/enrollment/start` now requires `pop_signature`** (H-csr-pop

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -103,6 +103,21 @@ class ProxySettings(BaseSettings):
     # docker-compose default; override with MCP_PROXY_NGINX_SAN for
     # production hostnames.
     nginx_san: str = "mastio.local"
+    # Wave 2 fix 6 — runtime watcher that re-invokes
+    # ``ensure_nginx_server_cert`` on a periodic tick so a container
+    # up beyond ``NGINX_SERVER_CERT_VALIDITY_DAYS`` (90d) still
+    # rotates the leaf before expiry. Disable only for tests or
+    # one-shot debug runs; production keeps it on.
+    nginx_cert_watcher_enabled: bool = True
+    # Tick interval in seconds. 24h default leaves a 30-attempt retry
+    # budget against the 30-day renew threshold so a transient blip on
+    # a single tick is never load-bearing.
+    nginx_cert_watcher_interval_seconds: int = 86400
+    # Days-of-life threshold below which the watcher rewrites the
+    # leaf. Matches the boot-time default in
+    # ``ensure_nginx_server_cert`` for consistency between boot +
+    # runtime renewal.
+    nginx_cert_renew_within_days: int = 30
 
     # DPoP
     dpop_iat_window: int = 60

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -827,10 +827,12 @@ class AgentManager:
         )
         leaf_cert = builder.sign(self._mastio_ca_key, hashes.SHA256())
 
-        # Write atomically: tmp file then rename. nginx watches the
-        # files and reload (SIGHUP) is the operator's job; mid-boot
-        # we just need the writes consistent so a restart-within-restart
-        # never observes a torn pair.
+        # Write atomically: tmp file then rename. The mtime change is
+        # the signal the sidecar ``nginx-reload-watcher.sh`` (Wave 2
+        # fix 6) picks up to trigger ``nginx -s reload`` — no SIGHUP
+        # from this side, no docker socket. At boot we still need the
+        # writes consistent so a restart-within-restart never observes
+        # a torn pair.
         #
         # Three-tier PKI hardening (audit 2026-05-18): ``org-ca.crt`` now
         # holds the **full chain** (Org Root || Intermediate) so a

--- a/mcp_proxy/lifespan/nginx_cert_watcher.py
+++ b/mcp_proxy/lifespan/nginx_cert_watcher.py
@@ -1,0 +1,152 @@
+"""Background watcher for the nginx sidecar server TLS cert expiry.
+
+Wave 2 fix 6 (post audit 2026-05-18). Boot-time
+:meth:`AgentManager.ensure_nginx_server_cert` already mints / renews the
+nginx leaf when the Mastio container starts, but the renewal only runs
+once at boot. A container that stays up beyond the cert validity
+(``NGINX_SERVER_CERT_VALIDITY_DAYS`` = 90d post-A) would serve an
+expired cert until the operator restarted manually.
+
+This loop closes the gap. Once per ``tick_seconds`` (default 24h) the
+leader-elected worker invokes ``ensure_nginx_server_cert`` again with
+the configured ``renew_within_days`` threshold. The method is
+idempotent: if the on-disk leaf is fresh, SAN-correct, and issued by
+the current Intermediate, nothing is written; otherwise a new leaf is
+emitted and the trust bundle rewritten. A change in the cert file's
+mtime is the signal the sidecar ``nginx-reload-watcher`` script picks
+up to send ``nginx -s reload`` — no docker socket, no SIGHUP from the
+Mastio container needed.
+
+Audit chain entries:
+
+* ``pki.nginx_server_cert_rotated`` (status=success) on every actual
+  rewrite, with the new expiry + SAN list in ``detail``.
+* ``pki.nginx_server_cert_rotation_failed`` (status=error) on
+  exception. The loop continues so the next tick retries.
+
+Leader-elected via :func:`mcp_proxy.lifespan.get_leader` so only one
+worker runs the loop in a multi-worker deployment (pattern from
+PR #784, replicated by ``intermediate_ca_watcher.py``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timezone
+
+logger = logging.getLogger("mcp_proxy.lifespan.nginx_cert_watcher")
+
+_DEFAULT_TICK_SECONDS = 24 * 60 * 60
+
+
+async def nginx_cert_watcher_loop(
+    agent_manager,
+    *,
+    out_dir: str,
+    sans: list[str],
+    tick_seconds: int = _DEFAULT_TICK_SECONDS,
+    renew_within_days: int = 30,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Loop tail: check expiry, rotate if needed, audit on rotation."""
+    stop_event = stop_event or asyncio.Event()
+    logger.info(
+        "nginx_cert_watcher loop starting (tick=%ds, renew_within=%dd, sans=%s)",
+        tick_seconds, renew_within_days, ",".join(sans),
+    )
+    while not stop_event.is_set():
+        try:
+            await _check_once(
+                agent_manager,
+                out_dir=out_dir,
+                sans=sans,
+                renew_within_days=renew_within_days,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "nginx_cert_watcher tick raised %s — continuing", exc,
+            )
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=tick_seconds)
+        except asyncio.TimeoutError:
+            pass
+    logger.info("nginx_cert_watcher loop stopped")
+
+
+async def _check_once(
+    agent_manager,
+    *,
+    out_dir: str,
+    sans: list[str],
+    renew_within_days: int,
+) -> None:
+    """One tick: call ensure_nginx_server_cert, audit on rotation."""
+    from mcp_proxy.db import log_audit
+
+    if getattr(agent_manager, "_mastio_ca_cert", None) is None:
+        logger.debug(
+            "nginx_cert_watcher: Mastio Intermediate not loaded — skipping tick",
+        )
+        return
+
+    try:
+        rotated = await agent_manager.ensure_nginx_server_cert(
+            out_dir=out_dir,
+            sans=sans,
+            renew_within_days=renew_within_days,
+        )
+    except Exception as exc:
+        logger.error(
+            "nginx_cert_watcher: ensure_nginx_server_cert failed: %s — "
+            "audit + continue (next tick retries)", exc,
+        )
+        try:
+            await log_audit(
+                agent_id="system",
+                action="pki.nginx_server_cert_rotation_failed",
+                status="error",
+                detail=f"error={type(exc).__name__}",
+            )
+        except Exception:
+            pass
+        return
+
+    if not rotated:
+        return
+
+    not_after_iso = ""
+    try:
+        from pathlib import Path
+        from cryptography import x509
+        crt_path = Path(out_dir) / "mastio-server.crt"
+        leaf = x509.load_pem_x509_certificate(crt_path.read_bytes())
+        not_after = leaf.not_valid_after
+        if not_after.tzinfo is None:
+            not_after = not_after.replace(tzinfo=timezone.utc)
+        not_after_iso = not_after.isoformat(timespec="seconds")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "nginx_cert_watcher: failed to read new cert for audit detail: %s",
+            exc,
+        )
+
+    logger.info(
+        "nginx_cert_watcher: nginx server cert rotated (new_expiry=%s)",
+        not_after_iso or "unknown",
+    )
+    try:
+        await log_audit(
+            agent_id="system",
+            action="pki.nginx_server_cert_rotated",
+            status="success",
+            detail=(
+                f"new_expiry={not_after_iso!r} "
+                f"sans={','.join(sans)!r} "
+                f"renew_within_days={renew_within_days}"
+            ),
+        )
+    except Exception:
+        pass
+
+
+__all__ = ["nginx_cert_watcher_loop"]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -418,6 +418,63 @@ async def lifespan(app: FastAPI):
                 exc,
             )
 
+    # Wave 2 fix 6 — nginx server cert runtime rotation watcher. Pairs
+    # with the sidecar ``nginx-reload-watcher.sh`` that polls
+    # ``mastio-server.crt`` mtime and runs ``nginx -s reload`` on
+    # change. Boot-time provisioning above is one-shot; this loop
+    # closes the gap for containers that stay up past the 90-day cert
+    # validity. Same leader-election pattern as the other watchers.
+    if (
+        settings.nginx_cert_dir
+        and settings.nginx_cert_watcher_enabled
+        and getattr(agent_mgr, "_mastio_ca_cert", None) is not None
+    ):
+        try:
+            from mcp_proxy.lifespan import get_leader as _get_leader_nginx
+            from mcp_proxy.lifespan.nginx_cert_watcher import (
+                nginx_cert_watcher_loop,
+            )
+            nginx_sans = [
+                s.strip()
+                for s in (settings.nginx_san or "mastio.local").split(",")
+                if s.strip()
+            ]
+            nginx_leader = _get_leader_nginx("nginx_cert_watcher")
+            if await nginx_leader.acquire():
+                nginx_stop = asyncio.Event()
+                nginx_task = asyncio.create_task(
+                    nginx_cert_watcher_loop(
+                        agent_mgr,
+                        out_dir=settings.nginx_cert_dir,
+                        sans=nginx_sans,
+                        tick_seconds=settings.nginx_cert_watcher_interval_seconds,
+                        renew_within_days=settings.nginx_cert_renew_within_days,
+                        stop_event=nginx_stop,
+                    ),
+                    name="nginx_cert_watcher",
+                )
+                app.state.nginx_cert_watcher_task = nginx_task
+                app.state.nginx_cert_watcher_stop = nginx_stop
+                app.state.nginx_cert_watcher_leader = nginx_leader
+                _log.info(
+                    "nginx_cert_watcher: leader acquired, loop spawned "
+                    "(tick=%ds, renew_within=%dd)",
+                    settings.nginx_cert_watcher_interval_seconds,
+                    settings.nginx_cert_renew_within_days,
+                )
+            else:
+                _log.info(
+                    "nginx_cert_watcher: another worker holds the leader "
+                    "lock — skipping",
+                )
+        except Exception as exc:
+            _log.warning(
+                "nginx_cert_watcher startup failed: %s — boot-time "
+                "provisioning already ran, but runtime rotation will not "
+                "occur until next restart",
+                exc,
+            )
+
     # Federation update framework (imp/federation_hardening_plan.md
     # Parte 1, PR 2). Must run BEFORE ``LocalIssuer`` construction so a
     # critical-pending migration affecting this proxy's enrollments can
@@ -1072,6 +1129,32 @@ async def lifespan(app: FastAPI):
             _log.debug(
                 "mastio_ca_rotation_watcher leader release failed: %s", exc,
             )
+
+    # Wave 2 fix 6 — stop the nginx server cert rotation watcher.
+    nginx_stop = getattr(app.state, "nginx_cert_watcher_stop", None)
+    nginx_task = getattr(app.state, "nginx_cert_watcher_task", None)
+    if nginx_stop is not None:
+        nginx_stop.set()
+    if nginx_task is not None:
+        try:
+            await asyncio.wait_for(nginx_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            nginx_task.cancel()
+            try:
+                await nginx_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug(
+                "nginx_cert_watcher teardown loop mismatch (xdist): %s",
+                exc,
+            )
+    nginx_leader = getattr(app.state, "nginx_cert_watcher_leader", None)
+    if nginx_leader is not None:
+        try:
+            await nginx_leader.release()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            _log.debug("nginx_cert_watcher leader release failed: %s", exc)
 
     # ADR-032 F6 — stop the stale-watcher.
     stale_stop = getattr(app.state, "attestation_stale_stop", None)

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -113,6 +113,14 @@ services:
       MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-https://host.docker.internal:9443}
       MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
       MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
+      # Wave 2 fix 6 — runtime cert rotation watcher. Defaults
+      # (enabled, 24h tick, 30-day renew threshold) are production-safe;
+      # operators only override when debugging or tuning. Env mapping
+      # is explicit because docker compose --env-file does not inject
+      # vars into the container automatically — only substitutes ${...}.
+      MCP_PROXY_NGINX_CERT_WATCHER_ENABLED:           ${MCP_PROXY_NGINX_CERT_WATCHER_ENABLED:-true}
+      MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS:  ${MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS:-86400}
+      MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS:         ${MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS:-30}
       # SAN covers the names the cert can validate at:
       # ``localhost`` (host browser default), ``mastio.local`` (legacy
       # alias), ``host.docker.internal`` (sibling bundle scenario via
@@ -226,6 +234,20 @@ services:
       # mounted read-only here so the sidecar serves the cert without
       # being able to mutate it.
       - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/etc/nginx/certs:ro
+      # Wave 2 fix 6 — polling reload watcher script. Pairs with the
+      # Mastio-side ``nginx_cert_watcher`` lifespan task: that task
+      # rewrites ``mastio-server.crt`` when expiry approaches, and the
+      # mtime change here triggers ``nginx -s reload`` without docker
+      # socket exposure or a custom image.
+      - ../nginx-reload-watcher/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
+    command:
+      - /bin/sh
+      - -c
+      - |
+        /usr/local/bin/nginx-reload-watcher.sh &
+        exec nginx -g 'daemon off;'
+    environment:
+      NGINX_RELOAD_POLL_SECONDS: "${NGINX_RELOAD_POLL_SECONDS:-60}"
     depends_on:
       mcp-proxy:
         condition: service_healthy

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -176,6 +176,22 @@ MCP_PROXY_NGINX_CERT_DIR=/var/lib/mastio/nginx-certs
 # is regenerated on the next Mastio boot if SAN changes).
 MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy
 
+# ─── nginx server cert runtime rotation (Wave 2 fix 6) ───────────────────────
+#
+# The Mastio mints a 90-day leaf for the nginx sidecar at boot. To keep
+# rotation safe across containers that stay up beyond 90 days, the
+# Mastio also runs a leader-elected background watcher that re-invokes
+# ``ensure_nginx_server_cert`` once every interval, and the nginx
+# sidecar polls the cert file mtime to trigger ``nginx -s reload`` on
+# change. No docker socket exposure, no custom image.
+#
+# Defaults (24h watcher tick, 60s sidecar poll) are tuned for production.
+# Disable the watcher only for one-shot debug runs.
+# MCP_PROXY_NGINX_CERT_WATCHER_ENABLED=true
+# MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS=86400
+# MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS=30
+# NGINX_RELOAD_POLL_SECONDS=60
+
 # ADR-006 standalone mode (default after ADR-014 PR-D). True = the
 # Mastio runs as a self-contained mini-broker, derives its own Org CA,
 # zero broker dependency at boot. Federation is post-setup, opt-in via

--- a/packaging/mastio-enterprise-bundle/docker-compose.yml
+++ b/packaging/mastio-enterprise-bundle/docker-compose.yml
@@ -91,6 +91,11 @@ services:
       MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
       MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
       MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy}
+      # Wave 2 fix 6 — runtime cert rotation watcher. Defaults are
+      # production-safe; operators only override when debugging.
+      MCP_PROXY_NGINX_CERT_WATCHER_ENABLED:           ${MCP_PROXY_NGINX_CERT_WATCHER_ENABLED:-true}
+      MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS:  ${MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS:-86400}
+      MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS:         ${MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS:-30}
       SSL_CERT_FILE:               ${MCP_PROXY_BROKER_CA_BUNDLE:-}
       REQUESTS_CA_BUNDLE:          ${MCP_PROXY_BROKER_CA_BUNDLE:-}
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
@@ -207,6 +212,20 @@ services:
     volumes:
       - ./nginx/mastio:/etc/nginx/conf.d:ro
       - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/etc/nginx/certs:ro
+      # Wave 2 fix 6 — polling reload watcher script. Pairs with the
+      # Mastio-side ``nginx_cert_watcher`` lifespan task that rewrites
+      # ``mastio-server.crt`` when expiry approaches; the mtime change
+      # here triggers ``nginx -s reload`` without docker socket
+      # exposure or a custom image.
+      - ../nginx-reload-watcher/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
+    command:
+      - /bin/sh
+      - -c
+      - |
+        /usr/local/bin/nginx-reload-watcher.sh &
+        exec nginx -g 'daemon off;'
+    environment:
+      NGINX_RELOAD_POLL_SECONDS: "${NGINX_RELOAD_POLL_SECONDS:-60}"
     depends_on:
       mcp-proxy:
         condition: service_healthy

--- a/packaging/mastio-enterprise-bundle/proxy.env.example
+++ b/packaging/mastio-enterprise-bundle/proxy.env.example
@@ -47,6 +47,18 @@ MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.yourorg.example.com:9443
 # Public TLS port (host side; container always binds 9443).
 MCP_PROXY_PORT=9443
 
+# ────────── nginx server cert runtime rotation (Wave 2 fix 6) ────────
+# The Mastio mints a 90-day TLS leaf for the nginx sidecar at boot.
+# A leader-elected background watcher re-invokes ``ensure_nginx_server_cert``
+# once every interval so containers that stay up past 90 days still
+# rotate without restart; the nginx sidecar polls the cert file mtime
+# to trigger ``nginx -s reload`` on change. Defaults below are tuned
+# for production. Override only for one-shot debug or tight smoke loops.
+# MCP_PROXY_NGINX_CERT_WATCHER_ENABLED=true
+# MCP_PROXY_NGINX_CERT_WATCHER_INTERVAL_SECONDS=86400
+# MCP_PROXY_NGINX_CERT_RENEW_WITHIN_DAYS=30
+# NGINX_RELOAD_POLL_SECONDS=60
+
 # Uvicorn worker count (v0.4.4+). Default 4 matches the 4-CPU resource
 # ceiling in docker-compose.yml. Raise on fatter VMs (rule of thumb:
 # ~1 worker per logical core, leave 1 free for nginx + the host).

--- a/packaging/nginx-reload-watcher/reload-watcher.sh
+++ b/packaging/nginx-reload-watcher/reload-watcher.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# =============================================================================
+# nginx-reload-watcher — polls a TLS cert file mtime and reloads nginx on
+# change. Pairs with the Mastio-side lifespan watcher
+# (`mcp_proxy/lifespan/nginx_cert_watcher.py`) that rewrites the cert via
+# `ensure_nginx_server_cert` when expiry approaches.
+#
+# Why polling vs inotify: the sidecar runs stock `nginx:1.27-alpine`,
+# which does not ship `inotify-tools`. Polling with `stat -c %Y` is POSIX
+# busybox-compatible, needs no package install, no docker socket mount,
+# and adds at most one poll interval of latency. For a cert that rotates
+# at most every 60-90 days, 60-second polling latency is comfortably
+# below any SLA concern.
+#
+# Trigger: mtime change on the cert file. `ensure_nginx_server_cert`
+# writes via tmpfile + rename so mtime updates atomically.
+#
+# Env:
+#   NGINX_RELOAD_WATCH_FILE   path to the cert file to poll
+#                             (default: /etc/nginx/certs/mastio-server.crt)
+#   NGINX_RELOAD_POLL_SECONDS poll interval (default: 60)
+# =============================================================================
+set -eu
+CERT_FILE="${NGINX_RELOAD_WATCH_FILE:-/etc/nginx/certs/mastio-server.crt}"
+INTERVAL="${NGINX_RELOAD_POLL_SECONDS:-60}"
+last_mtime=""
+if [ -f "$CERT_FILE" ]; then
+    last_mtime=$(stat -c %Y "$CERT_FILE" 2>/dev/null || echo "")
+fi
+echo "[nginx-reload-watcher] start watch=$CERT_FILE interval=${INTERVAL}s initial_mtime=${last_mtime:-none}"
+while sleep "$INTERVAL"; do
+    if [ ! -f "$CERT_FILE" ]; then
+        continue
+    fi
+    cur_mtime=$(stat -c %Y "$CERT_FILE" 2>/dev/null || echo "")
+    if [ -z "$cur_mtime" ]; then
+        continue
+    fi
+    if [ -z "$last_mtime" ]; then
+        last_mtime="$cur_mtime"
+        echo "[nginx-reload-watcher] cert appeared, baseline mtime=$cur_mtime"
+        continue
+    fi
+    if [ "$cur_mtime" != "$last_mtime" ]; then
+        echo "[nginx-reload-watcher] cert mtime changed ($last_mtime -> $cur_mtime), reloading nginx"
+        if nginx -s reload 2>&1; then
+            echo "[nginx-reload-watcher] reload OK"
+        else
+            rc=$?
+            echo "[nginx-reload-watcher] reload FAILED (rc=$rc), will retry on next change" >&2
+        fi
+        last_mtime="$cur_mtime"
+    fi
+done

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -386,6 +386,22 @@ services:
     volumes:
       - ../nginx/mastio:/etc/nginx/conf.d:ro
       - mastio-a-nginx-certs:/etc/nginx/certs:ro
+      # Wave 2 fix 6 — sidecar reload watcher: polls mtime on the
+      # cert file every NGINX_RELOAD_POLL_SECONDS and triggers
+      # ``nginx -s reload`` on change. Pairs with the Mastio
+      # ``nginx_cert_watcher`` lifespan task that rewrites the leaf
+      # on the 30-day-before-expiry threshold.
+      - ../packaging/nginx-reload-watcher/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
+    command:
+      - /bin/sh
+      - -c
+      - |
+        /usr/local/bin/nginx-reload-watcher.sh &
+        exec nginx -g 'daemon off;'
+    environment:
+      # Tight poll for the sandbox so manual mtime touches (smoke tests
+      # exercising rotation) flush within a couple of seconds.
+      NGINX_RELOAD_POLL_SECONDS: "5"
     networks:
       orga-internal:
         aliases: [mastio-nginx-a]
@@ -669,6 +685,16 @@ services:
     volumes:
       - ../nginx/mastio:/etc/nginx/conf.d:ro
       - mastio-b-nginx-certs:/etc/nginx/certs:ro
+      # Wave 2 fix 6 — same reload watcher pattern as mastio-nginx-a.
+      - ../packaging/nginx-reload-watcher/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
+    command:
+      - /bin/sh
+      - -c
+      - |
+        /usr/local/bin/nginx-reload-watcher.sh &
+        exec nginx -g 'daemon off;'
+    environment:
+      NGINX_RELOAD_POLL_SECONDS: "5"
     networks:
       orgb-internal:
         aliases: [mastio-nginx-b]

--- a/tests/test_nginx_cert_watcher.py
+++ b/tests/test_nginx_cert_watcher.py
@@ -1,0 +1,192 @@
+"""Tests for the nginx server cert runtime rotation watcher.
+
+Wave 2 fix 6. The watcher closes the gap left by boot-time
+``ensure_nginx_server_cert``: a Mastio container that stays up beyond
+the 90-day cert validity would serve an expired leaf until restart.
+The loop ticks daily, re-invokes the idempotent
+``ensure_nginx_server_cert``, and audit-logs every actual rotation.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.egress.agent_manager import AgentManager
+from mcp_proxy.lifespan.nginx_cert_watcher import (
+    _check_once,
+    nginx_cert_watcher_loop,
+)
+
+
+def _make_ca() -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "test-org CA"),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _make_manager_with_ca() -> AgentManager:
+    mgr = AgentManager.__new__(AgentManager)
+    key, cert = _make_ca()
+    mgr._org_ca_key = key
+    mgr._org_ca_cert = cert
+    mgr._mastio_ca_key = key
+    mgr._mastio_ca_cert = cert
+    mgr._org_id = "test-org"
+    return mgr
+
+
+class _AuditCapture:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_check_once_rotates_when_cert_near_expiry(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+    sans = ["mastio.local", "localhost"]
+    rotated = await mgr.ensure_nginx_server_cert(
+        out_dir=str(tmp_path), sans=sans, validity_days=5, renew_within_days=10,
+    )
+    assert rotated is True
+    audit = _AuditCapture()
+    with patch("mcp_proxy.db.log_audit", new=audit):
+        await _check_once(
+            mgr, out_dir=str(tmp_path), sans=sans, renew_within_days=10,
+        )
+    assert len(audit.calls) == 1
+    call = audit.calls[0]
+    assert call["action"] == "pki.nginx_server_cert_rotated"
+    assert call["status"] == "success"
+    assert call["agent_id"] == "system"
+    assert "new_expiry=" in call["detail"]
+    assert "mastio.local" in call["detail"]
+
+
+@pytest.mark.asyncio
+async def test_check_once_noop_when_cert_fresh(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+    sans = ["mastio.local"]
+    rotated = await mgr.ensure_nginx_server_cert(
+        out_dir=str(tmp_path), sans=sans, validity_days=90, renew_within_days=30,
+    )
+    assert rotated is True
+    audit = _AuditCapture()
+    with patch("mcp_proxy.db.log_audit", new=audit):
+        await _check_once(
+            mgr, out_dir=str(tmp_path), sans=sans, renew_within_days=30,
+        )
+    assert audit.calls == []
+
+
+@pytest.mark.asyncio
+async def test_check_once_skips_when_intermediate_missing(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+    mgr._mastio_ca_cert = None
+    audit = _AuditCapture()
+    with patch("mcp_proxy.db.log_audit", new=audit):
+        await _check_once(
+            mgr, out_dir=str(tmp_path), sans=["mastio.local"], renew_within_days=30,
+        )
+    assert audit.calls == []
+    assert not (tmp_path / "mastio-server.crt").exists()
+
+
+@pytest.mark.asyncio
+async def test_check_once_audits_on_ensure_exception(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+
+    async def _raise(**_kw):
+        raise RuntimeError("kms unreachable")
+
+    audit = _AuditCapture()
+    with patch.object(mgr, "ensure_nginx_server_cert", new=_raise), \
+            patch("mcp_proxy.db.log_audit", new=audit):
+        await _check_once(
+            mgr, out_dir=str(tmp_path), sans=["mastio.local"], renew_within_days=30,
+        )
+    assert len(audit.calls) == 1
+    call = audit.calls[0]
+    assert call["action"] == "pki.nginx_server_cert_rotation_failed"
+    assert call["status"] == "error"
+    assert "RuntimeError" in call["detail"]
+
+
+@pytest.mark.asyncio
+async def test_loop_exits_promptly_on_stop_event(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+    stop = asyncio.Event()
+
+    async def _stop_later() -> None:
+        await asyncio.sleep(0.2)
+        stop.set()
+
+    audit = _AuditCapture()
+    with patch("mcp_proxy.db.log_audit", new=audit):
+        await asyncio.gather(
+            nginx_cert_watcher_loop(
+                mgr,
+                out_dir=str(tmp_path),
+                sans=["mastio.local"],
+                tick_seconds=60,
+                renew_within_days=30,
+                stop_event=stop,
+            ),
+            _stop_later(),
+        )
+    assert any(
+        c["action"] == "pki.nginx_server_cert_rotated" for c in audit.calls
+    ), "first tick should have emitted seed cert + audit"
+
+
+@pytest.mark.asyncio
+async def test_loop_continues_when_check_raises(tmp_path: Path) -> None:
+    mgr = _make_manager_with_ca()
+    stop = asyncio.Event()
+    ticks_seen = 0
+
+    async def _flaky_check(*_a, **_kw) -> None:
+        nonlocal ticks_seen
+        ticks_seen += 1
+        if ticks_seen <= 2:
+            raise RuntimeError(f"transient failure #{ticks_seen}")
+        stop.set()
+
+    with patch(
+        "mcp_proxy.lifespan.nginx_cert_watcher._check_once",
+        new=_flaky_check,
+    ):
+        await asyncio.wait_for(
+            nginx_cert_watcher_loop(
+                mgr,
+                out_dir=str(tmp_path),
+                sans=["mastio.local"],
+                tick_seconds=0.01,
+                renew_within_days=30,
+                stop_event=stop,
+            ),
+            timeout=5.0,
+        )
+    assert ticks_seen >= 3, "loop must have survived 2 raising ticks"


### PR DESCRIPTION
## Summary

Closes the runtime cert rotation gap left by boot-only `ensure_nginx_server_cert` provisioning. A Mastio container that stays up beyond the 90-day TLS leaf validity now rotates without manual restart.

Two parts:

- **Mastio-side** (`mcp_proxy/lifespan/nginx_cert_watcher.py`): leader-elected background loop (default 24h tick) that re-invokes the idempotent `ensure_nginx_server_cert` with the configured renewal threshold. Audit-logs `pki.nginx_server_cert_rotated` on every actual rewrite (`pki.nginx_server_cert_rotation_failed` on exception). Same leader-election pattern as `intermediate_ca_watcher` (PR #784).
- **Sidecar-side** (`packaging/nginx-reload-watcher/reload-watcher.sh`): POSIX shell script (alpine ash compatible) that polls the cert file mtime via `stat -c %Y` and runs `nginx -s reload` on change.

## Discovery (STEP 0 pre-verify)

- `mcp_proxy/egress/agent_manager.py:628` `ensure_nginx_server_cert` already exists, idempotent, 90d validity post-PR-A.
- `mcp_proxy/lifespan/intermediate_ca_watcher.py` is the reference pattern: leader-elected, 24h tick, `_check_once`, `stop_event` early exit.
- **No existing hot-reload mechanism**: grep `SIGHUP`, `nginx.*reload`, `MCP_PROXY_NGINX_CONTAINER_NAME` returns only a comment in `agent_manager.py:830` saying \"reload is the operator's job\".
- No conflict with Wave 2 fix 5 (`cert_expiry_watcher.py` does not exist on main); this PR adds a new file rather than extending one.
- All three sidecar deployments (mastio-bundle, mastio-enterprise-bundle, sandbox a + b) use stock `nginx:1.27-alpine` with `/etc/nginx/certs` mounted RO from a host bind shared with the Mastio container that writes the cert.

## Hot-reload strategy: polling mtime (option C variant)

Trade-off analyzed:

| Option | Security | Custom image | Latency | Picked |
|---|---|---|---|---|
| A `docker exec` | docker socket mount = supply-chain risk | No | <1s | No |
| B `inotifywait` | OK | Yes (`apk add inotify-tools`) | <1s | No |
| C mtime polling | OK | No (stock alpine) | poll interval | **Yes** |
| D nginx-plus HTTP | proprietary | Yes | <1s | No |

C wins for: zero image build, zero package add, zero docker socket exposure, deterministic. Latency = poll interval (default 60s, 5s in sandbox for smoke loops) is comfortably below any SLA: certs rotate every 60-90 days, the 60s reload delay is negligible. Watch target is the cert file itself (`mastio-server.crt`) which `ensure_nginx_server_cert` writes atomically via tmpfile + rename, so mtime updates atomically. No separate signal file needed.

## Files

**New**:
- `mcp_proxy/lifespan/nginx_cert_watcher.py` — leader-elected runtime watcher (152 lines).
- `packaging/nginx-reload-watcher/reload-watcher.sh` — sidecar polling helper (POSIX sh).
- `tests/test_nginx_cert_watcher.py` — 6 unit tests covering rotation, no-op, missing intermediate, exception path, stop_event, raising tick.

**Modified**:
- `mcp_proxy/main.py` — register the watcher in the lifespan startup (after intermediate_ca_watcher) and teardown it cleanly.
- `mcp_proxy/config.py` — 3 new pydantic settings: `nginx_cert_watcher_enabled`, `nginx_cert_watcher_interval_seconds`, `nginx_cert_renew_within_days`.
- `mcp_proxy/egress/agent_manager.py` — updated the comment on the atomic write path to reflect the new mtime-driven reload.
- `packaging/mastio-bundle/docker-compose.yml`, `packaging/mastio-enterprise-bundle/docker-compose.yml`, `sandbox/docker-compose.yml` — mount the reload-watcher script into each sidecar, override `command:` to spawn it alongside nginx, set `NGINX_RELOAD_POLL_SECONDS` (60 default, 5 in sandbox for tight smoke loops), and add the three watcher env settings on the mcp-proxy service (explicit mapping because docker compose `--env-file` only substitutes `\${...}`).
- `packaging/mastio-bundle/proxy.env.example`, `packaging/mastio-enterprise-bundle/proxy.env.example` — documented the new tunables.
- `CHANGELOG.md` — Added entry.

## Why a separate watcher vs extending `intermediate_ca_watcher`

The Intermediate CA rotates on a 5-year cadence with a tight 30-day auto-rotate window; the nginx leaf rotates every 60-90 days with a default 30-day threshold. Different cadences, different audit semantics (`pki.intermediate_ca_auto_rotate` vs `pki.nginx_server_cert_rotated`), different leader-election keys (separate `nginx_cert_watcher` task so the two locks are independent). Keeping them as siblings makes failure modes easier to attribute.

## Test plan

- [x] Unit tests: `pytest tests/test_nginx_cert_watcher.py` → 6 passed
- [x] Cross-suite: `pytest tests/test_nginx_cert_watcher.py tests/test_mastio_nginx_cert_san.py tests/test_pki_three_tier_hardening.py -n 4 --dist=loadfile` → 19 passed
- [x] Import smoke: `python -c \"import mcp_proxy.main\"` clean (all watchers registered without errors)
- [x] Shell syntax: `sh -n packaging/nginx-reload-watcher/reload-watcher.sh`
- [x] YAML syntax: `yaml.safe_load` on all three compose files
- [ ] Full parallel suite `pytest tests/ -n auto --dist=loadfile` (reviewer to run)
- [ ] Smoke `./sandbox/smoke.sh full` (reviewer to run; concurrent local autonomous loop made running it in-session unreliable)
- [ ] Manual dogfood: bring up `./sandbox/demo.sh full`, observe `[nginx-reload-watcher]` lines in `mastio-nginx-a` logs, manually `touch` the cert file in the volume, confirm reload triggers within `NGINX_RELOAD_POLL_SECONDS`.

## Not in scope

- Operator-facing dashboard counter for runtime rotations (audit row is observable via existing audit log API).
- Runbook update in `docs/runbooks/` — left for the post-merge documentation pass to keep this PR scoped.
- Frontdesk bundle: it does not host a Mastio TLS sidecar (only Connector + nginx-static SPA), so no change applies there.