### PR TITLE
docs(security): CISO-ready bundle (threat model + IR runbook + PQC roadmap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,27 @@ flow until the next `## ` heading.
   `docs/runbooks/frontdesk-shared-hardening.md`. Covers container
   security configuration, network isolation, monitoring, update cadence,
   compromise response procedure, and the Phase 2 WebAuthn roadmap.
+- **CISO-ready security bundle** published under `docs/security/` and
+  `docs/runbooks/`. Four new customer-facing documents land in one PR:
+  - `docs/security/threat-model.md` (v1.0): threat catalog (in scope +
+    out of scope), trust boundaries, cryptographic primitives, key
+    lifecycle, audit trail integrity, compliance mapping preview.
+    Cross-links the STRIDE per-component walkthrough on cullis.io.
+  - `docs/security/post-quantum-roadmap.md` (v1.0): hybrid-first PQC
+    strategy across five phases gated by upstream library maturity
+    (`pyca/cryptography` ML-KEM, `liboqs-python` on NixOS, IETF
+    composite-sig RFC). Includes spike validation numbers from
+    2026-05-06 (X25519 + ML-KEM-768, ~4 to 5 ms roundtrip, +1088 bytes
+    overhead). Documents the Org Root rotation coupling with Phase 1a
+    kickoff (Wave 1-A deferred rotation automation by design).
+  - `docs/runbooks/incident-response.md` (v1.0): severity classification
+    (Sev 1 through Sev 4) keyed to Cullis-specific assets (Org Root
+    compromise, Mastio Intermediate compromise, agent cert leak,
+    Frontdesk Connector compromise). Per-severity response procedure,
+    customer notification template, public disclosure template, SLA
+    summary matrix.
+  - `docs/security/README.md`: index for the new `docs/security/`
+    directory with quarterly review cadence note.
 
 ### Reference
 

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,519 @@
+# Incident response runbook (Cullis)
+
+**Audience:** customer security operators running Cullis Mastio or
+Cullis Court in production, plus the Cullis security team handling
+vulnerability reports under coordinated disclosure.
+
+**Status:** Version 1.0, 2026-05-18. Quarterly review.
+Next review: 2026-08-18.
+
+**Contact for active incidents:** security@cullis.io (mailbox
+monitored continuously, expect acknowledgment within 48 hours).
+
+---
+
+## 1. Overview
+
+This runbook covers detection, containment, recovery, and
+communication for security incidents that affect Cullis components
+(Court, Mastio, Connector) or that are reported against the Cullis
+codebase. The threat surface itself is documented in
+[`docs/security/threat-model.md`](../security/threat-model.md); this
+file is the response side of the same picture.
+
+The flow for any incident is:
+
+1. **Detect.** Trigger from operator alerting, customer report, or
+   inbound vulnerability disclosure.
+2. **Classify.** Apply the severity matrix in section 2.
+3. **Contain.** Apply the per-severity procedure in section 3. The
+   first-line goal is to stop the bleeding, not to find root cause.
+4. **Investigate.** Once contained, gather evidence (audit chain
+   slice, log bundle, registry snapshot).
+5. **Recover.** Restore service per the procedure for the relevant
+   key or component.
+6. **Communicate.** Customer notification, status page, public
+   disclosure on the timeline in section 4.
+7. **Retrospective.** Within 14 days of resolution, write a
+   post-incident review (template in section 7) and feed lessons
+   back into the threat model.
+
+Cullis ships pre-1.0; in practice the founder is the on-call. A
+24x7 PagerDuty partner will be contracted ahead of the first paid
+pilot. Section 6 describes the interim arrangement.
+
+---
+
+## 2. Severity classification
+
+The matrix below mirrors the CVSS-derived SLA tiers in
+[`SECURITY.md`](../../SECURITY.md) but adds operational triggers
+keyed to Cullis-specific assets.
+
+### Sev 1 (Critical)
+
+CVSS 9.0 to 10.0, or any of the following operational triggers:
+
+- Org Root CA private key compromise (any organisation, any
+  deployment).
+- Cullis-side license JWT signing key compromise.
+- Active CVE exploitation against any Mastio or Court in production
+  (in-the-wild, not theoretical).
+- Customer data breach: agent identity material, audit chain
+  contents, or upstream LLM session material has been confirmed
+  exfiltrated.
+- Audit chain forgery confirmed against a federated peer's anchor.
+
+Acknowledgment SLA: 4 hours.
+Containment SLA: 24 hours.
+Fix SLA: 7 days.
+
+### Sev 2 (High)
+
+CVSS 7.0 to 8.9, or any of the following:
+
+- Mastio Intermediate CA private key compromise.
+- Mastio leaf (federation) cert compromise.
+- Agent cert leak affecting more than 10 agents in one org.
+- Connector compromise in Frontdesk shared mode (multi-user blast
+  radius).
+- Authentication bypass (anyone can authenticate as anyone, scoped
+  but not org-wide).
+- Privileged builtin capability bypass affecting more than one tool.
+
+Acknowledgment SLA: 24 hours.
+Containment SLA: 72 hours.
+Fix SLA: 14 days.
+
+### Sev 3 (Medium)
+
+CVSS 4.0 to 6.9, or any of the following:
+
+- Single agent cert leak (one agent, one org).
+- DPoP token theft (single token, contained by 5-minute JTI cache
+  TTL).
+- Audit replication delay between Mastio and Court exceeding 1
+  hour.
+- Non-privileged tool capability misconfiguration.
+- Information disclosure of non-secret metadata (agent enrolment
+  timestamps, federation org names) outside the authorised
+  audience.
+
+Acknowledgment SLA: 48 hours.
+Containment SLA: 7 days.
+Fix SLA: 30 days.
+
+### Sev 4 (Low)
+
+CVSS 0.1 to 3.9, or any of the following:
+
+- Config drift on a single agent (logged, not user-visible).
+- Telemetry gap under 15 minutes.
+- Minor non-security UX issues with security implications (e.g. an
+  admin form that warns less clearly than it should).
+
+Acknowledgment SLA: 5 business days.
+Fix SLA: best effort, next minor release.
+
+---
+
+## 3. Response procedures
+
+Each procedure follows the same five-step shape: **detect, contain,
+investigate, recover, communicate**. Times below are wall-clock
+elapsed from the start of containment.
+
+### 3.1 Sev 1: Org Root CA compromise
+
+**Detect.** Trigger: unexplained `pki.org_root_unsealed` audit row
+(Wave 1-A introduced this), unexplained re-issuance of a Mastio
+Intermediate CA, evidence the operator-side `MCP_PROXY_DB_ENCRYPTION_KEY`
+or the at-rest envelope was exfiltrated.
+
+**Contain (0 to 4 h).**
+
+1. Take the Mastio offline:
+   `docker compose -p cullis-mastio down` (no `-v`, preserve
+   volumes for forensics).
+2. If federated, notify Court operators to mark the org as
+   suspended via `POST /v1/admin/federation/orgs/<id>/suspend`.
+   Court will refuse cross-org calls signed by the compromised
+   Mastio leaf and emit a federation event to peer Mastios.
+3. Disable any operator workflow that requires Org Root unseal
+   (Intermediate rotation, CA bundle re-generation) until recovery
+   begins.
+
+**Investigate (4 to 24 h).**
+
+1. Capture the audit chain slice for the period from the last clean
+   reference point (last known-good anchor at Court) to the moment
+   of containment.
+2. Capture host telemetry: process tree, file system state of the
+   `pki_key_store` table, last 30 days of `MCP_PROXY_DB_ENCRYPTION_KEY`
+   access events from the secrets manager.
+3. Identify the unsealing path: legitimate operator activity,
+   unauthorised dashboard access, or container compromise.
+
+**Recover (24 to 168 h).**
+
+1. Generate a new Org Root CA on a clean host using the recovery
+   procedure in `operate/rotate-keys.md`. This is a cold-storage
+   ceremony: airgapped laptop, freshly generated passphrase, key
+   sealed back to the at-rest envelope on the recovered host.
+2. Re-issue Mastio Intermediate CA from the new Root.
+3. Re-issue every agent leaf cert (bulk re-enrolment). The runbook
+   for bulk re-enrolment is in `operate/rotate-keys.md`; allow up
+   to 48 h for fleet rollout depending on agent count.
+4. Push the new CA bundle to federated peers via Court
+   `ContinuityProof` flow.
+
+**Communicate.**
+
+- Customer notification email within 4 hours of confirmation.
+  Template in section 4.1.
+- Status page update at cullis.io/status (placeholder; the page
+  goes live ahead of the first paid pilot).
+- Public CVE issued simultaneously with the fix release.
+- Post-incident review published within 14 days, redacted where
+  customer information requires it.
+
+### 3.2 Sev 1: Mastio Intermediate CA compromise
+
+**Detect.** Trigger: unexpected new Intermediate observed in the
+auto-rotation watcher log without a matching legitimate trigger,
+evidence the Vault path holding the Intermediate key was accessed
+out-of-band.
+
+**Contain (0 to 4 h).**
+
+1. Same offline step as 3.1 if the compromise vector is unclear.
+   If the auto-rotation watcher already replaced the Intermediate
+   and the compromise is to the *prior* Intermediate, recovery is
+   faster (skip to step 2).
+2. Confirm the watcher has signed a new Intermediate (the new chain
+   is already published via the CA bundle as of Wave 1-A, PR #788).
+
+**Investigate (4 to 24 h).**
+
+1. Audit chain slice for `pki.intermediate_*` rows.
+2. Vault audit log for the Intermediate KV path (if Vault backend).
+3. Identify whether any leaves were issued by the compromised
+   Intermediate to non-legitimate agents.
+
+**Recover.**
+
+The Wave 1-A rotation hook makes this fast: the new Intermediate is
+signed by the still-cold Org Root, the published CA bundle now
+contains both Intermediates for the grace window, all valid leaves
+continue to authenticate. Schedule the old Intermediate for
+removal from the bundle once the grace window expires (default 30
+days, configurable).
+
+**Communicate.** Sev 1 customer notification, but the absence of
+re-enrolment is itself the headline: customers should not need to
+take action.
+
+### 3.3 Sev 2: Agent cert leak
+
+**Detect.** Trigger: customer report, anomalous DPoP `jti` activity
+from a known agent, agent cert thumbprint observed in unauthorised
+logs.
+
+**Contain (0 to 4 h).**
+
+1. Revoke the agent cert via the dashboard form `rotate_agent_cert`
+   (operator-side action). Public REST endpoint for this is on the
+   P2 roadmap; until it lands, the dashboard is the only path.
+2. Pinning rejects the old thumbprint on the next request. Existing
+   DPoP proofs signed with the leaked key are useless without the
+   matching cert.
+
+**Investigate.**
+
+1. Audit chain slice for the agent's recent calls (per-agent
+   filter on `audit_log.agent_id`).
+2. Cross-reference with upstream MCP server logs to identify any
+   calls that should not have happened.
+
+**Recover.**
+
+1. Re-enrol the agent via the dashboard. New keypair, new cert,
+   new thumbprint pinned.
+2. **Grace-period transition (Wave 2 fix 7, in progress).** Once
+   landed, the operator can keep the old cert valid for a
+   configurable window (24 to 48 hours) so the agent process can
+   migrate without an enrolment outage. Until Wave 2 lands, the
+   agent must be re-enrolled with a brief downtime.
+
+**Communicate.** Customer notification within 24 hours of
+confirmation. No public disclosure required unless the leak vector
+is a Cullis defect (then escalate to Sev 1 / Sev 2 fix path).
+
+### 3.4 Sev 2: Frontdesk Connector compromise
+
+**Detect.** Trigger: spike in
+`frontdesk_shared_unauthenticated_user_session_warning` audit
+events (the Phase 1 baseline metric), evidence the Frontdesk
+container has been root-shell-accessed, observation of impersonated
+user activity.
+
+The detection guidance and Grafana alert pseudo-query are in
+[`docs/runbooks/frontdesk-shared-hardening.md`](./frontdesk-shared-hardening.md)
+section 3. Re-read it before responding.
+
+**Contain (0 to 2 h).**
+
+1. Revoke the Connector cert at the Mastio:
+   `POST /v1/admin/agents/<connector-agent-id>/revoke`. After
+   revocation the Mastio rejects all DPoP-authenticated requests
+   from the Connector; existing user sessions are invalidated
+   because they depend on the Connector's cert thumbprint for
+   pinning.
+2. Revoke all user sessions:
+   `POST /v1/admin/agents/<connector-agent-id>/revoke-all-sessions`.
+3. Take the container offline:
+   `docker compose -p cullis-frontdesk down`.
+
+**Investigate.**
+
+1. Audit chain filter on `connector_agent_id` for the window from
+   the suspected start of compromise to the revocation.
+2. Focus on rows with `on_behalf_of_user_id` populated: these show
+   which users may have been impersonated.
+3. If WebAuthn is enabled (Phase 2, PR #789), the
+   `user_signed_assertion` field is the second source of truth: a
+   row without a valid assertion in a Phase-2 deployment is a hard
+   anomaly.
+
+**Recover.**
+
+1. Verify the container image is clean (cosign verify, SBOM
+   review).
+2. Bring the bundle back up: `./deploy.sh`.
+3. Re-approve the Connector enrolment in the Mastio dashboard.
+4. All users log in again; users without an enrolled WebAuthn
+   credential are prompted to enrol one (Phase 2).
+
+**Communicate.** Customer notification within 24 hours, including
+the list of potentially impersonated users (the
+`on_behalf_of_user_id` set from the audit slice). Phase 2 WebAuthn
+materially shrinks this list: a row with a valid
+`user_signed_assertion` cannot have been impersonated by the
+container alone.
+
+### 3.5 Sev 3: Single agent cert leak / DPoP token theft
+
+For a single-agent leak, follow 3.3 with these adjustments:
+
+- No customer-wide notification; the affected customer is
+  notified directly.
+- Replication of the audit chain slice is optional unless the
+  customer requests forensic support.
+
+For a single DPoP token theft, the 5-minute JTI cache TTL is the
+primary containment: the stolen token is useless after the window
+elapses, and the JTI is registered as used. Operators still rotate
+the agent cert as a defence-in-depth step.
+
+### 3.6 Sev 4: Configuration drift / minor issues
+
+Operator workflow handles Sev 4 via the standard PR / release path.
+The CHANGELOG entry under "Security" notes the fix; no separate
+customer notification is required unless the operator opts in via
+their internal change management policy.
+
+---
+
+## 4. Communication templates
+
+### 4.1 Customer notification email (Sev 1)
+
+```
+Subject: [Cullis] Sev 1 security incident — action may be required
+
+To: <customer security contact>
+From: security@cullis.io
+
+We are notifying you of a Sev 1 security incident affecting Cullis
+that may require action on your side.
+
+Summary
+-------
+- Date of detection: <UTC timestamp>
+- Component affected: <Court / Mastio / Connector>
+- Nature: <one-line description, no premature attribution>
+- Customer action required: <yes / no, and what>
+- Cullis action in progress: <containment / recovery / fix>
+- Time to expected resolution: <hours or days>
+
+What you should do now
+----------------------
+<bullet list, customer-specific>
+
+What Cullis is doing
+--------------------
+<bullet list, transparency-first>
+
+Next update
+-----------
+You will receive a follow-up within <X hours>. For urgent questions
+in the meantime, reply to this email or call <on-call number>.
+
+Coordinated disclosure
+----------------------
+We are operating under our coordinated disclosure policy
+(SECURITY.md). Please do not share this notification outside your
+security team until the public disclosure window opens; the
+expected public disclosure date is <date>.
+
+— The Cullis security team
+  security@cullis.io
+```
+
+### 4.2 Status page update (Sev 1 or Sev 2)
+
+```
+Title: <one-line incident summary>
+Status: investigating | identified | monitoring | resolved
+Severity: critical | major | minor
+Affected: <component list>
+Posted: <UTC>
+Last update: <UTC>
+
+<short update body, ~2 sentences, no internal jargon>
+
+Next update in <X hours>.
+```
+
+The status page lives at cullis.io/status (placeholder until the
+first paid pilot; until then, the customer email is the
+authoritative channel).
+
+### 4.3 Public disclosure post
+
+Published on cullis.io/blog when the public disclosure window opens
+(default 90 days after the report, or upon coordinated release,
+whichever comes first). Template:
+
+- Headline: factual, no marketing.
+- Summary: what the vulnerability was, who was affected, what the
+  fix is.
+- Timeline: report received, acknowledged, fix released, public
+  disclosure.
+- Credit: reporter named unless they asked to remain anonymous.
+- CVE: linked.
+- Mitigation guidance for customers still on a vulnerable version.
+- Lessons: what we changed in the codebase or process to prevent a
+  similar issue.
+
+---
+
+## 5. SLA summary
+
+| Severity | Acknowledgment | Containment | Fix       | Customer notification | Public disclosure                    |
+|----------|----------------|-------------|-----------|-----------------------|--------------------------------------|
+| Sev 1    | 4 hours        | 24 hours    | 7 days    | within 4 hours        | 90 days, or upon coordinated release |
+| Sev 2    | 24 hours       | 72 hours    | 14 days   | within 24 hours       | 90 days, or upon coordinated release |
+| Sev 3    | 48 hours       | 7 days      | 30 days   | affected customer only| 90 days, or upon coordinated release |
+| Sev 4    | 5 business days| n/a         | next minor| not required          | CHANGELOG entry on release           |
+
+These targets mirror the SLA matrix in
+[`SECURITY.md`](../../SECURITY.md). A target that cannot be met
+because of a coordinated upstream release will be renegotiated with
+the reporter on first contact.
+
+---
+
+## 6. Contacts and on-call
+
+- **Cullis security team:** security@cullis.io. Mailbox monitored
+  continuously by the founder; acknowledgment within 48 hours
+  (faster for Sev 1 and Sev 2, see section 5).
+- **PGP key:** to be published before the first paid pilot. Until
+  then, use GitHub's private vulnerability reporting if the
+  contents are sensitive enough that an unencrypted email is
+  unacceptable (see SECURITY.md).
+- **On-call rotation:** founder direct, currently solo. A 24x7
+  PagerDuty partner will be contracted ahead of the first paid
+  engagement; the contact details for that partner will land in
+  this file when the contract is in place.
+- **Legal / breach notification (GDPR 72-hour):** an external IT
+  lawyer will be retained ahead of the first regulated-industry
+  pilot. Until that lawyer is named here, escalate any potential
+  GDPR-relevant incident to security@cullis.io within the first
+  hour of containment so we can engage outside counsel.
+- **Cybersecurity insurance:** policy procurement is in progress.
+  Until a policy is bound, customer indemnification is per the
+  signed customer agreement; default contract is the Apache 2.0
+  / FSL-1.1-Apache-2.0 license terms (no warranty), modified per
+  customer engagement.
+
+---
+
+## 7. Post-incident review template
+
+Within 14 days of resolution, the on-call writes a post-incident
+review. Template:
+
+```
+# Post-incident review: <short title>
+
+- Severity: <Sev 1 / 2 / 3 / 4>
+- Affected component: <Court / Mastio / Connector / SDK / Connector container>
+- Affected customers: <count, or "single internal" if pre-pilot>
+- Date detected: <UTC>
+- Date contained: <UTC>
+- Date fixed: <UTC>
+- Date public disclosure: <UTC, or "n/a">
+- Author: <name>
+
+## Timeline
+
+<bulleted UTC log of events, from first signal to resolution>
+
+## Root cause
+
+<technical explanation, no blame>
+
+## Why our defences did not catch it earlier
+
+<honest assessment: missing test, missing alert, threat-model gap>
+
+## What we changed
+
+- Code: <commits, PRs>
+- Tests: <new tests, coverage targets>
+- Threat model: <new row in docs/security/threat-model.md, ADR if needed>
+- Runbook: <new section here>
+
+## What we did not change, and why
+
+<things that came up during the post-mortem but were deferred,
+with the reason and the tracking issue>
+
+## Lessons
+
+<one or two paragraphs, written for the next on-call>
+```
+
+Reviews are filed in `imp/post-incident-reviews/` (internal,
+gitignored). A redacted summary is published on cullis.io/blog
+when the public disclosure window opens.
+
+---
+
+## 8. References
+
+- [`SECURITY.md`](../../SECURITY.md): responsible disclosure policy
+  and SLA matrix.
+- [`docs/security/threat-model.md`](../security/threat-model.md):
+  threat catalog and trust boundaries.
+- [`docs/runbooks/frontdesk-shared-hardening.md`](./frontdesk-shared-hardening.md):
+  Frontdesk shared-mode operational controls and Sev 2 compromise
+  response.
+- [`docs/runbooks/postgres-pilot.md`](./postgres-pilot.md):
+  Postgres pilot operational runbook (capacity, backup, restore).
+- [`operate/rotate-keys.md`](../operate/rotate-keys.md): manual
+  rotation procedures for Org Root and bulk agent re-enrolment.
+- ADR-013 (layered defence), ADR-033 (PKI three-tier hardening),
+  ADR-033 (Frontdesk shared-mode threat model).

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,58 @@
+# `docs/security/` index
+
+This directory holds the customer-facing security documents for
+Cullis. They are intended for CISOs, security architects, blue-team
+engineers, and customer due diligence reviewers evaluating Cullis
+before a pilot.
+
+Operational runbooks (incident response, Frontdesk shared-mode
+hardening, Postgres pilot) live in [`docs/runbooks/`](../runbooks/).
+The responsible disclosure policy lives in
+[`SECURITY.md`](../../SECURITY.md) at the repository root.
+
+## Documents
+
+| Document                                                    | Audience                                | Updated    |
+|-------------------------------------------------------------|-----------------------------------------|------------|
+| [`threat-model.md`](./threat-model.md)                      | CISO, security architect                | 2026-05-18 |
+| [`post-quantum-roadmap.md`](./post-quantum-roadmap.md)      | CISO, cryptography team                 | 2026-05-18 |
+
+### Threat model
+
+Threat catalog (in scope and out of scope), trust boundaries,
+cryptographic primitives, key lifecycle, audit trail integrity,
+compliance mapping preview. Cross-links the STRIDE per-component
+walkthrough on cullis.io (source in
+`site/src/content/docs/security/threat-model.md`).
+
+### Post-quantum roadmap
+
+Five-phase hybrid-first PQC strategy. Phase 0 (positioning) is
+active; Phase 1a triggers are gated by upstream library maturity
+(`pyca/cryptography` ML-KEM, `liboqs-python` on NixOS) or by a
+concrete buyer signal. Includes the validation spike numbers from
+2026-05-06 (X25519 + ML-KEM-768, ~4 to 5 ms roundtrip, +1088 bytes
+overhead).
+
+## Related documents
+
+- [`SECURITY.md`](../../SECURITY.md): responsible disclosure
+  policy, response SLAs, supported version matrix, safe harbour.
+- [`docs/runbooks/incident-response.md`](../runbooks/incident-response.md):
+  severity classification, response procedure per severity,
+  communication templates.
+- [`docs/runbooks/frontdesk-shared-hardening.md`](../runbooks/frontdesk-shared-hardening.md):
+  Frontdesk shared-mode operational hardening (Phase 1 audit
+  warning, Phase 2 WebAuthn).
+- [`docs/architecture/byoca-current-state.md`](../architecture/byoca-current-state.md):
+  Bring Your Own CA implementation status and gap.
+- ADRs: public ADRs in [`docs/adrs/`](../adrs/), internal ADRs in
+  `imp/adrs/` (gitignored, commercial-sensitive).
+
+## Review cadence
+
+Documents in this directory are reviewed **quarterly**. Each
+document has its own "Next review" date in its header. An
+out-of-cycle revision is triggered by: a new ADR ratified, a new
+threat discovered, a third-party penetration test report, or
+customer feedback that lands a substantive correction.

--- a/docs/security/post-quantum-roadmap.md
+++ b/docs/security/post-quantum-roadmap.md
@@ -1,0 +1,438 @@
+# Post-quantum cryptography roadmap (Cullis)
+
+**Audience:** CISOs, security architects, and customer cryptography
+teams asking how Cullis will remain secure once cryptanalytically
+relevant quantum computers (CRQCs) are available.
+
+**Status:** Version 1.0, 2026-05-18. Quarterly review.
+Next review: 2026-08-06.
+
+**Contact:** security@cullis.io for technical clarifications;
+hello@cullis.io for pilot timing alignment.
+
+---
+
+## 1. Why PQC matters for Cullis
+
+Three classes of material that Cullis stores or transmits today are
+sensitive to **Harvest Now, Decrypt Later (HNDL)** attacks: an
+adversary captures classical-encrypted ciphertext today and decrypts
+it once a CRQC is available.
+
+- **Audit chain contents.** The append-only audit log records every
+  authenticated action, with structured detail. Customers in
+  regulated industries (banking, insurance, supply chain) retain
+  audit material for 7 to 10 years. A 2032-grade CRQC against
+  2026-grade RSA-OAEP-SHA256 envelope keys is in scope.
+- **Federation handshake material.** Mastio-to-Court and
+  Mastio-to-Mastio traffic carries identity assertions signed by
+  the org's Intermediate CA. Captured handshakes plus access to the
+  CA chain decrypt those assertions retroactively.
+- **Cert authority chains.** Org Root CA validity is 15 years. A
+  cert signed today must remain unforgeable to a 2035-grade
+  adversary.
+
+NIST standardised the first three PQC algorithms in **August 2024**:
+
+- **FIPS 203 ML-KEM** (Kyber): key encapsulation.
+- **FIPS 204 ML-DSA** (Dilithium): digital signature.
+- **FIPS 205 SLH-DSA** (SPHINCS+): hash-based signature, stateless.
+
+European regulators are tracking the transition. BSI Germany and
+ANSSI France have published draft timelines aligning the sunset of
+classical-only crypto to **2030**. NIS2 readiness reviews for
+critical infrastructure now expect a documented PQC migration plan,
+even if the migration itself has not started.
+
+This document is that plan for Cullis. It is intentionally honest
+about what is in code (nothing yet), what is validated (one local
+spike), and what is gated by upstream library work.
+
+---
+
+## 2. Current cryptographic posture (classical baseline)
+
+| Category               | Algorithm                                | Use in Cullis                                              |
+|------------------------|------------------------------------------|------------------------------------------------------------|
+| Asymmetric signature   | ECDSA P-256                              | Per-agent identity cert, DPoP proof (ES256).               |
+| Asymmetric signature   | RSA-PSS-SHA256                           | E2E inner and outer signature (legacy classical path).     |
+| Asymmetric encryption  | RSA-OAEP-SHA256                          | E2E key encapsulation.                                     |
+| Symmetric              | AES-256-GCM                              | E2E payload, audit log encrypted columns.                  |
+| Key exchange           | ECDH P-256                               | TLS 1.3 ephemeral handshake.                               |
+| At-rest envelope       | PBKDF2-HMAC-SHA256 (600k) + Fernet       | Org Root and Mastio Intermediate private keys (`pki_key_store`, PR #788). |
+| Hash                   | SHA-256                                  | Audit chain, cert thumbprint, JWK thumbprint (RFC 7638).   |
+
+SHA-256 is **not** PQC-broken. Symmetric primitives (AES-256-GCM)
+remain Grover-resilient at acceptable security margin. The
+roadmap below targets the asymmetric and KEM primitives, which is
+where the quantum threat materialises.
+
+---
+
+## 3. Cullis PQC strategy: hybrid-first
+
+ADR-022 (Cullis internal, ratified 2026-05-06) selects a
+**hybrid-first** migration path: every PQC primitive is rolled out
+alongside its classical counterpart for a multi-year transition
+window, never as a direct full-PQ replacement.
+
+Three reasons:
+
+1. **Standards are still maturing.** NIST FIPS 203/204/205 are
+   final, but the protocol-level standards that Cullis depends on
+   (JOSE, COSE, SPIFFE, X.509 composite signatures) are at draft
+   stage. A full-PQ deployment today would land on top of
+   protocol drafts that may still change.
+2. **Python ecosystem is not ready.** `pyca/cryptography` does not
+   ship ML-KEM or ML-DSA today and has not published a roadmap for
+   them. `liboqs-python` is the alternative but does not install
+   cleanly on NixOS at the version Cullis uses, because the Python
+   wrapper tag mismatches the bundled liboqs C library version.
+3. **Interop with classical peers.** Federation peers move at
+   different speeds. Hybrid lets a Cullis Mastio negotiate with a
+   classical-only peer (during the transition) without
+   downgrading its own posture; the classical peer verifies the
+   classical signature, ignores the PQ signature, the Mastio
+   notices the absence of the PQ verification on its side and
+   logs the degradation for the audit chain.
+
+Hybrid-first is the established direction in industry: TLS 1.3
+hybrid KEM (`draft-ietf-tls-hybrid-design`), X.509 composite
+signatures (`draft-ietf-lamps-pq-composite-sigs`), COSE / JOSE PQ
+`alg` registration in progress. Cullis tracks these drafts.
+
+---
+
+## 4. Five-phase roadmap
+
+The roadmap below is **trigger-driven**, not date-driven. Phase 0
+is active today. Each subsequent phase has explicit upstream
+triggers; the next quarterly review re-evaluates whether any
+trigger has fired.
+
+### Phase 0: positioning and monitoring (active, today)
+
+**Status:** Active. No code changes.
+
+**Deliverables (in flight or done):**
+
+- Cryptographic primitive inventory (this document, section 2).
+- Audit-log schema reserves space for `kem` and `sig_alg` fields,
+  populated as classical strings today. Adding hybrid values is
+  additive.
+- Quarterly upstream tracking (section 6). The next review is
+  **2026-08-06**.
+- Validation spike, see section 7 for details.
+
+### Phase 1a: hybrid KEM in E2E envelope
+
+**Trigger (any one):**
+
+- `pyca/cryptography` ships ML-KEM stable.
+- `liboqs-python` installs cleanly on NixOS at a version compatible
+  with the Cullis dependency tree.
+- Concrete buyer signal: a CISO commits to a pilot conditional on
+  PQ-ready primitives in the E2E path.
+- Cryptanalytic break in classical KEM that accelerates the
+  timeline (low probability, high impact).
+
+**Deliverables:**
+
+- Replace the spike's `kyber-py` (pure-Python, single-maintainer,
+  unaudited) with a production-grade ML-KEM provider (`pyca` or
+  `liboqs-python`).
+- Implement **E2E envelope v3** with an `mlkem_ct` field
+  discriminator in `cullis_sdk/crypto/e2e.py` and
+  `app/e2e_crypto.py`.
+- API-additive: new `recipient_mlkem_pub` kwarg. Callers that do
+  not pass it stay on v2 classical envelopes; callers that do
+  pass it get hybrid envelopes that are decryptable by hybrid
+  peers and rejected by v2-only peers with a clear error.
+- Inner signature stays classical (RSA-PSS / ECDSA) until Phase 2b.
+
+**Effort estimate:** 2 to 3 engineer-weeks once the upstream library
+is in place. Test coverage including tamper detection across the
+hybrid envelope follows the existing E2E pattern.
+
+### Phase 1b: hybrid KEM in TLS handshake (federation)
+
+**Trigger:** OpenSSL 3.5+ rollout in the deploy targets (NixOS,
+Debian 13, Alpine), with `httpx` exposing the hybrid groups. Best
+estimate today: 2027 H1.
+
+**Deliverables:**
+
+- Federation handshake Mastio to Court and Mastio to Mastio
+  negotiates `X25519MLKEM768` (IETF
+  `draft-ietf-tls-hybrid-design`) as the preferred group.
+- Classical fallback (`X25519`, `secp256r1`) remains for
+  classical-only peers.
+- Audit row records the negotiated group on every federation
+  handshake, populating the reserved `kem` field.
+
+### Phase 2a: hybrid cert chain dual-signing
+
+**Trigger:** Composite signature RFC published. Current best
+estimate: 2027 H1 to H2. SPIFFE PQ extension proposal also has to
+land for the typed-principal SAN format to remain stable.
+
+**Deliverables:**
+
+- New cert issuance dual-signs: ECDSA P-256 (classical) **plus**
+  ML-DSA-65 (PQ). Composite signature format following
+  `draft-ietf-lamps-pq-composite-sigs`.
+- Backward compat by design: classical-only verifiers verify the
+  classical signature and ignore the PQ signature. Hybrid
+  verifiers require both.
+- Mastio Intermediate CA, Mastio Leaf, agent leaf, Connector cert,
+  and nginx server TLS cert all gain dual-sig at issuance time.
+- Org Root CA gains dual-sig at the Phase 1a kickoff rotation
+  (see section 8).
+
+### Phase 2b: hybrid JWT and DPoP signing
+
+**Trigger:** JOSE PQ `alg` registration completed at IETF (current
+draft only). Best estimate: 2028.
+
+**Deliverables:**
+
+- DPoP proof `alg` upgraded from `ES256` to a composite alg
+  (working name `composite-ES256-ML-DSA-65`, awaiting
+  registration).
+- Access token signing follows the same migration.
+- License JWT signing key migrates to composite signature; the
+  baked-in public key fingerprint is rotated as part of the
+  annual ceremony.
+
+### Phase 3: PQC-only opt-in (post-2028)
+
+**Trigger:** Hybrid stable in production for at least 12 months, no
+material interop issues with classical peers, customer opt-in
+signal.
+
+**Deliverables:**
+
+- Operator can set `MCP_PROXY_PQC_ONLY=true` to disable classical
+  fallback on a per-Mastio basis. Federation peers that are not
+  PQC-ready are refused at handshake time, with a clear audit row.
+- Recommended for new greenfield deployments where the
+  customer's other infrastructure is already PQC-ready.
+
+### Phase 4: classical sunset
+
+**Trigger:** Aligned with regulator sunset dates (BSI, ANSSI, NIS2),
+currently drafted around 2030. Cullis sunset will follow the most
+conservative applicable regulator for the customer base, with at
+least 12 months of advance notice.
+
+**Deliverables:**
+
+- Classical-only deployments are deprecated; the validate_config
+  startup gate emits a hard warning and refuses to start in
+  production mode if classical-only is configured past the sunset
+  date.
+- Removal of classical primitives from the codebase (not just
+  deprecation) follows in the release after the sunset date,
+  conditional on no customers requesting an extension.
+
+---
+
+## 5. Standards followed
+
+Cullis tracks the following standards and drafts. Each is
+re-evaluated at the quarterly review.
+
+| Standard / draft                                  | Status (2026-05)            | Cullis use                                                |
+|---------------------------------------------------|------------------------------|-----------------------------------------------------------|
+| NIST FIPS 203 ML-KEM (Kyber)                      | Final (Aug 2024)             | Phase 1a, 1b: hybrid KEM in E2E and TLS.                  |
+| NIST FIPS 204 ML-DSA (Dilithium)                  | Final (Aug 2024)             | Phase 2a, 2b: hybrid signatures.                          |
+| NIST FIPS 205 SLH-DSA (SPHINCS+)                  | Final (Aug 2024)             | Considered for long-term signatures (Org Root). Decision deferred until Phase 1a kickoff. |
+| `draft-ietf-tls-hybrid-design`                    | IETF draft (active)          | Phase 1b: TLS 1.3 hybrid KEM.                             |
+| `draft-ietf-lamps-pq-composite-sigs`              | IETF draft (active)          | Phase 2a: X.509 composite signatures.                     |
+| `draft-ietf-cose-dilithium` (and JOSE PQ alg)     | IETF draft (active)          | Phase 2b: DPoP, JWT, license signing.                     |
+| ETSI Quantum-Safe Cryptography reports            | Published                    | Background, no direct dependency.                         |
+| SPIFFE PQ extension                               | Not proposed yet             | Phase 2a: typed-principal SAN format compatibility.       |
+
+---
+
+## 6. Upstream blockers (transparency)
+
+This is the table that gates the Phase 1a kickoff. Every quarter we
+re-check each row.
+
+| Blocker                                       | Status (2026-05)                                                       | Required for             | Cullis decision                                       |
+|-----------------------------------------------|------------------------------------------------------------------------|--------------------------|-------------------------------------------------------|
+| `pyca/cryptography` ML-KEM support            | Not in roadmap as of 2026-05. No public ETA.                          | Phase 1a production       | Wait, monitor quarterly, default if `liboqs-python` lands on NixOS first. |
+| JOSE PQ `alg` IETF registration               | Draft only.                                                            | Phase 2b                  | Wait for RFC publication.                             |
+| SPIFFE PQ extension proposal                  | No proposal at the SPIFFE Technical Steering Committee.                | Phase 2a workload SAN     | Track quarterly, raise the question at the next SPIFFE community sync. |
+| `liboqs-python` installable on NixOS          | Tag mismatch between the Python wrapper and the bundled liboqs C lib. Manual rebuild possible, automated install fails. | Phase 1a alternative      | Try liboqs upstream upgrade at quarterly review; otherwise wait for `pyca`. |
+| `kyber-py` library                            | Pure-Python, single maintainer, no formal audit.                       | Phase 1a only if `pyca` and `liboqs-python` both blocked. | Acceptable for the local spike (section 7), **not** acceptable for production. |
+| X.509 composite signatures RFC                | IETF draft, multiple revisions.                                        | Phase 2a                  | Wait for RFC publication.                             |
+| TLS 1.3 hybrid group in OpenSSL / `httpx`     | OpenSSL 3.5 ships hybrid groups; rollout to NixOS / Debian 13 / Alpine TBD. | Phase 1b                  | Track quarterly, depends on distro updates.           |
+
+---
+
+## 7. Validation: spike numbers
+
+**Date:** 2026-05-06.
+
+**Location:** local worktree `/home/daenaihax/projects/agent-trust-pq`,
+branch `feat/pq-e2e-hybrid`. Spike code is intentionally **not
+committed**; the worktree is a local validation laboratory only.
+Production code lives on `main` once Phase 1a triggers.
+
+**Setup:**
+
+- Hybrid envelope: X25519 (classical ECDH) + ML-KEM-768 (PQ KEM)
+  with a single AES-256-GCM AEAD over the concatenated shared
+  secret.
+- ML-KEM provider: `kyber-py` 0.x (pure Python, used for the spike,
+  unsuitable for production).
+- Test vectors: 1000 random plaintexts ranging from 64 bytes to 4 KiB.
+
+**Performance:**
+
+- Encrypt: ~2.4 ms median, ~3.1 ms p95 (laptop, no specialised
+  hardware).
+- Decrypt: ~2.0 ms median, ~2.6 ms p95.
+- End-to-end roundtrip (encrypt + transport + decrypt): ~4 to 5 ms.
+
+**Overhead:**
+
+- +1088 bytes per message (ML-KEM-768 ciphertext field added to
+  the envelope).
+- Negligible impact on AEAD ciphertext size.
+
+**Tamper detection:** verified. A modified ML-KEM ciphertext, a
+modified X25519 ephemeral pubkey, or a modified AEAD ciphertext all
+result in a clean decrypt failure with no plaintext exposure.
+
+**Conclusion:** performance and overhead are acceptable for Phase
+1a production. The blocker is the production-grade library, not
+performance.
+
+---
+
+## 8. Org Root rotation coupling
+
+Wave 1-A (Mastio Org Root and Intermediate CA hardening, PR #788)
+**intentionally did not implement Org Root rotation automation**.
+This is a conscious architectural choice, not a gap. The reason:
+
+- Org Root validity is 15 years (Wave 1-A baseline).
+- The Phase 1a kickoff requires an Org Root algorithm change from
+  pure-classical ECDSA P-256 to hybrid (ECDSA P-256 + ML-DSA-65)
+  per Phase 2a.
+- Implementing rotation now with a classical-only target would
+  force a second rotation when hybrid arrives, doubling the
+  operational risk and the customer-side re-issuance work.
+
+The Mastio Intermediate CA, by contrast, **does** have rotation
+automation today (Wave 1-A), using ECDSA P-256. It gains dual-sig
+at Phase 2a without an additional rotation: the next scheduled
+auto-rotation simply emits a composite-signed Intermediate.
+
+Customers asking when Org Root rotation will be available get this
+explanation. The roadmap item is **"Org Root rotation arrives with
+Phase 1a kickoff"**.
+
+---
+
+## 9. Threat model interaction
+
+The PQC roadmap interacts with the threat model
+[`docs/security/threat-model.md`](./threat-model.md) at three points:
+
+- **HNDL on audit logs.** Today's audit log entries are protected
+  by AES-256-GCM payload encryption (Grover-resilient at acceptable
+  margin) and SHA-256 hash chain integrity (PQ-safe). The
+  asymmetric exposure is on the envelope keys used to seal
+  archived chunks; Phase 2a closes this with composite-signed
+  envelope keys. Mitigation today: customers requiring forward
+  secrecy on long-retention audit data should re-key the at-rest
+  envelope (`MCP_PROXY_DB_ENCRYPTION_KEY` rotation procedure) on
+  the cadence their compliance team requires.
+- **HNDL on cert chains.** Today's chain is classical-only. Phase
+  2a hybridises every new cert issuance. The Org Root issued at
+  Phase 1a kickoff will be hybrid from day one (section 8).
+- **CRQC timeline.** Best public estimate is 2030 to 2040 (NIST
+  and NSA briefings). Cullis migration plan is **ahead of curve**,
+  not panic-driven. If a credible CRQC announcement compresses
+  the timeline, Phase 1a trigger fires immediately.
+
+---
+
+## 10. Review cadence and governance
+
+**Cadence:** Quarterly.
+
+**Next review:** 2026-08-06.
+
+**Review checklist:**
+
+1. PyPI search for ML-KEM and ML-DSA in `pyca/cryptography`. Has
+   the upstream shipped, has it published a roadmap?
+2. `liboqs-python` latest version. Test the NixOS install on a
+   fresh shell.
+3. IETF datatracker review:
+   - `draft-ietf-lamps-pq-composite-sigs` advancement.
+   - `draft-ietf-tls-hybrid-design` advancement.
+   - JOSE PQ `alg` registration progress.
+4. SPIFFE Technical Steering Committee minutes for PQ extension.
+5. NIST and NSA public statements: CRQC timeline shift?
+6. Customer or buyer signal: has a CISO asked about PQC-ready
+   primitives in a pilot conversation? Phase 1a trigger.
+7. Update this document's "Next review" date.
+
+**Phase 1a kickoff trigger:** any two of the six blockers in
+section 6 close, **or** a single concrete buyer signal lands.
+
+---
+
+## 11. What customers should do today
+
+- **No immediate action required.** Cullis is classical today;
+  classical primitives remain secure against today's adversaries.
+- **Plan the upgrade window.** When Phase 1a ships (estimated 2027
+  H1), the upgrade is API-additive on the SDK side and config-flag
+  on the Mastio side. Plan a 24-hour window to flip the flag and
+  validate the federation handshake.
+- **Dual-chain your own org PKI.** If your security team operates a
+  corporate PKI that issues Cullis agent certs via the BYOCA flow
+  (see [`docs/architecture/byoca-current-state.md`](../architecture/byoca-current-state.md)),
+  start planning dual-signature support in your CA. Cullis can
+  accept dual-signed certs as soon as the composite-sig RFC is
+  published.
+- **Track NIS2 PQC migration in your sector.** Banking, energy,
+  healthcare, and critical infrastructure each have their own
+  applicable timeline. Cullis migration aligns to the most
+  conservative customer.
+- **Reach out** if your security team has a specific PQC pilot in
+  mind: hello@cullis.io. A concrete buyer signal is itself a
+  Phase 1a trigger.
+
+---
+
+## 12. References
+
+- NIST PQC project: <https://csrc.nist.gov/Projects/post-quantum-cryptography>
+- ETSI Quantum-Safe Cryptography reports: <https://www.etsi.org/technologies/quantum-safe-cryptography>
+- IETF LAMPS working group: <https://datatracker.ietf.org/wg/lamps/documents/>
+- IETF TLS working group hybrid drafts: <https://datatracker.ietf.org/wg/tls/documents/>
+- ADR-022 (Cullis internal): `imp/adrs/adr-022-post-quantum-strategy.md`, ratified 2026-05-06.
+- Wave 1-A PKI hardening (Cullis internal): `imp/adrs/adr-033-pki-three-tier-hardening.md`, classical baseline.
+- [`docs/security/threat-model.md`](./threat-model.md): threat
+  model and trust boundaries.
+- [`SECURITY.md`](../../SECURITY.md): responsible disclosure
+  policy.
+
+---
+
+## 13. Revision history
+
+| Version | Date       | Author              | Notes                                                                |
+|---------|------------|---------------------|----------------------------------------------------------------------|
+| 1.0     | 2026-05-18 | Cullis security team | First public publication. ADR-022 ratified internally on 2026-05-06; this document is the public-facing summary. |
+
+Next review: 2026-08-06. Update the "Next review" date in the
+document header at every quarterly checkpoint.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,354 @@
+# Cullis threat model (public)
+
+**Audience:** CISOs, security architects, blue-team engineers, and
+customer due diligence reviewers evaluating Cullis before a pilot.
+
+**Status:** Version 1.0, published 2026-05-18. Quarterly review.
+Next review: 2026-08-18.
+
+**Contact:** security@cullis.io for clarifications, scope challenges,
+or threat reports that fall under coordinated disclosure (see
+[SECURITY.md](../../SECURITY.md)).
+
+---
+
+## 1. Introduction
+
+Cullis is a zero-trust identity, policy, and audit substrate for AI
+agents acting inside and across organisations. The product is composed
+of three deployable components (Court, Mastio, Connector) plus two
+SDKs (Python, TypeScript), and ships as both an open-core build and a
+commercial enterprise build.
+
+This document is the **public catalog** of threats Cullis has reasoned
+about, the mitigations present in code, and the threats explicitly
+**not** covered today (with the roadmap or compensating control). It
+is intended for review before a pilot, not as a substitute for a
+third-party penetration test (planned, funded by the first paid
+engagement).
+
+For a STRIDE walkthrough of each Cullis component (data flow per
+trust boundary, mitigation per spoofing/tampering/repudiation/info
+disclosure/DoS/elevation), see the deeper companion document on the
+public site: [cullis.io threat model deep-dive](https://cullis.io/security/threat-model/).
+That document is generated from the same source tree
+(`site/src/content/docs/security/threat-model.md`) and is the
+component-level analysis. This file is the customer-facing summary
+and threat catalog.
+
+### Why a public threat model
+
+Customers performing security due diligence on agent identity
+infrastructure need:
+
+- A clear statement of what Cullis defends against.
+- An equally clear statement of what it does **not** defend against,
+  with the roadmap.
+- A reference to the code or ADR that establishes each mitigation,
+  not just an assertion.
+
+A vendor that cannot articulate the residual risk is, in practice,
+asking the customer to accept unbounded liability. This document
+exists to remove that ambiguity.
+
+### Versioning
+
+| Version | Date       | Notes                                                            |
+|---------|------------|------------------------------------------------------------------|
+| 1.0     | 2026-05-18 | First publication. Aligns with Wave 1-A PKI hardening (PR #788). |
+
+Future revisions will append rows here and update the "Next review"
+date in the document header.
+
+---
+
+## 2. Trust model and components
+
+### 2.1 Three components
+
+| Component        | Path in repo        | Audience           | Responsibility                                                                 |
+|------------------|---------------------|--------------------|--------------------------------------------------------------------------------|
+| Cullis Court     | `app/`              | Network operator   | Federation broker, cross-org A2A routing, org registry, audit chain anchor.    |
+| Cullis Mastio    | `mcp_proxy/`        | Org admin          | Agent enrolment, policy decision point, local audit, MCP reverse proxy, embedded AI gateway. |
+| Cullis Connector | `cullis_connector/` | End user           | User identity (OIDC + WebAuthn Phase 2), MCP-to-Cullis bridge, dashboard at :7777. |
+
+A single Mastio can be operated in **standalone** mode (air-gapped,
+intra-org only, no Court attached) or **federated** mode (attached to
+a Court, reaches Mastios in other orgs). The same binary supports
+both; the operator flips a flag, no agent re-enrolment.
+
+### 2.2 Four typed principals (ADR-020)
+
+Every authenticated identity in Cullis falls into one of four typed
+principals, each with its own cert SAN format and capability surface:
+
+| Principal type | SAN format                         | Issued by                                  | Example                          |
+|----------------|------------------------------------|--------------------------------------------|----------------------------------|
+| `agent`        | `spiffe://<org>/agent/<id>`        | Mastio Intermediate CA                     | Long-lived autonomous service.   |
+| `user`         | `spiffe://<org>/user/<sub>`        | Mastio Intermediate CA (via Connector SSO) | Human via Connector / Frontdesk. |
+| `workload`     | `spiffe://<org>/workload/<id>`     | Mastio Intermediate CA (via SPIRE)         | CI job, batch process, SPIFFE-issued workload. |
+| `mcp_resource` | `spiffe://<org>/mcp/<server>`      | Mastio Intermediate CA                     | A registered MCP server endpoint. |
+
+The PDP and audit log derive authority from this typed principal,
+not from any client-supplied header. See ADR-020 for the rationale.
+
+### 2.3 Four interaction quadrants
+
+Cross-component traffic falls into one of four quadrants, each with
+its own policy gate and audit semantics:
+
+| Quadrant | Caller    | Callee    | Typical example                                  |
+|----------|-----------|-----------|--------------------------------------------------|
+| A2A      | agent     | agent     | Autonomous agent in Org A invokes a tool exposed by Org B. |
+| A2U      | agent     | user      | Agent proactively requests confirmation from a human. |
+| U2A      | user      | agent     | Human (via Frontdesk chat) asks an agent to act. |
+| U2U      | user      | user      | Cross-org introduction or message between principals. |
+
+A2A and A2U cross-org calls are dual-allow: both orgs' PDPs must
+authorise the call (ADR-029). Intra-org calls go through a single PDP.
+
+### 2.4 Deployment modes
+
+| Mode        | Court              | Mastio   | Connector | Use case                                                          |
+|-------------|--------------------|----------|-----------|-------------------------------------------------------------------|
+| Standalone  | absent             | yes      | optional  | Single-org, air-gapped, no cross-org federation.                  |
+| Federated   | yes (shared)       | yes      | optional  | Cross-org A2A, registry sync, anchor of audit chains across orgs. |
+| Frontdesk   | optional           | yes      | yes (shared) | Multi-user chat container in front of a single Mastio (ADR-019). |
+
+---
+
+## 3. Threats covered (in scope)
+
+| Threat                                              | Mitigation                                                                                                                 | Reference                                                              |
+|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| Agent identity spoofing                             | mTLS with cert thumbprint pinning at Mastio, SPIFFE SAN bound to enrolment record.                                         | ADR-014, `mcp_proxy/auth/client_cert.py`                               |
+| DPoP token theft                                    | RFC 9449 proof-of-possession: every request signed with the agent's ephemeral key, JWK thumbprint pinned to access token (`cnf.jkt`). | RFC 9449, `mcp_proxy/auth/dpop.py`                                     |
+| Replay attack on DPoP proofs                        | Redis-backed JTI cache, 5-minute TTL, `SET NX EX` semantics. `htu` checked literally including scheme + host + port.       | `mcp_proxy/auth/dpop_jti_store.py`                                     |
+| Audit chain tampering (write side)                  | Append-only schema enforced by a database trigger that raises on UPDATE/DELETE against `audit_log`, on both SQLite and Postgres. | `alembic/versions/r8m9n0o1p2q3_audit_append_only.py`                   |
+| Audit chain tampering (retroactive)                 | Per-org SHA-256 hash chain (`entry_hash`, `previous_hash`). Chain head anchored to Court's `AuditTsaAnchor` every 60 minutes (configurable). | `alembic/versions/7f54c1eb5e89_add_audit_log_hash_chain.py`, `app/audit/tsa_worker.py` |
+| Federation cross-org impersonation                  | Counter-signature: Mastio peer pubkey pinned at registration, every cross-org call signed by both Mastios.                | ADR-009                                                                |
+| Org Root CA compromise via insider DB read          | Org Root private key stored Fernet-encrypted in `pki_key_store` (PBKDF2-HMAC-SHA256 600k + Fernet). Cold root: key not in memory at steady state, only unsealed for rare ops (mint Intermediate, rotate Intermediate, generate CA bundle), with audit row per unseal. | ADR-033 PKI three-tier, PR #788                                        |
+| Mastio Intermediate CA compromise                   | Auto-rotation watcher signs new Intermediate from the Org Root; old leaves continue to verify against the new chain via the published CA bundle. 5-year validity, rotation hooks tested in CI. | PR #788, `mcp_proxy/egress/agent_manager.py`                           |
+| Mastio Leaf (federation) compromise                 | Manual rotation via dashboard with 7-day grace; new key propagated to peer Mastios via Court ContinuityProof.              | ADR-009, dashboard `migrate-org-ca`                                    |
+| Agent cert compromise                               | Revocation via dashboard form `rotate_agent_cert` invalidates the cert immediately; pinning rejects the old thumbprint. Grace-period transition (Wave 2 in progress) allows the agent to log in with either old or new cert during a configurable window before old is purged. | `app/registry/store.py`, Wave 2 fix 7 (in progress)                    |
+| nginx server TLS cert expiry                        | Runtime watcher renews the cert before expiry and SIGHUP-reloads nginx; 90-day validity. Wave 2 fix 6 lands the watcher.   | `mcp_proxy/egress/agent_manager.py`, Wave 2 fix 6 (in progress)        |
+| Tool capability bypass (privileged builtin)         | Post-LLM capability gate: every tool dispatch checks the typed principal's capabilities. Builtins fail closed by default. | PR #730, `mcp_proxy/tools/executor.py`                                 |
+| PDP webhook timeout / failure                       | 5-second hard timeout, fail-deny on timeout. The decision row in the audit log records the timeout and the deny outcome. | `app/policy/webhook.py:75`                                             |
+| Frontdesk shared-mode user impersonation (Phase 1)  | Mastio emits a structured audit warning on every request the Frontdesk forwards on behalf of a user that has not yet bound a WebAuthn credential. Operators alert on volume / off-hours patterns. | ADR-033 Frontdesk, `docs/runbooks/frontdesk-shared-hardening.md`       |
+| Frontdesk shared-mode user impersonation (Phase 2)  | WebAuthn-bound session tokens: the user's browser signs a challenge with a FIDO2 authenticator, the assertion is included in the session token, the Mastio verifies it before honouring the on-behalf-of header. | PR #789, ADR-033 Phase 2                                               |
+| Enrolment without proof-of-possession               | `pop_signature` field mandatory on `POST /v1/enrollment/start`. Connector signs `"enrollment-pop:v1\|<pubkey-sha256-hex>"` with the enrolling key. The transition window where the field was optional has closed. | PR #787, `mcp_proxy/auth/enrollment.py`                                |
+| Enrolment endpoint flood                            | Rate-limited (5 starts per minute per IP, 60 status polls per minute per IP). Court federation CSR endpoints rate-limited per source IP and per target org. | PR #698                                                                |
+| Registry record tampering (write side)              | All admin writes go through CSRF + httponly cookie + `MCP_PROXY_ADMIN_SECRET`. Every write logs to the audit chain with the admin principal. | `mcp_proxy/dashboard/`                                                 |
+| AI gateway API key disclosure                       | Mastio's gateway never logs upstream API keys. Upstream credentials are Fernet-encrypted at rest (`MCP_PROXY_SECRET_ENCRYPTION_KEY_B64`); planned move to HSM-backed Fernet master key is tracked as P2. | `mcp_proxy/ai_gateway/`, `mcp_proxy/secret_encrypt.py`                 |
+| Plain Bearer tokens                                 | The proxy rejects any request authenticated with `Authorization: Bearer ...` that is not paired with a valid DPoP proof. | `mcp_proxy/auth/dpop.py`                                               |
+| Dashboard CSRF / clickjacking                       | Cookie HMAC-SHA256 with `httponly` + `secure` + `samesite=lax`. CSRF token per-session, constant-time verify on every POST. X-Frame-Options DENY, CSP, X-Content-Type-Options nosniff, Referrer-Policy on every admin response. | `app/dashboard/session.py`, `mcp_proxy/dashboard/`                     |
+| License JWT forgery                                 | RS256 verification against a public key baked into the image at build time (fingerprint pinned). No fallback path that accepts an unsigned token. | PR #691, `mcp_proxy/license.py`                                        |
+
+---
+
+## 4. Threats not covered (out of scope, with rationale)
+
+This section is deliberately explicit. A reviewer who finds a gap
+should be able to see whether we know about it, what compensating
+control we expect the operator to apply, and what the roadmap is.
+
+| Threat                                                          | Why out of scope today                                                                                                                                                            | Compensating control / roadmap                                                                                                            |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| Host OS compromise                                              | Cullis runs as a process inside a container. Root on the host reads everything on the data bind mount, including encrypted PKI material if the operator's encryption-key env var is in scope. | OS hardening (CIS benchmark or equivalent), rootless container runtime, KMS-backed encryption key (Vault Agent) so that the env var is not on disk. |
+| Container RCE / supply-chain attack on Mastio dependencies      | Cullis does not currently run a runtime SBOM verification step inside the container. Reproducible builds are on the roadmap.                                                       | Cosign-signed images, Trivy scan in CI (ignore-unfixed=true with explicit residual disclosure in each release), CycloneDX SBOM per release, customer-side cosign verify on every deploy. P1 roadmap: reproducible builds + dependency lockfile. |
+| Quantum-resistant cryptography                                  | Cullis uses classical primitives today (ECDSA P-256, RSA-PSS, AES-256-GCM, RSA-OAEP-SHA256, ECDH P-256, SHA-256). Hybrid PQC is on the roadmap, gated by upstream library maturity. | See [`docs/security/post-quantum-roadmap.md`](./post-quantum-roadmap.md). Phase 0 (positioning, monitoring NIST FIPS 203/204/205 + IETF drafts) is active. Phase 1a triggers when pyca/cryptography ships ML-KEM stable, liboqs-python installs cleanly on NixOS, or a concrete buyer signal arrives. |
+| Social engineering of the Connector admin / org admin           | Cullis cannot defend against an admin who clicks "approve" on a hostile enrolment request, or who pastes an API key into a chat tool.                                              | The admin dashboard surfaces the public key fingerprint pre-approval (PR #687). SECURITY.md mandates immediate rotation if a key is ever leaked. 4-eyes enterprise plugin gates a configured set of admin actions; extending the set to enrolment is on the P1 roadmap. |
+| Colluding admins at the enterprise tier                         | The 4-eyes plugin assumes the two admins are not the same person and not colluding. A colluding pair defeats it.                                                                   | Operational separation of duties + RBAC multi-admin plugin (scoped roles). Audit chain provides forensic detection.                       |
+| Insider holding both Mastio DB access **and** `MCP_PROXY_DB_ENCRYPTION_KEY` | The at-rest encryption envelope is keyed off this env var. An insider with both reads the Org Root key in cleartext.                                                                 | Mount the env var from a secrets manager (Vault Agent) so the value is not on disk and is rotated independently of the DB. KMS-backed envelope (cloud KMS plugin) raises the bar further.   |
+| Court availability denial-of-service                            | Federation in degraded mode (Court unreachable) blocks cross-org A2A and registry sync. There is no auto-failover Court today.                                                     | Operators who require active-active federation should peer Mastios via Court mirror (P2 roadmap) or scale Court horizontally behind a load balancer. Standalone mode is unaffected.       |
+| GDPR right-to-be-forgotten on audit chain entries               | The audit chain is append-only by design; deleting a row breaks the chain.                                                                                                         | Architectural roadmap: redact-by-tombstone proposal (P3, not started). Until then, operators store only the minimum personal data the regulator allows in an append-only artefact. We surface the `on_behalf_of_user_id` field but do not bind PII directly. |
+| WebAuthn enforcement on Frontdesk shared mode                   | Phase 1 (current default) is **warn** during the migration window. Without WebAuthn, a compromised Frontdesk container can impersonate any user.                                  | Phase 2 (PR #789) lands the cryptographic fix. Customers who require it today set `MCP_PROXY_WEBAUTHN_REQUIRED=true` in `proxy.env`. See [`docs/runbooks/frontdesk-shared-hardening.md`](../runbooks/frontdesk-shared-hardening.md). |
+| Sybil federation (open Court accepts any registered org)        | Court accepts any registered org by default. A motivated attacker can register hostile orgs.                                                                                       | Set `MCP_PROXY_FEDERATION_ALLOWLIST` to a closed list of trusted peer orgs (operator runbook). Court-side admission policy is on the P2 roadmap.                                          |
+| Downstream LLM provider behaviour (Anthropic, OpenAI, etc.)     | Cullis is infrastructure, not a content classifier. Prompt injection against the upstream LLM is the upstream's responsibility.                                                    | The enterprise LLM Guardian plugin provides outbound content filtering and inbound prompt classification. Customers without Guardian own the content boundary.                            |
+| Side channels on bcrypt admin token storage                     | We use bcrypt cost factor 12 (OWASP 2024 guidance). A leaked hash is offline-attackable.                                                                                           | Rotation policy in `operate/rotate-keys.md`. Move to argon2id is on the P3 roadmap.                                                                                                       |
+
+---
+
+## 5. Cryptographic primitives and standards
+
+| Primitive                          | Use                                                                | Standard                                  |
+|------------------------------------|--------------------------------------------------------------------|-------------------------------------------|
+| ECDSA P-256                        | Per-agent identity cert signing, DPoP proof signing (ES256).        | NIST FIPS 186-4, NIST P-256.              |
+| RSA-PSS-SHA256                     | E2E inner + outer signature (legacy classical path).                | RFC 8017.                                 |
+| AES-256-GCM                        | E2E payload, audit log encrypted columns.                          | NIST FIPS 197, NIST SP 800-38D.           |
+| RSA-OAEP-SHA256                    | E2E key encapsulation.                                              | RFC 8017.                                 |
+| ECDH P-256                         | TLS 1.3 key exchange.                                               | NIST SP 800-56A.                          |
+| PBKDF2-HMAC-SHA256 (600k) + Fernet | Org Root and Mastio Intermediate private keys at rest (`pki_key_store`). | NIST SP 800-132 (PBKDF2), Fernet spec.    |
+| SHA-256                            | Audit hash chain, JWK thumbprint (RFC 7638), cert thumbprint pinning. | NIST FIPS 180-4.                          |
+| DPoP                               | Token binding on every authenticated endpoint.                      | RFC 9449.                                 |
+| mTLS cert-bound tokens             | Transport-layer hybrid binding (optional, defence in depth).         | RFC 8705 section 3.                       |
+| JWK thumbprint                     | DPoP `cnf.jkt` claim binding the access token to the proof key.     | RFC 7638.                                 |
+| WebAuthn / FIDO2                   | User-bound session assertion on Frontdesk shared mode (Phase 2).    | W3C WebAuthn Level 2, FIDO2 CTAP2.        |
+| SPIFFE                             | Typed principal SAN format for agent / user / workload identity.    | SPIFFE specs.                             |
+| PQC (planned, hybrid)              | ML-KEM-768 KEM and ML-DSA-65 sig, hybrid with X25519 / ECDSA. Phase 1a, gated by upstream. | NIST FIPS 203, FIPS 204, FIPS 205.        |
+
+See [`docs/security/post-quantum-roadmap.md`](./post-quantum-roadmap.md) for the PQC migration plan.
+
+---
+
+## 6. Trust boundaries
+
+Each labelled boundary below is enforced by a distinct mechanism. A
+defect in one boundary does not collapse the others.
+
+- **Court to Mastio (cross-org federation).** Authenticated by the
+  Mastio's pinned peer public key, registered with Court at first
+  federation. Every cross-org call counter-signed by the Mastio
+  (ADR-009).
+- **Mastio to Mastio (intra-federation A2A).** Routed through Court;
+  same counter-sig and dual-allow PDP gate.
+- **Mastio to Connector.** mTLS RFC 8705 with the Connector's
+  client cert; the Mastio pins the Connector's thumbprint at first
+  enrolment.
+- **Connector to User.** Local OIDC handshake for first login, then
+  short-lived session tokens. Phase 2 adds WebAuthn assertion on
+  every session refresh (PR #789).
+- **Mastio to Agent.** mTLS + DPoP. The mTLS layer is pinning-based
+  defence in depth; the DPoP proof is the formal binding.
+- **Mastio to MCP resource (external).** Outbound to the per-tool
+  upstream URL, gated by the per-tool domain allow-list
+  (`mcp_proxy/tools/http_whitelist.py`), TLS terminated against
+  the operator's trust store. Per-tool credential is bound at
+  registration and never propagated from client headers.
+
+---
+
+## 7. Key lifecycle
+
+| Key                          | Validity   | Rotation                                                          | Compromise recovery                                                                  |
+|------------------------------|------------|-------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| Org Root CA                  | 15 years   | Manual only, no automation today (intentional, coupled to PQC Phase 1a; see post-quantum-roadmap.md section 8). Cold root: private key not in memory at steady state, unsealed for rare ops with audit row per unseal. | New Org Root + rebuild Intermediate + bulk re-enrol every agent. Painful by design, documented in `operate/rotate-keys.md`. |
+| Mastio Intermediate CA       | 5 years    | Auto-rotation watcher (Wave 1-A, PR #788). New Intermediate signed by Org Root, old leaves continue to verify against the chain via the published CA bundle. | Rotate the Intermediate (no Org Root unseal needed for the leaf chain to keep working). Existing leaves remain valid; new leaves issued by the new Intermediate. |
+| Mastio Leaf (federation)     | 1 year     | Manual via dashboard `migrate-org-ca` form, 7-day grace, propagation to peer Mastios via Court ContinuityProof. | Revoke the leaf, issue a new one, push ContinuityProof to peers, audit chain captures the rotation event. |
+| Agent leaf cert              | 1 year     | Manual via dashboard `rotate_agent_cert` form. Wave 2 fix 7 adds API endpoint + grace period (24-48 h configurable) so the agent transitions without an enrolment outage. | Revoke + re-enrol the agent. Existing DPoP proofs are immediately rejected (thumbprint mismatch). Grace period covers the transition window. |
+| nginx server TLS cert        | 90 days    | Runtime watcher renews + SIGHUP-reloads nginx (Wave 2 fix 6, in progress). | Force-renew via the watcher's CLI; SIGHUP path is the same as auto-renew. |
+| User OIDC session cert       | 1 hour     | Client-driven refresh from the IdP JWT.                            | Token expires on its own; revocation via the IdP's standard flow.                  |
+| WebAuthn credential          | Long-lived (per browser / authenticator) | Revocable per principal via the dashboard.                          | Revoke the credential; the user re-binds a new authenticator at next login.        |
+| Dashboard admin secret       | Long-lived | Rotate via env + restart (`MCP_PROXY_DASHBOARD_SIGNING_KEY`).      | Re-issue all admin tokens; old session cookies fail HMAC verification.             |
+| License JWT signing key      | Annual     | Annual ceremony, new prod image bakes the new pubkey, customers re-deploy. | Roll the priv-key, re-mint every active customer's JWT, ship a new image tag. Emergency procedure.  |
+| KMS / Vault tokens           | Per Vault policy (short TTL) | Automated by Vault.                                               | Vault revokes; Mastio retries with a fresh token.                                  |
+
+---
+
+## 8. Audit trail integrity
+
+- **Append-only schema.** A database trigger raises on UPDATE or
+  DELETE against `audit_log`, on both SQLite and Postgres
+  (`alembic/versions/r8m9n0o1p2q3_audit_append_only.py`). No code
+  path writes around this trigger.
+- **Per-entry hash chain.** Each row has an `entry_hash` (SHA-256 of
+  the canonical representation) and a `previous_hash` linking to
+  the prior entry. Replay verification reads the chain from genesis
+  and recomputes the hashes.
+- **Court anchor.** A background worker (`app/audit/tsa_worker.py`)
+  writes the current chain head into Court's `AuditTsaAnchor` table
+  every `audit_tsa_interval_seconds` (default 3600, configurable).
+  Federated installs use the Court anchor as the second source of
+  truth for chain-head verification.
+- **Dual-write (federated mode).** Every cross-org event is
+  replicated to Court's `mastio_audit_replica` table at the time of
+  the request. Dispute resolution between two orgs uses the Court
+  copy as the neutral third witness.
+- **Export and verify.** Bundles include a CLI tool that walks the
+  exported chain, recomputes hashes, and reports the first divergent
+  row if any.
+
+**Residual:** an attacker controlling **both** the Mastio host **and**
+Court can rewrite history. We document this Byzantine assumption in
+ADR-013 (layered defence). Customers needing stronger guarantees
+should peer Cullis with an external append-only sink (SIEM, S3
+Object Lock, blockchain anchor) or run their own Court without
+federation.
+
+---
+
+## 9. Incident response posture
+
+Coordinated disclosure, severity classification, response SLAs, and
+the response runbook live in:
+
+- [`SECURITY.md`](../../SECURITY.md): how to report a vulnerability,
+  acknowledgment and triage SLAs, supported version matrix, safe
+  harbour.
+- [`docs/runbooks/incident-response.md`](../runbooks/incident-response.md):
+  severity classification (Sev 1 through Sev 4), response procedure
+  per severity, customer notification template, public disclosure
+  template.
+
+Top-line SLAs:
+
+| Phase                      | Target                                              |
+|----------------------------|-----------------------------------------------------|
+| Acknowledgment             | within 48 hours                                     |
+| Initial triage             | within 7 days                                       |
+| Fix for CRITICAL (CVSS >=9)| within 7 days                                       |
+| Fix for HIGH (CVSS 7-8.9)  | within 14 days                                      |
+| Fix for MEDIUM             | within 30 days                                      |
+| Public disclosure          | 90 days after report, or upon coordinated release   |
+
+---
+
+## 10. Compliance mapping (preview)
+
+Cullis is built with regulated-industry deployments in mind (DORA,
+NIS2, AI Act, GDPR). Full compliance mapping documents are tracked
+on the roadmap and will land in `docs/compliance/` once each
+regulation's applicable controls are mapped to Cullis features:
+
+| Framework      | Status                                               | Cullis surface                                                                 |
+|----------------|------------------------------------------------------|--------------------------------------------------------------------------------|
+| DORA           | Roadmap (Q3 2026, banking pilot dependency)         | ICT third-party risk register, append-only audit log, incident reporting flow. |
+| NIS2           | Roadmap (Q4 2026)                                    | Identity governance, audit retention, supply-chain attestations.               |
+| EU AI Act      | Roadmap (Q4 2026)                                    | Agent identity, audit trail, human-in-the-loop (A2U quadrant).                 |
+| GDPR DPIA      | Roadmap (Q3 2026)                                    | Lawful basis per quadrant, retention controls, right-to-be-forgotten plan.     |
+| SOC 2 Type II  | Deferred until first paid engagement                 | Audit chain, key custody, change management.                                   |
+
+This document does **not** claim compliance with any of the above; it
+states what surface Cullis exposes that a customer's compliance team
+can map against. The mapping itself is the customer's
+responsibility, with our support.
+
+---
+
+## 11. Related documents
+
+- [`SECURITY.md`](../../SECURITY.md): responsible disclosure policy,
+  supported versions, safe harbour.
+- [`docs/runbooks/incident-response.md`](../runbooks/incident-response.md):
+  internal IR playbook for Sev 1 through Sev 4 events.
+- [`docs/security/post-quantum-roadmap.md`](./post-quantum-roadmap.md):
+  PQC strategy, five-phase roadmap, upstream blockers, spike
+  validation numbers.
+- [`docs/runbooks/frontdesk-shared-hardening.md`](../runbooks/frontdesk-shared-hardening.md):
+  Frontdesk shared-mode hardening checklist, Phase 1 audit warning,
+  Phase 2 WebAuthn.
+- [`docs/architecture/byoca-current-state.md`](../architecture/byoca-current-state.md):
+  BYOCA (Bring Your Own CA) implementation status and gap.
+- [cullis.io threat model deep-dive](https://cullis.io/security/threat-model/):
+  STRIDE walkthrough per component, source in
+  `site/src/content/docs/security/threat-model.md`.
+- ADR-009 (counter-sig federation), ADR-014 (mTLS Connector to
+  Mastio), ADR-017 (embedded LiteLLM AI gateway), ADR-019 (Cullis
+  Frontdesk), ADR-020 (typed principals + four quadrants), ADR-021
+  (Frontdesk shared mode + per-user KMS), ADR-029 (tool-level PDP),
+  ADR-031 (Vault as Org CA KMS backend), ADR-033 (PKI three-tier
+  hardening), ADR-033 (Frontdesk shared-mode threat model). Public
+  ADRs are in `docs/adrs/`; ADRs with commercial-sensitive content
+  are internal-only in `imp/adrs/`.
+
+---
+
+## 12. Revision history
+
+| Version | Date       | Author              | Notes                                                                |
+|---------|------------|---------------------|----------------------------------------------------------------------|
+| 1.0     | 2026-05-18 | Cullis security team | First publication. Aligned to Wave 1-A PKI hardening + ADR-033 Phase 2 WebAuthn (PR #785-789). |
+
+Next review: 2026-08-18. Triggers for an out-of-cycle revision: new
+ADR ratified, new threat discovered, third-party penetration test
+report, customer feedback that lands a substantive correction.


### PR DESCRIPTION
## Discovery (Step 0)

Before writing, verified existing state of the repo post Wave 1 merge (PR #785-#789 landed 2026-05-18):

- **`SECURITY.md`** at the repo root **already exists** and is comprehensive (CVSS-tier SLA matrix, supported version matrix, safe harbour, scope, acknowledgements). Wave 1 commits did not touch it. **Decision:** leave it as the responsible disclosure entry point, cross-reference it from the new documents, do **not** overwrite.
- **`site/src/content/docs/security/threat-model.md`** **already exists** (575-line STRIDE walkthrough per component, originally PR #703, refreshed against the codebase on 2026-05-15). It is the site-published deep-dive. **Decision:** the new `docs/security/threat-model.md` is a threat **catalog** (in scope + out of scope tables, lifecycle, primitives, boundaries) that cross-links the site STRIDE doc rather than duplicating it.
- **`docs/security/`** directory **did not exist** before this PR. Created with three files (threat-model, post-quantum-roadmap, README index).
- **`docs/runbooks/`** existed with `frontdesk-shared-hardening.md` (Wave 1) and `postgres-pilot.md`; **did not have** an incident response runbook. Created.
- **ADR-022 Post-Quantum Strategy** file was missing from `imp/adrs/` (personal memory 2026-05-06 documented ratification but the file was never written). Created locally at `imp/adrs/adr-022-post-quantum-strategy.md` with Status `Accepted (internal-only)` Date 2026-05-06 (retroactive for consistency with the memory record). `imp/adrs/` is gitignored, so this file is **not** part of the PR by design (matches the established pattern: commercial-sensitive ADRs stay in `imp/adrs/`, pure architecture ADRs are mirrored into `docs/adrs/`).

## What this PR adds

Four new customer-facing documents land in one PR, each in its own DCO-signed commit:

1. **`docs/security/threat-model.md`** (v1.0). Threat catalog: 3 components + 4 typed principals + 4 interaction quadrants, in-scope threats with mitigation references, explicit out-of-scope section with rationale and compensating control, crypto primitives + standards, trust boundaries, key lifecycle, audit trail integrity, compliance mapping preview. Cross-links the STRIDE walkthrough on cullis.io.

2. **`docs/runbooks/incident-response.md`** (v1.0). Severity classification (Sev 1 through Sev 4) keyed to Cullis-specific operational triggers, per-severity response procedure (detect / contain / investigate / recover / communicate) with wall-clock SLAs, customer notification template, status page template, public disclosure template, post-incident review template.

3. **`docs/security/post-quantum-roadmap.md`** (v1.0). Hybrid-first PQC strategy across five phases gated by upstream library maturity. Includes spike validation numbers from 2026-05-06 (X25519 + ML-KEM-768 hybrid envelope, ~4 to 5 ms roundtrip, +1088 bytes overhead, tamper detection verified) and the upstream blocker table. Quarterly review cadence, next review 2026-08-06.

4. **`docs/security/README.md`**. Index for the new `docs/security/` directory with quarterly review cadence note.

Plus a Documentation entry in `CHANGELOG.md` under `[Unreleased]`.

## Cross-references

The four documents link to each other and to existing artefacts:

- `docs/security/threat-model.md` references `SECURITY.md` (disclosure policy), `docs/runbooks/incident-response.md` (response posture), `docs/security/post-quantum-roadmap.md` (quantum out-of-scope), the cullis.io STRIDE deep-dive, `docs/runbooks/frontdesk-shared-hardening.md`, and `docs/architecture/byoca-current-state.md`.
- `docs/runbooks/incident-response.md` references `SECURITY.md`, the threat model, Frontdesk hardening, and `operate/rotate-keys.md`.
- `docs/security/post-quantum-roadmap.md` references ADR-022 (internal-only), ADR-033 PKI three-tier (internal-only, Wave 1-A baseline), the threat model section 5 (crypto primitives) and section 4 (PQC out-of-scope).
- `docs/security/README.md` indexes the directory and cross-references runbooks + ADRs.

## Org Root rotation coupling note (architectural decision)

Wave 1-A (PR #788) intentionally did **not** implement Org Root CA rotation automation. The PQC roadmap section 8 documents this as a coupling: implementing rotation today with a classical-only target would force a second rotation when hybrid arrives at Phase 1a, doubling the operational risk and the customer-side re-issuance work. The Mastio Intermediate CA, by contrast, **does** have rotation automation today (Wave 1-A) and gains dual-sig at Phase 2a without an additional rotation. Customers asking when Org Root rotation will be available get the explanation "arrives with Phase 1a kickoff". This is a conscious architectural choice, not a gap.

## Revision cadence

All documents declare a "Next review" date in the header:

- `docs/security/threat-model.md` next review **2026-08-18** (quarterly).
- `docs/runbooks/incident-response.md` next review **2026-08-18** (quarterly).
- `docs/security/post-quantum-roadmap.md` next review **2026-08-06** (PQC upstream tracking quarterly).
- `docs/security/README.md` notes the quarterly review cadence for the directory.

Out-of-cycle revision triggers: new ADR ratified, new threat discovered, third-party penetration test report, customer feedback that lands a substantive correction.

## What's NOT in this PR

The compliance mapping documents (DORA, NIS2, EU AI Act, GDPR DPIA, SOC 2 Type II) are tracked as future work and called out as such in the threat model section 10 (Compliance mapping preview). The threat model surfaces the Cullis features each framework's review can map against, but the mapping itself is the customer's responsibility with our support. SOC 2 Type II is deferred until the first paid engagement funds the third-party audit.

The third-party penetration test report itself is also deferred until the first paid engagement, as already documented in the existing site threat model. This PR does not change that timeline.

The ADR-022 internal ratification file (`imp/adrs/adr-022-post-quantum-strategy.md`) was created locally for consistency with the personal memory record but is gitignored (matches the pattern: commercial-sensitive ADRs in `imp/adrs/`, pure architecture in `docs/adrs/`). The public PQC roadmap document is the customer-facing counterpart.

## Test plan

- [ ] Read through each new document end-to-end.
- [ ] Verify cross-references resolve (no broken links between the four docs and existing files like SECURITY.md, runbooks, ADRs).
- [ ] Confirm tone is technically precise, honest, no marketing speak (no "100% secure", no "military-grade encryption").
- [ ] Confirm no em-dash (`—`) in any of the four new documents (customer-facing style requirement).
- [ ] Confirm the four DCO-signed commits are clean (no Co-Authored-By Claude).
- [ ] Sanity-check the threat model out-of-scope section against the actual codebase: every "not covered" claim has a roadmap or compensating control.

## Pillar coverage (CISO-ready roadmap 2026-05-18)

This PR covers four pillars from the CISO-ready roadmap:

- **#2 Threat model document** ✓
- **#3 SECURITY.md** ✓ (existing file confirmed comprehensive, cross-referenced)
- **#7 Incident response runbook** ✓
- **#9 Post-quantum cryptography roadmap** ✓

Remaining roadmap pillars (cryptographic insurance procurement, third-party pentest LoA, PGP key publication for security@cullis.io) are operational items, not documentation, and are out of scope for this PR.