### PR TITLE
fix(integration): alembic multi-head + webauthn runtime dep + docstring stale (pre-test validation findings)

### DIFF
--- a/mcp_proxy/alembic/versions/0039_webauthn_credentials.py
+++ b/mcp_proxy/alembic/versions/0039_webauthn_credentials.py
@@ -1,7 +1,7 @@
 """ADR-033 Phase 2: WebAuthn-bound user session tokens for Frontdesk shared mode.
 
-Revision ID: 0038_webauthn_credentials
-Revises: 0037_audit_dev_attest
+Revision ID: 0039_webauthn_credentials
+Revises: 0038_pki_key_store
 Create Date: 2026-05-18 14:00:00.000000
 
 Phase 1 (PR #786) added an audit warning when a Connector-issued user

--- a/mcp_proxy/alembic/versions/0040_merge_grace_webauthn.py
+++ b/mcp_proxy/alembic/versions/0040_merge_grace_webauthn.py
@@ -1,0 +1,45 @@
+"""Merge agent_cert_grace + webauthn_credentials heads.
+
+Revision ID: 0040_merge_grace_webauthn
+Revises: 0039_agent_cert_grace, 0039_webauthn_credentials
+Create Date: 2026-05-18 14:30:00.000000
+
+Multi-head emerged after Wave 2 fix 7+8 (PR #790, agent leaf cert
+rotation grace period) and Wave 1-E WebAuthn (PR #789, ADR-033 Phase 2
+user assertion binding) both targeted ``0038_pki_key_store`` as
+``down_revision`` during parallel development on 2026-05-18. Neither PR
+rebased against the other before merge, so ``alembic upgrade head``
+refuses with ``Multiple head revisions are present`` and the Mastio
+``proxy-*-init`` container in ``sandbox/`` exits 1 at boot.
+
+The two migrations touch disjoint schema:
+
+* ``0039_agent_cert_grace`` adds three nullable columns
+  (``previous_cert_pem``, ``previous_dpop_jkt``,
+  ``previous_grace_period_expires_at``) to ``internal_agents``.
+* ``0039_webauthn_credentials`` creates the new
+  ``user_webauthn_credentials`` table plus indices.
+
+Because the two upgrade DAGs commute, this is a pure structural merge:
+no DDL is needed, the revision exists only to re-collapse the head set
+back to a single ``0040_merge_grace_webauthn`` so downstream migrations
+can resume linear numbering.
+"""
+from typing import Sequence, Union
+
+
+revision: str = "0040_merge_grace_webauthn"
+down_revision: Union[str, Sequence[str], None] = (
+    "0039_agent_cert_grace",
+    "0039_webauthn_credentials",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No-op structural merge of the two 0039_* heads."""
+
+
+def downgrade() -> None:
+    """No-op structural merge of the two 0039_* heads."""

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -24,3 +24,12 @@ redis>=5.0.0
 # federation-only, AI gateway egress runs in-process on Mastio).
 # Required when MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded.
 litellm>=1.50.0
+# ADR-033 Phase 2 WebAuthn user assertion binding (PR #789). The lazy
+# importer in mcp_proxy/auth/webauthn/_lib.py raises
+# WebAuthnLibraryMissingError on every register/authenticate path and
+# on warn-mode session emission that carries a user_signed_assertion
+# when this package is absent. ``pyproject.toml`` exposes the same pin
+# via the ``[webauthn]`` extra for SDK consumers; the Mastio container
+# installs from requirements-proxy.txt rather than the cullis-agent-sdk
+# extra, so the dep must be pinned here too.
+webauthn>=2.0,<3.0

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -389,7 +389,7 @@ async def test_approve_re_enroll_same_agent_id_updates_cert(db_engine):
       - admin-managed columns (capabilities, federated, reach) are
         preserved across the re-enroll so a re-approval cannot reset
         operator decisions
-      - audit_log carries an ``agent.cert_renewed`` event distinct from
+      - audit_log carries an ``agent.cert_rotated`` event distinct from
         the original ``agent.create``
       - ``federation_revision`` is bumped so the publisher republishes
     """
@@ -490,7 +490,7 @@ async def test_approve_re_enroll_same_agent_id_updates_cert(db_engine):
     # Audit chain: one create (first approve), one cert_renewed (second).
     actions = [row["action"] for row in audits]
     assert "agent.create" in actions
-    assert "agent.cert_renewed" in actions
+    assert "agent.cert_rotated" in actions
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0038_pki_key_store",)]
+    assert rows == [("0040_merge_grace_webauthn",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0038_pki_key_store",)]
+    assert version == [("0040_merge_grace_webauthn",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0038_pki_key_store"
+HEAD_REVISION = "0040_merge_grace_webauthn"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0038_pki_key_store"
+HEAD_REVISION = "0040_merge_grace_webauthn"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0038_pki_key_store"
+HEAD_REVISION = "0040_merge_grace_webauthn"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

Three integration findings from the **pre-test integration validation 2026-05-18** (`imp/pre-test-validation-report-2026-05-18.md`) run against the Wave 1 + Wave 2 + docs CISO merge cohort (#785-#793). All three slipped the per-PR pre-push gate because they only surface when the merged branches sit on top of each other.

- **CRITICAL** Alembic multi-head: PR #789 and PR #790 both used revision id 0039_* with down_revision=0038_pki_key_store. Every Mastio boot, every pytest run, every sandbox-init container started failing with \"Multiple head revisions are present\". Fix: a no-op merge revision `0040_merge_grace_webauthn`.
- **MAJOR** `webauthn` runtime dep missing: PR #789 added the pin to `pyproject.toml [webauthn]` extra of `cullis-agent-sdk`, but the Mastio Docker image consumes `mcp_proxy/requirements-proxy.txt` which is its own pin list. Fix: pin `webauthn>=2.0,<3.0` directly there.
- **MINOR** docstring drift: `0039_webauthn_credentials.py` header still says `Revision ID: 0038_webauthn_credentials` from a pre-rebase numbering. Fix: align.

Also bundled (regressions surfaced by the alembic fix):

- 4 test files had `HEAD_REVISION = \"0038_pki_key_store\"` hardcoded. Bumped to `0040_merge_grace_webauthn`.
- `test_approve_re_enroll_same_agent_id_updates_cert` asserted `agent.cert_renewed` but PR #790 renamed the action to `agent.cert_rotated` (`mcp_proxy/enrollment/service.py:642`). Realigned the assertion + docstring.

## Root cause analysis

The same parallel-development race already documented in memory as `feedback_dual_repo_sync_before_branch` (origin/main stantio + parallel sessions) applied intra-repo on 2026-05-18 across two PRs that landed ~90 minutes apart. The 2nd-merged PR did not rebase against the 1st-merged PR's revision id, so the duplicate `0039_*` slot was never observed pre-merge. Per-branch CI/pre-push is a single-head gate by construction; multi-head only emerges once both branches sit on the same commit.

## Lesson

Post-rebase of any branch that touches `mcp_proxy/alembic/versions/`, lanciare `python -m alembic heads` come gate locale (esce con singolo head o ALARM). Candidate memory bump:

> Multiple PRs merging same day with adjacent alembic revision id MUST rebase pre-2nd-merge and re-run `alembic heads`. Co-locates with `feedback_dual_repo_sync_before_branch` and `feedback_alembic_revision_length`.

## Commits

1. `fix(alembic): merge multi-head from PR #789 + #790 parallel development` (Finding 1 + 4 stale HEAD_REVISION test assertions).
2. `fix(mcp_proxy): add webauthn runtime dep to requirements-proxy.txt` (Finding 2).
3. `chore(alembic): fix stale Revision ID in 0039_webauthn_credentials docstring` (Finding 3).
4. `chore(tests): align test_approve_re_enroll to agent.cert_rotated (PR #790 follow-up)` (regression after the alembic fix unblocked the pytest suite).

## Test plan

- [x] `python -m alembic heads` returns single `0040_merge_grace_webauthn`
- [x] `pytest tests/ -n auto --dist=loadfile` -> 4051 passed, 7 skipped, 1 failed (pre-existing `test_badge_approvals_empty_when_plugin_unavailable` — documented in memory: enterprise plugin installed locally)
- [x] `python -c \"import webauthn; print(webauthn.__version__)\"` in venv with `requirements-proxy.txt` -> `2.7.1`
- [ ] `./sandbox/smoke.sh full` — DEFERRED, blocked by Finding 4 below
- [ ] `./sandbox/demo.sh full` — DEFERRED, blocked by Finding 4 below

## Out-of-scope follow-up surfaced by this validation run

**Finding 4 (separate PR needed):** sandbox `proxy-a` + `proxy-b` Mastios fail to boot post legacy-PKI wipe. PR #788 (PKI 3-tier hardening) `_phase_0_wipe_legacy_pki` archives `proxy_config.org_ca_key` into `legacy_pki_archive` and deletes the key, leaving `org_ca_cert` in place. Subsequent `load_org_ca_from_config` returns `False` (KMS provider requires both), `mastio_loaded` stays False, and `_generate_mastio_identity` cannot mint a fresh Intermediate without unsealing the Org Root that is now cold in the archive. Effect:

- `proxy-a-1` boot log: `Org CA not found via KMS provider — agent cert issuance unavailable`
- `mastio-nginx-a-1` exits 1 because `/etc/nginx/certs/mastio-server.crt` never gets written.

This regression is **independent of this PR** (same code path is hit on the pre-fix multi-head tree, it just never got that far because alembic short-circuited boot earlier). Treating as a separate Wave 2 follow-up: either the sandbox seed flow re-seeds the encrypted PKI key store at startup, or `_phase_0_wipe_legacy_pki` migrates instead of archiving when the env is `development`. Suggested label: `pki/sandbox-bootstrap`.

## Dual-repo

Pushed only to `origin`. Not staged on `enterprise`.

## Status

DRAFT — please review then move to ready / merge per gestione settimana test.