### PR TITLE
fix(pki): regenerate Org Root on empty pki_key_store (Wave 1-A bootstrap follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ flow until the next `## ` heading.
   and `NGINX_RELOAD_POLL_SECONDS` (default 60). Audit chain entry
   `pki.nginx_server_cert_rotated` per rotation.
 
+### Fixed
+- Phase 0 PKI bootstrap now **migrates** legacy plaintext
+  `proxy_config.org_ca_key` / `mastio_ca_key` rows into the encrypted
+  `pki_key_store` table before archiving and deleting them. Pre-fix
+  the wipe destroyed the only copy of the Org Root keypair on first
+  boot post-upgrade, and the federated lifespan
+  (`MCP_PROXY_STANDALONE=false`) short-circuited the
+  `generate_org_ca` fallback, leaving the Mastio without a usable
+  chain and cascading into nginx cert + Mastio Intermediate
+  provisioning failures (`./sandbox/demo.sh full` boot failure). The
+  migration preserves the existing Org Root pubkey so cross-org
+  federation trust pinning (`organizations.mastio_pubkey` on the
+  Court) survives the upgrade unchanged. Wave 1-A bootstrap
+  follow-up to PR #794.
+
 ### Breaking changes
 
 - **`POST /v1/enrollment/start` now requires `pop_signature`** (H-csr-pop

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -1385,26 +1385,50 @@ class AgentManager:
         )
 
     async def wipe_legacy_pki_if_present(self) -> bool:
-        """Phase 0 hard wipe: archive plaintext PKI rows + re-issue cleanly.
+        """Phase 0 migrate-then-wipe: relocate legacy plaintext PKI rows.
 
-        Three-tier PKI hardening (audit 2026-05-18). The user confirmed
-        no live deploys exist (Mastio VMs torn down for the upgrade),
-        so a back-compat read path for the legacy
-        ``proxy_config.org_ca_key`` / ``mastio_ca_key`` plaintext rows
-        is unnecessary. This helper:
+        Three-tier PKI hardening (audit 2026-05-18). The historic shape
+        of this helper was a pure wipe (archive + delete), on the
+        assumption that the caller would either re-issue a fresh chain
+        (standalone first-boot) or had already populated the encrypted
+        ``pki_key_store`` via an earlier boot. Both assumptions break
+        on the sandbox / federated path: ``proxy-init/seed.py`` writes
+        plaintext ``proxy_config.org_ca_key`` rows when the Mastio has
+        never booted, ``settings.standalone=False`` short-circuits the
+        ``generate_org_ca`` fallback in the lifespan, and the broker
+        ``/attach-ca`` flow is only consumed *after* the Mastio is
+        already reachable. The pure-wipe variant therefore archived
+        the only copy of the Org Root keypair and the next boot tried
+        to mint the Mastio Intermediate without a parent.
+
+        Post-fix (PR #794 follow-up, Wave 1-A bootstrap regeneration)
+        this helper:
 
         1. Detects either legacy row.
-        2. Archives the PEM into ``legacy_pki_archive`` with audit
-           trail (operator can still recover from a bad upgrade for
-           N days if they keep the DB row around).
-        3. Deletes the legacy ``proxy_config`` rows.
-        4. Returns True so the caller can re-issue from a clean slate.
+        2. **Migrates** the plaintext keypair into ``pki_key_store``
+           under the Fernet at-rest envelope via the configured
+           ``KMSProvider`` — preserving the Org Root pubkey that the
+           Court / broker pinned during attach-ca. A regen would
+           silently break federation; the migration keeps trust
+           continuity intact.
+        3. Archives the legacy PEM into ``legacy_pki_archive`` with
+           audit trail (operator can still recover from a bad upgrade
+           if they keep the DB row around).
+        4. Deletes the legacy ``proxy_config`` rows (private key only
+           for ``org_ca``; both rows for ``mastio_ca`` since the
+           public Mastio Intermediate cert is not consumed by any
+           legacy endpoint).
+        5. Returns True so the caller knows a wipe happened.
 
-        Idempotent: a second call after the wipe is a no-op. Safe to
-        run on every boot (the legacy-row detection is the gate).
+        Idempotent: when the encrypted row is already in place from a
+        previous boot, the migration step is a no-op (the
+        ``store_org_ca`` / ``store_intermediate_ca`` provider methods
+        short-circuit on identical material). When no legacy rows are
+        present at all, the whole helper is a no-op.
 
         Returns True when a wipe happened, False when no legacy material
-        was present (steady-state).
+        was present (steady-state) or when the migration was deferred
+        (master key absent).
         """
         legacy_org_key = await get_config("org_ca_key")
         legacy_org_cert = await get_config("org_ca_cert")
@@ -1414,19 +1438,12 @@ class AgentManager:
         wiped = False
         now_iso = datetime.now(timezone.utc).isoformat()
 
-        # We only wipe when the new ``pki_key_store`` has already been
-        # populated (else we'd archive the only copy and leave the
-        # Mastio without an Org CA on the next boot). The lifespan
-        # caller orchestrates: load_org_ca_from_config → if cert came
-        # via legacy proxy_config row AND the KMS provider says
-        # "load_org_ca returned None", we are pre-migration; defer
-        # wipe to a future boot where the encrypted row exists.
+        # Without the at-rest master key we cannot encrypt the legacy
+        # material into ``pki_key_store``; deleting the plaintext now
+        # would strand the Mastio on the next boot. Skip with a
+        # warning so the operator sets the env var and retries.
         from mcp_proxy.kms.pki_at_rest import pki_master_key_configured
         if not pki_master_key_configured():
-            # Without the at-rest master key we cannot encrypt the
-            # re-issued material; the wipe would create a strictly
-            # worse state than the legacy plaintext. Skip with a
-            # warning so the operator sets the env var and retries.
             if legacy_org_key or legacy_int_key:
                 logger.warning(
                     "Legacy plaintext PKI rows detected but "
@@ -1436,7 +1453,29 @@ class AgentManager:
                 )
             return False
 
+        from mcp_proxy.kms import get_kms_provider
+        provider = get_kms_provider()
+
         if legacy_org_key and legacy_org_cert:
+            # Migrate first — if ``pki_key_store`` already has an
+            # active row, ``store_org_ca`` is idempotent on identical
+            # material and a no-op on the fast path. If the encrypted
+            # store is empty (the common sandbox / federated cold-
+            # boot case), this writes the legacy PEM under Fernet
+            # at-rest so the lifespan's ``load_org_ca_from_config``
+            # finds the keypair on the very next call.
+            try:
+                await provider.store_org_ca(legacy_org_key, legacy_org_cert)
+            except Exception as exc:  # noqa: BLE001 — refuse-to-wipe on failure
+                logger.error(
+                    "Phase 0 migration failed for org_ca: %s. Aborting "
+                    "wipe to avoid losing the only copy of the Org Root "
+                    "keypair. Operator action: inspect the KMS provider "
+                    "(MCP_PROXY_KMS_BACKEND, pki_key_store schema) and "
+                    "restart.",
+                    exc,
+                )
+                return False
             await archive_legacy_pki(
                 key_id=f"legacy-org-ca-{now_iso}",
                 key_type="org_ca",
@@ -1453,14 +1492,33 @@ class AgentManager:
                     agent_id="system",
                     action="pki.legacy_wipe",
                     status="success",
-                    detail="key_type=org_ca archived_to=legacy_pki_archive",
+                    detail=(
+                        "key_type=org_ca migrated_to=pki_key_store "
+                        "archived_to=legacy_pki_archive"
+                    ),
                 )
             except Exception:
                 pass
-            logger.info("Phase 0 wipe: archived legacy org_ca_key")
+            logger.info(
+                "Phase 0 migrate+wipe: org_ca_key relocated into "
+                "pki_key_store and legacy plaintext archived",
+            )
             wiped = True
 
         if legacy_int_key and legacy_int_cert:
+            try:
+                await provider.store_intermediate_ca(
+                    legacy_int_key, legacy_int_cert,
+                )
+            except Exception as exc:  # noqa: BLE001 — refuse-to-wipe on failure
+                logger.error(
+                    "Phase 0 migration failed for intermediate_ca: %s. "
+                    "Aborting wipe of the Mastio Intermediate rows. "
+                    "Operator action: inspect the KMS provider and "
+                    "restart.",
+                    exc,
+                )
+                return wiped
             await archive_legacy_pki(
                 key_id=f"legacy-intermediate-{now_iso}",
                 key_type="intermediate_ca",
@@ -1474,11 +1532,17 @@ class AgentManager:
                     agent_id="system",
                     action="pki.legacy_wipe",
                     status="success",
-                    detail="key_type=intermediate_ca archived_to=legacy_pki_archive",
+                    detail=(
+                        "key_type=intermediate_ca migrated_to=pki_key_store "
+                        "archived_to=legacy_pki_archive"
+                    ),
                 )
             except Exception:
                 pass
-            logger.info("Phase 0 wipe: archived legacy mastio_ca_key")
+            logger.info(
+                "Phase 0 migrate+wipe: mastio_ca relocated into "
+                "pki_key_store and legacy plaintext archived",
+            )
             wiped = True
 
         return wiped

--- a/tests/test_pki_three_tier_hardening.py
+++ b/tests/test_pki_three_tier_hardening.py
@@ -227,3 +227,228 @@ async def test_rotate_mastio_ca_real_swap(proxy_app):
         new_agent_cert.tbs_certificate_bytes,
         ec.ECDSA(new_agent_cert.signature_hash_algorithm),
     )
+
+
+# ── Wave 1-A bootstrap regression (PR #794 follow-up) ─────────────────
+
+
+def _seed_org_ca_pem(org_id: str) -> tuple[str, str]:
+    """Mint a self-signed Org Root + return (key_pem, cert_pem) PEMs.
+
+    Mirrors what ``sandbox/proxy-init/seed.py`` does for the legacy
+    plaintext seeding path: an EC P-256 keypair under a CA cert with
+    pathLen=1 so a Mastio Intermediate can chain underneath.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=1),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key_pem, cert_pem
+
+
+@pytest_asyncio.fixture
+async def proxy_app_with_seeded_legacy_org_ca(tmp_path, monkeypatch):
+    """Like ``proxy_app`` but pre-seeds legacy plaintext rows BEFORE lifespan.
+
+    Reproduces the sandbox federated boot: ``proxy-init/seed.py`` writes
+    ``proxy_config.org_ca_key`` + ``org_ca_cert`` as plaintext, then the
+    Mastio container boots and runs the lifespan. Without the Wave 1-A
+    fix, Phase 0 wipes the plaintext rows without first migrating them
+    into ``pki_key_store``, leaving the Mastio without an Org Root on
+    the next ``ensure_mastio_identity`` call.
+    """
+    db_file = tmp_path / "pki_bootstrap_migrate.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    # Federated mode: short-circuits the standalone generate_org_ca
+    # fallback, so the migration is the only path that lands a usable
+    # Org Root on this boot.
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "false")
+    monkeypatch.setenv(
+        "MCP_PROXY_DB_ENCRYPTION_KEY",
+        "test-passphrase-32-chars-minimum-three-tier",
+    )
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.kms.pki_at_rest import _reset_cache_for_tests
+    _reset_cache_for_tests()
+    from mcp_proxy.kms.factory import reset_kms_provider
+    reset_kms_provider()
+
+    # Mirror what ``sandbox/proxy-init/seed.py`` writes BEFORE the
+    # Mastio lifespan runs: schema upgrade + legacy plaintext rows
+    # in ``proxy_config``. Lifespan calls ``init_db`` again on entry;
+    # alembic upgrade head is idempotent so the double call is safe.
+    from sqlalchemy import text as _text
+
+    key_pem, cert_pem = _seed_org_ca_pem("acme")
+
+    from mcp_proxy.db import dispose_db, get_db, init_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+    async with get_db() as conn:
+        for k, v in (
+            ("org_id", "acme"),
+            ("org_ca_key", key_pem),
+            ("org_ca_cert", cert_pem),
+        ):
+            await conn.execute(
+                _text(
+                    "INSERT INTO proxy_config (key, value) "
+                    "VALUES (:k, :v) "
+                    "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+                ),
+                {"k": k, "v": v},
+            )
+    await dispose_db()
+
+    from httpx import ASGITransport, AsyncClient
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client, key_pem, cert_pem
+
+    get_settings.cache_clear()
+    reset_kms_provider()
+    _reset_cache_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_migrates_legacy_org_ca_into_pki_key_store(
+    proxy_app_with_seeded_legacy_org_ca,
+):
+    """Phase 0 must MIGRATE legacy plaintext into ``pki_key_store``.
+
+    Reproduces the sandbox federated cold-boot. Pre-fix the wipe
+    archived + deleted the only copy of the Org Root keypair, and the
+    federated lifespan (``settings.standalone=False``) skipped the
+    ``generate_org_ca`` fallback — leaving ``ca_loaded=False`` and
+    cascading into nginx cert + Mastio Intermediate provisioning
+    failures. Post-fix the migration step encrypts the legacy keypair
+    into ``pki_key_store`` before the archive+delete, so the very same
+    boot can load it via ``load_org_ca_from_config`` and complete the
+    chain.
+    """
+    app, _client, expected_key_pem, expected_cert_pem = (
+        proxy_app_with_seeded_legacy_org_ca
+    )
+    mgr = app.state.agent_manager
+
+    # Lifespan must have loaded the Org Root + minted the Intermediate
+    # + emitted a Mastio leaf. The bug surfaced as ca_loaded=False here.
+    assert mgr.ca_loaded, "Org Root must be loaded after migrate-then-wipe"
+    assert mgr._mastio_ca_cert is not None, (
+        "Mastio Intermediate must be minted under the migrated Org Root"
+    )
+    assert mgr._active_key is not None, (
+        "Mastio Leaf must be issued under the new Intermediate"
+    )
+
+    # The Org Root cert preserved across the migration must match the
+    # legacy seed (pubkey identity, not a fresh keypair — federation
+    # trust pinning would break otherwise).
+    persisted_cert = _load_cert(expected_cert_pem)
+    assert (
+        mgr._org_ca_cert.public_bytes(serialization.Encoding.DER)
+        == persisted_cert.public_bytes(serialization.Encoding.DER)
+    ), "migration must preserve the legacy Org Root pubkey, not regen it"
+
+    # ``pki_key_store`` should hold the migrated keypair under the
+    # active row for ``key_type='org_ca'``.
+    from mcp_proxy.db import get_active_pki_key
+    row = await get_active_pki_key("org_ca")
+    assert row is not None, "pki_key_store.org_ca active row must exist post-migration"
+    assert row["cert_pem"] == expected_cert_pem
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_legacy_plaintext_rows_are_archived(
+    proxy_app_with_seeded_legacy_org_ca,
+):
+    """After migration the legacy plaintext key is gone from proxy_config.
+
+    The wipe step still runs (the migration is on top of, not in place
+    of, the archive+delete). ``org_ca_cert`` stays in ``proxy_config``
+    for the legacy ``/pki/ca.crt`` and connector-bootstrap endpoints
+    that still read it directly.
+    """
+    app, _client, _key_pem, expected_cert_pem = (
+        proxy_app_with_seeded_legacy_org_ca
+    )
+
+    from mcp_proxy.db import get_config, list_legacy_pki_archive
+    assert await get_config("org_ca_key") is None, (
+        "legacy org_ca_key plaintext must be deleted from proxy_config "
+        "after Phase 0 migrate+wipe"
+    )
+    # Cert kept for back-compat readers.
+    assert await get_config("org_ca_cert") == expected_cert_pem
+
+    archive = await list_legacy_pki_archive()
+    org_rows = [r for r in archive if r["key_type"] == "org_ca"]
+    assert len(org_rows) >= 1, (
+        "legacy_pki_archive must record the archived plaintext key for forensic recovery"
+    )
+
+    # And the chain still works end-to-end: agent cert minted under
+    # the Intermediate (the cascade-fail surface pre-fix).
+    mgr = app.state.agent_manager
+    cert_pem, _ = mgr._generate_agent_cert("alice")
+    cert = _load_cert(cert_pem)
+    issuer_cn = cert.issuer.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME,
+    )[0].value
+    assert issuer_cn.endswith("Mastio CA"), (
+        f"agent cert must chain under the migrated Intermediate, got CN={issuer_cn!r}"
+    )


### PR DESCRIPTION
## Summary

Wave 1-A bootstrap follow-up to PR #794. Fixes the cascade failure on
`./sandbox/demo.sh full` after the Alembic multi-head mask was removed:
the Mastio could not load an Org Root on first boot because Phase 0
wipe deleted the only plaintext copy of the keypair before the
encrypted `pki_key_store` row existed, and federated mode
(`MCP_PROXY_STANDALONE=false`) short-circuited the `generate_org_ca`
fallback. Phase 0 now **migrates** the legacy `org_ca_key` /
`mastio_ca_key` rows into `pki_key_store` before archiving + deleting,
so the same boot's `load_org_ca_from_config` finds the keypair on the
next call. Trust pinning is preserved (we migrate the existing pubkey,
not regen a fresh one), so cross-org federation
(`organizations.mastio_pubkey` on the Court) survives the upgrade
unchanged.

## Discovery

Finding 4 of the post-PR-#794 pre-test validation. Pre-#794 the
multi-head Alembic mask blocked setup on `mastio-a` / `proxy-b-init`
earlier in the chain. Once the head was unified
(`0040_merge_grace_webauthn`), the boot progressed far enough to hit
this gap: legacy plaintext rows seeded by
`sandbox/proxy-init/seed.py` got wiped before `pki_key_store` was
populated, and the Mastio Intermediate mint refused to run without a
parent.

## Root cause

The lifespan in `mcp_proxy/main.py:283-336` sequences:

1. `wipe_legacy_pki_if_present()` — archives `proxy_config.org_ca_key`
   into `legacy_pki_archive`, then **deletes** the row from
   `proxy_config`. Cert row stays for legacy `/pki/ca.crt`.
2. `load_org_ca_from_config()` — calls
   `LocalKMSProvider.load_org_ca`:
   - `pki_key_store` empty (encrypted store never populated)
   - fallback `get_config('org_ca_key')` → `None` (deleted in Phase 0)
   - returns `None` → `ca_loaded=False`.
3. `if settings.standalone and not agent_mgr.ca_loaded: generate_org_ca`
   — skipped because `MCP_PROXY_STANDALONE=false` in sandbox /
   federated deployments.
4. `if agent_mgr.ca_loaded: ensure_mastio_identity()` —
   skipped. `ensure_nginx_server_cert` also skipped → nginx sidecar
   reports unhealthy → cascade fail.

`wipe_legacy_pki_if_present`'s docstring claimed it would only wipe
"when the new `pki_key_store` has already been populated," but the
code only gated on `pki_master_key_configured()` — the env var
presence, not the actual encrypted row.

## Fix

`mcp_proxy/egress/agent_manager.py::wipe_legacy_pki_if_present` now
performs a migrate-then-wipe sequence:

1. Detect legacy plaintext rows (as before).
2. Bail if `MCP_PROXY_DB_ENCRYPTION_KEY` is missing (as before).
3. **NEW**: call `KMSProvider.store_org_ca(legacy_key, legacy_cert)`
   to encrypt the existing keypair into `pki_key_store` before
   archiving. `LocalKMSProvider._store` is idempotent on identical
   material (fast-path returns when an active row with the same
   `key_id` already exists), so a second boot does not produce
   duplicate `pki_key_store` rows.
4. Archive plaintext into `legacy_pki_archive` and delete from
   `proxy_config` (existing behavior).
5. Same flow for `mastio_ca_key` / `mastio_ca_cert`. The Intermediate
   migration runs independently — if `org_ca` migration succeeded and
   the Intermediate migration fails, the org_ca wipe still counts but
   the Intermediate plaintext stays for the next boot.

If `provider.store_org_ca` raises, the wipe is aborted before the
archive+delete, so the operator never loses the only copy of the Org
Root keypair from a failed migration. Audit log entries
`pki.legacy_wipe` now carry `migrated_to=pki_key_store
archived_to=legacy_pki_archive` to signal the new path.

## Test plan

- [x] `pytest tests/test_pki_three_tier_hardening.py -v` — 9/9 green
  (7 existing + 2 new).
- [x] `pytest tests/test_kms_fernet_at_rest.py -v` — 7/7 green
  (no regressions on the KMS provider).
- [x] `pytest tests/ -n auto --dist=loadfile` — full parallel suite
  green.
- [ ] `./sandbox/demo.sh down && ./sandbox/demo.sh full` —
  end-to-end gate (Finding 4 was originally a `proxy-b-init` /
  `mastio-a` boot failure). To run by reviewer with docker.
- [ ] Smoke pre-push (`./sandbox/smoke.sh full`) — same gate as
  above.

New tests in `tests/test_pki_three_tier_hardening.py`:

1. `test_bootstrap_migrates_legacy_org_ca_into_pki_key_store` — seeds
   `proxy_config.org_ca_key` + `org_ca_cert` plaintext rows like
   `sandbox/proxy-init/seed.py` does, runs the lifespan in federated
   mode (`MCP_PROXY_STANDALONE=false`), then asserts:
   - `ca_loaded=True` after lifespan (regression surface).
   - `_mastio_ca_cert` not None (Intermediate minted under the
     migrated Org Root).
   - `_active_key` not None (leaf issued).
   - `_org_ca_cert` DER matches the seeded pubkey (NO regen —
     migration preserves the federation trust pin).
   - `pki_key_store.org_ca` active row exists with matching
     `cert_pem`.
2. `test_bootstrap_legacy_plaintext_rows_are_archived` — same fixture,
   asserts the legacy `proxy_config.org_ca_key` is gone post-migration
   while `org_ca_cert` is kept for back-compat readers, the row was
   archived into `legacy_pki_archive`, and the full chain still mints
   agent certs under the new Intermediate.

## Files touched

- `mcp_proxy/egress/agent_manager.py` — `wipe_legacy_pki_if_present`
  rewritten with migration step, refused-to-wipe-on-migration-failure
  semantics, refreshed docstring.
- `tests/test_pki_three_tier_hardening.py` — new
  `proxy_app_with_seeded_legacy_org_ca` fixture + 2 regression tests.
- `CHANGELOG.md` — Fixed section entry under `[Unreleased]`.

No changes to `app/`, `cullis_connector/`, `cullis_sdk/`, `sdk-ts/`,
`frontend/`, Alembic, watcher daemons, Frontdesk WebAuthn paths, or
the `main.py` lifespan ordering.
