### PR TITLE
test: parallelize via loadgroup + tmpfs + trigger cleanup (11m → 1m43s)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -26,4 +26,8 @@ markers =
         2026-05-15 quick win #2.
 
 # Skip the e2e marker by default. The unit suite still runs everything else.
-addopts = -m "not e2e" -n auto --dist=loadfile
+# ``--dist=loadgroup`` work-steals at item level except for files marked with
+# ``pytestmark = pytest.mark.xdist_group(name="serial_*")`` which stay colocated
+# on a single worker. Cuts wall-clock by ~5x vs ``loadfile`` on 16-thread hosts
+# by unblocking intra-file parallelism for files with N independent slow tests.
+addopts = -m "not e2e" -n auto --dist=loadgroup

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,15 @@
 import os
+import tempfile
+
+# Route pytest tmp_path + every temporary file through tmpfs when the host
+# exposes one. 80+ test files write disk-backed SQLite via tmp_path; on ext4
+# the fsync storm dominated wall-clock. /dev/shm is RAM-backed so the cost
+# collapses. No-op on hosts without /dev/shm (e.g. macOS).
+if os.path.isdir("/dev/shm") and os.access("/dev/shm", os.W_OK):
+    _shm_tmp = "/dev/shm/pytest-tmp"
+    os.makedirs(_shm_tmp, exist_ok=True)
+    os.environ.setdefault("TMPDIR", _shm_tmp)
+    tempfile.tempdir = _shm_tmp
 
 # M3.6 — disable broker queue ops invoked from lifespan/WS-connect paths.
 # The in-memory SQLite StaticPool used in tests cannot sustain the
@@ -168,6 +179,57 @@ async def setup_db():
     yield
     async with test_engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
+
+
+# Cached at module level so the autouse wipe doesn't re-query sqlite_master
+# for every test. Populated lazily on first wipe.
+_COURT_TABLES_FOR_WIPE: list[str] | None = None
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _wipe_court_db_between_unmarked_tests(request):
+    """Cross-test DB isolation for tests that don't opt into a serial group.
+
+    With ``--dist=loadgroup`` xdist co-locates only tests sharing an
+    ``xdist_group`` marker. Unmarked tests are work-stolen individually
+    across workers, and two unrelated tests can land on the same worker
+    process — which means they share the module-global ``test_engine``
+    + ``TestSessionLocal`` (:memory: SQLite, StaticPool). Cross-test
+    pollution then breaks any test that asserts on row counts (e.g.
+    test_audit_export_tsa, test_user_inbox, test_reach_policy).
+
+    Tests inside an ``xdist_group="serial_*"`` cluster intentionally
+    chain state across multiple test functions (e.g. test_e2e step1→10
+    builds up an org + session + binding incrementally), so the wipe is
+    skipped for them.
+    """
+    yield
+    if request.node.get_closest_marker("xdist_group"):
+        return
+    global _COURT_TABLES_FOR_WIPE
+    from sqlalchemy import text
+    async with test_engine.begin() as conn:
+        if _COURT_TABLES_FOR_WIPE is None:
+            result = await conn.execute(text(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%' "
+                "AND name != 'alembic_version'"
+            ))
+            _COURT_TABLES_FOR_WIPE = [row[0] for row in result.fetchall()]
+        for t in _COURT_TABLES_FOR_WIPE:
+            try:
+                await conn.execute(text(f'DELETE FROM "{t}"'))
+            except Exception:
+                # Tables with an append-only trigger installed by a
+                # specific test (e.g. test_wave_b_pr5 explicitly creates
+                # the trigger) can't be wiped via DELETE. Those tests
+                # are themselves marked xdist_group so this branch is
+                # only hit if the trigger leaks across tests — at which
+                # point the next test will inherit a wedged table, but
+                # that's a pre-existing problem, not one this fixture
+                # introduces.
+                pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/connector/test_csr_flow.py
+++ b/tests/connector/test_csr_flow.py
@@ -18,6 +18,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from fastapi.testclient import TestClient
 
+pytestmark = pytest.mark.xdist_group(name="serial_csr_flow")
+
 from cullis_connector.ambassador.shared.credentials import (
     UserCredentialCache,
 )

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -6,7 +6,10 @@ from sqlalchemy import update
 from app.db.audit import AuditLog, log_event, verify_chain
 from tests.conftest import TestSessionLocal
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_audit_chain"),
+]
 
 
 @pytest_asyncio.fixture

--- a/tests/test_audit_export_tsa.py
+++ b/tests/test_audit_export_tsa.py
@@ -17,7 +17,10 @@ from app.db.audit import AuditLog, AuditTsaAnchor, log_event, log_event_cross_or
 from tests.conftest import TestSessionLocal
 
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_audit_export_tsa"),
+]
 
 _SCRIPT = Path(__file__).parent.parent / "scripts" / "cullis-audit-verify.py"
 

--- a/tests/test_cert_expiry_watcher.py
+++ b/tests/test_cert_expiry_watcher.py
@@ -32,6 +32,8 @@ from cryptography.x509.oid import NameOID
 
 import mcp_proxy.lifespan.cert_expiry_watcher as watcher_mod
 
+pytestmark = pytest.mark.xdist_group(name="serial_cert_expiry_watcher")
+
 
 # ─── helpers ───────────────────────────────────────────────────────────
 

--- a/tests/test_dashboard_api_tokens.py
+++ b/tests/test_dashboard_api_tokens.py
@@ -21,6 +21,8 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+pytestmark = pytest.mark.xdist_group(name="serial_dashboard_api_tokens")
+
 
 @pytest_asyncio.fixture
 async def proxy_logged_in(tmp_path, monkeypatch):

--- a/tests/test_dashboard_first_boot.py
+++ b/tests/test_dashboard_first_boot.py
@@ -13,7 +13,10 @@ from httpx import AsyncClient
 
 from app.config import get_settings
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_dashboard_first_boot"),
+]
 
 
 FRESH_BOOTSTRAP_TOKEN = "fresh-deploy-bootstrap-token-for-tests"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -24,7 +24,10 @@ from httpx import AsyncClient
 from tests.cert_factory import make_assertion, get_org_ca_pem, make_encrypted_envelope, DPoPHelper
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_e2e"),
+]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -37,7 +37,10 @@ def _pg_available():
     except OSError:
         return False
 
-pytestmark = pytest.mark.skipif(not _pg_available(), reason="Postgres not available")
+pytestmark = [
+    pytest.mark.skipif(not _pg_available(), reason="Postgres not available"),
+    pytest.mark.xdist_group(name="serial_postgres_integration"),
+]
 
 pg_engine = create_async_engine(POSTGRES_URL, echo=False, poolclass=NullPool)
 PgSession = async_sessionmaker(pg_engine, expire_on_commit=False)

--- a/tests/test_reach_policy.py
+++ b/tests/test_reach_policy.py
@@ -27,7 +27,10 @@ from app.policy.reach import (
 )
 from tests.conftest import TestSessionLocal
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_reach_policy"),
+]
 
 
 # ── fixtures ────────────────────────────────────────────────────────

--- a/tests/test_require_mastio_mtls_admin.py
+++ b/tests/test_require_mastio_mtls_admin.py
@@ -15,7 +15,10 @@ from httpx import AsyncClient
 from app.config import get_settings
 from tests.cert_factory import get_org_ca_pem
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_require_mastio_mtls_admin"),
+]
 
 ADMIN_SECRET = get_settings().admin_secret
 

--- a/tests/test_revocation.py
+++ b/tests/test_revocation.py
@@ -21,7 +21,10 @@ from tests.cert_factory import (
 )
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_revocation"),
+]
 
 from app.config import get_settings
 ADMIN_SECRET = get_settings().admin_secret

--- a/tests/test_rfq.py
+++ b/tests/test_rfq.py
@@ -17,7 +17,10 @@ from httpx import AsyncClient
 from tests.cert_factory import get_org_ca_pem
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_rfq"),
+]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -22,7 +22,10 @@ from tests.cert_factory import (
 from app.broker.session import Session, SessionStatus, SessionStore
 from tests.conftest import seed_court_agent, seed_court_agent_sync
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_security_fixes"),
+]
 
 
 # ────────────────────────────────────────────────────────────────────────

--- a/tests/test_spiffe.py
+++ b/tests/test_spiffe.py
@@ -22,6 +22,8 @@ from app.spiffe import (
 from tests.cert_factory import make_agent_cert, make_assertion, get_org_ca_pem
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
+pytestmark = pytest.mark.xdist_group(name="serial_spiffe")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Test mapping bidirezionale
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -15,7 +15,10 @@ from httpx import AsyncClient
 from tests.cert_factory import make_assertion, get_org_ca_pem
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_token_revocation"),
+]
 
 
 async def _setup_agent(client: AsyncClient, agent_id: str, org_id: str, dpop) -> str:

--- a/tests/test_updates_admin_endpoint.py
+++ b/tests/test_updates_admin_endpoint.py
@@ -29,6 +29,8 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+pytestmark = pytest.mark.xdist_group(name="serial_updates_admin_endpoint")
+
 from mcp_proxy.updates import registry as registry_mod
 from mcp_proxy.updates.base import Migration
 

--- a/tests/test_user_inbox.py
+++ b/tests/test_user_inbox.py
@@ -32,7 +32,10 @@ from app.policy.reach import (
 )
 from tests.conftest import TestSessionLocal
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_user_inbox"),
+]
 
 
 @pytest_asyncio.fixture

--- a/tests/test_wave_b_pr5_court_audit_append_only.py
+++ b/tests/test_wave_b_pr5_court_audit_append_only.py
@@ -17,10 +17,14 @@ same SQL the migration emits for SQLite.
 from __future__ import annotations
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import text
 
 
-pytestmark = pytest.mark.asyncio
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.xdist_group(name="serial_wave_b_pr5_court_audit_append_only"),
+]
 
 
 _SQLITE_TRIGGER_SQL = [
@@ -53,6 +57,32 @@ async def _install_triggers(db) -> None:
     for sql in _SQLITE_TRIGGER_SQL:
         await db.execute(text(sql))
     await db.commit()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _drop_audit_log_triggers_after_test():
+    """The append-only triggers installed by ``_install_triggers`` use
+    ``CREATE TRIGGER IF NOT EXISTS`` on the session-scoped ``:memory:``
+    SQLite (one DB per xdist worker process). Without an explicit DROP
+    they survive into the next test on the same worker, which then sees
+    ``DELETE FROM audit_log`` rejected with ``RAISE(ABORT)`` —
+    deterministically breaking ``test_audit_export_tsa`` and the
+    conftest auto-wipe fixture.
+
+    ``--dist=loadfile`` used to mask this because audit-related tests
+    landed on a dedicated worker; ``loadgroup`` distributes more
+    aggressively and surfaces the leak.
+    """
+    yield
+    from app.db.database import get_db
+    async for db in get_db():
+        bind = db.get_bind()
+        if bind.dialect.name != "sqlite":
+            break
+        await db.execute(text("DROP TRIGGER IF EXISTS audit_log_no_update"))
+        await db.execute(text("DROP TRIGGER IF EXISTS audit_log_no_delete"))
+        await db.commit()
+        break
 
 
 async def test_log_event_writes_v2_hash_format(client):

--- a/tests/test_wave_b_pr8_audit_replication.py
+++ b/tests/test_wave_b_pr8_audit_replication.py
@@ -25,6 +25,7 @@ import json
 from datetime import datetime, timezone
 
 import pytest
+import pytest_asyncio
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from httpx import AsyncClient
@@ -33,7 +34,11 @@ from sqlalchemy import select
 from tests.cert_factory import get_org_ca_pem
 from tests.conftest import ADMIN_HEADERS
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.mastio_strict]
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.mastio_strict,
+    pytest.mark.xdist_group(name="serial_wave_b_pr8_audit_replication"),
+]
 
 
 def _gen_mastio_keypair():
@@ -453,6 +458,33 @@ async def test_org_without_pinned_pubkey_rejected(client: AsyncClient):
     )
     assert r.status_code == 403
     assert "pubkey" in r.text.lower() or "pinned" in r.text.lower()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _drop_replica_triggers_after_test():
+    """Mirror of the cleanup in test_wave_b_pr5: drop the
+    ``mastio_audit_replica`` append-only triggers after each test so
+    they don't leak into other tests on the same xdist worker (which
+    would break any DELETE/UPDATE on the replica table).
+    """
+    yield
+    from sqlalchemy import text
+    from app.db.database import engine
+
+    is_pg = engine.dialect.name == "postgresql"
+    async with engine.begin() as conn:
+        if is_pg:
+            await conn.execute(text(
+                "DROP TRIGGER IF EXISTS mastio_audit_replica_no_update_or_delete "
+                "ON mastio_audit_replica"
+            ))
+        else:
+            await conn.execute(text(
+                "DROP TRIGGER IF EXISTS mastio_audit_replica_no_update"
+            ))
+            await conn.execute(text(
+                "DROP TRIGGER IF EXISTS mastio_audit_replica_no_delete"
+            ))
 
 
 async def _install_replica_triggers():


### PR DESCRIPTION
## Summary

- Switch pytest-xdist from `--dist=loadfile` to `--dist=loadgroup` + autouse cross-test DB isolation + tmpfs TMPDIR. Cuts the full suite from **11m01s to 1m43s mediana (6.4x)** with CPU utilisation moving from ~12% to ~70% on the 16-thread dev host.
- Fix architectural trigger leak in `test_wave_b_pr5_court_audit_append_only` + `test_wave_b_pr8_audit_replication`: SQLite `BEFORE UPDATE/DELETE` triggers were installed via `CREATE TRIGGER IF NOT EXISTS` and never dropped, breaking any later `DELETE FROM audit_log` on the same xdist worker. `loadfile` masked the leak because audit tests parked on a dedicated worker.
- 18 test files marked with `pytestmark = pytest.mark.xdist_group(name="serial_*")` so files whose tests share intra-file setup (test_e2e step1→10, CLI flows, RFQ chains, etc.) stay co-located on a single worker — recovering the `loadfile` guarantee on the files that need it without serialising the rest.

## Mechanics

1. **`pytest.ini`**: addopts `--dist=loadfile` → `--dist=loadgroup`.
2. **`tests/conftest.py`**:
   - TMPDIR rerouted to `/dev/shm` (tmpfs) when available. 80+ test files write disk-backed SQLite via tmp_path; on ext4 the fsync storm dominated wall-clock.
   - Autouse fixture `_wipe_court_db_between_unmarked_tests` does post-test `DELETE FROM ...` across every Court table. Tests inside an `xdist_group=\"serial_*\"` cluster skip the wipe (they chain state intentionally).
3. **Trigger teardown**: autouse `DROP TRIGGER IF EXISTS` in the two append-only test files.
4. **18 module-level markers** (kept exhaustively to cover every file caught by 5-run mapping + iteration loops).

## Validation

5 consecutive full-suite runs after these changes — **all 5 identical**:
\`\`\`
4026 passed, 1 failed [pre-existing test_dashboard_approvals_nav], 32 skipped
1m39s → 1m48s wall, mediana 1m43s
\`\`\`

No new flake introduced. The pre-existing failure (`test_badge_approvals_empty_when_plugin_unavailable`) is unrelated — same fail on `main` with the old config.

## Test plan

- [ ] Maintainer: run `pytest tests/ --disable-warnings` once locally and confirm wall + fail count
- [ ] Maintainer: smoke `./sandbox/smoke.sh full` to confirm no production-code regression from the conftest changes