### PR TITLE
fix(pki): write nginx server cert as full chain bundle (Wave 1-A bootstrap follow-up #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ flow until the next `## ` heading.
   `pki.nginx_server_cert_rotated` per rotation.
 
 ### Fixed
+- `AgentManager.ensure_nginx_server_cert` now writes
+  `mastio-server.crt` as a **full chain bundle** (leaf || Mastio
+  Intermediate) instead of leaf-only. Pre-fix the file held only the
+  Intermediate-signed leaf, so strict TLS clients (Python `ssl`,
+  OpenSSL, Go `crypto/tls`) whose trust store contains only the Org
+  Root cert (the sandbox / standalone bundle layout) failed the
+  handshake with `unable to get local issuer certificate`, the path
+  `Leaf -> Intermediate -> Org Root` was un-buildable. Symptom
+  observed in `./sandbox/demo.sh full` post-PR #795: agent-a, agent-b,
+  byoca-a unhealthy with `broker https://mastio-nginx-a:9443 not
+  reachable`. The reuse path also regenerates a pre-fix single-cert
+  `mastio-server.crt` on next boot so upgrades self-heal without
+  manual file deletion. Wave 1-A bootstrap follow-up #2 to PR #788
+  (which had already updated the `org-ca.crt` trust bundle to the
+  full chain but missed the server cert path).
 - Phase 0 PKI bootstrap now **migrates** legacy plaintext
   `proxy_config.org_ca_key` / `mastio_ca_key` rows into the encrypted
   `pki_key_store` table before archiving and deleting them. Pre-fix

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -640,8 +640,13 @@ class AgentManager:
         - ``org-ca.crt`` — the Org CA's public certificate (the trust
           bundle nginx uses as ``ssl_client_certificate`` to verify
           Connector certs at the TLS handshake).
-        - ``mastio-server.crt`` — the leaf cert nginx serves on 9443,
-          signed by the Org CA, with the requested SANs.
+        - ``mastio-server.crt`` — the **full chain bundle** nginx serves
+          on 9443: leaf (Intermediate-signed, with the requested SANs)
+          followed by the Mastio Intermediate cert. Without the
+          Intermediate in the bundle, a client whose trust store holds
+          only the Org Root cannot build the path ``Leaf -> Intermediate
+          -> Org Root`` and rejects the handshake with
+          ``unable to get local issuer certificate``.
         - ``mastio-server.key`` — the leaf's private key.
 
         Idempotent: at every boot the method checks whether the existing
@@ -701,7 +706,16 @@ class AgentManager:
         reuse = False
         if ca_path.exists() and crt_path.exists() and key_path.exists():
             try:
-                existing = x509.load_pem_x509_certificate(crt_path.read_bytes())
+                # The on-disk crt is a bundle (leaf + Intermediate, audit
+                # 2026-05-18 follow-up #2). A pre-fix single-cert file
+                # falls through to the mint path because it is missing
+                # the Intermediate that strict TLS clients need to build
+                # the chain.
+                existing_bundle_bytes = crt_path.read_bytes()
+                bundle_blocks = existing_bundle_bytes.count(
+                    b"-----BEGIN CERTIFICATE-----",
+                )
+                existing = x509.load_pem_x509_certificate(existing_bundle_bytes)
                 # SAN match — read DNSName + IPAddress because the same
                 # ``san_list`` may contain both (now that we split). A
                 # cert that already carries the right entries — even if
@@ -749,7 +763,8 @@ class AgentManager:
                     and existing_ips == set(san_ips)
                 )
 
-                if issuer_ok and expiry_ok and ca_ok and sans_ok:
+                bundle_ok = bundle_blocks == 2
+                if issuer_ok and expiry_ok and ca_ok and sans_ok and bundle_ok:
                     reuse = True
             except Exception as exc:  # treat any parse failure as "regenerate"
                 logger.info(
@@ -844,7 +859,18 @@ class AgentManager:
             self._org_ca_cert.public_bytes(serialization.Encoding.PEM)
             + self._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
         )
-        crt_pem = leaf_cert.public_bytes(serialization.Encoding.PEM)
+        # Three-tier PKI hardening (audit 2026-05-18) follow-up #2:
+        # ``mastio-server.crt`` is now a full chain bundle
+        # (leaf || Intermediate). Strict TLS clients (Python ssl,
+        # OpenSSL, Go crypto/tls) require the Intermediate to build the
+        # path ``Leaf -> Intermediate -> Org Root`` when only the Org
+        # Root is in the trust store. Standard PEM ordering: leaf first,
+        # then Intermediate; the root is omitted because it lives in the
+        # client trust store.
+        crt_pem = (
+            leaf_cert.public_bytes(serialization.Encoding.PEM)
+            + self._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
+        )
         key_pem = leaf_key.private_bytes(
             serialization.Encoding.PEM,
             serialization.PrivateFormat.PKCS8,

--- a/tests/test_pki_three_tier_hardening.py
+++ b/tests/test_pki_three_tier_hardening.py
@@ -452,3 +452,149 @@ async def test_bootstrap_legacy_plaintext_rows_are_archived(
     assert issuer_cn.endswith("Mastio CA"), (
         f"agent cert must chain under the migrated Intermediate, got CN={issuer_cn!r}"
     )
+
+
+# ── Wave 1-A bootstrap follow-up #2: nginx server cert full chain ──────
+
+
+def _split_pem_bundle(bundle_bytes: bytes) -> list[x509.Certificate]:
+    """Parse every cert block in a PEM bundle, preserving order."""
+    marker = b"-----BEGIN CERTIFICATE-----"
+    end_marker = b"-----END CERTIFICATE-----"
+    certs: list[x509.Certificate] = []
+    cursor = 0
+    while True:
+        start = bundle_bytes.find(marker, cursor)
+        if start == -1:
+            break
+        end = bundle_bytes.find(end_marker, start)
+        if end == -1:
+            break
+        block = bundle_bytes[start:end + len(end_marker)]
+        certs.append(x509.load_pem_x509_certificate(block))
+        cursor = end + len(end_marker)
+    return certs
+
+
+@pytest.mark.asyncio
+async def test_ensure_nginx_server_cert_writes_full_chain_bundle(
+    proxy_app, tmp_path,
+):
+    """``mastio-server.crt`` must hold ``leaf || Intermediate``.
+
+    Finding 5 (sandbox dogfood 2026-05-18 post-PR #795): pre-fix the
+    server cert file contained only the Intermediate-issued leaf, so
+    strict TLS clients with only the Org Root in their trust store
+    failed the handshake with ``unable to get local issuer certificate``.
+    """
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    out_dir = tmp_path / "nginx-certs"
+    await mgr.ensure_nginx_server_cert(
+        out_dir=str(out_dir), sans=["mastio.local"],
+    )
+
+    bundle_bytes = (out_dir / "mastio-server.crt").read_bytes()
+    block_count = bundle_bytes.count(b"-----BEGIN CERTIFICATE-----")
+    assert block_count == 2, (
+        f"mastio-server.crt must hold (leaf || Intermediate); got "
+        f"{block_count} cert blocks"
+    )
+
+    certs = _split_pem_bundle(bundle_bytes)
+    assert len(certs) == 2
+    leaf, intermediate = certs
+
+    # Ordering: leaf first (standard PEM bundle).
+    leaf_san_ext = leaf.extensions.get_extension_for_class(
+        x509.SubjectAlternativeName,
+    ).value
+    assert "mastio.local" in leaf_san_ext.get_values_for_type(x509.DNSName), (
+        "first cert in the bundle must be the leaf"
+    )
+    # Second cert is the Intermediate (CA=True, CN ends with 'Mastio CA').
+    int_bc = intermediate.extensions.get_extension_for_class(
+        x509.BasicConstraints,
+    ).value
+    assert int_bc.ca is True, "second cert in the bundle must be a CA"
+    int_cn = intermediate.subject.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME,
+    )[0].value
+    assert int_cn.endswith("Mastio CA"), (
+        f"second cert must be the Mastio Intermediate, got CN={int_cn!r}"
+    )
+
+    # Bundle order matches the chain: leaf.issuer == intermediate.subject.
+    assert leaf.issuer.rfc4514_string() == intermediate.subject.rfc4514_string()
+
+    # And the on-disk Intermediate equals the one currently held by the
+    # manager (no stale or drifted copy).
+    assert (
+        intermediate.public_bytes(serialization.Encoding.DER)
+        == mgr._mastio_ca_cert.public_bytes(serialization.Encoding.DER)
+    )
+
+
+@pytest.mark.asyncio
+async def test_nginx_server_cert_chain_validates_against_org_root_only(
+    proxy_app, tmp_path,
+):
+    """Client with only the Org Root in trust store validates the chain.
+
+    Re-creates the sandbox client trust model: agent + Connector ship
+    with the Org Root cert as their TLS trust anchor (``/state/{org}/
+    ca.pem``). They MUST be able to build the full path
+    ``Leaf -> Intermediate -> Org Root`` from what nginx serves. If the
+    server bundle is leaf-only, path building fails with
+    ``unable to get local issuer certificate`` (Finding 5).
+    """
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    out_dir = tmp_path / "nginx-certs"
+    await mgr.ensure_nginx_server_cert(
+        out_dir=str(out_dir), sans=["mastio.local"],
+    )
+
+    bundle_bytes = (out_dir / "mastio-server.crt").read_bytes()
+    certs = _split_pem_bundle(bundle_bytes)
+    assert len(certs) == 2, "bundle must hold leaf + Intermediate"
+    leaf, intermediate = certs
+    org_root = mgr._org_ca_cert
+    assert org_root is not None
+
+    # Manual chain build, matching what stdlib verifiers do under the
+    # hood: from the leaf, follow issuer up until we hit a self-signed
+    # trust anchor that is present in the trust store. The trust store
+    # here holds ONLY the Org Root (simulating ``ca.pem`` on the agent
+    # side). The Intermediate must come from what the server presented
+    # in the bundle.
+    intermediate.public_key().verify(
+        leaf.signature,
+        leaf.tbs_certificate_bytes,
+        ec.ECDSA(leaf.signature_hash_algorithm),
+    )
+    org_root.public_key().verify(
+        intermediate.signature,
+        intermediate.tbs_certificate_bytes,
+        ec.ECDSA(intermediate.signature_hash_algorithm),
+    )
+    # Org Root is the trust anchor (self-signed).
+    assert org_root.issuer.rfc4514_string() == org_root.subject.rfc4514_string()
+    org_root.public_key().verify(
+        org_root.signature,
+        org_root.tbs_certificate_bytes,
+        ec.ECDSA(org_root.signature_hash_algorithm),
+    )
+
+    # Negative control: a trust store WITHOUT the Intermediate but only
+    # the leaf cannot build the chain (this is the pre-fix failure mode
+    # we are guarding against). Verify that without the Intermediate
+    # present in the bundle, signature verification of the leaf against
+    # the Org Root pubkey fails — proving the Intermediate is load-
+    # bearing for chain construction.
+    with pytest.raises(Exception):
+        org_root.public_key().verify(
+            leaf.signature,
+            leaf.tbs_certificate_bytes,
+            ec.ECDSA(leaf.signature_hash_algorithm),
+        )


### PR DESCRIPTION
## Summary

`AgentManager.ensure_nginx_server_cert` writes `mastio-server.crt` as a **full chain bundle** (leaf || Mastio Intermediate) instead of leaf-only. The reuse path also regenerates a pre-fix single-cert file on next boot, so upgrades self-heal without manual file deletion.

## Discovery

Finding 5 from sandbox dogfood **2026-05-18 post-PR #795** (Org Root regeneration fix). After Phase 0 bootstrap migration landed, `./sandbox/demo.sh full` came up with all containers in `(healthy)` state but `agent-a`, `agent-b`, `byoca-a` immediately failed with:

```
broker https://mastio-nginx-a:9443 not reachable
```

The container probe was actually a TLS handshake failure: `unable to get local issuer certificate`.

## Root cause

PR #788 (three-tier PKI hardening) moved agent / Connector / nginx leaves from being Org-Root-signed to being **Mastio-Intermediate-signed**, and updated `org-ca.crt` (the `ssl_client_certificate` trust bundle) to hold `Org Root || Intermediate`.

But `ensure_nginx_server_cert` kept writing `mastio-server.crt` (the `ssl_certificate` nginx serves on 9443) as leaf-only. Strict TLS clients (Python `ssl`, OpenSSL, Go `crypto/tls`) whose trust store holds only the Org Root cert (the sandbox / standalone bundle layout, `/state/{org}/ca.pem`) could not build the path `Leaf -> Intermediate -> Org Root` from what the server presented and rejected the handshake.

## Fix

In `mcp_proxy/egress/agent_manager.py:ensure_nginx_server_cert`:

- Mint path: write `crt_pem = leaf_cert.PEM || self._mastio_ca_cert.PEM`. Standard PEM ordering: leaf first, Intermediate second, root omitted (it lives in the client trust store).
- Reuse path: validate the on-disk bundle has **2 `-----BEGIN CERTIFICATE-----` blocks**. A pre-fix single-cert file falls through to the mint path so upgrades self-heal on the next boot.
- Updated docstring to describe the bundle shape and the failure mode it guards against.

No changes to `app/`, `cullis_connector/`, `cullis_sdk/`, `sdk-ts/`, `frontend/`, `mcp_proxy/auth/*`, sandbox bootstrap, leader-elected watcher, alembic, or WebAuthn (all out of scope per the prompt).

## Test plan

- [x] `pytest tests/test_pki_three_tier_hardening.py -v` — 11/11 passed (9 pre-existing + 2 new)
- [x] Full parallel suite `pytest tests/ -n auto --dist=loadfile` — 4053 passed, 3 pre-existing fails on `main` unrelated to this fix (`test_badge_approvals_empty_when_plugin_unavailable`, 2 `test_lifespan_tier_matrix_cache.py` parallel-only flake)
- [x] `./sandbox/smoke.sh full` — 25 PASS / 0 FAIL / 1 SKIP
- [x] `./sandbox/demo.sh full` — all 19 containers healthy in ~60s, no `broker not reachable` cascade
- [x] `docker exec sandbox-mastio-nginx-a-1 sh -c 'grep -c "BEGIN CERTIFICATE" /etc/nginx/certs/mastio-server.crt'` → `2` (was `1` pre-fix on `main`)
- [x] Same check on `sandbox-mastio-nginx-b-1` → `2`
- [x] `./sandbox/demo.sh oneshot-a-to-b` — cross-org A2A enqueued end-to-end

## New tests

1. `test_ensure_nginx_server_cert_writes_full_chain_bundle` — bundle has 2 cert blocks, leaf is first (SAN `mastio.local`), second is the Mastio Intermediate (CA=true, CN ends with `Mastio CA`), `leaf.issuer == intermediate.subject`, and the on-disk Intermediate DER equals the one held by the manager.
2. `test_nginx_server_cert_chain_validates_against_org_root_only` — manual chain build using only the Org Root as trust anchor: intermediate.pubkey verifies leaf signature, org_root.pubkey verifies intermediate signature, org_root is self-signed. Negative control: org_root.pubkey rejects leaf signature directly, proving the Intermediate is load-bearing for chain construction.

## Hotfix verified live 2026-05-18

Before this PR, hotfix in sandbox was:

```bash
docker exec sandbox-mastio-nginx-a-1 sh -c \
  'cat /etc/nginx/certs/mastio-intermediate.crt >> /etc/nginx/certs/mastio-server.crt && \
   nginx -s reload'
```

All agents immediately went healthy. This PR produces the same bundle shape from the code path so the hotfix is no longer needed.

## DCO

- [x] `git commit -s`