### PR TITLE
fix(stress): k6 wrapper with EXIT-trap NDJSON cleanup

### DIFF
--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -30,25 +30,54 @@ a JSON dump (`summary.json`, `soak-summary.json`,
 # walkthrough). The script targets the public TLS edge by default.
 ./deploy.sh
 
-# Run the scenario (override BASE_URL when the stack is elsewhere).
+# Quick smoke / triage (<10 min): run k6 directly, summary only.
 cd scripts/stress
 nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify health-throughput.js"
 
+# Soak / burst (any run that writes raw NDJSON output): use the
+# wrapper. It traps EXIT and drops the ndjson if it exceeds 1 GiB,
+# keeping the summary JSON. See "NDJSON cleanup wrapper" below for
+# why this matters.
+nix-shell -p k6 --run "bash _run-k6.sh soak-stability.js"
+nix-shell -p k6 --run "bash _run-k6.sh intra-org-mastio-burst.js"
+
 # Or against a remote stack:
 BASE_URL=https://mastio.example.com:9443 \
-    k6 run --insecure-skip-tls-verify health-throughput.js
-
-# Soak (1h sustained 50 VUs, watch for RSS drift in a second terminal):
-nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify soak-stability.js"
-docker stats --no-stream cullis-mastio-mcp-proxy-1   # in another shell
+    nix-shell -p k6 --run "bash _run-k6.sh health-throughput.js"
 
 # Shorter soak smoke (e.g. validate the script itself):
-SOAK_MINUTES=2 k6 run --insecure-skip-tls-verify soak-stability.js
+SOAK_MINUTES=2 bash _run-k6.sh soak-stability.js
 ```
 
 The scripts write `summary.json` / `soak-summary.json` next to
 themselves and print a one-screen text summary to stdout. Both JSON
 artefacts are gitignored.
+
+### NDJSON cleanup wrapper (`_run-k6.sh`)
+
+`k6 --out json=` writes one NDJSON line per HTTP sample. At 2k req/s
+that's ~30 MiB/min — a 1h soak is ~1.8 GiB, a 30-min 5k-VU burst is
+~18 GiB, a 3h partial soak filled 89 GiB on 2026-05-18 and killed k6
+mid-run with ENOSPC. `_run-k6.sh` invokes k6 with the same `--out
+json=` + `--summary-export=` pair, then on EXIT (success or failure)
+drops the ndjson if it exceeded a threshold. The summary always
+survives.
+
+Tunables (env):
+
+- `K6_KEEP_NDJSON=1` — never drop the ndjson. Use this when you plan
+  to run `_analyze_burst.py` against it, or need forensic per-sample
+  data. Make sure the output dir lives on a disk with enough room.
+- `K6_NDJSON_KEEP_THRESHOLD_MB=<N>` — drop only if the ndjson grew
+  past N MiB. Default 1024.
+- `K6_RESULTS_DIR=<path>` — where to write ndjson + summary. Default
+  `/tmp/k6-run-<scenario>-<epoch>`. Point this at `/var/tmp` or a
+  dedicated mount when `K6_KEEP_NDJSON=1` for long runs, since `/`
+  hitting 100 % poisons every other process on the box.
+- `K6_EXTRA_ARGS="..."` — extra args appended to the k6 invocation.
+
+The wrapper also pre-flights `df` on the output dir and warns when
+less than 5 GiB is free.
 
 ## When to re-run
 
@@ -199,11 +228,17 @@ ssh cullis@192.168.122.170 "docker logs -f cullis-mastio-mcp-proxy-1 \
     2>&1 | grep -iE 'error|warning|429|503|circuit|busy|deadlock'" \
     > scripts/stress/mastio-errors.log &
 
-# 4. Run k6. Saves the raw ndjson stream + the summary export.
-nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify \
-    --out json=scripts/stress/intra-org-results.ndjson \
-    --summary-export=scripts/stress/intra-org-summary.json \
-    scripts/stress/intra-org-mastio-burst.js"
+# 4. Run k6. Use the wrapper with K6_KEEP_NDJSON=1 because the
+#    per-plateau analyzer (_analyze_burst.py) needs the raw ndjson.
+#    Point the output dir at the repo so the analyzer finds it.
+nix-shell -p k6 --run "K6_KEEP_NDJSON=1 \
+    K6_RESULTS_DIR=scripts/stress \
+    bash scripts/stress/_run-k6.sh intra-org-mastio-burst.js"
+# Wrapper writes scripts/stress/results.ndjson + scripts/stress/summary.json.
+# Rename to intra-org-* if you want the legacy file names the analyzer
+# defaults to, or pass the paths explicitly to _analyze_burst.py.
+# When the analysis is done, drop the ndjson — at 5k VUs it's
+# ~10 GiB per 30-min run.
 ```
 
 The k6 scenario can be re-shaped via env:

--- a/scripts/stress/_run-k6.sh
+++ b/scripts/stress/_run-k6.sh
@@ -84,8 +84,11 @@ fi
 echo "[_run-k6] scenario=${SCENARIO_NAME} results_dir=${RESULTS_DIR}" >&2
 echo "[_run-k6] keep_ndjson=${KEEP_NDJSON} threshold_mb=${KEEP_THRESHOLD_MB} tmp_free_mb=${TMP_FREE_MB}" >&2
 
+# Run k6 inline (not via exec) so the EXIT trap above can fire and
+# clean up the ndjson. With `exec` the bash process is replaced by
+# k6 and the trap is lost.
 # shellcheck disable=SC2086
-exec k6 run \
+k6 run \
     --insecure-skip-tls-verify \
     --out "json=${NDJSON}" \
     --summary-export="${SUMMARY}" \

--- a/scripts/stress/_run-k6.sh
+++ b/scripts/stress/_run-k6.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# _run-k6.sh: k6 wrapper with post-run NDJSON cleanup.
+#
+# Why: `k6 --out json=` writes one NDJSON line per HTTP sample. At 2k req/s
+# this is ~30 MiB/min. A 1h soak is ~1.8 GiB, a 30min 5k-VU burst is ~18 GiB,
+# a 3h partial soak is ~89 GiB. The 2026-05-18 incident saturated 107 GiB of
+# /tmp + 18 GiB in repo path, killed k6 mid-soak with ENOSPC, and lost the
+# tail of the telemetry. See memory feedback_k6_ndjson_saturates_tmp.
+#
+# What it does: invokes k6 with --out json=<ndjson> + --summary-export=<json>,
+# then on exit (success OR failure) drops the ndjson if it exceeded the size
+# threshold. The summary always survives. Override behaviour via env:
+#
+#   K6_KEEP_NDJSON=1                  Never drop ndjson (forensic / _analyze_burst.py).
+#   K6_NDJSON_KEEP_THRESHOLD_MB=<N>   Drop only if ndjson > N MiB. Default 1024.
+#   K6_RESULTS_DIR=<path>             Where to write ndjson + summary. Default
+#                                     /tmp/k6-run-<scenario>-<epoch>.
+#   K6_EXTRA_ARGS="..."               Extra args appended to the k6 invocation.
+#
+# Usage:
+#   bash scripts/stress/_run-k6.sh soak-stability.js
+#   bash scripts/stress/_run-k6.sh intra-org-mastio-burst.js
+#   K6_KEEP_NDJSON=1 bash scripts/stress/_run-k6.sh intra-org-mastio-burst.js
+#
+# Requires: k6 on PATH (use `nix-shell -p k6 --run "bash scripts/stress/_run-k6.sh ..."`
+# on NixOS).
+
+set -euo pipefail
+
+SCRIPT="${1:-}"
+if [[ -z "${SCRIPT}" ]]; then
+    echo "usage: $0 <scenario.js> [extra k6 args...]" >&2
+    exit 2
+fi
+shift
+
+STRESS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENARIO_PATH="${STRESS_DIR}/${SCRIPT}"
+if [[ ! -f "${SCENARIO_PATH}" ]]; then
+    echo "scenario not found: ${SCENARIO_PATH}" >&2
+    exit 2
+fi
+
+SCENARIO_NAME="$(basename "${SCRIPT}" .js)"
+EPOCH="$(date +%s)"
+RESULTS_DIR="${K6_RESULTS_DIR:-/tmp/k6-run-${SCENARIO_NAME}-${EPOCH}}"
+mkdir -p "${RESULTS_DIR}"
+
+NDJSON="${RESULTS_DIR}/results.ndjson"
+SUMMARY="${RESULTS_DIR}/summary.json"
+
+KEEP_NDJSON="${K6_KEEP_NDJSON:-0}"
+KEEP_THRESHOLD_MB="${K6_NDJSON_KEEP_THRESHOLD_MB:-1024}"
+
+cleanup() {
+    local rc=$?
+    if [[ -f "${NDJSON}" ]]; then
+        local size_bytes
+        size_bytes=$(stat -c '%s' "${NDJSON}" 2>/dev/null || echo 0)
+        local size_mb=$((size_bytes / 1024 / 1024))
+        if [[ "${KEEP_NDJSON}" == "1" ]]; then
+            echo "[_run-k6] K6_KEEP_NDJSON=1, kept ${NDJSON} (${size_mb} MiB)" >&2
+        elif (( size_mb > KEEP_THRESHOLD_MB )); then
+            rm -f "${NDJSON}"
+            echo "[_run-k6] dropped ndjson (${size_mb} MiB > ${KEEP_THRESHOLD_MB} MiB threshold). summary at ${SUMMARY}" >&2
+        else
+            echo "[_run-k6] kept ndjson (${size_mb} MiB <= ${KEEP_THRESHOLD_MB} MiB threshold) at ${NDJSON}" >&2
+        fi
+    fi
+    if [[ -f "${SUMMARY}" ]]; then
+        echo "[_run-k6] summary preserved: ${SUMMARY}" >&2
+    fi
+    exit "${rc}"
+}
+trap cleanup EXIT
+
+# Pre-flight: warn if /tmp has less than 5 GiB free. ndjson can grow fast,
+# k6 also writes its own buffer files alongside.
+TMP_FREE_MB=$(df -BM --output=avail "${RESULTS_DIR}" | tail -1 | tr -dc '0-9')
+if (( TMP_FREE_MB < 5120 )); then
+    echo "[_run-k6] WARNING: only ${TMP_FREE_MB} MiB free at ${RESULTS_DIR}. ndjson at 2k req/s grows ~30 MiB/min." >&2
+fi
+
+echo "[_run-k6] scenario=${SCENARIO_NAME} results_dir=${RESULTS_DIR}" >&2
+echo "[_run-k6] keep_ndjson=${KEEP_NDJSON} threshold_mb=${KEEP_THRESHOLD_MB} tmp_free_mb=${TMP_FREE_MB}" >&2
+
+# shellcheck disable=SC2086
+exec k6 run \
+    --insecure-skip-tls-verify \
+    --out "json=${NDJSON}" \
+    --summary-export="${SUMMARY}" \
+    ${K6_EXTRA_ARGS:-} \
+    "${SCENARIO_PATH}" \
+    "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/stress/_run-k6.sh` wrapper that invokes k6 with `--out json=` + `--summary-export=` and traps EXIT to drop the raw NDJSON when it exceeds a size threshold (default 1 GiB). Summary JSON always survives.
- Updates `scripts/stress/README.md` to point soak/burst runs at the wrapper and to document how to keep the ndjson when `_analyze_burst.py` needs it (`K6_KEEP_NDJSON=1` + `K6_RESULTS_DIR=scripts/stress`).
- Triggered by the 2026-05-18 incident: a 3h soak filled 89 GiB on `/tmp`, killed k6 mid-run with `no space left on device`, and lost the tail of the telemetry. A parallel 30-min 5k-VU burst left another 18 GiB ndjson under `scripts/stress/`. Root filesystem hit 100 % on the dev box.

## Why a wrapper

`k6 --out json=` writes one NDJSON line per HTTP sample. At 2k req/s that's ~30 MiB/min. A 1h soak is ~1.8 GiB, a 30-min 5k-VU burst is ~18 GiB. The raw ndjson is rarely needed (only `_analyze_burst.py` reads it); the summary JSON covers throughput, latency p50/p95/p99, error rate, threshold check in ~4 KB. The default should be summary-only with the raw stream cleaned up after the run, with an opt-in for forensic / per-plateau analysis.

## Env knobs

| Env | Default | Purpose |
|---|---|---|
| `K6_KEEP_NDJSON` | `0` | Keep the ndjson regardless of size. Use for `_analyze_burst.py` or forensic analysis. |
| `K6_NDJSON_KEEP_THRESHOLD_MB` | `1024` | Drop only if ndjson exceeded N MiB. |
| `K6_RESULTS_DIR` | `/tmp/k6-run-<scenario>-<epoch>` | Output dir. Point at a dedicated mount for long runs. |
| `K6_EXTRA_ARGS` | (empty) | Extra args appended to the k6 invocation. |

Pre-flight: warns when output dir has less than 5 GiB free.

## Test plan

- [x] `bash -n scripts/stress/_run-k6.sh` — syntax OK
- [x] `chmod +x` — executable
- [x] Smoke run against the local Mastio bundle on `:9443` (5s stage, 3 VU, `--no-thresholds`):
  - `K6_NDJSON_KEEP_THRESHOLD_MB=0` → `dropped ndjson (37 MiB > 0 MiB threshold)` ✓
  - `K6_KEEP_NDJSON=1` → `kept /tmp/.../results.ndjson (38 MiB)` ✓
  - threshold default `1024` → `kept ndjson (32 MiB <= 1024 MiB threshold)` ✓
  - Summary JSON preserved in all three cases.

Initial commit shipped with `exec k6 ...` which replaced the bash process and killed the EXIT trap — the smoke run caught it, fixed in the follow-up commit on this branch.

## Operator note

After this PR lands, the next soak / burst the maintainer runs should use the wrapper — see updated README. Existing `scripts/stress/intra-org-results.ndjson` leftover from the 2026-05-18 burst has already been cleaned up locally; the wrapper makes that cleanup automatic going forward.