### PR TITLE
fix(stress): K6_SKIP_NDJSON knob for high-RPS local targets

### DIFF
--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -35,11 +35,12 @@ cd scripts/stress
 nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify health-throughput.js"
 
 # Soak / burst (any run that writes raw NDJSON output): use the
-# wrapper. It traps EXIT and drops the ndjson if it exceeds 1 GiB,
+# wrapper. It traps EXIT and drops the ndjson if it exceeds 1 GiB
+# (or skip it entirely with K6_SKIP_NDJSON=1 for high-RPS targets),
 # keeping the summary JSON. See "NDJSON cleanup wrapper" below for
-# why this matters.
-nix-shell -p k6 --run "bash _run-k6.sh soak-stability.js"
-nix-shell -p k6 --run "bash _run-k6.sh intra-org-mastio-burst.js"
+# why this matters and which mode each scenario wants.
+K6_SKIP_NDJSON=1 nix-shell -p k6 --run "bash _run-k6.sh soak-stability.js"
+K6_KEEP_NDJSON=1 K6_RESULTS_DIR=. nix-shell -p k6 --run "bash _run-k6.sh intra-org-mastio-burst.js"
 
 # Or against a remote stack:
 BASE_URL=https://mastio.example.com:9443 \
@@ -65,9 +66,18 @@ survives.
 
 Tunables (env):
 
+- `K6_SKIP_NDJSON=1` — do not write the ndjson at all. Use this for
+  high-RPS scenarios against fast targets (e.g. `soak-stability.js`
+  or `health-throughput.js` against a local Mastio bundle), where
+  post-run cleanup is too late because the file grows faster than
+  disk can hold it. Observed 2026-05-18: `soak-stability.js` against
+  the local bundle sustained 7k req/s and produced ~110 GiB/h of
+  NDJSON, hitting ENOSPC well before the 1h run finished. Wins over
+  `K6_KEEP_NDJSON`.
 - `K6_KEEP_NDJSON=1` — never drop the ndjson. Use this when you plan
   to run `_analyze_burst.py` against it, or need forensic per-sample
   data. Make sure the output dir lives on a disk with enough room.
+  Ignored when `K6_SKIP_NDJSON=1`.
 - `K6_NDJSON_KEEP_THRESHOLD_MB=<N>` — drop only if the ndjson grew
   past N MiB. Default 1024.
 - `K6_RESULTS_DIR=<path>` — where to write ndjson + summary. Default
@@ -77,7 +87,16 @@ Tunables (env):
 - `K6_EXTRA_ARGS="..."` — extra args appended to the k6 invocation.
 
 The wrapper also pre-flights `df` on the output dir and warns when
-less than 5 GiB is free.
+less than 5 GiB is free (skipped when `K6_SKIP_NDJSON=1`).
+
+### When to use which mode
+
+| Scenario | Recommended mode | Why |
+|---|---|---|
+| `soak-stability.js` against any target | `K6_SKIP_NDJSON=1` | Read-only `/health` loop, summary covers all assertions, no analyzer reads the ndjson. |
+| `health-throughput.js` smoke / triage | `K6_SKIP_NDJSON=1` | Same — high RPS, no per-sample analysis needed. |
+| `intra-org-mastio-burst.js` baseline | `K6_KEEP_NDJSON=1` + `K6_RESULTS_DIR=scripts/stress` | `_analyze_burst.py` walks the ndjson for per-plateau aggregation. Run on a disk with at least 50 GiB free. |
+| Quick local probe (<2 min) | default | Default threshold 1024 MiB will keep the small ndjson, useful if you want to peek at raw samples. |
 
 ## When to re-run
 

--- a/scripts/stress/_run-k6.sh
+++ b/scripts/stress/_run-k6.sh
@@ -11,7 +11,14 @@
 # then on exit (success OR failure) drops the ndjson if it exceeded the size
 # threshold. The summary always survives. Override behaviour via env:
 #
+#   K6_SKIP_NDJSON=1                  Do not write the ndjson at all. Use this for
+#                                     high-RPS scenarios against fast targets where
+#                                     post-run cleanup is too late (file grows faster
+#                                     than disk can hold it — observed 110 GiB/h on a
+#                                     local Mastio bundle 2026-05-18). Wins over
+#                                     K6_KEEP_NDJSON.
 #   K6_KEEP_NDJSON=1                  Never drop ndjson (forensic / _analyze_burst.py).
+#                                     Ignored when K6_SKIP_NDJSON=1.
 #   K6_NDJSON_KEEP_THRESHOLD_MB=<N>   Drop only if ndjson > N MiB. Default 1024.
 #   K6_RESULTS_DIR=<path>             Where to write ndjson + summary. Default
 #                                     /tmp/k6-run-<scenario>-<epoch>.
@@ -51,10 +58,22 @@ SUMMARY="${RESULTS_DIR}/summary.json"
 
 KEEP_NDJSON="${K6_KEEP_NDJSON:-0}"
 KEEP_THRESHOLD_MB="${K6_NDJSON_KEEP_THRESHOLD_MB:-1024}"
+SKIP_NDJSON="${K6_SKIP_NDJSON:-0}"
+
+# K6_SKIP_NDJSON=1 wins over K6_KEEP_NDJSON. Skipping means we never
+# pass --out json= to k6, so no NDJSON file exists at all. Use this
+# for high-RPS scenarios against fast targets where the file would
+# grow faster than disk can hold it (~110 GiB/h soak on a local
+# bundle observed 2026-05-18).
+if [[ "${SKIP_NDJSON}" == "1" && "${KEEP_NDJSON}" == "1" ]]; then
+    echo "[_run-k6] WARNING: K6_SKIP_NDJSON=1 overrides K6_KEEP_NDJSON=1 (no ndjson will be written)." >&2
+fi
 
 cleanup() {
     local rc=$?
-    if [[ -f "${NDJSON}" ]]; then
+    if [[ "${SKIP_NDJSON}" == "1" ]]; then
+        echo "[_run-k6] K6_SKIP_NDJSON=1, no ndjson was written" >&2
+    elif [[ -f "${NDJSON}" ]]; then
         local size_bytes
         size_bytes=$(stat -c '%s' "${NDJSON}" 2>/dev/null || echo 0)
         local size_mb=$((size_bytes / 1024 / 1024))
@@ -74,15 +93,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Pre-flight: warn if /tmp has less than 5 GiB free. ndjson can grow fast,
-# k6 also writes its own buffer files alongside.
+# Pre-flight: warn if the output dir has less than 5 GiB free, only
+# when we are about to write the NDJSON (skipping = no growth on disk).
 TMP_FREE_MB=$(df -BM --output=avail "${RESULTS_DIR}" | tail -1 | tr -dc '0-9')
-if (( TMP_FREE_MB < 5120 )); then
-    echo "[_run-k6] WARNING: only ${TMP_FREE_MB} MiB free at ${RESULTS_DIR}. ndjson at 2k req/s grows ~30 MiB/min." >&2
+if [[ "${SKIP_NDJSON}" != "1" ]] && (( TMP_FREE_MB < 5120 )); then
+    echo "[_run-k6] WARNING: only ${TMP_FREE_MB} MiB free at ${RESULTS_DIR}. ndjson at 2k req/s grows ~30 MiB/min and can hit 100+ GiB/h against fast targets. Consider K6_SKIP_NDJSON=1." >&2
 fi
 
 echo "[_run-k6] scenario=${SCENARIO_NAME} results_dir=${RESULTS_DIR}" >&2
-echo "[_run-k6] keep_ndjson=${KEEP_NDJSON} threshold_mb=${KEEP_THRESHOLD_MB} tmp_free_mb=${TMP_FREE_MB}" >&2
+echo "[_run-k6] skip_ndjson=${SKIP_NDJSON} keep_ndjson=${KEEP_NDJSON} threshold_mb=${KEEP_THRESHOLD_MB} tmp_free_mb=${TMP_FREE_MB}" >&2
+
+# Build the k6 argv. When K6_SKIP_NDJSON=1 we omit --out json= so k6
+# never opens the NDJSON file in the first place. The summary export
+# is always on.
+K6_OUTPUT_ARGS=()
+if [[ "${SKIP_NDJSON}" != "1" ]]; then
+    K6_OUTPUT_ARGS+=(--out "json=${NDJSON}")
+fi
 
 # Run k6 inline (not via exec) so the EXIT trap above can fire and
 # clean up the ndjson. With `exec` the bash process is replaced by
@@ -90,7 +117,7 @@ echo "[_run-k6] keep_ndjson=${KEEP_NDJSON} threshold_mb=${KEEP_THRESHOLD_MB} tmp
 # shellcheck disable=SC2086
 k6 run \
     --insecure-skip-tls-verify \
-    --out "json=${NDJSON}" \
+    "${K6_OUTPUT_ARGS[@]}" \
     --summary-export="${SUMMARY}" \
     ${K6_EXTRA_ARGS:-} \
     "${SCENARIO_PATH}" \


### PR DESCRIPTION
## Summary

PR #798 wrapper drops the NDJSON post-run. That covers the original incident shape (4 vCPU VM, ~600 RPS, ~30 GiB/h) but it does NOT cover a local Mastio bundle on workstation hardware, where the same scenario sustains 7k req/s and produces ~110 GiB/h of NDJSON — the disk fills well before the post-run trap can fire.

This adds `K6_SKIP_NDJSON=1` that omits `--out json=` entirely. k6 never opens the file. The `--summary-export` keeps everything we need for read-only soak / health scenarios.

## Evidence (2026-05-18 dogfood)

`bash scripts/stress/_run-k6.sh soak-stability.js` against the local bundle on `:9443`:

- 50 VU constant, **7192 req/s sustained**
- 75 GiB of NDJSON in 42 min
- Disk hit 89 %, run killed manually before ENOSPC
- 43-min partial: 0 errors, p95 9.5 ms, p99 11.8 ms, RSS drift −1.2 % (no leak)

Same failure mode as the original soak h7 incident the PR #798 wrapper was meant to prevent — just shifted by 60x because the target is faster.

## Behaviour

| `K6_SKIP_NDJSON` | `K6_KEEP_NDJSON` | NDJSON written? | Post-run |
|---|---|---|---|
| `1` | any | NO | nothing to clean up |
| `0` (default) | `1` | yes | kept |
| `0` (default) | `0` (default) | yes | dropped if > `K6_NDJSON_KEEP_THRESHOLD_MB` (1024) |

`K6_SKIP_NDJSON=1` wins over `K6_KEEP_NDJSON=1`; warning logged when both set.

## Test plan

- [x] `bash -n scripts/stress/_run-k6.sh` — syntax OK
- [x] Smoke `K6_SKIP_NDJSON=1` (5s/3 VU): no `results.ndjson` on disk, `summary.json` (4 KB) preserved, log line `K6_SKIP_NDJSON=1, no ndjson was written` ✓
- [x] Regression default mode (5s/3 VU): `results.ndjson` written (~15 MiB), kept under 1024 MiB threshold, log line `kept ndjson (15 MiB <= 1024 MiB threshold)` ✓
- [ ] Follow-up: re-run the full 1h soak with `K6_SKIP_NDJSON=1 nix-shell -p k6 --run "bash scripts/stress/_run-k6.sh soak-stability.js"` and confirm clean completion.

## README

New "When to use which mode" table:

| Scenario | Recommended mode |
|---|---|
| `soak-stability.js` | `K6_SKIP_NDJSON=1` |
| `health-throughput.js` smoke | `K6_SKIP_NDJSON=1` |
| `intra-org-mastio-burst.js` baseline | `K6_KEEP_NDJSON=1` + `K6_RESULTS_DIR=.` |
| Quick local probe (<2 min) | default |

The intra-org burst still wants the ndjson because `_analyze_burst.py` walks it for per-plateau aggregation.