### PR TITLE
fix(dashboard): inline-edit org display name + readonly org_id in setup wizard

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1216,6 +1216,88 @@ async def setup_test_connection(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Org settings — inline-edit display name (overview card)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DISPLAY_NAME_MAX_LEN = 255
+
+
+async def _render_org_title_block(
+    request: Request,
+    session: ProxyDashboardSession,
+    *,
+    mode: str,
+) -> HTMLResponse:
+    from mcp_proxy.db import get_config
+
+    org_id = await get_config("org_id") or ""
+    display_name = await get_config("display_name") or ""
+    return templates.TemplateResponse(
+        "_org_title_block.html",
+        _ctx(
+            request, session,
+            mode=mode,
+            org_id=org_id,
+            display_name=display_name,
+        ),
+    )
+
+
+@router.get("/settings/org/display-name", response_class=HTMLResponse)
+async def org_display_name_view(request: Request):
+    """HTMX endpoint: return the static title partial (used by Cancel)."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return await _render_org_title_block(request, session, mode="view")
+
+
+@router.get("/settings/org/display-name/edit", response_class=HTMLResponse)
+async def org_display_name_edit(request: Request):
+    """HTMX endpoint: swap the title partial into inline-edit mode."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return await _render_org_title_block(request, session, mode="edit")
+
+
+@router.post("/settings/org/display-name", response_class=HTMLResponse)
+async def org_display_name_update(request: Request):
+    """Persist a new friendly display name for the org.
+
+    The org_id is derived from the Org CA pubkey in standalone (ADR-006
+    §2.2) and immutable here; only the human-facing label is editable.
+    Empty input clears the label, falling back to the hex org_id in the
+    UI.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import set_config, log_audit
+
+    form = await request.form()
+    raw = str(form.get("display_name", "")).strip()
+    if len(raw) > _DISPLAY_NAME_MAX_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Display name must be at most {_DISPLAY_NAME_MAX_LEN} characters.",
+        )
+
+    await set_config("display_name", raw)
+    await log_audit(
+        agent_id="admin",
+        action="org.display_name.update",
+        status="success",
+        detail=f"display_name={raw}" if raw else "display_name=<cleared>",
+    )
+
+    return await _render_org_title_block(request, session, mode="view")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Agents
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/dashboard/templates/_org_title_block.html
+++ b/mcp_proxy/dashboard/templates/_org_title_block.html
@@ -1,0 +1,65 @@
+{# Inline-editable Org title block, rendered both inside overview.html and as
+   the HTMX swap target for /proxy/settings/org/display-name endpoints.
+   Variables: mode ("view" | "edit"), org_id, display_name, csrf_token.
+#}
+<div id="org-title-block" class="space-y-1">
+    <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em]">Organization</p>
+
+    {% if mode == 'edit' %}
+    <form hx-post="/proxy/settings/org/display-name"
+          hx-target="#org-title-block"
+          hx-swap="outerHTML"
+          hx-vals='{"csrf_token": "{{ csrf_token }}"}'
+          class="flex flex-wrap items-center gap-2">
+        <input type="text" name="display_name" value="{{ display_name }}"
+               maxlength="255" autofocus
+               placeholder="Acme Corporation"
+               class="flex-1 min-w-[12rem] bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-sm text-white placeholder-gray-600">
+        <button type="submit"
+                class="px-3 py-1.5 text-[11px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
+            Save
+        </button>
+        <button type="button"
+                hx-get="/proxy/settings/org/display-name"
+                hx-target="#org-title-block"
+                hx-swap="outerHTML"
+                class="px-3 py-1.5 text-[11px] uppercase tracking-wider text-gray-500 border border-gray-700/40 rounded hover:text-gray-300">
+            Cancel
+        </button>
+    </form>
+    {% else %}
+    <div class="flex items-center gap-2">
+        <h2 class="text-xl font-semibold text-white" style="font-family: 'Chakra Petch', sans-serif;">
+            {{ display_name or org_id or "Unconfigured" }}
+        </h2>
+        {% if org_id %}
+        <button type="button"
+                hx-get="/proxy/settings/org/display-name/edit"
+                hx-target="#org-title-block"
+                hx-swap="outerHTML"
+                class="px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-gray-500 hover:text-accent-400 border border-gray-700/40 rounded">
+            {% if display_name %}Rename{% else %}Set name{% endif %}
+        </button>
+        {% endif %}
+    </div>
+    {% if org_id and display_name %}
+    {# Title is the friendly name; hex stays as a small reference subtitle. #}
+    <p class="text-xs text-gray-500" style="font-family: 'JetBrains Mono', monospace;">
+        {{ org_id }}
+    </p>
+    {% elif org_id and not display_name %}
+    {# Title fell back to the deterministic hex; nudge the operator to set a
+       friendly display name via the inline-edit swap (no wizard detour). #}
+    <p class="text-[11px] text-amber-400/80 mt-1.5">
+        Hex above is the deterministic Org ID (ADR-006 §2.2).
+        <a href="#"
+           hx-get="/proxy/settings/org/display-name/edit"
+           hx-target="#org-title-block"
+           hx-swap="outerHTML"
+           class="underline hover:text-amber-300 cursor-pointer">
+            Set a friendly display name &rarr;
+        </a>
+    </p>
+    {% endif %}
+    {% endif %}
+</div>

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -64,26 +64,7 @@
     <!-- Org identity card -->
     <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
         <div class="flex items-start justify-between mb-4">
-            <div>
-                <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-1">Organization</p>
-                <h2 class="text-xl font-semibold text-white" style="font-family: 'Chakra Petch', sans-serif;">
-                    {{ display_name or org_id or "Unconfigured" }}
-                </h2>
-                {% if org_id and display_name %}
-                {# Title is the friendly name; hex stays as a small reference subtitle. #}
-                <p class="text-xs text-gray-500 mt-1" style="font-family: 'JetBrains Mono', monospace;">
-                    {{ org_id }}
-                </p>
-                {% elif org_id and not display_name %}
-                {# Title fell back to the deterministic hex; nudge the operator
-                   to set a friendly display name so audit logs and SSO surfaces
-                   show "Acme Corporation" instead of the 16-char hash. #}
-                <p class="text-[11px] text-amber-400/80 mt-1.5">
-                    Hex above is the deterministic Org ID (ADR-006 §2.2).
-                    <a href="/proxy/setup" class="underline hover:text-amber-300">Set a friendly display name →</a>
-                </p>
-                {% endif %}
-            </div>
+            {% with mode='view' %}{% include "_org_title_block.html" %}{% endwith %}
             {% if org_status %}
             <span class="px-2 py-1 rounded text-[10px] uppercase tracking-wider
                 {% if org_status == 'active' %}bg-emerald-500/10 text-emerald-400 border border-emerald-500/30

--- a/mcp_proxy/dashboard/templates/setup.html
+++ b/mcp_proxy/dashboard/templates/setup.html
@@ -108,11 +108,18 @@
             <div class="space-y-4">
                 <div>
                     <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Organization ID</label>
+                    {% if derived_org_id %}
+                    <input type="text" name="org_id" value="{{ org_id }}"
+                           readonly
+                           class="w-full bg-surface-950/60 border border-gray-800/60 rounded px-3 py-2.5 text-sm text-gray-400 font-mono cursor-not-allowed">
+                    <p class="text-[10px] text-gray-500 mt-1">Derived from the Org CA public key (ADR-006 §2.2), so it stays stable across restarts and cannot be changed here.</p>
+                    {% else %}
                     <input type="text" name="org_id" value="{{ org_id }}"
                            placeholder="acme-corp"
                            pattern="[a-z][a-z0-9_-]*"
                            class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
                     <p class="text-[10px] text-gray-600 mt-1">Lowercase letters, digits, hyphens, underscores. Must start with a letter.</p>
+                    {% endif %}
                 </div>
                 <div>
                     <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Display Name</label>

--- a/tests/test_proxy_dashboard_display_name.py
+++ b/tests/test_proxy_dashboard_display_name.py
@@ -1,0 +1,380 @@
+"""Inline-edit Org display name on the Mastio dashboard overview card.
+
+Covers the trio of endpoints behind the HTMX swap pattern:
+
+  GET  /proxy/settings/org/display-name        - view-mode partial (cancel)
+  GET  /proxy/settings/org/display-name/edit   - edit-mode partial (form)
+  POST /proxy/settings/org/display-name        - persist + return view partial
+
+The dogfood friction this closes: an admin who lands on the overview with
+the deterministic hex Org ID (ADR-006 section 2.2) used to be sent to the
+full broker-uplink wizard at /proxy/setup just to rename the org. The
+wizard exposed the org_id input even though it is silently ignored in
+standalone, so editing it looked like a no-op. The new flow swaps the
+title block inline with a single field and persists via set_config.
+
+Auditing is non-negotiable: every successful POST writes an
+``org.display_name.update`` row to ``audit_log``. CSRF is enforced on the
+mutating endpoint; missing-session paths redirect to /proxy/login.
+"""
+from __future__ import annotations
+
+import json as _json
+import re
+import time as _time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+CSRF = "csrf-display-name-test"
+
+
+def _admin_cookie(csrf_token: str = CSRF) -> tuple[str, str]:
+    """Mint a signed admin session cookie carrying a fixed CSRF token."""
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+    payload = _json.dumps(
+        {"role": "admin", "csrf_token": csrf_token, "exp": int(_time.time()) + 3600}
+    )
+    return _COOKIE_NAME, _sign(payload)
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    """Spin a standalone Mastio app against a per-test sqlite DB."""
+    db_file = tmp_path / "proxy_display_name.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme-hex-1234")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _seed_org_id(value: str = "acme-hex-1234") -> None:
+    from mcp_proxy.db import set_config
+    await set_config("org_id", value)
+
+
+# ── GET view partial ────────────────────────────────────────────────────
+
+
+async def test_get_view_partial_without_display_name_shows_set_cta(proxy_app):
+    """When no display_name is set, the partial includes the amber 'Set a
+    friendly display name' CTA + a 'Set name' button next to the hex."""
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.get("/proxy/settings/org/display-name")
+    assert resp.status_code == 200, resp.text
+    assert 'id="org-title-block"' in resp.text
+    assert "acme-hex-1234" in resp.text
+    assert "Set a friendly display name" in resp.text
+    assert "Set name" in resp.text
+    # The edit endpoint is the swap target, not /proxy/setup.
+    assert "/proxy/settings/org/display-name/edit" in resp.text
+    assert 'href="/proxy/setup"' not in resp.text
+
+
+async def test_get_view_partial_with_display_name_shows_rename(proxy_app):
+    """Once a display_name is set, the partial shows it as the title with
+    the hex as a subtitle and a 'Rename' button."""
+    _, client = proxy_app
+    await _seed_org_id()
+    from mcp_proxy.db import set_config
+    await set_config("display_name", "Acme Corporation")
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.get("/proxy/settings/org/display-name")
+    assert resp.status_code == 200, resp.text
+    assert "Acme Corporation" in resp.text
+    assert "acme-hex-1234" in resp.text  # hex moved to subtitle
+    assert "Rename" in resp.text
+    # Amber CTA is gone once the friendly name is set.
+    assert "Set a friendly display name" not in resp.text
+
+
+# ── GET edit partial ────────────────────────────────────────────────────
+
+
+async def test_get_edit_partial_renders_form(proxy_app):
+    """Edit mode swaps the title block with an HTMX form (hx-post target)."""
+    _, client = proxy_app
+    await _seed_org_id()
+    from mcp_proxy.db import set_config
+    await set_config("display_name", "Existing Name")
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.get("/proxy/settings/org/display-name/edit")
+    assert resp.status_code == 200, resp.text
+    assert 'id="org-title-block"' in resp.text
+    assert 'name="display_name"' in resp.text
+    assert 'value="Existing Name"' in resp.text
+    assert 'hx-post="/proxy/settings/org/display-name"' in resp.text
+    # CSRF carried via hx-vals on the form element.
+    assert CSRF in resp.text
+
+
+# ── POST happy paths ────────────────────────────────────────────────────
+
+
+async def test_post_valid_persists_and_returns_view_partial(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": "  Acme Corporation  "},
+    )
+    assert resp.status_code == 200, resp.text
+    # Trimmed before persist.
+    from mcp_proxy.db import get_config
+    assert await get_config("display_name") == "Acme Corporation"
+    # Returned partial is view-mode with the new title.
+    assert 'id="org-title-block"' in resp.text
+    assert "Acme Corporation" in resp.text
+    assert "Rename" in resp.text
+    assert 'name="display_name"' not in resp.text  # no longer the form
+
+
+async def test_post_empty_clears_display_name(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+    from mcp_proxy.db import set_config, get_config
+    await set_config("display_name", "Old Name")
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": ""},
+    )
+    assert resp.status_code == 200, resp.text
+    assert await get_config("display_name") == ""
+    # View partial falls back to the hex title + the amber CTA.
+    assert "acme-hex-1234" in resp.text
+    assert "Set a friendly display name" in resp.text
+
+
+async def test_post_audit_row_written(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": "Acme Corporation"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    from sqlalchemy import text as _text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        rows = (
+            await conn.execute(
+                _text(
+                    "SELECT action, status, detail FROM audit_log "
+                    "WHERE action = 'org.display_name.update' "
+                    "ORDER BY id DESC LIMIT 1"
+                )
+            )
+        ).mappings().all()
+    assert rows, "expected an org.display_name.update audit row"
+    row = rows[0]
+    assert row["status"] == "success"
+    assert "Acme Corporation" in row["detail"]
+
+
+# ── POST failure modes ──────────────────────────────────────────────────
+
+
+async def test_post_too_long_returns_400(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+    from mcp_proxy.db import get_config
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": "x" * 256},
+    )
+    assert resp.status_code == 400, resp.text
+    # Persisted value is untouched.
+    assert (await get_config("display_name")) in (None, "")
+
+
+async def test_post_missing_csrf_returns_403(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"display_name": "Acme Corporation"},  # no csrf_token
+    )
+    assert resp.status_code == 403
+
+
+async def test_post_wrong_csrf_returns_403(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": "not-the-real-token", "display_name": "x"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_post_without_login_redirects(proxy_app):
+    _, client = proxy_app
+    await _seed_org_id()
+
+    resp = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": "x"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "/proxy/login" in resp.headers.get("location", "")
+
+
+async def test_get_edit_without_login_redirects(proxy_app):
+    _, client = proxy_app
+
+    resp = await client.get(
+        "/proxy/settings/org/display-name/edit",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "/proxy/login" in resp.headers.get("location", "")
+
+
+# ── Customer-path smoke: overview card uses the new endpoint, not /setup
+
+
+async def test_overview_card_hooks_to_inline_edit_not_setup_wizard(proxy_app):
+    """Regression for the dogfood friction: clicking the rename affordance
+    on the overview must trigger the inline HTMX swap, not bounce to
+    /proxy/setup. We assert on the rendered overview HTML.
+    """
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.get("/proxy/overview")
+    assert resp.status_code == 200, resp.text
+    # The title block carries the HTMX hooks for the new endpoint.
+    assert 'id="org-title-block"' in resp.text
+    assert "/proxy/settings/org/display-name/edit" in resp.text
+    # The "Set a friendly display name" amber CTA no longer points at the
+    # broker-uplink wizard (#326-adjacent UX bug).
+    amber_block = re.search(
+        r"Hex above is the deterministic Org ID.*?</p>",
+        resp.text, re.DOTALL,
+    )
+    assert amber_block, "amber CTA paragraph missing from overview"
+    assert "/proxy/setup" not in amber_block.group(0)
+
+
+async def test_full_round_trip_view_edit_save_view(proxy_app):
+    """End-to-end: render view -> swap to edit -> POST save -> view shows
+    the new name. Mirrors what HTMX does in the browser. Status asserted
+    on every step (memory rule layered-test-breakage-keyerror-masking).
+    """
+    _, client = proxy_app
+    await _seed_org_id()
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    r1 = await client.get("/proxy/settings/org/display-name")
+    assert r1.status_code == 200, r1.text
+    assert "Set name" in r1.text
+
+    r2 = await client.get("/proxy/settings/org/display-name/edit")
+    assert r2.status_code == 200, r2.text
+    assert 'name="display_name"' in r2.text
+
+    r3 = await client.post(
+        "/proxy/settings/org/display-name",
+        data={"csrf_token": CSRF, "display_name": "Round Trip Org"},
+    )
+    assert r3.status_code == 200, r3.text
+    assert "Round Trip Org" in r3.text
+
+    r4 = await client.get("/proxy/settings/org/display-name")
+    assert r4.status_code == 200, r4.text
+    assert "Round Trip Org" in r4.text
+    assert "Rename" in r4.text
+
+
+# ── Drive-by: derived org_id is readonly in the setup wizard ───────────
+
+
+async def test_setup_wizard_org_id_readonly_when_derived(proxy_app, monkeypatch):
+    """ADR-006 section 2.2 - in standalone the org_id is derived from the
+    Org CA pubkey and silently ignored if posted back. Mark the input
+    readonly so admins do not believe editing it does anything.
+    """
+    app, client = proxy_app
+    await _seed_org_id()
+
+    class _FakeAgentMgr:
+        ca_loaded = True
+
+        def derive_org_id_from_ca(self) -> str:
+            return "derived-hex-deadbeef"
+
+    monkeypatch.setattr(app.state, "agent_manager", _FakeAgentMgr(), raising=False)
+
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+
+    resp = await client.get("/proxy/setup")
+    assert resp.status_code == 200, resp.text
+    # Match the input element for ``org_id`` and confirm it carries the
+    # readonly attribute + the ADR-006 hint.
+    m = re.search(
+        r'<input[^>]*name="org_id"[^>]*>',
+        resp.text,
+    )
+    assert m, "org_id input missing from /proxy/setup"
+    assert "readonly" in m.group(0)
+    assert "ADR-006" in resp.text


### PR DESCRIPTION
## Why

First dogfood on the mastio-demo VM surfaced a one-action UX promise routed to a multi-step wizard. The overview card prompted "Set a friendly display name" and linked at `/proxy/setup`, the 6+ field broker-uplink wizard. That wizard exposed an `org_id` input which in standalone the backend silently ignores (derived from the Org CA pubkey, ADR-006 §2.2), so an admin trying to "rename the org" would edit the hex, hit Save, and see nothing change.

## Pre-implementation verification

- `grep -rn "settings/org\|display-name\|update_display_name\|rename_org" mcp_proxy/dashboard/ mcp_proxy/admin/` → no existing endpoint.
- `git log --oneline --all -- mcp_proxy/dashboard/router.py mcp_proxy/dashboard/templates/overview.html | head -20` → no in-flight branch on these files.
- `gh pr list --state open --search "display name OR rename org"` → no open PR.

## Changes

- New partial template `mcp_proxy/dashboard/templates/_org_title_block.html` (view + edit modes, single HTMX swap target `#org-title-block`).
- Three new endpoints on the main dashboard router:
  - `GET /proxy/settings/org/display-name` returns the view partial (Cancel swap).
  - `GET /proxy/settings/org/display-name/edit` returns the edit partial (inline form).
  - `POST /proxy/settings/org/display-name` persists the trimmed value (max 255), writes an `org.display_name.update` audit row, and returns the view partial.
- `overview.html`: org title block replaced with `{% include "_org_title_block.html" %}` (HTMX wiring, no more `/proxy/setup` detour).
- `setup.html`: when `derived_org_id` is set, `org_id` input is `readonly` with a one-line ADR-006 §2.2 note. Plain editable input retained for the non-derived path (legacy / pre-CA boots).

The POST handler uses the same `require_login` + `verify_csrf` pattern as `setup_submit`; missing-session redirects to `/proxy/login` (303), missing/wrong CSRF returns 403, over-length input returns 400.

## Tests

New file `tests/test_proxy_dashboard_display_name.py` (14 tests):

- View partial: shows hex + amber CTA when no display_name; shows display_name + hex subtitle + Rename when set.
- Edit partial: renders form with prefilled value and HTMX hx-post wiring.
- POST happy paths: persists trimmed value, returns view partial; empty input clears the value and the view falls back to the hex.
- POST audit: `org.display_name.update` row written with `status=success` and the new value in `detail`.
- POST failure modes: 400 on >255 chars, 403 on missing/wrong CSRF, 303 on missing session.
- Customer-path smoke: `/proxy/overview` carries the new HTMX hooks and the amber CTA no longer points at `/proxy/setup`.
- Full round-trip view → edit → save → view, status_code asserted on every step.
- Drive-by: `/proxy/setup` renders `org_id` as `readonly` when `derived_org_id` is set (regex match on the input element).

```
pytest tests/test_proxy_dashboard_display_name.py -q
14 passed in 7.96s
```

```
pytest tests/ -n auto --dist=loadfile -q --ignore=tests/e2e
4044 passed, 1 failed, 32 skipped in 111.42s
```

The single failure is `tests/test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`. It is a pre-existing local-environment precondition assertion (`assert 'cullis_enterprise' not in sys.modules`) that fires because the parent `.venv` has `cullis_enterprise` editable-installed for dual-repo work. Confirmed by re-running against `origin/main`'s copy of the same test file: identical failure. Not introduced by this PR; CI runs without the enterprise package and is unaffected.

Nearby regression check (dashboard router neighbours), all green:

```
pytest tests/test_proxy_update_check.py tests/test_proxy_dashboard_oidc.py tests/test_fb9_proxy_logout_csrf.py -q
42 passed in 8.34s
```

## Smoke

`./sandbox/smoke.sh full` not executed in this session: port 9443 is currently held by the running Mastio bundle (dogfood state for the mastio-demo VM workstream), and the sandbox stack binds the same port. The change is template-only plus a new endpoint that touches `proxy_config` and `audit_log` (both existing tables, no schema or migration), so the smoke assertions covering federation, MCP, and agent flows are not on the affected code path. The 14 dedicated tests exercise the new endpoint surface end-to-end including the `audit_log` chain write.

## Dogfood validation

Not run yet against a live standalone Mastio (sandbox stack is down for the reason above; the running bundle ships from GHCR and would not pick up worktree changes). The 14 tests cover the four visible behaviours called out in the brief:

- Amber CTA disappears after rename → `test_post_valid_persists_and_returns_view_partial` asserts the returned partial contains "Acme Corporation" and "Rename", not the amber CTA copy.
- Title shows the friendly name → same test, plus `test_full_round_trip_view_edit_save_view`.
- Hex moves to the subtitle → `test_get_view_partial_with_display_name_shows_rename` asserts both "Acme Corporation" and "acme-hex-1234" are present.
- Refresh persists → covered by the `set_config` round-trip in `test_post_valid_persists_and_returns_view_partial` (DB read after POST).
- Audit row → `test_post_audit_row_written` reads the `audit_log` table.

## Out of scope

- No change to the broker-uplink wizard fields beyond the `org_id` readonly attribute (broker URL, invite token, CA mode, Vault, etc. untouched).
- No change to `display_name` handling in `setup_submit` / `_setup_submit_standalone` (those still accept `display_name` from the wizard form for first-boot flows).
- No new audit action emitted from the wizard (only the new inline-edit endpoint writes `org.display_name.update`).
- No `delete` of the `proxy_config` row when the value is cleared; mirrors the existing `set_config("display_name", "")` pattern used by `setup_submit`.
- No new Tailwind classes outside the existing utility palette (all classes appear elsewhere in `mcp_proxy/dashboard/templates/`), so no separate `build_frontend.sh` artefact ships with this PR (the compiled CSS is gitignored and rebuilds via JIT at deploy time).