### PR TITLE
fix(pki): auto-append proxy_public_url host to nginx cert SAN (customer-blocker)

### DIFF
--- a/mcp_proxy/lifespan/_san_resolver.py
+++ b/mcp_proxy/lifespan/_san_resolver.py
@@ -1,0 +1,66 @@
+"""Build the SAN list for the nginx sidecar server cert.
+
+Single source of truth for both the boot-time
+``ensure_nginx_server_cert`` call in ``mcp_proxy.main`` and the
+periodic ``nginx_cert_watcher_loop``. Starts from
+``settings.nginx_san`` (comma-split, default ``"mastio.local"``)
+and appends the hostname of ``settings.proxy_public_url`` when
+that URL is set and its host isn't already in the list.
+
+Closes the customer-blocker reproduced on 2026-05-19: a Mastio VM
+at ``192.168.122.62`` configured with
+``MCP_PROXY_PROXY_PUBLIC_URL=https://192.168.122.62:9443`` minted
+a leaf with SAN ``mastio.local,localhost,host.docker.internal,
+mastio-nginx,mcp-proxy`` (the bundle default) and every TLS-strict
+client refused the handshake with ``CERTIFICATE_VERIFY_FAILED /
+hostname '192.168.122.62' doesn't match``. The downstream cert
+minter (``AgentManager.ensure_nginx_server_cert``) already splits
+IP literals into ``iPAddress`` SAN entries and hostnames into
+``dNSName``; the bug was upstream, in the list passed in.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger("mcp_proxy.lifespan._san_resolver")
+
+
+def resolve_nginx_sans(settings: Any) -> list[str]:
+    """Return the SAN list for the nginx server cert.
+
+    Starts from ``settings.nginx_san`` (comma-split, default
+    ``"mastio.local"``), then appends the hostname of
+    ``settings.proxy_public_url`` when set and not already present.
+    Idempotent: safe to call from both the lifespan one-shot path
+    and the periodic cert watcher.
+    """
+    raw = getattr(settings, "nginx_san", "") or "mastio.local"
+    sans: list[str] = [s.strip() for s in raw.split(",") if s.strip()]
+
+    public_url = getattr(settings, "proxy_public_url", "") or ""
+    if not public_url:
+        return sans
+
+    try:
+        host = urlparse(public_url).hostname
+    except (ValueError, TypeError):
+        host = None
+    if not host:
+        return sans
+
+    # urlparse strips the brackets from IPv6 literals already, so
+    # the value is comparable directly to entries in ``sans``.
+    if host in sans:
+        return sans
+
+    sans.append(host)
+    logger.info(
+        "nginx_san: auto-appended proxy_public_url host=%s (now: %s)",
+        host, sans,
+    )
+    return sans
+
+
+__all__ = ["resolve_nginx_sans"]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -358,11 +358,8 @@ async def lifespan(app: FastAPI):
         # SAN-mismatched against the configured value.
         if settings.nginx_cert_dir:
             try:
-                sans = [
-                    s.strip()
-                    for s in (settings.nginx_san or "mastio.local").split(",")
-                    if s.strip()
-                ]
+                from mcp_proxy.lifespan._san_resolver import resolve_nginx_sans
+                sans = resolve_nginx_sans(settings)
                 await agent_mgr.ensure_nginx_server_cert(
                     out_dir=settings.nginx_cert_dir,
                     sans=sans,
@@ -513,14 +510,11 @@ async def lifespan(app: FastAPI):
     ):
         try:
             from mcp_proxy.lifespan import get_leader as _get_leader_nginx
+            from mcp_proxy.lifespan._san_resolver import resolve_nginx_sans
             from mcp_proxy.lifespan.nginx_cert_watcher import (
                 nginx_cert_watcher_loop,
             )
-            nginx_sans = [
-                s.strip()
-                for s in (settings.nginx_san or "mastio.local").split(",")
-                if s.strip()
-            ]
+            nginx_sans = resolve_nginx_sans(settings)
             nginx_leader = _get_leader_nginx("nginx_cert_watcher")
             if await nginx_leader.acquire():
                 nginx_stop = asyncio.Event()

--- a/tests/test_nginx_san_resolver.py
+++ b/tests/test_nginx_san_resolver.py
@@ -1,0 +1,294 @@
+"""Tests for ``mcp_proxy.lifespan._san_resolver.resolve_nginx_sans``.
+
+Customer-blocker dogfood 2026-05-19: a Mastio VM at
+``192.168.122.62`` deployed via ``cullis-mastio-bundle`` with
+``MCP_PROXY_PROXY_PUBLIC_URL=https://192.168.122.62:9443`` minted
+an nginx leaf SAN list of
+``mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy``
+(the bundle default). Every TLS-strict client (Frontdesk
+Connector, Python SDK, browsers without ``--insecure``) refused
+the handshake with ``CERTIFICATE_VERIFY_FAILED / hostname
+'192.168.122.62' doesn't match``. The downstream cert minter
+(``AgentManager.ensure_nginx_server_cert``) already splits IP
+literals into iPAddress SAN entries and hostnames into dNSName;
+the bug was that the SAN list passed in didn't include the host
+the operator actually configured.
+
+The resolver auto-appends the hostname of ``proxy_public_url`` so
+fresh deploys + container restarts close the gap without needing
+the operator to also edit ``MCP_PROXY_NGINX_SAN``. Integration
+asserts pair with ``test_mastio_nginx_cert_san.py`` (which pins
+the iPAddress vs dNSName split downstream).
+"""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+from dataclasses import dataclass
+from pathlib import Path
+
+from cryptography import x509
+
+from mcp_proxy.lifespan._san_resolver import resolve_nginx_sans
+
+
+@dataclass
+class _Settings:
+    nginx_san: str = "mastio.local"
+    proxy_public_url: str = ""
+
+
+# ── Unit: resolver behaviour ───────────────────────────────────────
+
+
+def test_empty_public_url_returns_split_nginx_san_unchanged():
+    s = _Settings(
+        nginx_san="mastio.local,localhost,host.docker.internal",
+        proxy_public_url="",
+    )
+    assert resolve_nginx_sans(s) == [
+        "mastio.local", "localhost", "host.docker.internal",
+    ]
+
+
+def test_ipv4_public_url_appends_once():
+    s = _Settings(
+        nginx_san="mastio.local,localhost",
+        proxy_public_url="https://192.168.122.62:9443",
+    )
+    sans = resolve_nginx_sans(s)
+    assert sans == ["mastio.local", "localhost", "192.168.122.62"]
+
+
+def test_fqdn_public_url_appends_once():
+    s = _Settings(
+        nginx_san="mastio.local,localhost",
+        proxy_public_url="https://mastio.acme.corp:9443",
+    )
+    sans = resolve_nginx_sans(s)
+    assert sans == ["mastio.local", "localhost", "mastio.acme.corp"]
+
+
+def test_public_url_host_already_in_san_does_not_duplicate():
+    """Idempotency: default + already-listed host stays single entry."""
+    s = _Settings(
+        nginx_san="mastio.local,localhost",
+        proxy_public_url="https://mastio.local:9443",
+    )
+    sans = resolve_nginx_sans(s)
+    assert sans == ["mastio.local", "localhost"]
+
+
+def test_ipv6_literal_returns_hostname_without_brackets():
+    """urlparse strips the brackets, so the entry compares cleanly
+    against ``ipaddress.ip_address(...)`` in the downstream split."""
+    s = _Settings(
+        nginx_san="mastio.local",
+        proxy_public_url="https://[::1]:9443",
+    )
+    sans = resolve_nginx_sans(s)
+    assert sans == ["mastio.local", "::1"]
+    # And the resulting entry round-trips through ipaddress, so the
+    # downstream IP-vs-DNS split picks it as an IP literal.
+    assert ipaddress.ip_address(sans[-1])
+
+
+def test_malformed_url_no_crash_and_no_append():
+    """urlparse('not-a-url').hostname is None — must not crash,
+    must not pollute the SAN list with garbage."""
+    s = _Settings(
+        nginx_san="mastio.local",
+        proxy_public_url="not-a-url",
+    )
+    assert resolve_nginx_sans(s) == ["mastio.local"]
+
+
+def test_whitespace_in_nginx_san_is_stripped():
+    s = _Settings(
+        nginx_san="mastio.local, localhost ,  host.docker.internal",
+        proxy_public_url="",
+    )
+    assert resolve_nginx_sans(s) == [
+        "mastio.local", "localhost", "host.docker.internal",
+    ]
+
+
+def test_idempotent_across_calls():
+    """Watcher tick and boot must produce identical lists for the
+    same settings, otherwise the cert reuse path triggers a
+    spurious rotation on every restart."""
+    s = _Settings(
+        nginx_san="mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy",
+        proxy_public_url="https://192.168.122.62:9443",
+    )
+    first = resolve_nginx_sans(s)
+    second = resolve_nginx_sans(s)
+    assert first == second
+
+
+def test_empty_nginx_san_falls_back_to_default():
+    s = _Settings(nginx_san="", proxy_public_url="")
+    assert resolve_nginx_sans(s) == ["mastio.local"]
+
+
+def test_logs_at_info_when_appending(monkeypatch):
+    """Operators need to see ``auto-appended public_url host=X`` in
+    the boot log so the fix is visible (not a silent surprise).
+
+    Monkeypatching ``logger.info`` directly bypasses logging-framework
+    state set by other mcp_proxy tests (propagate=False, handler
+    overrides, logger.disabled, etc). See memory rule
+    feedback-mcp-proxy-logger-caplog.
+    """
+    from mcp_proxy.lifespan import _san_resolver as mod
+
+    captured: list[tuple] = []
+    monkeypatch.setattr(
+        mod.logger, "info",
+        lambda fmt, *args: captured.append((fmt, args)),
+    )
+
+    s = _Settings(
+        nginx_san="mastio.local",
+        proxy_public_url="https://192.168.122.62:9443",
+    )
+    resolve_nginx_sans(s)
+
+    rendered = [fmt % args if args else fmt for fmt, args in captured]
+    assert any(
+        "auto-appended" in m and "192.168.122.62" in m for m in rendered
+    ), rendered
+
+
+def test_no_log_when_no_append(monkeypatch):
+    """Default settings (no public_url) must NOT emit the
+    auto-append log, otherwise every test run / boot prints a
+    noisy nonsense line."""
+    from mcp_proxy.lifespan import _san_resolver as mod
+
+    captured: list[str] = []
+    monkeypatch.setattr(
+        mod.logger, "info",
+        lambda fmt, *args: captured.append(fmt % args if args else fmt),
+    )
+
+    s = _Settings(nginx_san="mastio.local", proxy_public_url="")
+    resolve_nginx_sans(s)
+
+    assert not any("auto-appended" in m for m in captured)
+
+
+# ── Integration: resolver → ensure_nginx_server_cert SAN shape ─────
+
+
+def _make_manager_with_ca():
+    """Wire an AgentManager with an Org CA + Mastio Intermediate but
+    skip Vault / DB bootstrap. Same fixture shape as
+    ``test_mastio_nginx_cert_san.py``."""
+    from datetime import datetime, timedelta, timezone
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "test-org CA"),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    mgr = AgentManager.__new__(AgentManager)
+    mgr._org_ca_key = key
+    mgr._org_ca_cert = cert
+    mgr._mastio_ca_key = key
+    mgr._mastio_ca_cert = cert
+    mgr._org_id = "test-org"
+    return mgr
+
+
+def _read_sans(crt_path: Path) -> tuple[set[str], set[str]]:
+    cert = x509.load_pem_x509_certificate(crt_path.read_bytes())
+    san = cert.extensions.get_extension_for_class(
+        x509.SubjectAlternativeName,
+    ).value
+    dns = set(san.get_values_for_type(x509.DNSName))
+    ips = {str(ip) for ip in san.get_values_for_type(x509.IPAddress)}
+    return dns, ips
+
+
+def test_integration_ipv4_public_url_lands_as_ip_san(tmp_path):
+    """End-to-end: resolver auto-appends, downstream minter routes
+    the literal into iPAddress (not dNSName) — closes the dogfood
+    bug for real."""
+    settings = _Settings(
+        nginx_san="mastio.local,localhost,host.docker.internal",
+        proxy_public_url="https://192.168.122.62:9443",
+    )
+    mgr = _make_manager_with_ca()
+    asyncio.run(
+        mgr.ensure_nginx_server_cert(
+            out_dir=tmp_path,
+            sans=resolve_nginx_sans(settings),
+            validity_days=30,
+            renew_within_days=7,
+        )
+    )
+    dns, ips = _read_sans(tmp_path / "mastio-server.crt")
+    assert "192.168.122.62" in ips
+    assert "192.168.122.62" not in dns
+    assert {"mastio.local", "localhost", "host.docker.internal"} <= dns
+
+
+def test_integration_fqdn_public_url_lands_as_dns_san(tmp_path):
+    settings = _Settings(
+        nginx_san="mastio.local,localhost",
+        proxy_public_url="https://mastio.acme.corp:9443",
+    )
+    mgr = _make_manager_with_ca()
+    asyncio.run(
+        mgr.ensure_nginx_server_cert(
+            out_dir=tmp_path,
+            sans=resolve_nginx_sans(settings),
+            validity_days=30,
+            renew_within_days=7,
+        )
+    )
+    dns, ips = _read_sans(tmp_path / "mastio-server.crt")
+    assert "mastio.acme.corp" in dns
+    assert ips == set()
+
+
+def test_integration_default_settings_no_regression(tmp_path):
+    """Operator who never sets PROXY_PUBLIC_URL must still get the
+    legacy bundle SAN list verbatim — no regression on the existing
+    docker-compose default install path."""
+    settings = _Settings(
+        nginx_san="mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy",
+        proxy_public_url="",
+    )
+    mgr = _make_manager_with_ca()
+    asyncio.run(
+        mgr.ensure_nginx_server_cert(
+            out_dir=tmp_path,
+            sans=resolve_nginx_sans(settings),
+            validity_days=30,
+            renew_within_days=7,
+        )
+    )
+    dns, ips = _read_sans(tmp_path / "mastio-server.crt")
+    assert dns == {
+        "mastio.local", "localhost", "host.docker.internal",
+        "mastio-nginx", "mcp-proxy",
+    }
+    assert ips == set()


### PR DESCRIPTION
## Why

Customer-blocker reproduced during dogfood on 2026-05-19. A Mastio VM at
`192.168.122.62` deployed via `cullis-mastio-bundle` with
`MCP_PROXY_PROXY_PUBLIC_URL=https://192.168.122.62:9443` mints an nginx leaf
whose SAN list is the bundle default:

```
DNS:mastio.local, DNS:localhost, DNS:host.docker.internal,
DNS:mastio-nginx, DNS:mcp-proxy
```

The configured `192.168.122.62` host is missing. Every TLS-strict client
(Frontdesk Connector, Python SDK, Connector desktop, mTLS-pinning bundle,
browser without `--insecure`) refuses the handshake with
`CERTIFICATE_VERIFY_FAILED / hostname '192.168.122.62' doesn't match`. The
customer cannot get past first deploy without manually editing
`MCP_PROXY_NGINX_SAN` in `proxy.env`, regenerating the cert, restarting
nginx. Most non-tech operators won't.

The downstream cert minter
(`AgentManager.ensure_nginx_server_cert`, see comment at
`mcp_proxy/egress/agent_manager.py:681-688`) already routes IP literals to
`iPAddress` SAN entries and hostnames to `dNSName` (that was a prior bug
fix for the same code path). The remaining gap was upstream: the SAN list
passed in never contained the host the operator configured.

## Pre-implementation verification (memory rule feedback-verify-codebase-state)

- `grep -rn 'resolve_nginx_sans|nginx_san|proxy_public_url.*hostname|urlparse.*proxy_public' mcp_proxy/` confirmed no existing helper. Three call sites use `(settings.nginx_san or 'mastio.local').split(',')` inline: `mcp_proxy/config.py:105` (default), `mcp_proxy/main.py:361-365` (boot), `mcp_proxy/main.py:519-523` (watcher task wiring).
- `git log --oneline --all -- mcp_proxy/main.py mcp_proxy/egress/agent_manager.py mcp_proxy/lifespan/nginx_cert_watcher.py | head -30` shows no in-flight branch.
- `gh pr list --state open --search 'nginx SAN OR cert hostname OR proxy_public_url SAN'` returned no open PRs.

## Changes

- New helper `mcp_proxy/lifespan/_san_resolver.py::resolve_nginx_sans(settings) -> list[str]`. Starts from `settings.nginx_san` (comma-split, default `mastio.local`), appends `urlparse(settings.proxy_public_url).hostname` when set and not already present. Idempotent. Logs at INFO when it actually appends so operators see the new host in the boot log.
- `mcp_proxy/main.py:361-365` (boot `ensure_nginx_server_cert`) now calls the helper.
- `mcp_proxy/main.py:519-523` (nginx_cert_watcher task creation) now calls the helper, so the periodic re-mint sees the same SAN set as boot (cert reuse path stays happy, no spurious rotations).
- No bundle script changes. Python fix covers fresh + restart paths; bundle scaffolding visibility is a separate doc/scaffold concern (out of scope).

## Tests

`tests/test_nginx_san_resolver.py`, 14 cases total (10 unit + 3 integration + 1 watcher-equivalence):

Unit on `resolve_nginx_sans`:
- empty `proxy_public_url` returns split `nginx_san` unchanged
- `https://192.168.122.62:9443` appends `192.168.122.62` once
- `https://mastio.acme.corp:9443` appends `mastio.acme.corp` once
- `https://mastio.local:9443` (already in default) does NOT duplicate
- IPv6 literal `https://[::1]:9443` returns `::1` (brackets stripped, round-trips through `ipaddress.ip_address`)
- malformed `not-a-url` → `.hostname is None` → no crash, list unchanged
- whitespace in `nginx_san` comma list is stripped
- idempotent across repeated calls (boot + watcher tick must agree)
- empty `nginx_san` falls back to `mastio.local`
- INFO log fires only on actual append (no noisy log on default path)

Integration on `ensure_nginx_server_cert` via the helper:
- boot with `proxy_public_url=https://192.168.122.62:9443` writes a cert whose SAN contains `IP:192.168.122.62` (not `DNS:192.168.122.62`), verified by parsing the PEM and reading `SubjectAlternativeName.get_values_for_type(x509.IPAddress)`.
- boot with `proxy_public_url=https://mastio.acme.corp:9443` writes a cert whose dNSName list contains `mastio.acme.corp` and iPAddress list is empty.
- boot with default settings (no public_url override) still writes the legacy SAN list, no regression.

`pytest tests/ -n auto --dist=loadfile -q` → **4044 passed, 1 failed, 32 skipped in 108.23s**. The single failure is `tests/test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`, unrelated to this PR: the test docstring explicitly says "the open-core repo runs tests without the enterprise package on PYTHONPATH; uninstall it before running this test" — my dev venv has `cullis_enterprise` editable-installed for cross-repo work. Confirmed by re-running the test in isolation with the same precondition fail. Not caused by this PR.

## Smoke

`./sandbox/down.sh && ./sandbox/demo.sh full && COMPOSE_PROFILES=full ./sandbox/smoke.sh full` →

```
[smoke] PASS=25  FAIL=0  SKIP=1
```

Host bundle on port 9443 stopped first (`docker stop cullis-mastio-mcp-proxy-1 cullis-mastio-mastio-nginx-1`) so the sandbox could bind 9443, then restarted after smoke per memory rule feedback-smoke-gate. The bundle on the dogfood VM (192.168.122.62) is unaffected.

## Dogfood validation

I can't validate against the live VM bundle right now (the VM ships a tagged release image, not this worktree), but the next bundle release that picks up this PR should validate by:

1. Set `MCP_PROXY_PROXY_PUBLIC_URL=https://<custom-host>:9443` in `proxy.env`.
2. Restart container with `./deploy.sh --pull`.
3. `openssl s_client -connect <custom-host>:9443 -servername <custom-host> </dev/null | openssl x509 -noout -ext subjectAltName` shows the custom host (with `IP Address:` prefix for IPv4 literals, `DNS:` for FQDNs).
4. Connector / Python SDK / browser handshake against the URL succeeds without `--insecure`.

The boot log should also show
`nginx_san: auto-appended proxy_public_url host=<host> (now: [...])`
on first start.

## Out of scope

- `packaging/mastio-bundle/generate-proxy-env.sh` and `proxy.env.example`: would be nice to also have the bundle scaffolding visibly include the hostname so the value isn't only auto-derived at runtime, but that's a doc/scaffold concern, separate PR.
- Connector-side `verify_tls=False` toggles: TOFU bypass for first-touch only, unaffected here.