### PR TITLE
docs(bundle): refresh AI gateway env.example for 6-provider catalog

### DIFF
--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -212,29 +212,36 @@ MCP_PROXY_STANDALONE=true
 # The Mastio embeds LiteLLM in-process to dispatch /v1/chat/completions
 # directly to the upstream LLM provider, with Cullis identity + audit on
 # every call. Required for Cullis Chat (canale 1) and Frontdesk (canale
-# 2) end-user chat flows. Without a provider key, those endpoints return
-# HTTP 503 ``provider_key_missing`` and the chat UI shows an error.
+# 2) end-user chat flows. Without a provider configured, those endpoints
+# return HTTP 503 ``provider_not_configured`` and the chat UI shows an
+# error.
 #
-# Today only ``anthropic`` is wired as provider (other providers return
-# 501 ``provider_not_implemented`` — OpenAI / Gemini are roadmap). The
-# default backend is the embedded LiteLLM library; switch to a Portkey
-# sidecar by setting ``MCP_PROXY_AI_GATEWAY_BACKEND=portkey`` and
-# pointing ``MCP_PROXY_AI_GATEWAY_URL`` at it.
+# Six providers are wired (mcp_proxy/egress/provider_catalog.py):
+# Anthropic, OpenAI, Gemini, AWS Bedrock, Vertex AI, and Ollama (local
+# models, dynamic discovery, no API key). Configure credentials per
+# provider from the dashboard at ``Settings -> AI Providers``; the SPA
+# dropdown surfaces only models from enabled providers. The default
+# backend is the embedded LiteLLM library; switch to a Portkey sidecar
+# by setting ``MCP_PROXY_AI_GATEWAY_BACKEND=portkey`` (Portkey path is
+# legacy Phase-1 and only routes Anthropic).
 
-# [REQUIRED for chat UI] Anthropic API key — the upstream LLM credential
-# used by every chat completion. Mint a scoped key at
-# https://console.anthropic.com/settings/keys and rotate per the org's
-# secret-rotation policy. Leaving this empty disables chat (the rest of
-# the Mastio still works — registry, MCP, audit).
+# [OPTIONAL legacy] Anthropic API key, env-only path kept for backward
+# compatibility with deployments that pre-date the dashboard provider
+# UI. When set, the gateway uses this key for Anthropic models even if
+# no ``ai_provider_credentials`` row exists. New deployments should
+# configure Anthropic (and every other provider) from the dashboard
+# instead so the credential is org-scoped, rotatable, and auditable.
 MCP_PROXY_ANTHROPIC_API_KEY=
 
 # Backend dispatcher. ``litellm_embedded`` (default) calls LiteLLM in
 # the same process; ``portkey`` proxies through a Portkey sidecar at
-# ``MCP_PROXY_AI_GATEWAY_URL``.
+# ``MCP_PROXY_AI_GATEWAY_URL`` (legacy, Anthropic-only).
 #MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded
 
-# Active upstream provider. Anthropic only at v0.3.x; other values are
-# rejected with HTTP 501 until the corresponding wiring lands.
+# Default upstream provider when the request model id has no explicit
+# ``provider/model`` prefix and no heuristic matches. Routing for
+# explicit prefixes (``openai/``, ``gemini/``, ``ollama_chat/``, ...)
+# happens regardless of this value; this is only the fallback tag.
 #MCP_PROXY_AI_GATEWAY_PROVIDER=anthropic
 
 # Portkey sidecar URL — only consulted when backend=portkey.


### PR DESCRIPTION
## Why

Dogfood finding #2 (2026-05-19). The operator-facing env.example told a story that doesn't match the code:

> Today only \`\`anthropic\`\` is wired as provider (other providers return 501 \`\`provider_not_implemented\`\` -- OpenAI / Gemini are roadmap)

In reality the embedded LiteLLM catalog has been six providers for a while (\`mcp_proxy/egress/provider_catalog.py\` PROVIDERS dict: Anthropic, OpenAI, Gemini, AWS Bedrock, Vertex AI, Ollama). The dashboard exposes them at \`Settings -> AI Providers\`. The doc was confidently wrong, and an operator reading the env file before clicking around could plausibly conclude they cannot configure Ollama at all and abandon.

## Changes

\`packaging/mastio-bundle/proxy.env.example\`:

- Replaced the \"only anthropic / OpenAI / Gemini are roadmap\" paragraph with the actual six-provider list, plus a pointer to the dashboard as the recommended config path.
- Reframed \`MCP_PROXY_ANTHROPIC_API_KEY\` from \"REQUIRED for chat UI\" to \"OPTIONAL legacy\" (kept for backward compat with env-only deployments). Steers new operators toward the dashboard provider UI so credentials are org-scoped, rotatable, and auditable.
- Clarified the Portkey backend note (Phase-1 legacy, Anthropic-only) and the meaning of \`MCP_PROXY_AI_GATEWAY_PROVIDER\` (fallback tag when the model id has no explicit prefix, not a hard gate).
- Fixed the error code reference (\`provider_not_configured\`, the one the dispatcher actually raises) and removed the em-dash.

## Out of scope

- No code change. The behaviour and env var schema are unchanged.
- \`packaging/mastio-bundle/proxy.env\` (the gitignored local file) is not touched; operator dev deployments will keep their local copy until they regenerate.
- Sister bundles (\`mastio-enterprise-bundle\`) do not ship their own env.example for this block.
- \`generate-proxy-env.sh\` already lets the dashboard own credentials, no scaffold change needed.

## Tests

Doc-only change, no tests added. The accuracy claim (\"six providers, all wired\") is verifiable by inspection of \`PROVIDERS\` in \`mcp_proxy/egress/provider_catalog.py:91-170\`.

## Dogfood validation

After a fresh \`./generate-proxy-env.sh --prod --force\` run, the operator now reads accurate guidance and reaches the dashboard provider UI on first try. Smoke chain Mastio -> Ollama validated in the same dogfood session.