### PR TITLE
chore(release): mastio-v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+## [v0.4.5] — Mastio three-tier PKI + WebAuthn user sessions + dogfood UX fixes — 2026-05-19
+
 ### Added
 - nginx sidecar runtime cert rotation via leader-elected lifespan
   watcher (default 24h tick). Pairs with a polling reload-watcher
@@ -24,6 +26,35 @@ flow until the next `## ` heading.
   `pki.nginx_server_cert_rotated` per rotation.
 
 ### Fixed
+- **TLS server cert SAN now auto-includes the host of
+  `MCP_PROXY_PROXY_PUBLIC_URL`** (`mcp_proxy/lifespan/_san_resolver.py`,
+  customer-blocker fix). Pre-fix the SAN list came verbatim from
+  `MCP_PROXY_NGINX_SAN` (default `mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy`)
+  and no code path appended the operator-configured public hostname.
+  Operators who set `PROXY_PUBLIC_URL=https://<custom-fqdn-or-ip>:9443`
+  got a cert that did not match their own URL, so any TLS-strict client
+  (Frontdesk Connector, Python SDK, browser without `--insecure`) hit
+  `CERTIFICATE_VERIFY_FAILED / hostname doesn't match` on first
+  handshake. The new resolver parses `urlparse(public_url).hostname`,
+  splits IPv4/IPv6 literals into `IPAddress` SAN entries and DNS names
+  into `DNSName` entries, and idempotently appends them to the list
+  passed to `ensure_nginx_server_cert`. Surfaced during the 2026-05-19
+  dogfood on a VM at `192.168.122.62`.
+- **Org display name is now editable inline from the dashboard
+  overview card** (`mcp_proxy/dashboard/router.py`,
+  `_org_title_block.html` partial). Pre-fix the amber CTA "Set a
+  friendly display name" linked to `/proxy/setup`, the full broker
+  uplink wizard with six unrelated fields. The wizard's
+  `Organization ID` input also looked editable but was silently
+  ignored in standalone mode (derived from the Org CA pubkey,
+  ADR-006 §2.2), so an operator trying to rename the org typically
+  edited the wrong field, hit Save, and saw no change. Three new
+  endpoints (`GET /proxy/settings/org/display-name/edit`,
+  `POST /proxy/settings/org/display-name`, view fragment) drive an
+  HTMX inline edit on the overview title. The setup wizard's
+  `org_id` input is now `readonly` when the CA is loaded, with a
+  small note explaining the derivation. Surfaced during the
+  2026-05-19 dogfood.
 - `AgentManager.ensure_nginx_server_cert` now writes
   `mastio-server.crt` as a **full chain bundle** (leaf || Mastio
   Intermediate) instead of leaf-only. Pre-fix the file held only the
@@ -163,6 +194,18 @@ flow until the next `## ` heading.
 
 ### Documentation
 
+- **`packaging/mastio-bundle/proxy.env.example` AI gateway block
+  refreshed** to reflect the six-provider catalog (Anthropic, OpenAI,
+  Gemini, AWS Bedrock, Vertex AI, Ollama). The prior wording told
+  operators "only `anthropic` is wired (other providers return 501
+  `provider_not_implemented`, OpenAI / Gemini are roadmap)" which had
+  been stale since the catalog grew. New copy points operators at the
+  dashboard `Settings -> AI Providers` as the recommended config path,
+  reframes `MCP_PROXY_ANTHROPIC_API_KEY` as optional-legacy backward
+  compat, and clarifies that `MCP_PROXY_AI_GATEWAY_PROVIDER` is a
+  fallback tag rather than a hard whitelist. Surfaced during the
+  2026-05-19 dogfood (operator read env file before opening dashboard,
+  mentally ruled out Ollama as unsupported).
 - **Frontdesk shared-mode security hardening runbook** added at
   `docs/runbooks/frontdesk-shared-hardening.md`. Covers container
   security configuration, network isolation, monitoring, update cadence,


### PR DESCRIPTION
## Why

Cuts the existing \`[Unreleased]\` section into a stamped \`[v0.4.5]\` release header so the operator-facing CHANGELOG matches what is about to ship. Adds the three release-day fixes that were not yet in the file:

- #800 (Fixed) — org display name inline-editable from overview card; setup org_id readonly when CA-derived
- #801 (Fixed) — TLS server cert SAN auto-includes the host of \`MCP_PROXY_PROXY_PUBLIC_URL\`
- #802 (Documentation) — \`packaging/mastio-bundle/proxy.env.example\` AI gateway block refreshed for the six-provider catalog

All three surfaced during the 2026-05-19 dogfood (solo founder simulating first-customer Mastio install on a libvirt VM at 192.168.122.62).

## What's not here

The cloud CI release workflow (\`release-mastio.yml\`) was removed in #782 along with the rest of \`.github/workflows/\`. The image build, image push, git tag, and \`gh release create\` are now manual steps that follow this merge:

1. \`git checkout main && git pull --ff-only origin main\` (post-merge)
2. \`docker login ghcr.io\` once with a classic PAT scoped \`write:packages\`
3. \`docker build -f mcp_proxy/Dockerfile --build-arg VERSION=0.4.5 -t ghcr.io/cullis-security/cullis-mastio:v0.4.5 -t ghcr.io/cullis-security/cullis-mastio:latest .\`
4. \`docker push ghcr.io/cullis-security/cullis-mastio:v0.4.5 && docker push ghcr.io/cullis-security/cullis-mastio:latest\`
5. \`git tag mastio-v0.4.5 && git push origin mastio-v0.4.5\`
6. \`gh release create mastio-v0.4.5\` with the \`[v0.4.5]\` body extracted from this CHANGELOG section

These are scripted-friendly but no script exists yet. Filing a follow-up for a \`scripts/release-mastio.sh\` orchestrator is out of scope for the PR.

## Dogfood validation

After steps 3-6 above, the VM Mastio at 192.168.122.62 (currently running \`mastio-v0.4.4\` from the 2026-05-16 release) should:

1. Surface the update banner on the dashboard within the 24h poll window (faster by restarting the container or deleting the \`update_check_last_poll\` row in \`proxy_config\`).
2. After \`./deploy.sh --pull\` on the VM, run \`v0.4.5\` (\`CULLIS_MASTIO_VERSION=0.4.5\` in container env).
3. Auto-regenerate the nginx server cert with \`192.168.122.62\` in SAN (verifiable via \`openssl s_client\`).
4. Show the inline display-name editor on the overview card (no longer routes through the broker uplink wizard).

## Tests

CHANGELOG-only change. No code or tests touched. \`./sandbox/smoke.sh full\` is unaffected.