### PR TITLE
fix(frontdesk): preserve Host port through TLS sidecar (wizard 403)

### DIFF
--- a/packaging/frontdesk-bundle/nginx-tls/default.conf
+++ b/packaging/frontdesk-bundle/nginx-tls/default.conf
@@ -70,11 +70,21 @@ server {
         set $inner_upstream http://nginx:80;
         proxy_pass $inner_upstream;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        # $http_host preserves the port the browser sent (e.g.
+        # 192.168.122.87:8443), while $host strips it. The Connector
+        # CSRF middleware (cullis_connector/web.py:881) builds
+        # expected_origins from request.url.netloc which is derived
+        # from this Host header; if the port is missing here, the
+        # browser's Origin header (which always includes a non-default
+        # port like :8443) will not match and every POST /setup/*
+        # request from the in-browser enrollment wizard gets a 403
+        # ``cross-origin request blocked``. Setting $http_host keeps
+        # the netloc intact through both proxy hops.
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Host  $http_host;
         proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        $connection_upgrade;


### PR DESCRIPTION
## Why

Dogfood finding 2026-05-19, customer-blocker. The Frontdesk TLS sidecar forwarded the inner nginx using \`proxy_set_header Host \$host\` which strips the port from the client's Host header. On any deployment where the bundle is reachable on a non-default HTTPS port (the default \`:8443\` already qualifies, plus any custom port a customer maps in), every POST from the in-browser enrollment wizard hit \`403 cross-origin request blocked\` immediately after FETCH FINGERPRINT.

## Repro

1. Deploy Frontdesk bundle with \`CULLIS_SITE_URL\` empty (browser-wizard mode), TLS sidecar on \`:8443\` (default)
2. Reach the wizard from a non-loopback host: \`https://<bundle-host>:8443/setup/discover\`
3. Click FETCH FINGERPRINT
4. Wizard surfaces \`HTTP 403\`, manual navigation to \`/setup\` returns the body \`{\"detail\":\"cross-origin request blocked\"}\`

## Trace

- Browser request: \`Host: <bundle-host>:8443\`, \`Origin: https://<bundle-host>:8443\`
- TLS sidecar (\`nginx-tls/default.conf:73\` pre-fix) rewrites Host to \`\$host\` = \`<bundle-host>\` (port stripped)
- Inner nginx (\`nginx/default.conf:171\`) forwards \`Host: \$http_host\` unchanged, but the value it received already lacks the port
- Connector CSRF middleware (\`cullis_connector/web.py:881-892\`) builds \`expected_origins\` from \`request.url.netloc\` = \`<bundle-host>\` and compares to the browser's Origin header (\`https://<bundle-host>:8443\`) → mismatch → 403

The middleware behaviour is correct (same-origin guard against CSRF on cookie-auth POSTs). The bug is the sidecar stripping the port before the Connector ever sees the request.

## Fix

Switch \`Host\` and \`X-Forwarded-Host\` from \`\$host\` to \`\$http_host\` in the TLS sidecar location block. \`\$http_host\` is the literal Host header sent by the client, port included. \`X-Forwarded-Port\` is unchanged because it carries the port separately and downstream consumers already split the two values.

Inline comment in the diff explains the trap so the next person editing nginx config doesn't reintroduce it.

## Tests

nginx config change, no Python tests touched. Validated end-to-end against the dogfood VM:

- VM frontdesk-demo, \`192.168.122.87\`, Frontdesk bundle on \`:8443\`
- Browser from workstation hits \`https://192.168.122.87:8443/setup/discover\`
- Pre-fix: FETCH FINGERPRINT → 403, \`/setup\` body \`{\"detail\":\"cross-origin request blocked\"}\`
- Post-fix (validation below before opening the PR):
  - Edit \`~/frontdesk-bundle/nginx-tls/default.conf\` on the VM with the same change (bind-mounted, no image rebuild)
  - \`docker exec cullis-frontdesk-frontdesk-nginx-1 nginx -s reload\`
  - Wizard FETCH FINGERPRINT now returns the SHA-256 and the wizard proceeds

## Out of scope

- Inner nginx config — already uses \`\$http_host\`, no change needed once the sidecar forwards the value with port intact
- Customer-blocker UX of the wizard fields (\"Your Name\" / \"Work Email\" default-Connector-personal-mode copy in a Frontdesk shared deployment) is a separate finding, tracked separately