### PR TITLE
fix(connector): wizard mode signs pop_signature on /v1/enrollment/start

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -999,12 +999,19 @@ def build_app(config: ConnectorConfig) -> FastAPI:
 
         try:
             from cullis_connector.config import verify_arg_for
+            # ``private_key`` MUST flow into ``_start`` so the body
+            # carries ``pop_signature``. Without it ``start_enrollment``
+            # gates the signature behind ``if private_key is not None``
+            # and Mastio v0.4.5+ rejects the bare body with HTTP 422
+            # ``Field required: pop_signature`` (PR #787 closed the
+            # transition window where the field was Optional).
             start_resp = _start(
                 site_url=site_url,
                 pubkey_pem=pubkey_pem,
                 requester=requester,
                 verify_tls=verify_arg_for(verify_tls, config.ca_chain_path),
                 timeout_s=config.request_timeout_s,
+                private_key=private_key,
             )
         except EnrollmentFailed as exc:
             return templates.TemplateResponse(


### PR DESCRIPTION
## Why

Dogfood finding 2026-05-19, customer-blocker. The in-browser setup wizard (\`POST /setup\` on the Connector, used by Frontdesk first-boot mode and any operator filling the discover form by hand) generates a fresh keypair, sends the public half to Mastio at \`/v1/enrollment/start\`, but never forwards the private half down into \`_start(...)\`. The enrollment helper gates the proof-of-possession signature behind \`if private_key is not None\` (\`enrollment.py:267\`), so a wizard caller leaving the kwarg at its default produces a body without \`pop_signature\`. Mastio v0.4.5+ closed the transition window for that field (PR #787, breaking change in v0.4.5 CHANGELOG), so every wizard-driven enrollment against a current Mastio now fails with:

\`\`\`
HTTP 422
{\"detail\":[{\"type\":\"missing\",\"loc\":[\"body\",\"pop_signature\"],\"msg\":\"Field required\", ...}]}
\`\`\`

The CLI device-code path (\`enrollment.py:1417\`) already passes \`private_key=_pending.private_key\` and was unaffected.

The v0.4.5 CHANGELOG line \"Connectors v0.4.4+ already ship \`_build_pop_signature\` and sign by default\" was true for the CLI path but optimistic for the wizard path. This PR closes that gap.

## Repro

1. Fresh Frontdesk v0.4.4 bundle against Mastio v0.4.5 (released 2026-05-19), \`CULLIS_SITE_URL\` empty so the in-browser wizard fires
2. Open \`https://<bundle-host>:8443/setup/discover\`, fill the form (Mastio URL, name, email)
3. Submit → wizard surfaces the 422 detail as \`Site rejected enrollment start (HTTP 422)\` and stops

## Fix

Pass the freshly-generated \`private_key\` from \`web.py:setup_post\` into \`_start(...)\`. Inline comment in the diff so the next person touching this path sees why the kwarg matters.

## Tests

The Connector test suite covers the CLI enrollment path through \`enrollment.py\`. Adding a dedicated test for the wizard happy path here would require a Mastio-side fake that asserts presence of \`pop_signature\` and a generated keypair, which is wider than the one-line fix and overlaps with the contract test the CLI path already covers. Filed as a follow-up: the contract assertion \"every \`_start(...)\` caller forwards \`private_key\`\" belongs on \`_start\` itself, either by making \`private_key\` non-default or by raising when omitted on a Mastio that requires PoP. Out of scope here.

## Dogfood validation

Will rebuild and push \`ghcr.io/cullis-security/cullis-connector:0.4.7\` after this merges, then bump \`CONNECTOR_VERSION\` in the dogfood VM's \`frontdesk.env\`, \`./deploy.sh\` to pick up the new image, and re-run the wizard end-to-end. Mastio side already runs v0.4.5 (which mandates the field).

## Out of scope

- The Connector release (image build + push + git tag + GitHub release) follows this merge as a separate manual sequence, same as the Mastio mastio-v0.4.5 cut earlier today
- The wizard UX fields (\"Your Name\" / \"Work Email\" defaulting to \`frontdesk@cullis.demo\` in Frontdesk shared mode, semantically wrong since the deployment is multi-user not single-user) is a separate finding that needs its own discussion before changing copy + defaults