### PR TITLE
chore(release): connector-v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+## [v0.4.7] — Connector wizard pop_signature + Frontdesk TLS sidecar Host port — 2026-05-19
+
+### Fixed
+
+- **Connector in-browser setup wizard now signs `pop_signature` on `POST /v1/enrollment/start`.**
+  `cullis_connector/web.py:setup_post` generates a fresh keypair, hands the
+  public half to `_start(...)`, but pre-fix it left `private_key` at the
+  kwarg default `None`. The helper gates the proof-of-possession signature
+  behind `if private_key is not None` (`enrollment.py:267`), so the
+  body shipped without `pop_signature`. Mastio v0.4.5+ closed the
+  transition window for that field (PR #787), so every wizard-driven
+  enrollment against a current Mastio returned HTTP 422 `Field required:
+  pop_signature`. The CLI device-code path already passed the kwarg and
+  was unaffected. Customer-blocker surfaced during the 2026-05-19 dogfood
+  (Frontdesk first-boot wizard against the freshly released Mastio
+  v0.4.5).
+- **Frontdesk TLS sidecar preserves the request port on `Host` and
+  `X-Forwarded-Host`.** `packaging/frontdesk-bundle/nginx-tls/default.conf`
+  forwarded the inner nginx with `proxy_set_header Host $host`, which
+  strips the port. Any deployment reachable on a non-default HTTPS port
+  (the default `:8443` already qualifies, plus any custom port) saw
+  every POST from the in-browser enrollment wizard hit
+  `403 cross-origin request blocked`: the Connector CSRF middleware
+  (`cullis_connector/web.py:881-892`) built `expected_origins` from
+  `request.url.netloc` (port stripped by the sidecar) and the browser's
+  `Origin` header (port intact) failed to match. Switch to `$http_host`
+  on both `Host` and `X-Forwarded-Host` so the port survives both proxy
+  hops.
+
 ## [v0.4.5] — Mastio three-tier PKI + WebAuthn user sessions + dogfood UX fixes — 2026-05-19
 
 ### Added

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.6"
+version = "0.4.7"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

Cuts the existing [Unreleased] section into a stamped [v0.4.7] header so the operator-facing CHANGELOG matches what is about to ship. Bumps the two Connector version source files (\`cullis_connector/__init__.py\` + \`packaging/pypi/pyproject.toml\`) from 0.4.6 to 0.4.7 in lockstep (the release-connector.yml workflow used to verify the two match before publishing — same convention here even with manual release).

Two fixes ship in v0.4.7, both surfaced during the 2026-05-19 Frontdesk dogfood:

- #805 — Connector wizard signs \`pop_signature\` on \`POST /v1/enrollment/start\` (was missing, Mastio v0.4.5+ requires it, every first-boot wizard against current Mastio returned HTTP 422)
- #804 — Frontdesk TLS sidecar forwards \`Host\` and \`X-Forwarded-Host\` as \`\$http_host\` instead of \`\$host\`, preserving the request port so the Connector CSRF middleware accepts the browser's Origin

Both are wizard-path customer-blockers. The CLI device-code enrollment path was unaffected.

## Manual release sequence (post-merge)

1. \`git checkout main && git pull --ff-only origin main\`
2. \`docker build -f packaging/docker/Dockerfile -t ghcr.io/cullis-security/cullis-connector:0.4.7 -t ghcr.io/cullis-security/cullis-connector:latest .\` (already running in background; will be re-tagged from the merge commit if material changes)
3. \`docker push ghcr.io/cullis-security/cullis-connector:0.4.7 && docker push ghcr.io/cullis-security/cullis-connector:latest\`
4. \`git tag -a connector-v0.4.7 -m \"...\" <sha>\` + \`git push origin connector-v0.4.7\`
5. \`gh release create connector-v0.4.7 --title \"Cullis Connector connector-v0.4.7\" --notes-file <body from CHANGELOG section> --target main\`

Image tag uses semver-puro (no \`v\` prefix), git tag uses \`connector-v\` prefix, GitHub release uses the git tag (same asymmetry documented in memory rule \`feedback-mastio-release-tag-convention\` and applied earlier today for mastio-v0.4.5).

## Dogfood validation

After steps 2-5, the dogfood VM frontdesk-demo at \`192.168.122.87\` bumps \`CONNECTOR_VERSION=0.4.7\` in \`frontdesk.env\`, runs \`./deploy.sh --pull\`, and re-opens \`https://192.168.122.87:8443/setup/discover\`. The wizard should now make it past FETCH FINGERPRINT and POST the enrollment with \`pop_signature\` in the body. Mastio side already runs v0.4.5 (which mandates the field).

## Tests

CHANGELOG + version-file bump only, no code change beyond what already merged in #804 + #805. No tests touched.