### PR TITLE
fix(connector): model picker live-only in shared mode

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -38,6 +38,7 @@ from cullis_connector.ambassador.streaming import (
     fake_stream,
 )
 from cullis_connector.ambassador.streaming_loop import stream_tool_use_loop
+from cullis_connector.identity.auth_mode import is_shared_mode
 
 _log = logging.getLogger("cullis_connector.ambassador.router")
 
@@ -199,7 +200,22 @@ def _fallback_models(state: dict) -> list[dict]:
 
 
 @router.get("/v1/models")
-def list_models(request: Request) -> dict:
+def list_models(request: Request):
+    """List the models reachable through Cullis.
+
+    Single mode (Cullis Chat desktop, ``AMBASSADOR_MODE != "shared"``):
+    fall back to ``advertised_models`` when the live Mastio fetch
+    fails. The desktop user keeps a usable dropdown when Mastio is
+    momentarily unreachable, which matches the consumer UX baseline.
+
+    Shared mode (Frontdesk container, ``AMBASSADOR_MODE=shared``):
+    fail loud with a 503 instead of returning a hardcoded list. In
+    multi-user deployments the admin configures providers via the
+    Mastio dashboard; a fallback list would advertise models that
+    aren't actually configured and the user would click chat only to
+    get ``provider not configured`` from Mastio. ADR-034 §5 promotes
+    the inconsistency upstream.
+    """
     _enforce_loopback(request)
     state = _get_state(request)
     _enforce_bearer(request, state)
@@ -211,8 +227,8 @@ def list_models(request: Request) -> dict:
         return _models_response(cached[1], cached[2])
 
     holder = state.get("client")
-    data = _fallback_models(state)
-    source = "fallback"
+    data: list[dict] = []
+    source = "live"
     error_reason: str | None = None
     if holder is not None:
         try:
@@ -220,17 +236,39 @@ def list_models(request: Request) -> dict:
             live = client.list_models()
             if live:
                 data = live
-                source = "live"
             else:
                 error_reason = "Mastio returned empty model list"
         except Exception as exc:
             error_reason = str(exc) or exc.__class__.__name__
             _log.debug(
-                "Mastio /v1/models fetch failed, using advertised fallback: %s",
-                exc,
+                "Mastio /v1/models fetch failed: %s", exc,
             )
     else:
         error_reason = "Ambassador has no Mastio client wired"
+
+    if not data:
+        # Live fetch did not yield a usable list. ADR-034 §5: in
+        # shared mode fail loud so the SPA can banner the issue; in
+        # single mode keep the legacy fallback for desktop UX. The
+        # 503 path skips the cache write so a transient fetch error
+        # doesn't pin the dropdown to error for 30s.
+        if is_shared_mode():
+            _log.warning(
+                "Mastio /v1/models unavailable in shared mode: %s",
+                error_reason,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": "mastio_unavailable",
+                    "cullis_meta": {
+                        "source": "error",
+                        "error": error_reason or "mastio_unavailable",
+                    },
+                },
+            )
+        data = _fallback_models(state)
+        source = "fallback"
 
     _models_cache[cache_key] = (now, data, source)
     return _models_response(data, source, error=error_reason)
@@ -245,6 +283,8 @@ def _models_response(
     drop-in for `api.openai.com/v1/models`. The Cullis SPA reads
     ``cullis_meta.source`` to render a banner when the live fetch
     failed and the dropdown is showing the hardcoded fallback list.
+    Shared-mode failure no longer reaches this helper — see ADR-034
+    §5 and the 503 branch in ``list_models``.
     """
     body: dict = {"object": "list", "data": data}
     meta: dict = {"source": source}

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -81,7 +81,15 @@ class AmbassadorConfig:
             "claude-opus-4-7",
         ]
     )
-    """Models surfaced via /v1/models. Must be supported by Mastio's egress."""
+    """Single-mode fallback list surfaced via ``/v1/models`` when Mastio
+    is unreachable. Used by Cullis Chat desktop so the dropdown stays
+    usable while the live fetch retries.
+
+    Shared mode (``AMBASSADOR_MODE=shared``) ignores this list: per
+    ADR-034 §5, an unreachable Mastio yields HTTP 503 instead of a
+    fallback list, so the SPA can banner the failure honestly rather
+    than offering models the admin never configured.
+    """
 
     require_local_only: bool = True
     """Reject any non-loopback peer regardless of bind. Defence-in-depth

--- a/frontend/cullis-chat/src/components/ModelPicker.tsx
+++ b/frontend/cullis-chat/src/components/ModelPicker.tsx
@@ -107,8 +107,8 @@ export default function ModelPicker() {
           aria-live="polite"
           title={
             fetchError
-              ? `Live model list unavailable: ${fetchError}. Showing cached defaults.`
-              : 'Live model list unavailable. Showing cached defaults.'
+              ? `Cannot reach Mastio — live model list unavailable (${fetchError})`
+              : 'Cannot reach Mastio — live model list unavailable'
           }
         >
           offline

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -275,6 +275,79 @@ def test_models_lists_default_three(client, bearer):
     assert len(ids) == 3
 
 
+# ── ADR-034 §5 — /v1/models live-only in shared mode ───────────────
+
+
+def test_models_503_in_shared_mode_when_mastio_unreachable(
+    client, bearer, monkeypatch,
+):
+    """ADR-034 §5: shared mode (Frontdesk) must fail loud when the
+    live Mastio fetch fails. Returning a hardcoded ``advertised_models``
+    list would advertise models the admin never configured and the
+    user would only learn at chat time. The 503 lets the SPA banner
+    "Cannot reach Mastio" up front.
+
+    Single-mode (Cullis Chat desktop) behaviour is covered by
+    ``test_models_lists_default_three`` above — the fallback there is
+    intentional consumer UX baseline.
+    """
+    monkeypatch.setenv("AMBASSADOR_MODE", "shared")
+    # Bust the in-process cache so the previous single-mode test's
+    # cached fallback list doesn't bleed in.
+    from cullis_connector.ambassador.router import _models_cache
+
+    _models_cache.clear()
+
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 503, resp.text
+    body = resp.json()
+    assert body["detail"] == "mastio_unavailable"
+    assert body["cullis_meta"]["source"] == "error"
+    assert body["cullis_meta"]["error"]
+    # Second call must also 503 — the cache write is gated past the
+    # fallback branch, so a transient fetch failure doesn't pin the
+    # dropdown to "error" for 30s.
+    resp2 = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp2.status_code == 503, resp2.text
+
+
+def test_models_live_passes_through_in_shared_mode(
+    client, bearer, monkeypatch,
+):
+    """The 503 only fires when the live fetch yields no models.
+    A working Mastio reply still goes through with ``source: live``.
+    """
+    monkeypatch.setenv("AMBASSADOR_MODE", "shared")
+    monkeypatch.setattr(
+        FakeCullisClient,
+        "list_models",
+        lambda self: [
+            {"id": "qwen3.5:2b", "object": "model", "owned_by": "ollama",
+             "created": 0},
+        ],
+        raising=False,
+    )
+    from cullis_connector.ambassador.router import _models_cache
+
+    _models_cache.clear()
+
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["cullis_meta"]["source"] == "live"
+    ids = [m["id"] for m in body["data"]]
+    assert ids == ["qwen3.5:2b"]
+
+
 def test_chat_completions_rejects_wrong_bearer(client):
     resp = client.post(
         "/v1/chat/completions",


### PR DESCRIPTION
## Summary

- ADR-034 §5 (PR-F): in Frontdesk shared mode (`AMBASSADOR_MODE=shared`) the Ambassador now returns **HTTP 503** from `/v1/models` when the live Mastio fetch fails, instead of serving the hardcoded `advertised_models` list. In multi-user deployments the admin configures providers via the Mastio dashboard; a fallback list advertises models that aren't actually configured and the user only learns at chat time ("provider not configured" round-trip).
- Single mode (Cullis Chat desktop, `AMBASSADOR_MODE != "shared"`) is unchanged: the fallback list keeps the dropdown usable when Mastio is momentarily unreachable on a consumer laptop. That's the intentional consumer UX baseline.
- The 503 path skips the cache write so a transient fetch failure doesn't pin the dropdown to error for 30s — the next request retries the live fetch immediately.
- SPA copy update in `ModelPicker.tsx`: tooltip now says "Cannot reach Mastio — live model list unavailable" instead of "Showing cached defaults", so the message stays honest in both modes.

This is the first sub-PR of the ADR-034 (Frontdesk identity rewrite) migration plan (PR-F). Independent of PR-A...PR-E and shippable on its own — see ADR-034 §6 for ordering.

## Why this comes before PR-A

PR-F has zero schema migration, zero auth surface change, zero blast radius beyond `/v1/models`. Customer-visible win (chat picker shows real models in shared mode) at ~15 lines of Python + 5 lines of TypeScript. Shipping it first lets the dogfood VM `frontdesk-demo` exercise the new fail-loud behaviour while PR-A (workload identity migration) is in design.

## Test plan

- [x] `pytest tests/connector/test_ambassador_router.py -k models -v` — 4/4 pass:
  - `test_models_requires_bearer` (existing)
  - `test_models_lists_default_three` (existing single-mode fallback, unchanged)
  - `test_models_503_in_shared_mode_when_mastio_unreachable` (new) — 503 + `cullis_meta.source=error`, second call still 503 (cache not poisoned)
  - `test_models_live_passes_through_in_shared_mode` (new) — 503 only fires on empty/failing live fetch; a working Mastio reply still ships with `source: live`
- [x] `pytest tests/ -n auto --dist=loadfile` — 4090/4091 pass. The one failure (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`) is pre-existing on `main`, see PR #807 description.
- [x] `./sandbox/smoke.sh full` — 25 PASS / 0 FAIL / 1 SKIP. No regression in proxy reverse-proxy, OIDC flow, SPIRE attestation, A2A messaging.

## Files touched

- `cullis_connector/ambassador/router.py` — +52 -7 (list_models gate + docstring + JSONResponse 503 branch)
- `cullis_connector/config.py` — +9 -1 (docstring on `advertised_models` clarifies single-mode-only role)
- `frontend/cullis-chat/src/components/ModelPicker.tsx` — +2 -2 (tooltip copy update)
- `tests/connector/test_ambassador_router.py` — +73 (two new regression cases)