### PR TITLE
feat(mcp_proxy): workload principal type for Frontdesk identity

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -260,6 +260,18 @@ def _start(
         body["device_info"] = _wrap_device_info_with_shared_mode(
             body.get("device_info"),
         )
+        # ADR-034 §2 — declare the Frontdesk bundle as a ``workload``
+        # principal so Mastio audit + reach policy treat the container
+        # as the web-tier broker it is, not as an AI agent. Operators
+        # who need to override (e.g. a one-off agent-only bundle in
+        # shared topology) can set ``FRONTDESK_PRINCIPAL_TYPE=agent``
+        # in the env explicitly.
+        principal_type = (
+            _os.environ.get("FRONTDESK_PRINCIPAL_TYPE", "").strip().lower()
+            or "workload"
+        )
+        if principal_type in {"agent", "workload"}:
+            body["principal_type"] = principal_type
     # F-B-11 Phase 3d — include the public DPoP JWK so Mastio can
     # compute + store its thumbprint on approve (wire added in #207).
     if dpop_jwk is not None:

--- a/mcp_proxy/alembic/versions/0041_agents_principal_type.py
+++ b/mcp_proxy/alembic/versions/0041_agents_principal_type.py
@@ -1,0 +1,97 @@
+"""``internal_agents`` — ``principal_type`` column.
+
+Revision ID: 0041_agents_principal_type
+Revises: 0040_merge_grace_webauthn
+Create Date: 2026-05-19 15:00:00.000000
+
+ADR-034 §2 — Frontdesk identity rewrite, PR-A foundation.
+
+Pre-fix, the ``internal_agents`` table lacks any column to record the
+caller's principal taxonomy (``agent`` / ``workload``). The dispatcher
+in ``mcp_proxy/auth/client_cert.py`` defaulted every enrolled row to
+``agent`` via the ``TokenPayload`` dataclass default
+(``mcp_proxy/models.py:56``), so a Frontdesk shared bundle ended up
+attributed as ``agent::frontdesk`` even though it is structurally a
+web-tier workload (reverse-proxy + identity broker, not an AI agent).
+The misclassification mistriggered reach policies (A2U cross-org deny)
+and obscured the audit chain.
+
+ADR-020 §1 declared the three principal types (``agent`` / ``user`` /
+``workload``) as first-class. ``local_bindings`` and
+``local_user_principals`` already carry the column. This migration
+brings ``internal_agents`` in line so the agent-side enrollment can
+mark a Connector as ``workload`` when ``AMBASSADOR_MODE=shared``.
+
+Backfill is via ``server_default='agent'`` — every existing row stays
+attributed as today; only future enrollments (or the explicit
+``mastio frontdesk reclassify`` admin command in a follow-up PR) flip
+the value.
+
+NOT NULL with a server default keeps the column safe to add online
+without a window where readers see NULL. Postgres ``ALTER TABLE ADD
+COLUMN`` with default is a metadata-only rewrite on 11+; SQLite
+rewrites the table but the migration footprint is tiny.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0041_agents_principal_type"
+down_revision: Union[str, Sequence[str], None] = "0040_merge_grace_webauthn"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    internal_cols = {col["name"] for col in inspector.get_columns("internal_agents")}
+    if "principal_type" not in internal_cols:
+        op.add_column(
+            "internal_agents",
+            sa.Column(
+                "principal_type",
+                sa.Text(),
+                nullable=False,
+                server_default="agent",
+            ),
+        )
+
+    # ``pending_enrollments`` carries the value forward from
+    # ``start_enrollment`` to the approve handler so the INSERT into
+    # ``internal_agents`` lands the right principal_type. Same default
+    # so a Connector that doesn't ship the field (legacy single-mode)
+    # ends up tagged ``agent`` exactly as today.
+    pending_cols = {
+        col["name"] for col in inspector.get_columns("pending_enrollments")
+    }
+    if "principal_type" not in pending_cols:
+        op.add_column(
+            "pending_enrollments",
+            sa.Column(
+                "principal_type",
+                sa.Text(),
+                nullable=False,
+                server_default="agent",
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    pending_cols = {
+        col["name"] for col in inspector.get_columns("pending_enrollments")
+    }
+    if "principal_type" in pending_cols:
+        op.drop_column("pending_enrollments", "principal_type")
+
+    internal_cols = {col["name"] for col in inspector.get_columns("internal_agents")}
+    if "principal_type" in internal_cols:
+        op.drop_column("internal_agents", "principal_type")

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -693,4 +693,10 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
         previous_grace_period_expires_at=agent_data.get(
             "previous_grace_period_expires_at"
         ),
+        # ADR-034 §2 — DB column is authoritative for enrolled rows.
+        # Migration 0041 backfills existing rows to ``agent``, so a
+        # row missing the field is impossible after upgrade; the
+        # ``or "agent"`` guard is belt-and-braces for any synthetic
+        # dict that omits it in tests.
+        principal_type=agent_data.get("principal_type") or "agent",
     )

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -94,6 +94,15 @@ class InternalAgent(Base):
     previous_dpop_jkt = Column(Text, nullable=True)
     previous_grace_period_expires_at = Column(Text, nullable=True)
 
+    # ADR-034 §2 — principal taxonomy for the enrolled identity.
+    # Migration 0041 backfills existing rows to ``agent`` (the legacy
+    # default). Frontdesk shared bundles enroll with ``workload``; the
+    # auth dispatcher reads this column instead of guessing from the
+    # canonical_id prefix.
+    principal_type = Column(
+        Text, nullable=False, server_default="agent",
+    )
+
 
 class AuditLogEntry(Base):
     __tablename__ = "audit_log"
@@ -262,6 +271,13 @@ class PendingEnrollment(Base):
     # Connector ships a verified ``tpm_quote`` at start_enrollment time;
     # carried to ``internal_agents.device_attestation_json`` on approve.
     device_attestation_json = Column(Text, nullable=True)
+
+    # ADR-034 §2 — principal_type carried from start_enrollment so the
+    # approve handler can land it on ``internal_agents``. Default
+    # ``agent`` keeps legacy single-mode Connectors behaving as today.
+    principal_type = Column(
+        Text, nullable=False, server_default="agent",
+    )
 
     __table_args__ = (
         Index("idx_pending_enrollments_status", "status"),

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -133,6 +133,7 @@ async def start_enrollment(
                 tpm_quote_b64=payload.tpm_quote_b64,
                 tpm_manufacturer=payload.tpm_manufacturer,
                 tpm_ek_cert_present=payload.tpm_ek_cert_present,
+                principal_type=payload.principal_type,
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -110,6 +110,21 @@ class EnrollmentStartRequest(BaseModel):
             " typically report ``False`` and stay at ``hw_isolated``."
         ),
     )
+    # ── ADR-034 §2: workload vs agent principal type ─────────────────
+    principal_type: Literal["agent", "workload"] = Field(
+        "agent",
+        description=(
+            "Principal taxonomy for this Connector. ``agent`` is the"
+            " single-mode default (Cullis Chat desktop, standalone"
+            " PyPI Connector). ``workload`` marks the Frontdesk shared"
+            " bundle as a web-tier identity broker so the audit chain"
+            " and reach policies treat it as the Ambassador it is"
+            " rather than as an AI agent. Set automatically by the"
+            " Connector when ``AMBASSADOR_MODE=shared``; the legacy"
+            " single-mode caller never sends this field and the"
+            " server-side default keeps the behaviour identical."
+        ),
+    )
 
 
 class EnrollmentStartResponse(BaseModel):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -230,6 +230,7 @@ async def start_enrollment(
     tpm_quote_b64: str | None = None,
     tpm_manufacturer: str | None = None,
     tpm_ek_cert_present: bool = False,
+    principal_type: str = "agent",
 ) -> StartedEnrollment:
     """Create a new pending enrollment.
 
@@ -291,18 +292,29 @@ async def start_enrollment(
     now = _now()
     expires_at = now + ENROLLMENT_TTL
 
+    # ADR-034 §2: reject anything outside the {agent, workload} set so
+    # the dispatcher downstream can rely on the column. A typo would
+    # otherwise pin the row to an unrecognised string and confuse the
+    # audit chain semantics.
+    if principal_type not in {"agent", "workload"}:
+        raise EnrollmentError(
+            f"principal_type must be 'agent' or 'workload', got "
+            f"{principal_type!r}",
+            http_status=400,
+        )
+
     await conn.execute(
         text(
             """INSERT INTO pending_enrollments (
                 session_id, pubkey_pem, pubkey_fingerprint,
                 requester_name, requester_email, reason, device_info,
                 status, created_at, expires_at, dpop_jkt,
-                device_attestation_json
+                device_attestation_json, principal_type
             ) VALUES (
                 :sid, :pk, :fp,
                 :name, :email, :reason, :device,
                 'pending', :created, :expires, :dpop_jkt,
-                :dev_attest
+                :dev_attest, :ptype
             )"""
         ),
         {
@@ -317,6 +329,7 @@ async def start_enrollment(
             "expires": _iso(expires_at),
             "dpop_jkt": dpop_jkt,
             "dev_attest": attestation_json,
+            "ptype": principal_type,
         },
     )
 
@@ -526,11 +539,12 @@ async def approve(
                    (agent_id, display_name, capabilities,
                     cert_pem, created_at, is_active, device_info, dpop_jkt,
                     enrollment_method, enrolled_at, spiffe_id,
-                    federated, federated_at, reach, federation_revision)
+                    federated, federated_at, reach, federation_revision,
+                    principal_type)
                    VALUES (:aid, :dn, :caps, :cert, :created, 1,
                            :device, :dpop_jkt, 'connector', :created,
                            :spiffe_id,
-                           1, :created, 'both', 1)"""
+                           1, :created, 'both', 1, :ptype)"""
             ),
             {
                 "aid": canonical_id,
@@ -548,6 +562,10 @@ async def approve(
                 # flip to required mode (Phase 6).
                 "dpop_jkt": record.get("dpop_jkt"),
                 "spiffe_id": spiffe_id,
+                # ADR-034 §2 — carried from pending_enrollments. The
+                # server_default on both tables means a legacy Connector
+                # that doesn't set the field still lands as ``agent``.
+                "ptype": record.get("principal_type") or "agent",
             },
         )
         await conn.execute(

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -372,6 +372,122 @@ async def test_approve_registers_agent_in_internal_registry(db_engine):
 
 
 @pytest.mark.asyncio
+async def test_approve_lands_workload_principal_type_in_internal_agents(
+    db_engine,
+):
+    """ADR-034 §2 — when ``start_enrollment`` is called with
+    ``principal_type='workload'`` (the Frontdesk shared bundle path),
+    the value is persisted on ``pending_enrollments`` and carried to
+    ``internal_agents`` on approve. A legacy call that omits the field
+    keeps the row tagged ``agent`` via the server default.
+    """
+    from sqlalchemy import text as _text
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+    await manager.ensure_mastio_identity()
+
+    # Workload-typed enrollment.
+    _priv_w, pubkey_w = _rsa_keypair()
+    async with get_db() as conn:
+        started_w = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey_w,
+            pop_signature=_sign_pop(_priv_w, pubkey_w),
+            requester_name="A",
+            requester_email="a@x.com",
+            reason=None,
+            device_info=None,
+            principal_type="workload",
+        )
+
+    # Legacy agent-typed enrollment (no field set).
+    _priv_a, pubkey_a = _rsa_keypair()
+    async with get_db() as conn:
+        started_a = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey_a,
+            pop_signature=_sign_pop(_priv_a, pubkey_a),
+            requester_name="A",
+            requester_email="a@x.com",
+            reason=None,
+            device_info=None,
+        )
+
+    # Pending rows carry the right principal_type.
+    async with get_db() as conn:
+        pending = {
+            row["session_id"]: row["principal_type"]
+            for row in (await conn.execute(
+                _text(
+                    "SELECT session_id, principal_type "
+                    "FROM pending_enrollments"
+                ),
+            )).mappings().all()
+        }
+    assert pending[started_w.session_id] == "workload"
+    assert pending[started_a.session_id] == "agent"
+
+    # Approve both — internal_agents.principal_type follows.
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started_w.session_id,
+            agent_id="frontdesk",
+            capabilities=[],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+        await service.approve(
+            conn,
+            session_id=started_a.session_id,
+            agent_id="legacy-bot",
+            capabilities=["test.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    async with get_db() as conn:
+        agents = {
+            row["agent_id"]: row["principal_type"]
+            for row in (await conn.execute(
+                _text(
+                    "SELECT agent_id, principal_type FROM internal_agents"
+                ),
+            )).mappings().all()
+        }
+    assert agents["acme::frontdesk"] == "workload"
+    assert agents["acme::legacy-bot"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_rejects_unknown_principal_type(db_engine):
+    """ADR-034 §2 — only ``agent`` and ``workload`` are accepted. A
+    typo (``user``, ``operator``, …) would otherwise land on the row
+    and confuse the downstream dispatcher; reject with 400 instead.
+    """
+    _priv, pubkey = _rsa_keypair()
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as excinfo:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=pubkey,
+                pop_signature=_sign_pop(_priv, pubkey),
+                requester_name="A",
+                requester_email="a@x.com",
+                reason=None,
+                device_info=None,
+                principal_type="user",
+            )
+    assert excinfo.value.http_status == 400
+    assert "agent" in str(excinfo.value).lower()
+    assert "workload" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
 async def test_approve_re_enroll_same_agent_id_updates_cert(db_engine):
     """Re-approving the same ``agent_id`` with a fresh keypair MUST update
     ``internal_agents.cert_pem`` to the newly-signed cert.

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0040_merge_grace_webauthn",)]
+    assert rows == [("0041_agents_principal_type",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0040_merge_grace_webauthn",)]
+    assert version == [("0041_agents_principal_type",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0040_merge_grace_webauthn"
+HEAD_REVISION = "0041_agents_principal_type"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0040_merge_grace_webauthn"
+HEAD_REVISION = "0041_agents_principal_type"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0040_merge_grace_webauthn"
+HEAD_REVISION = "0041_agents_principal_type"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

- ADR-034 §2 (PR-A foundation): mark the Frontdesk shared bundle as a `workload` principal so the audit chain and reach policies treat it as a web-tier identity broker, not as an AI agent.
- Adds `principal_type` column to `internal_agents` and `pending_enrollments` (Alembic 0041) with `server_default='agent'` so legacy rows preserve today's behaviour.
- Wires the value end-to-end: `EnrollmentStartRequest` schema → service `start_enrollment` (persists on pending) → `approve` (carries to internal_agents INSERT) → `client_cert.py` read path → `InternalAgent` envelope. The Connector in `AMBASSADOR_MODE=shared` automatically declares `principal_type=workload` in the enrollment body. `FRONTDESK_PRINCIPAL_TYPE` env overrides for edge cases.
- Foundation for PR-B (setup surface separation) and PR-D (UserPrincipal CSR provisioning), both of which key on the workload-vs-agent distinction.

First sub-PR of the ADR-034 (Frontdesk identity rewrite) migration plan after PR-F (#808 — model picker live-only). See ADR-034 §6 ordering. PR-B will be stacked on this once it lands.

## Why this is foundational

Before this change, the dispatcher `mcp_proxy/auth/client_cert.py:682-689` built `InternalAgent` envelopes for enrolled agents without setting `principal_type`, so the dataclass default `"agent"` (`mcp_proxy/models.py:56`) always won. The "typed-on-the-fly" branch at line 668 could resolve `workload` for non-enrolled callers via the canonical_id pattern, but every enrolled Connector (including Frontdesk) hit the default path and stayed tagged `agent`. The DB column is now the authoritative source.

ADR-020 §1 already declared the three principal types as first-class and `local_bindings` / `local_user_principals` already carried the column — `internal_agents` was the missing piece.

## Test plan

- [x] `pytest tests/test_enrollment.py -k "principal_type or unknown_principal" -v` — 2/2 pass:
  - `test_approve_lands_workload_principal_type_in_internal_agents` — workload value propagates pending → approve → internal_agents; legacy (no field set) stays `agent`.
  - `test_start_enrollment_rejects_unknown_principal_type` — typo `user` → 400, doesn't land an unrecognised string.
- [x] Migration head pins bumped from 0040 to 0041 in `test_proxy_migrations.py` + three `test_proxy_migrations_adr00*.py` files.
- [x] `pytest tests/ -n auto --dist=loadfile` — 4092/4093 pass. The one failure (`test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable`) is pre-existing on `main` (verified in PR #807 description).
- [x] `./sandbox/smoke.sh full` — 25 PASS / 0 FAIL / 1 SKIP. Single-head Alembic confirmed (`alembic heads` returns `0041_agents_principal_type (head)`). No regression in proxy reverse-proxy, OIDC, SPIRE, A2A.

## Compatibility matrix

| Mastio | Connector | Outcome |
|---|---|---|
| ≥ 0.5 | ≥ 0.5 | Workload identity end-to-end. |
| ≥ 0.5 | ≤ 0.4.x | Connector doesn't send the field; Mastio `server_default` lands it as `agent` (legacy behaviour preserved). |
| ≤ 0.4.5 | ≥ 0.5 | Pydantic `extra="ignore"` silently drops the field on Mastio; Frontdesk enrolls as `agent` semantically. **Semantic failure, not hard failure** — documented in ADR-034 §6. PR-B will add a Connector-side Mastio version probe before enrollment in shared mode to refuse the silent downgrade. |

## Files touched

- Schema: `mcp_proxy/alembic/versions/0041_agents_principal_type.py` (new), `mcp_proxy/db_models.py` (+16)
- API/service: `mcp_proxy/enrollment/schemas.py` (+15), `mcp_proxy/enrollment/router.py` (+1), `mcp_proxy/enrollment/service.py` (+26 -3), `mcp_proxy/auth/client_cert.py` (+6)
- Connector: `cullis_connector/enrollment.py` (+12)
- Tests: `tests/test_enrollment.py` (+116), 4 migration test files (+5 head bumps)

## ADR ratification

ADR-034 ratified as `Accepted (internal-only)` 2026-05-19. This PR is the first half of the v0.5.0-rc1 batch (PR-A + PR-B). PR-B will follow once this merges.