### PR TITLE
feat(connector): shared-mode workload setup wizard + completion hook

### DIFF
--- a/cullis_connector/templates/setup_workload.html
+++ b/cullis_connector/templates/setup_workload.html
@@ -1,0 +1,251 @@
+{% extends "base.html" %}
+{% block title %}Workload setup{% endblock %}
+{% block content %}
+
+{#
+   ADR-034 §3 — shared-mode wizard (Form W1).
+
+   In single mode the ``setup.html`` page asks the operator for "Your
+   name / Work email" because the single user IS the operator. In
+   shared mode that framing is wrong: this container is the Frontdesk
+   web tier serving many end-users behind it, and the wizard is
+   configuring the *workload identity*, not a person. The labels +
+   copy here reflect the three distinct subjects (Mastio admin,
+   workload, end-users) instead of collapsing them onto one form.
+#}
+
+<div class="steps" aria-label="Frontdesk setup progress">
+    <div class="step active">
+        <span class="step-circle">01</span>
+        <span class="step-label">Workload</span>
+    </div>
+    <div class="step-sep"></div>
+    <div class="step">
+        <span class="step-circle">02</span>
+        <span class="step-label">Approve</span>
+    </div>
+    <div class="step-sep"></div>
+    <div class="step">
+        <span class="step-circle">03</span>
+        <span class="step-label">Users</span>
+    </div>
+</div>
+
+{% if error %}
+<div class="alert alert-error">{{ error }}</div>
+{% endif %}
+
+{% if ca_pinned_from_wizard %}
+<div class="alert" style="background: rgba(126,203,126,0.10); border: 1px solid rgba(126,203,126,0.25); color: #7ecb7e;">
+    <strong>✓ Mastio CA pinned from auto-discovery.</strong>
+    <span class="field-hint" style="margin-left: 6px;">Fill in the workload identity below and submit.</span>
+</div>
+{% else %}
+<p class="field-hint" style="text-align: right; margin-top: 0;">
+    <a href="/setup/discover">← Try auto-discovery instead</a>
+</p>
+{% endif %}
+
+<div class="alert" style="background: rgba(0,229,199,0.06); border: 1px solid rgba(0,229,199,0.18); color: #c9e9e3; margin-bottom: 16px;">
+    <strong>You are configuring the Frontdesk workload, not a user.</strong>
+    <p class="field-hint" style="margin-top: 6px;">
+        This wizard enrolls the container itself as a
+        <span class="mono">workload</span> principal on your Mastio.
+        End-users sign in separately at <span class="mono">/login</span>
+        and get their own user principals minted on first login
+        (ADR-021 §3 + ADR-034 §4). Capabilities and chat history
+        belong to those user principals, not to this container.
+    </p>
+</div>
+
+<form method="post" action="/setup" class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Frontdesk setup · Step 01</div>
+        <h1 class="panel-title">Register this <em>workload</em> with Mastio</h1>
+        <p class="panel-sub">
+            The Mastio admin reviews this request and assigns the
+            container an x509 identity. Future end-user logins ride
+            this identity on the way upstream.
+        </p>
+    </div>
+
+    <div class="field">
+        <label class="field-label" for="site_url">Mastio URL</label>
+        <input
+            id="site_url"
+            name="site_url"
+            type="url"
+            required
+            placeholder="https://mastio.acme.corp:9443"
+            value="{{ site_url or '' }}"
+            class="input mono"
+            autofocus>
+        <span class="field-hint">The Mastio address your IT team gave you — typically ends with <span class="mono">:9443</span>.</span>
+    </div>
+
+    <div class="field" id="tofu-box">
+        <label class="field-label">Mastio CA fingerprint <span class="muted">(recommended)</span></label>
+        <p class="field-hint" style="margin-bottom: 8px;">
+            Compare with the value your admin gave you over a
+            separate channel. Pinning the CA closes the man-in-the-
+            middle window during TOFU bootstrap.
+        </p>
+        <div class="btn-row" style="margin-top: 4px; gap: 8px;">
+            <button type="button" id="tofu-fetch-btn" class="btn">Fetch fingerprint</button>
+            <button type="button" id="tofu-pin-btn" class="btn btn-primary" style="display: none;">Pin this CA</button>
+            <span id="tofu-status" class="field-hint" style="margin: 0; align-self: center;"></span>
+        </div>
+        <pre id="tofu-fingerprint" class="mono" style="display: none; margin-top: 10px; padding: 10px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; word-break: break-all; white-space: pre-wrap; font-size: 12px;"></pre>
+        <input type="hidden" id="tofu-fingerprint-value" name="ca_fingerprint" value="">
+    </div>
+    <script>
+    (function () {
+        const $url = document.getElementById('site_url');
+        const $fetch = document.getElementById('tofu-fetch-btn');
+        const $pin = document.getElementById('tofu-pin-btn');
+        const $status = document.getElementById('tofu-status');
+        const $print = document.getElementById('tofu-fingerprint');
+        const $hidden = document.getElementById('tofu-fingerprint-value');
+        let pendingFingerprint = '';
+
+        function setStatus(text, ok) {
+            $status.textContent = text;
+            $status.style.color = ok === true ? '#7ecb7e'
+                : ok === false ? '#e08585'
+                : '';
+        }
+
+        async function postForm(url, data) {
+            const body = new URLSearchParams(data);
+            const resp = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: body.toString(),
+            });
+            const json = await resp.json();
+            if (!resp.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+            return json;
+        }
+
+        $fetch.addEventListener('click', async () => {
+            if (!$url.value.trim()) {
+                setStatus('Enter the Mastio URL first.', false);
+                return;
+            }
+            setStatus('Fetching…');
+            try {
+                const data = await postForm('/setup/preview-ca', {site_url: $url.value.trim()});
+                pendingFingerprint = data.fingerprint_sha256;
+                $print.textContent = data.fingerprint_short;
+                $print.style.display = 'block';
+                $pin.style.display = '';
+                setStatus('Compare ↑ with the value your admin gave you.', null);
+            } catch (e) {
+                setStatus(e.message, false);
+                $print.style.display = 'none';
+                $pin.style.display = 'none';
+            }
+        });
+
+        $pin.addEventListener('click', async () => {
+            setStatus('Pinning…');
+            try {
+                const data = await postForm('/setup/pin-ca', {
+                    site_url: $url.value.trim(),
+                    fingerprint_expected: pendingFingerprint,
+                });
+                $hidden.value = data.fingerprint_sha256;
+                $pin.style.display = 'none';
+                $fetch.disabled = true;
+                setStatus('✓ CA pinned — TLS will verify against this fingerprint.', true);
+            } catch (e) {
+                setStatus(e.message, false);
+            }
+        });
+    })();
+    </script>
+
+    <div class="field">
+        <label class="field-label" for="workload_name">Workload name</label>
+        <input
+            id="workload_name"
+            name="requester_name"
+            type="text"
+            required
+            placeholder="frontdesk"
+            value="{{ requester_name or 'frontdesk' }}"
+            class="input mono">
+        <span class="field-hint">
+            The identifier this container will carry on the Mastio
+            audit chain (e.g. <span class="mono">frontdesk</span>,
+            <span class="mono">frontdesk-eu-prod</span>). Appears
+            verbatim in every audit row downstream traffic produces.
+        </span>
+    </div>
+
+    <div class="field">
+        <label class="field-label" for="operator_admin_email">Operator admin email</label>
+        <input
+            id="operator_admin_email"
+            name="requester_email"
+            type="email"
+            required
+            placeholder="ops@acme.corp"
+            value="{{ requester_email or '' }}"
+            class="input mono">
+        <span class="field-hint">
+            The Mastio admin reviewing this enrollment uses it to
+            verify the request is genuine. Saved in
+            <span class="mono">internal_agents.device_info</span> as
+            <em>operator-of-record</em> for accountability — not as
+            the principal name. End-users have their own email at
+            login time.
+        </span>
+    </div>
+
+    <div class="field">
+        <label class="field-label" for="reason">Workload description <span class="muted">(optional)</span></label>
+        <textarea
+            id="reason"
+            name="reason"
+            placeholder="What this Frontdesk serves — e.g. 'support team shared chat'"
+            class="textarea">{{ reason or '' }}</textarea>
+        <span class="field-hint">Free-form context for the admin
+        approval queue. Visible on the Mastio dashboard.</span>
+    </div>
+
+    <div class="field" style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 6px; padding: 10px 12px;">
+        <label class="field-label" style="margin-bottom: 4px;">Principal type</label>
+        <div class="mono" style="font-size: 13px; color: #c9e9e3;">workload</div>
+        <span class="field-hint" style="margin-top: 6px;">
+            Locked to <span class="mono">workload</span> in shared
+            mode (ADR-034 §2). End-users that sign in at
+            <span class="mono">/login</span> get their own
+            <span class="mono">user</span> principals minted on first
+            login.
+        </span>
+    </div>
+
+    <label class="field" style="flex-direction: row; align-items: center; gap: 10px; margin-top: 4px;">
+        <input type="checkbox" name="verify_tls_off" value="1" {% if verify_tls_off %}checked{% endif %}>
+        <span class="field-hint" style="margin: 0;">
+            Disable TLS verification <span class="muted">(development only)</span>
+        </span>
+    </label>
+
+    <div class="btn-row btn-row-end">
+        <button type="submit" class="btn btn-primary">
+            Register workload
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </button>
+    </div>
+</form>
+
+<p class="footer-hint">
+    Once the Mastio admin approves, end-users can sign in at
+    <span class="mono">/login</span> with the credentials your team
+    provisioned. See <a href="https://cullis.io/docs/frontdesk" target="_blank" rel="noopener">the Frontdesk runbook</a>
+    for the multi-user onboarding flow.
+</p>
+
+{% endblock %}

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -1021,6 +1021,17 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             return RedirectResponse("/waiting", status_code=303)
         return RedirectResponse("/setup/discover", status_code=303)
 
+    def _setup_template_for_mode() -> str:
+        """ADR-034 §3 — pick the wizard variant that matches the
+        deployment topology. Shared mode (Frontdesk container) gets
+        the workload-identity framing; single mode (Cullis Chat
+        desktop, standalone PyPI Connector) keeps the legacy
+        single-user wizard.
+        """
+        from cullis_connector.identity.auth_mode import is_shared_mode
+
+        return "setup_workload.html" if is_shared_mode() else "setup.html"
+
     @app.get("/setup", response_class=HTMLResponse)
     def setup_get(
         request: Request,
@@ -1037,7 +1048,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         # form with a pre-filled URL and an already-pinned CA.
         return templates.TemplateResponse(
             request,
-            "setup.html",
+            _setup_template_for_mode(),
             {
                 "connector_status": "offline",
                 "connector_status_label": "Offline",
@@ -1095,7 +1106,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         except EnrollmentFailed as exc:
             return templates.TemplateResponse(
                 request,
-                "setup.html",
+                _setup_template_for_mode(),
                 {
                     "connector_status": "offline",
                     "connector_status_label": "Offline",
@@ -1505,6 +1516,30 @@ def build_app(config: ConnectorConfig) -> FastAPI:
                 metadata=metadata,
             )
             _clear_pending()
+            # ADR-034 §1 — shared-mode setup wizard is single-shot.
+            # After a successful enrollment the bootstrap bearer is no
+            # longer needed and ``/setup/*`` must refuse all further
+            # access. PR-B (#810) introduced ``mark_setup_completed`` +
+            # the 410 Gone refusal in ``_setup_admin_guard`` but never
+            # wired the completion hook; without this call site the
+            # wizard surface stays open after enrollment and the
+            # workload could be re-targeted by a stale ``docker logs``
+            # line. Single mode (Cullis Chat desktop) is a no-op here
+            # because ``mark_setup_completed`` is only read in shared
+            # mode (see ``cullis_connector/setup_auth.py``).
+            try:
+                from cullis_connector.identity.auth_mode import is_shared_mode
+                from cullis_connector.setup_auth import mark_setup_completed
+                if is_shared_mode():
+                    mark_setup_completed(config.config_dir)
+            except Exception as exc:  # noqa: BLE001 — never block the
+                # approval response on setup-state housekeeping; the
+                # operator can still run ``docker compose down + up`` to
+                # rotate the surface manually.
+                _log.warning(
+                    "ADR-034: mark_setup_completed failed (continuing): %s",
+                    exc,
+                )
             # First moment the identity exists on disk — kick the
             # inbox poller now so the operator sees notifications
             # without having to restart the dashboard. The next

--- a/tests/connector/test_setup_admin_only.py
+++ b/tests/connector/test_setup_admin_only.py
@@ -1,4 +1,4 @@
-"""ADR-034 §1 — admin-only setup surface in shared mode.
+"""ADR-034 §1 + §3 — admin-only setup surface + wizard dispatcher.
 
 Covers:
 
@@ -9,6 +9,9 @@ Covers:
     persistence + invalidation lifecycle.
   * ``cullis_connector.enrollment._check_mastio_version_for_shared_mode``
     refuses Mastio < 0.5 (PR-A compat blocker).
+  * Setup wizard dispatcher (ADR-034 §3): ``/setup`` returns
+    ``setup.html`` in single mode and ``setup_workload.html`` in
+    shared mode so the wizard framing matches the deployment topology.
 """
 from __future__ import annotations
 
@@ -21,7 +24,9 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from fastapi.testclient import TestClient
 
+from cullis_connector.config import ConnectorConfig
 from cullis_connector.enrollment import (
     EnrollmentFailed,
     _check_mastio_version_for_shared_mode,
@@ -41,6 +46,7 @@ from cullis_connector.setup_auth import (
     read_setup_auth_enforcement,
     verify_setup_request,
 )
+from cullis_connector.web import build_app
 
 
 # ── verify_setup_request ───────────────────────────────────────────
@@ -376,3 +382,124 @@ def test_parse_semver_handles_rc_and_v_prefix():
     assert _parse_semver("dev") is None
     assert _parse_semver("") is None
     assert _parse_semver("not-a-version") is None
+
+
+# ── Setup wizard dispatcher (ADR-034 §3) ────────────────────────────
+
+
+def _setup_dispatcher_client(tmp_path, monkeypatch) -> TestClient:
+    """Build the dashboard app with a clean tmp config_dir + identity
+    forced to absent so ``/setup`` lands on the wizard rather than
+    short-circuiting to ``/connected``.
+    """
+    import cullis_connector.web as _web
+
+    monkeypatch.setattr(_web, "has_identity", lambda _: False)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test:9443",
+        verify_tls=False,
+    )
+    return TestClient(build_app(cfg))
+
+
+def test_setup_get_renders_single_mode_template_by_default(
+    tmp_path, monkeypatch,
+):
+    """In single mode the wizard keeps the legacy ``setup.html`` page
+    with the "Your name / Work email" framing — the operator IS the
+    single user, so the labelling is honest.
+    """
+    monkeypatch.delenv("AMBASSADOR_MODE", raising=False)
+    monkeypatch.delenv("AUTH_MODE", raising=False)
+    client = _setup_dispatcher_client(tmp_path, monkeypatch)
+    resp = client.get("/setup", headers={"Origin": "http://testserver"})
+    assert resp.status_code == 200, resp.text
+    # Single-mode wizard advertises the personal framing.
+    assert "Your name" in resp.text
+    assert "Work email" in resp.text
+    # And does NOT carry the workload-only banner from the shared
+    # template — that copy is exclusive to ``setup_workload.html``.
+    assert "You are configuring the Frontdesk workload" not in resp.text
+
+
+def test_setup_get_renders_workload_template_in_shared_mode(
+    tmp_path, monkeypatch,
+):
+    """In shared mode the wizard switches to ``setup_workload.html``
+    so the operator sees workload-not-user framing. The
+    ``principal_type=workload`` lock and the "end-users sign in
+    separately" banner are the discriminators against single-mode
+    output.
+    """
+    monkeypatch.setenv("AMBASSADOR_MODE", "shared")
+    client = _setup_dispatcher_client(tmp_path, monkeypatch)
+    resp = client.get(
+        "/setup",
+        headers={
+            "Origin": "http://testserver",
+            # PR-B middleware is in warn mode by default, so we don't
+            # need a bearer to reach the handler. The test confirms
+            # the dispatcher chooses the right template, not the
+            # admin-proof check that PR-B already covers.
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert "Register this <em>workload</em>" in resp.text
+    assert "You are configuring the Frontdesk workload" in resp.text
+    assert "Workload name" in resp.text
+    assert "Operator admin email" in resp.text
+    # Principal type is locked + visible to the operator. The shared
+    # template carries the "End-users sign in separately" banner
+    # copy that the single-mode wizard never mentions; assert it as
+    # the discriminator instead of the more generic ``workload``
+    # token (which appears in single mode too via field hints).
+    assert "End-users sign in separately" in resp.text
+
+
+def test_setup_get_redirects_to_connected_when_identity_exists(
+    tmp_path, monkeypatch,
+):
+    """If the workload already enrolled, no wizard — the route 303s
+    to ``/connected``. Independent of mode: in either topology a
+    completed enrollment means the wizard is done.
+    """
+    import cullis_connector.web as _web
+
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test:9443",
+        verify_tls=False,
+    )
+    client = TestClient(build_app(cfg))
+    resp = client.get(
+        "/setup",
+        headers={"Origin": "http://testserver"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/connected"
+
+
+def test_mark_setup_completed_is_wired_to_save_identity_branch():
+    """Regression for the gap left by PR-B (#810): the call site to
+    ``mark_setup_completed`` is supposed to fire after a successful
+    enrollment so the ``/setup/*`` middleware refuses any further
+    access. PR-B introduced the helper but didn't wire it; this test
+    pins the call site by reading the web.py source.
+
+    A real end-to-end test of the polling enrollment loop would
+    require a live Mastio fake — the source-level pin catches the
+    "orphaned helper" failure mode cheaply while leaving the wiring
+    visible to a future reader.
+    """
+    import inspect
+
+    from cullis_connector import web as _web
+
+    src = inspect.getsource(_web)
+    assert "mark_setup_completed(config.config_dir)" in src, (
+        "mark_setup_completed must be invoked from the save_identity "
+        "success branch in shared mode (ADR-034 §1)"
+    )


### PR DESCRIPTION
## Summary

Closes the remaining workflow gap of ADR-034 v0.5.0-rc2:

1. **Workload-framed wizard for shared mode** (ADR-034 §3). In single mode (Cullis Chat desktop, standalone PyPI Connector) the wizard keeps the legacy "Your name / Work email" framing — there the operator IS the single user. In shared mode (Frontdesk container) the same form collapsed three distinct subjects (Mastio admin, workload, end-users) onto one page; the operator filling in "Your name" was registering the container as a person. New template `setup_workload.html` reframes the wizard with "Workload name", "Operator admin email", a banner "You are configuring the Frontdesk workload, not a user. End-users sign in separately at /login", and a locked `principal_type=workload` display. `_setup_template_for_mode()` dispatches GET + POST-error-rerender to the variant matching `is_shared_mode()`.

2. **`mark_setup_completed` wiring (PR-B residual)**. PR-B (#810) introduced the helper + the 410 Gone refusal in `_setup_admin_guard` but never wired the completion hook — `mark_setup_completed` had zero call sites in the codebase, so a Frontdesk container that completed enrollment kept `/setup/*` reachable forever as long as the operator still had the bootstrap bearer. The `save_identity` success branch in `poll_enrollment_status` now calls `mark_setup_completed(config.config_dir)` in shared mode (no-op in single). Exception path swallowed with WARN so housekeeping never blocks the approval response.

## Discovery: PR-D was already implemented

A code audit before starting confirmed that the ADR-034 §4 flow (UserPrincipal CSR provisioning at first login) is already shipped in `cullis_connector/auth/local_router.py` under ADR-025 Phase 3 + Phase 5 / F4 R3:

- `_bind_login_cert` (line 478): `provisioner.provision_for_user(user_name)` → KMS `create_keypair` → CSR build → POST `/v1/principals/csr` → `attach_certificate` → persisted binding row.
- `_bind_mastio_user_session` (line 543): mints the `user_sessions` row on Mastio so future MCP calls carry `X-Cullis-Session-Token` + `X-Cullis-On-Behalf-Of-User`.
- `EmbeddedUserPrincipalKMS` (`app/kms/user_principal_embedded.py`) + `SdkMastioCsrTransport` (`cullis_connector/ambassador/shared/provisioning.py:114`) + `UserProvisioner` (line 378) wired via `cullis_connector/web.py:_maybe_install_local_provisioner`.

No further code work needed. This PR documents the discovery in the commit body so a future reader doesn't re-implement it, and pins the call site via `test_mark_setup_completed_is_wired_to_save_identity_branch` as a regression catch.

This completes the v0.5.0-rc2 batch (PR-C + PR-D). PR-E (ADR-033 Phase 2 enforcement in local-mode) is next for v0.5.0-rc3.

## Test plan

- [x] `pytest tests/connector/test_setup_admin_only.py -v` — 25/25 pass:
  - 21 existing PR-B cases (admin-proof matrix, completed refuse, bearer + HMAC + replay, version probe).
  - 4 new PR-C cases: single-mode template, shared-mode template, `/connected` redirect when identity exists, source-level pin on `mark_setup_completed` wiring.
- [x] `pytest tests/ -n auto --dist=loadfile` — 4116/4118 pass. Two failures pre-existing on `main` (the `test_dashboard_approvals_nav` flake from PR #807 / #809 + the `test_cert_middleware` xdist parallelism flake that passes when isolated).
- [x] `./sandbox/smoke.sh full` — 25 PASS / 0 FAIL / 1 SKIP. No regression in proxy reverse-proxy, OIDC, SPIRE, A2A.

## Files touched

- `cullis_connector/templates/setup_workload.html` — **new** (~230 lines). Workload-identity wizard for shared mode.
- `cullis_connector/web.py` — +39 lines. `_setup_template_for_mode()` dispatcher + `mark_setup_completed` call site in the `save_identity` success branch.
- `tests/connector/test_setup_admin_only.py` — +129 lines. Four new regression cases.

## Compatibility matrix

| Mode | Outcome |
|---|---|
| Single (Cullis Chat desktop, standalone PyPI) | Dispatcher + completion hook are gated on `is_shared_mode()`. Zero observable change. |
| Shared (Frontdesk) upgrading from rc1 | Re-enrolment attempts see the new workload template. Existing approvals are not re-triggered. Completion hook fires only from the `save_identity` branch, so a Frontdesk that already passed that point on rc1 is not retroactively marked completed — bearer rotation note in the PR-B runbook covers the edge case. |
| Shared (Frontdesk) fresh install on rc2 | New template, completion hook on successful enrollment, `/setup/*` returns 410 Gone afterward. |