### PR TITLE
chore: bump Connector to 0.5.0-rc1 for ADR-034 dogfood

### DIFF
--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0-rc1"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.7"
+version = "0.5.0-rc1"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps the Connector version to ``0.5.0-rc1`` so the dogfood VM ``frontdesk-demo`` (192.168.122.87) can pull the new image from GHCR and exercise the ADR-034 v0.5.0-rc2 chain end-to-end (PR #807-#811).

Mastio side carries its version via ``CULLIS_MASTIO_VERSION`` env injected at image build time (memory ``mastio-release-tag-convention``), so no Python version file change needed there. The tag ``mastio-v0.5.0-rc1`` + image ``ghcr.io/cullis-security/cullis-mastio:0.5.0-rc1`` are minted from this same commit.

``-rc1`` so a regression caught during dogfood doesn't pin a real 0.5.0 on PyPI; promote to 0.5.0 after the VM scenario completes green.

## Files touched

- ``cullis_connector/__init__.py`` — ``__version__`` 0.4.7 → 0.5.0-rc1
- ``packaging/pypi/pyproject.toml`` — ``version`` 0.4.7 → 0.5.0-rc1

Sync of both files matches the convention in memory ``feedback_connector_version_sync_all_files``.