### PR TITLE
fix(connector): widen Frontdesk gate to cover ADR-025 modern bundle

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -325,15 +325,19 @@ def _start(
         body["reason"] = requester.reason
     if requester.device_info:
         body["device_info"] = requester.device_info
-    # Shared-mode flag (Frontdesk container): when ``AMBASSADOR_MODE=shared``
-    # is set on this Connector, the workload enrolls *itself* as a shared
-    # multi-user host. The proxy reads ``ambassador_mode`` out of
-    # ``device_info`` at approve() time to skip the auto-baseline binding —
-    # capabilities scoped to MCP resources belong on user principals, not
-    # on the container (see ADR-021 + memory note
+    # Frontdesk-bundle flag (multi-user container): triggered by either
+    # the legacy ``AMBASSADOR_MODE=shared`` (ADR-021 fake-SSO topology)
+    # or the modern ``FRONTDESK_BUNDLE=1`` marker the bundle's
+    # docker-compose.yml ships (ADR-025 ``AUTH_MODE=local`` real
+    # users.db + login form). Both make this Connector enroll *itself*
+    # as a multi-user host; the proxy reads ``ambassador_mode`` out of
+    # ``device_info`` at approve() time to skip the auto-baseline
+    # binding — capabilities scoped to MCP resources belong on user
+    # principals, not on the container (see ADR-021 + memory note
     # ``feedback_frontdesk_shared_mode_capability_model``).
     import os as _os
-    if _os.environ.get("AMBASSADOR_MODE", "").strip().lower() == "shared":
+    from cullis_connector.identity.auth_mode import is_frontdesk_bundle
+    if is_frontdesk_bundle():
         body["device_info"] = _wrap_device_info_with_shared_mode(
             body.get("device_info"),
         )

--- a/cullis_connector/identity/auth_mode.py
+++ b/cullis_connector/identity/auth_mode.py
@@ -33,6 +33,14 @@ _log = logging.getLogger("cullis_connector.identity.auth_mode")
 
 ENV_AUTH_MODE = "AUTH_MODE"
 ENV_AMBASSADOR_MODE = "AMBASSADOR_MODE"
+# ADR-034 §1 — explicit marker the Frontdesk bundle sets in its
+# docker-compose.yml so the multi-user guards (admin-only setup,
+# workload principal type, ADR-033 audit warning) fire for the modern
+# ADR-025 ``AUTH_MODE=local`` Frontdesk deployment, not only for the
+# legacy ADR-021 ``AMBASSADOR_MODE=shared`` fake-SSO path. Cullis Chat
+# desktop + standalone PyPI Connector ship without this marker and
+# stay on the single-user behaviour.
+ENV_FRONTDESK_BUNDLE = "FRONTDESK_BUNDLE"
 
 MODE_LOCAL = "local"
 MODE_OIDC = "oidc"
@@ -74,12 +82,43 @@ def is_shared_mode(env: Optional[dict] = None) -> bool:
     return read_auth_mode(env) == MODE_SHARED
 
 
+def is_frontdesk_bundle(env: Optional[dict] = None) -> bool:
+    """True when this Connector is launched inside the Frontdesk bundle.
+
+    ADR-034 §1: the legacy ``is_shared_mode()`` check matches only
+    ``AMBASSADOR_MODE=shared`` (the ADR-021 fake-SSO topology), but the
+    modern Frontdesk bundle ships with ``AUTH_MODE=local`` (ADR-025 SMB
+    multi-user, real ``users.db`` + login form, no IdP). Both
+    deployments are ``container-multi-user`` and must trigger the same
+    admin-only setup guard, workload principal-type enrollment, and
+    audit-warning visibility — single-user Cullis Chat desktop or the
+    standalone PyPI Connector must NOT.
+
+    ``FRONTDESK_BUNDLE`` is set to ``1`` in
+    ``packaging/frontdesk-bundle/docker-compose.yml`` so the bundle
+    always carries the marker; standalone deployments leave it unset
+    and stay on the single-user behaviour.
+
+    Accepts the legacy ``AMBASSADOR_MODE=shared`` path so a pre-rc1
+    deployment that already set the env explicitly keeps working
+    without flipping a new variable.
+    """
+    e = env if env is not None else os.environ
+    if (e.get(ENV_FRONTDESK_BUNDLE) or "").strip().lower() in {
+        "1", "true", "yes",
+    }:
+        return True
+    return is_shared_mode(e)
+
+
 __all__ = [
     "ENV_AMBASSADOR_MODE",
     "ENV_AUTH_MODE",
+    "ENV_FRONTDESK_BUNDLE",
     "MODE_LOCAL",
     "MODE_OIDC",
     "MODE_SHARED",
+    "is_frontdesk_bundle",
     "is_local_mode",
     "is_oidc_mode",
     "is_shared_mode",

--- a/cullis_connector/setup_auth.py
+++ b/cullis_connector/setup_auth.py
@@ -50,7 +50,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from cullis_connector.identity.auth_mode import is_shared_mode
+from cullis_connector.identity.auth_mode import is_frontdesk_bundle
 
 _log = logging.getLogger("cullis_connector.setup_auth")
 
@@ -165,7 +165,7 @@ def read_or_generate_setup_bearer(
     Returns ``None`` in single mode (no bearer needed) or when setup
     is already completed (no further bearer should be served).
     """
-    if not is_shared_mode(env):
+    if not is_frontdesk_bundle(env):
         return None
     state = _load_state(config_dir)
     if state.get("setup_completed"):
@@ -291,7 +291,7 @@ def verify_setup_request(
     e = env if env is not None else os.environ
     enforcement = read_setup_auth_enforcement(e)
 
-    if not is_shared_mode(e):
+    if not is_frontdesk_bundle(e):
         return SetupAuthOutcome(True, "single_mode_bypass", enforcement)
 
     if is_setup_completed(config_dir):

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -858,7 +858,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
 
     @app.middleware("http")
     async def _setup_admin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
-        from cullis_connector.identity.auth_mode import is_shared_mode
+        from cullis_connector.identity.auth_mode import is_frontdesk_bundle
         from cullis_connector.setup_auth import (
             ENFORCEMENT_REQUIRED,
             verify_setup_request,
@@ -867,7 +867,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         path = request.url.path
         if not (path == "/setup" or path.startswith("/setup/")):
             return await call_next(request)
-        if not is_shared_mode():
+        if not is_frontdesk_bundle():
             return await call_next(request)
 
         # Read body once so HMAC verification + the downstream handler
@@ -1028,9 +1028,9 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         desktop, standalone PyPI Connector) keeps the legacy
         single-user wizard.
         """
-        from cullis_connector.identity.auth_mode import is_shared_mode
+        from cullis_connector.identity.auth_mode import is_frontdesk_bundle
 
-        return "setup_workload.html" if is_shared_mode() else "setup.html"
+        return "setup_workload.html" if is_frontdesk_bundle() else "setup.html"
 
     @app.get("/setup", response_class=HTMLResponse)
     def setup_get(
@@ -1528,9 +1528,9 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             # because ``mark_setup_completed`` is only read in shared
             # mode (see ``cullis_connector/setup_auth.py``).
             try:
-                from cullis_connector.identity.auth_mode import is_shared_mode
+                from cullis_connector.identity.auth_mode import is_frontdesk_bundle
                 from cullis_connector.setup_auth import mark_setup_completed
-                if is_shared_mode():
+                if is_frontdesk_bundle():
                     mark_setup_completed(config.config_dir)
             except Exception as exc:  # noqa: BLE001 — never block the
                 # approval response on setup-state housekeeping; the

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -99,6 +99,17 @@ services:
       # frontdesk.env explicitly (also requires CULLIS_TRUSTED_PROXIES).
       AUTH_MODE: ${AUTH_MODE:-local}
       AMBASSADOR_MODE: ${AMBASSADOR_MODE:-}
+      # ADR-034 §1 — marker so the Connector knows it is running
+      # inside the Frontdesk bundle. The multi-user guards
+      # (admin-only ``/setup/*``, ``principal_type=workload`` at
+      # enrollment, Mastio version probe, ADR-033 audit warning)
+      # fire when this is set even if ``AMBASSADOR_MODE`` is empty —
+      # the modern ``AUTH_MODE=local`` Frontdesk deployment has the
+      # same multi-user blast radius as the legacy fake-SSO topology
+      # and must carry the same defences. Cullis Chat desktop and
+      # the standalone PyPI Connector ship without this env so they
+      # keep the single-user behaviour.
+      FRONTDESK_BUNDLE: "1"
       CULLIS_CONNECTOR_ADMIN_SECRET: ${CULLIS_CONNECTOR_ADMIN_SECRET:-}
       # Loopback enforcement is the right default on a laptop where the
       # Ambassador binds to 127.0.0.1, but on the Frontdesk bundle the

--- a/tests/connector/test_setup_admin_only.py
+++ b/tests/connector/test_setup_admin_only.py
@@ -374,6 +374,52 @@ def test_version_probe_refuses_unreachable_mastio():
     assert "/health" in str(excinfo.value)
 
 
+def test_frontdesk_bundle_env_triggers_multi_user_guard(tmp_path):
+    """ADR-034 §1 fix — the modern bundle marker ``FRONTDESK_BUNDLE=1``
+    must trigger the same admin-only guard as the legacy
+    ``AMBASSADOR_MODE=shared`` path. Without this, a Frontdesk
+    container deployed with ``AUTH_MODE=local`` (ADR-025 SMB default)
+    would leave ``/setup/*`` reachable in warn mode, defeating the
+    point of PR-B.
+    """
+    env = {
+        "FRONTDESK_BUNDLE": "1",
+        ENV_ENFORCEMENT: ENFORCEMENT_REQUIRED,
+    }
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="POST",
+        path="/setup/pin-ca",
+        headers={},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == "no_proof_refused"
+
+
+def test_single_mode_still_bypasses_without_frontdesk_bundle(tmp_path):
+    """Negative case for the same fix: a Connector that doesn't carry
+    the ``FRONTDESK_BUNDLE`` marker AND no ``AMBASSADOR_MODE=shared``
+    (i.e. Cullis Chat desktop, standalone PyPI Connector) stays on the
+    single-mode bypass even when ``AUTH_MODE=local`` is set (the
+    default for both).
+    """
+    env = {"AUTH_MODE": "local"}
+    outcome = verify_setup_request(
+        config_dir=tmp_path,
+        method="GET",
+        path="/setup",
+        headers={},
+        query_params={},
+        body_bytes=b"",
+        env=env,
+    )
+    assert outcome.allowed is True
+    assert outcome.reason == "single_mode_bypass"
+
+
 def test_parse_semver_handles_rc_and_v_prefix():
     assert _parse_semver("0.5.0") == (0, 5, 0)
     assert _parse_semver("v0.5.0") == (0, 5, 0)


### PR DESCRIPTION
## Summary

Dogfood of v0.5.0-rc1 against the ``frontdesk-demo`` VM (192.168.122.87) surfaced an architectural gap in PR-A / PR-B / PR-C (#809 / #810 / #811): every multi-user guard keys off ``is_shared_mode()`` which resolves ``True`` only when ``AMBASSADOR_MODE=shared`` (legacy ADR-021 fake-SSO). The modern Frontdesk bundle ships with ``AUTH_MODE=local`` (ADR-025 SMB default — real ``users.db`` + login form, no IdP) and **does not set** ``AMBASSADOR_MODE``, so the multi-user guards stayed dormant: ``/setup/*`` reachable from any LAN host, ``principal_type=workload`` never set at enrollment, Mastio version probe skipped, ADR-033 audit warning never fired.

Forcing ``AMBASSADOR_MODE=shared`` in ``frontdesk.env`` during dogfood worked around the gap, but that is the kind of workaround a paying customer would carry into production unnoticed (memory ``feedback_dogfood_simulates_paying_customer``). Fix the gate proper.

## Implementation

- ``cullis_connector/identity/auth_mode.py`` — new helper ``is_frontdesk_bundle(env)`` returns ``True`` when either the legacy ``AMBASSADOR_MODE=shared`` is set OR the new explicit marker ``FRONTDESK_BUNDLE=1`` (env ``ENV_FRONTDESK_BUNDLE``) is present.
- ``packaging/frontdesk-bundle/docker-compose.yml`` — sets ``FRONTDESK_BUNDLE: "1"`` in the Connector service environment so the bundle always carries the marker regardless of operator ``frontdesk.env`` choices.
- ``cullis_connector/setup_auth.py`` — both call sites in ``verify_setup_request`` and ``read_or_generate_setup_bearer`` use the new helper.
- ``cullis_connector/web.py`` — three call sites (setup admin-guard middleware, template dispatcher, completion hook on enrollment success) use the new helper.
- ``cullis_connector/enrollment.py`` — inline ``AMBASSADOR_MODE=shared`` check in ``_start`` replaced with ``is_frontdesk_bundle()`` so PR-A workload identity + PR-B Mastio version probe fire on the modern bundle path.

## Compatibility

| Deployment | Outcome |
|---|---|
| Pre-rc1 with explicit ``AMBASSADOR_MODE=shared`` in ``frontdesk.env`` | Keeps working unchanged — legacy branch of the new helper. |
| rc1 with default ``AUTH_MODE=local`` + bundle-shipped ``FRONTDESK_BUNDLE=1`` | Now gets multi-user guards on first ``./deploy.sh --pull`` of rc2. |
| Cullis Chat desktop, standalone PyPI Connector | Leave both env unset — single-user bypass preserved (verified by the new negative test). |

## Test plan

- [x] ``pytest tests/connector/test_setup_admin_only.py -v`` — 27/27 pass:
  - 25 existing (PR-B + PR-C cases).
  - ``test_frontdesk_bundle_env_triggers_multi_user_guard`` — ``FRONTDESK_BUNDLE=1`` activates the guard standalone.
  - ``test_single_mode_still_bypasses_without_frontdesk_bundle`` — ``AUTH_MODE=local`` alone keeps the single-user bypass; the gate widening doesn't accidentally pull consumer Cullis Chat into multi-user guards.
- [x] ``pytest tests/ -n auto --dist=loadfile`` — 4117/4120 pass. Three pre-existing failures (``test_dashboard_approvals_nav`` from PR #807 / #809 + two ``test_lifespan_tier_matrix_cache`` xdist flake cases that pass when isolated).
- Smoke deferred — this is Connector-side only, no Mastio change.

## Follow-up after merge

Rebuild ``ghcr.io/cullis-security/cullis-connector:0.5.0-rc2`` + re-dogfood the ``frontdesk-demo`` VM without the manual ``AMBASSADOR_MODE=shared`` override that PR-B / PR-C had silently required.