### PR TITLE
chore: bump Connector to 0.5.0-rc2 (post-#813 gate fix)

### DIFF
--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.5.0-rc1"
+__version__ = "0.5.0-rc2"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.5.0-rc1"
+version = "0.5.0-rc2"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
PR #813 widened the Frontdesk multi-user gate. Bump Connector version + rebuild ghcr.io/cullis-security/cullis-connector:0.5.0-rc2 so the frontdesk-demo VM (192.168.122.87) can be re-dogfooded without the manual AMBASSADOR_MODE=shared override that rc1 silently required.