### PR TITLE
fix(mcp_proxy): include intermediate in external pubkey cert chain

### DIFF
--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -230,20 +230,33 @@ def _cert_der_digest(cert: x509.Certificate) -> bytes:
 
 
 def _pem_der_digest(pem: str) -> bytes | None:
-    """SHA-256 of a PEM-encoded cert's DER bytes.
+    """SHA-256 of the leaf cert's DER bytes.
 
-    Robust to whitespace and the ``-----BEGIN/END-----`` markers — we
-    decode the base64 body directly so the comparison doesn't break
-    on ``\\r\\n`` vs ``\\n`` line endings the cert went through on its
-    way into the database.
+    Three-tier PKI hardening (audit 2026-05-18) made
+    ``internal_agents.cert_pem`` carry the full chain
+    (``leaf + intermediate``) so the SDK's
+    ``build_client_assertion`` can pack the chain into the JWT
+    ``x5c`` header for ``/v1/auth/login-challenge-response``. The
+    cert pin must still compare against the **leaf** DER digest —
+    the presented mTLS handshake only ships the leaf, and hashing
+    the raw concatenated PEM body would always mismatch. Load the
+    PEM properly and digest the first (leaf) cert's DER bytes.
+
+    Robust to whitespace and ``\\r\\n`` line endings via the
+    standard PEM parser (which tolerates both); legacy callers
+    that stored a single-cert PEM still get the same digest as
+    before the chain hardening.
     """
     if not pem:
         return None
     try:
-        body = re.sub(r"-----.*?-----|\s", "", pem)
-        return hashlib.sha256(base64.b64decode(body)).digest()
-    except (ValueError, TypeError):
+        certs = x509.load_pem_x509_certificates(pem.encode())
+    except ValueError:
         return None
+    if not certs:
+        return None
+    der = certs[0].public_bytes(serialization.Encoding.DER)
+    return hashlib.sha256(der).digest()
 
 
 def _cert_serial_hex(cert: x509.Certificate) -> str:

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -1022,9 +1022,25 @@ class AgentManager:
             .sign(self._mastio_ca_key, hashes.SHA256())
         )
 
-        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        leaf_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        # Three-tier PKI hardening (audit 2026-05-18) — the leaf is
+        # signed by the Mastio Intermediate, not the Org CA directly.
+        # Without the intermediate concatenated alongside the leaf,
+        # the SDK's ``build_client_assertion`` packs only the leaf into
+        # the JWT ``x5c`` header, and ``mcp_proxy/auth/challenge_response.py``
+        # (``/v1/auth/login-challenge-response``) cannot walk the
+        # chain back to the Org CA — every
+        # ``login_via_proxy_with_local_key`` call comes back HTTP 401
+        # ``x509 chain verification failed``. Discovered during ADR-034
+        # dogfood rc2 when the Frontdesk user-login provisioning
+        # surfaced the deferred state via the cert middleware.
+        intermediate_pem = self._mastio_ca_cert.public_bytes(
+            serialization.Encoding.PEM,
+        ).decode()
+        cert_pem = leaf_pem + intermediate_pem
         logger.info(
-            "Signed external pubkey for %s (SAN %s, issuer=Intermediate)",
+            "Signed external pubkey for %s (SAN %s, issuer=Intermediate, "
+            "chain=leaf+intermediate)",
             agent_id, spiffe_uri,
         )
         return cert_pem

--- a/tests/test_pki_three_tier_hardening.py
+++ b/tests/test_pki_three_tier_hardening.py
@@ -107,6 +107,85 @@ async def test_external_pubkey_chains_under_intermediate(proxy_app):
 
 
 @pytest.mark.asyncio
+async def test_external_pubkey_returns_leaf_and_intermediate_chain(proxy_app):
+    """ADR-034 dogfood rc2 finding — ``sign_external_pubkey`` MUST
+    return the concatenated chain ``leaf + intermediate``, not just
+    the leaf. The SDK's ``build_client_assertion`` packs every PEM
+    block in ``cert_pem`` into the JWT ``x5c`` header, and
+    ``/v1/auth/login-challenge-response`` walks that chain back to the
+    Org CA. A leaf-only return value drops the bridge and every
+    ``login_via_proxy_with_local_key`` call comes back HTTP 401
+    ``x509 chain verification failed`` — the user-login provisioning
+    on Frontdesk then deferred silently and chat broke.
+    """
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+
+    ext_key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = ext_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    chain_pem = mgr.sign_external_pubkey(pubkey_pem=pub_pem, agent_name="ext")
+    chain = x509.load_pem_x509_certificates(chain_pem.encode())
+    assert len(chain) == 2, (
+        f"expected leaf + intermediate, got {len(chain)} cert(s)"
+    )
+    leaf, intermediate = chain
+    leaf_issuer = leaf.issuer.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME,
+    )[0].value
+    intermediate_subject = intermediate.subject.get_attributes_for_oid(
+        x509.NameOID.COMMON_NAME,
+    )[0].value
+    assert leaf_issuer == intermediate_subject, (
+        f"chain not stitched: leaf.issuer={leaf_issuer!r} != "
+        f"intermediate.subject={intermediate_subject!r}"
+    )
+    assert "Mastio CA" in intermediate_subject
+
+
+@pytest.mark.asyncio
+async def test_pem_der_digest_pins_leaf_when_chain_stored(proxy_app):
+    """ADR-034 dogfood rc2 — the cert-pinning verifier must compare
+    the **leaf** DER digest, not the digest of the raw concatenated
+    PEM bytes. After ``sign_external_pubkey`` started returning the
+    chain (above), ``internal_agents.cert_pem`` carries
+    ``leaf + intermediate``; the presented mTLS handshake only ships
+    the leaf, so ``_pem_der_digest`` MUST parse the PEM properly and
+    digest the first cert. The pre-fix raw-base64 path computed
+    ``sha256(b64(leaf_body || intermediate_body))`` and always
+    mismatched.
+    """
+    import hashlib
+    from cryptography.hazmat.primitives import serialization as _ser
+    from mcp_proxy.auth.client_cert import _pem_der_digest
+
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    ext_key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = ext_key.public_key().public_bytes(
+        _ser.Encoding.PEM, _ser.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    chain_pem = mgr.sign_external_pubkey(pubkey_pem=pub_pem, agent_name="ext")
+    chain = x509.load_pem_x509_certificates(chain_pem.encode())
+    leaf = chain[0]
+    expected_leaf_digest = hashlib.sha256(
+        leaf.public_bytes(_ser.Encoding.DER),
+    ).digest()
+    assert _pem_der_digest(chain_pem) == expected_leaf_digest, (
+        "_pem_der_digest must pin the leaf cert's DER, not the raw "
+        "PEM body — otherwise the mTLS handshake (which only ships "
+        "the leaf) cannot match the stored chain"
+    )
+    leaf_only_pem = leaf.public_bytes(_ser.Encoding.PEM).decode()
+    assert _pem_der_digest(leaf_only_pem) == expected_leaf_digest, (
+        "_pem_der_digest must keep the same result for a legacy "
+        "single-cert PEM (no chain) so pre-rc2 pins keep matching"
+    )
+
+
+@pytest.mark.asyncio
 async def test_nginx_server_cert_chains_under_intermediate(proxy_app, tmp_path):
     app, _ = proxy_app
     mgr = app.state.agent_manager


### PR DESCRIPTION
ADR-034 dogfood rc2 finding. PKI three-tier hardening (#779/#780) moved agent leaf signing under the Mastio Intermediate, but `sign_external_pubkey` kept returning only the **leaf**. SDK's `build_client_assertion` packs every PEM block in `cert_pem` into the JWT `x5c` header, and `/v1/auth/login-challenge-response` walks the chain back to Org CA — without the intermediate the verifier dropped the bridge and every Connector login came back HTTP 401 `x509 chain verification failed`. Frontdesk user-login provisioning then deferred silently.

Fix: concatenate Mastio Intermediate PEM after leaf in `sign_external_pubkey`. `_pem_der_digest` switched from raw-base64 hash to leaf-DER hash so the cert pin keeps matching the leaf-only mTLS handshake against the now-chain-bearing stored PEM. Legacy single-cert PEMs digest identically (verified). 2 new regression tests in `test_pki_three_tier_hardening.py`.

Verification: 13/13 PKI tests pass, full 4122/4123 (the 1 fail is pre-existing). Follow-up: rebuild rc3 + retry dogfood user login.