### PR TITLE
fix(dashboard): Delete on users list + verify_tls knob for self-signed Frontdesk

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -543,6 +543,24 @@ class ProxySettings(BaseSettings):
     # page read-only (legacy behaviour).
     frontdesk_ambassador_url: str = ""
     frontdesk_admin_secret: str = ""
+    # When the Frontdesk Ambassador is reached over HTTPS with a
+    # self-signed TLS cert (the bundle's built-in sidecar, default),
+    # the Mastio cannot validate the leaf against any CA it knows.
+    # Two ways to bridge:
+    #   * ``frontdesk_verify_tls=false`` — skip verification entirely.
+    #     Cheap dogfood / dev path; fine inside a private libvirt
+    #     network where the only reason the leaf is unverifiable is
+    #     that the sidecar minted it locally.
+    #   * ``frontdesk_ca_bundle`` — path to the Frontdesk CA chain
+    #     (e.g. ``./frontdesk-ca.crt`` copied from the bundle's
+    #     ``tls/`` dir at deploy time). Use in production so the
+    #     Mastio still validates the leaf.
+    # If both are set the explicit CA bundle wins. Empty + verify=true
+    # (the default) means: standard system trust store, which is the
+    # right shape when the Frontdesk is terminated by a corporate
+    # ingress / oauth2-proxy fronting a real CA cert.
+    frontdesk_verify_tls: bool = True
+    frontdesk_ca_bundle: str = ""
 
     # ADR-032 Layer 1 (F2 spike) — Intune device attestation polling.
     # ``mdm_intune_enabled=false`` keeps the polling task off so

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3342,6 +3342,25 @@ def _frontdesk_admin_target() -> tuple[str, str] | None:
     return url, secret
 
 
+def _frontdesk_verify_arg():
+    """Return the ``verify=`` argument for the httpx call to the
+    Frontdesk Ambassador.
+
+    ``MCP_PROXY_FRONTDESK_CA_BUNDLE`` (path) wins when set; otherwise
+    ``MCP_PROXY_FRONTDESK_VERIFY_TLS`` (bool, default ``true``)
+    controls the standard-trust path. ``false`` means "skip
+    verification" — fine for the libvirt dogfood and any deployment
+    that fronts the Ambassador with a self-signed sidecar; production
+    deployments behind a real CA leave the default.
+    """
+    from mcp_proxy.config import get_settings
+    s = get_settings()
+    bundle = (s.frontdesk_ca_bundle or "").strip()
+    if bundle:
+        return bundle
+    return bool(s.frontdesk_verify_tls)
+
+
 async def _fetch_frontdesk_users() -> dict[str, dict] | None:
     """Pull the canale's user list. Keyed by ``user_name`` for join.
 
@@ -3354,7 +3373,9 @@ async def _fetch_frontdesk_users() -> dict[str, dict] | None:
         return None
     url, secret = target
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
+        async with httpx.AsyncClient(
+            timeout=5.0, verify=_frontdesk_verify_arg(),
+        ) as client:
             r = await client.get(
                 f"{url}/admin/users",
                 headers={"X-Admin-Secret": secret},
@@ -3391,7 +3412,9 @@ async def _frontdesk_admin_call(
         return 0, None, "frontdesk_not_configured"
     url, secret = target
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(
+            timeout=10.0, verify=_frontdesk_verify_arg(),
+        ) as client:
             r = await client.request(
                 method,
                 f"{url}{path}",

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -213,10 +213,29 @@
                         {{ u.created_at[:19] if u.created_at else '—' }}
                     </td>
                     <td class="px-5 py-4">
-                        <a href="/proxy/users/{{ u.principal_id|urlencode }}"
-                           class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-white transition-colors">
-                            Details
-                        </a>
+                        <div class="flex items-center gap-2">
+                            <a href="/proxy/users/{{ u.principal_id|urlencode }}"
+                               class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-white transition-colors">
+                                Details
+                            </a>
+                            {# Inline delete — was only reachable from
+                               the per-user detail page before; the
+                               list lacked any action other than
+                               Details, so an admin who wanted to clean
+                               up a batch of pre-seeded rows had to
+                               drill into each one separately. Confirm
+                               dialog stays as the brake. #}
+                            <form method="post"
+                                  action="/proxy/users/{{ u.principal_id|urlencode }}/delete"
+                                  onsubmit="return confirm('Delete user {{ u.user_name }}? This wipes the principal row on the Mastio + the credential on the canale. Cannot be undone.')"
+                                  class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <button type="submit"
+                                        class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-red-900/40 text-red-400/70 rounded hover:bg-red-500/10 hover:text-red-400 transition-colors">
+                                    Delete
+                                </button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
                 {% endfor %}

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -148,6 +148,16 @@ services:
       # leave /proxy/users in read-only mode.
       MCP_PROXY_FRONTDESK_AMBASSADOR_URL: ${MCP_PROXY_FRONTDESK_AMBASSADOR_URL:-}
       MCP_PROXY_FRONTDESK_ADMIN_SECRET:   ${MCP_PROXY_FRONTDESK_ADMIN_SECRET:-}
+      # TLS verification for the Frontdesk Ambassador callback.
+      # ``true`` (default) — standard system trust store, the right
+      # default when the Ambassador is fronted by a corporate ingress
+      # with a real CA cert. ``false`` skips verification for the
+      # built-in sidecar's self-signed leaf (libvirt dogfood, local
+      # demos). ``MCP_PROXY_FRONTDESK_CA_BUNDLE`` (path inside the
+      # container, typically mounted via volume) pins a specific CA
+      # and overrides the boolean.
+      MCP_PROXY_FRONTDESK_VERIFY_TLS: ${MCP_PROXY_FRONTDESK_VERIFY_TLS:-true}
+      MCP_PROXY_FRONTDESK_CA_BUNDLE:   ${MCP_PROXY_FRONTDESK_CA_BUNDLE:-}
       # ADR-029 Phase C — tool-call PDP gate. When true, the Mastio's
       # ``run_tool_use_loop`` calls /v1/policy/tool-call for every tool
       # the model wants to invoke and refuses the tools the org's


### PR DESCRIPTION
Two dogfood-driven fixes for the Mastio dashboard users page, both surfaced on the ADR-034 rc3 ``frontdesk-demo`` VM.

## 1. Delete action exposed on the users list

The ``/proxy/users`` list had ``Details`` as the only inline action, so an admin who wanted to clean up a batch of pre-seeded rows had to drill into each user's detail page, scroll to the Danger Zone, and click Delete N times. The endpoint (``POST /proxy/users/{principal_id:path}/delete`` in ``mcp_proxy/dashboard/router.py:4051``) already worked from the detail page — only the list-view template was missing the button. Adds inline form with CSRF token + confirm dialog matching the detail-page Danger Zone form. Zero router changes.

## 2. ``verify_tls`` + ``ca_bundle`` knobs for self-signed Frontdesk

Larger fix. ``_fetch_frontdesk_users`` + ``_frontdesk_admin_call`` were calling the Frontdesk Ambassador over HTTPS with the default httpx verify (system trust store). The Frontdesk bundle's built-in TLS sidecar mints a self-signed leaf at deploy time, so the Mastio's call failed with cert-verification → ``_build_user_view`` saw ``fd_users=None`` → ``frontdesk_enabled=False`` → the entire Danger Zone block (Provision to Frontdesk / Reset Password / Reset TOFU pin / Delete) on the user-detail page **and** the password fields on the Create User form were both gated off. Admins ended up on a dashboard where every user landed ``PRE-SEEDED / NO CREDENTIAL`` because the password inputs never rendered and the form silently fell into the registry-only fallback path.

Two new config fields:

- ``MCP_PROXY_FRONTDESK_VERIFY_TLS`` (bool, default ``true``) — ``false`` skips verification for the libvirt dogfood and any deployment that fronts the Ambassador with the bundle's self-signed sidecar.
- ``MCP_PROXY_FRONTDESK_CA_BUNDLE`` (path, default empty) — wins over the boolean. Pin a specific CA file in production deployments that want to keep TLS verification on.

``_frontdesk_verify_arg`` resolves them into the right ``verify=`` argument for httpx and is now called from both the read path (``_fetch_frontdesk_users``) and the write path (``_frontdesk_admin_call``).

## Files

- ``mcp_proxy/dashboard/templates/users.html`` — Delete button inline in the Actions column.
- ``mcp_proxy/dashboard/router.py`` — ``_frontdesk_verify_arg`` helper + both httpx clients pick it up.
- ``mcp_proxy/config.py`` — two new settings fields.
- ``packaging/mastio-bundle/docker-compose.yml`` — env mapping for the two new vars (memory ``feedback_bundle_compose_env_explicit_mapping`` pattern).

## Test plan

- [x] ``pytest tests/test_dashboard_users_via_ambassador.py -v`` — 19/19 pass. The in-test fake Frontdesk monkey-patches httpx so TLS is bypassed; existing tests cover both the handler logic and the new Delete button reaches the existing endpoint.
- Live dogfood verification queued post-merge: rebuild Mastio rc4, set ``MCP_PROXY_FRONTDESK_VERIFY_TLS=false`` + the Ambassador URL/secret in the VM's ``proxy.env``, expect Danger Zone visible + Create User password fields rendered.