### PR TITLE
feat(sandbox): dogfood-frontdesk.sh end-to-end + complete PR-A propagation

### DIFF
--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -243,6 +243,9 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
             jti=payload.jti,
             scope=[],
             cnf=None,
+            principal_type=(
+                "user" if "::user::" in payload.agent_id else "workload"
+            ),
         )
 
     record = await get_agent(payload.agent_id)
@@ -271,6 +274,14 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
         jti=payload.jti,
         scope=list(capabilities),
         cnf=None,
+        # ADR-034 §2 — propagate principal_type from the DB row so
+        # downstream gates (F-001 on /v1/principals/csr) see the
+        # workload classification. Without this the dataclass
+        # default ``"agent"`` always wins and the Connector workload
+        # cannot mint user-principal certs. Sandbox dogfood caught
+        # this on the Bearer LOCAL_TOKEN ingress path; the JWT-mint
+        # counterpart is in local_token.py (issue_local_token).
+        principal_type=record.get("principal_type") or "agent",
     )
 
 
@@ -396,6 +407,16 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
         # reach. The mTLS path (client_cert.py:333) already does
         # this correctly; mirror it here for parity.
         reach=record.get("reach") or "both",
+        # ADR-034 §2 — same parity for principal_type. Without this,
+        # a Frontdesk workload that authenticates over LOCAL_TOKEN
+        # (the ADR-012 Phase 4 fast path that the Connector's
+        # ``login_via_proxy_with_local_key`` lands on) ends up with
+        # ``principal_type=agent`` from the dataclass default, then
+        # the F-001 gate on ``/v1/principals/csr`` refuses to mint
+        # user-principal certs because the caller "is not a workload".
+        # client_cert.py:714 already pulls this from the DB row;
+        # mirror it here. Sandbox-frontdesk dogfood caught this.
+        principal_type=record.get("principal_type") or "agent",
     )
 
 

--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -242,10 +242,10 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
     # stamp it into the token's ``cnf.jkt`` claim. Replay of a leaked
     # LOCAL_TOKEN without the bound private key is then rejected by the
     # ingress dep (``_maybe_local_token``).
-    extra_claims: dict[str, Any] | None = None
+    extra_claims: dict[str, Any] = {}
     cnf_jkt = await _maybe_extract_dpop_jkt_at_mint(request)
     if cnf_jkt is not None:
-        extra_claims = {"cnf": {"jkt": cnf_jkt}}
+        extra_claims["cnf"] = {"jkt": cnf_jkt}
     else:
         from mcp_proxy.config import get_settings as _gs
         if _gs().local_token_require_dpop:
@@ -260,8 +260,30 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
             "the SDK has rolled out to enforce.", agent_id,
         )
 
+    # ADR-034 §2 — stamp the agent's ``principal_type`` into the JWT so
+    # downstream auth deps (``_get_authenticated_agent_dpop``) read
+    # it back via ``TokenPayload(**raw)`` instead of falling through to
+    # the dataclass default ``"agent"``. Without this, a Frontdesk
+    # workload (``principal_type='workload'`` on internal_agents) gets
+    # ``token.principal_type='agent'`` and the F-001 gate on
+    # ``/v1/principals/csr`` refuses every user-cert mint. Sandbox
+    # dogfood caught this — local_agent_dep.py was already fixed for
+    # the Bearer LOCAL_TOKEN path, this is the JWT-mint counterpart.
+    try:
+        from mcp_proxy.db import get_agent as _get_agent
+        record = await _get_agent(agent_id)
+        if record and record.get("principal_type"):
+            extra_claims["principal_type"] = record["principal_type"]
+            extra_claims["org"] = record.get("agent_id", agent_id).split("::", 1)[0]
+    except Exception as exc:  # noqa: BLE001 — defensive
+        _log.warning(
+            "local /auth/token: principal_type lookup failed for %s: %s",
+            agent_id, exc,
+        )
+
     token = issuer.issue(
-        agent_id=agent_id, ttl_seconds=ttl, extra_claims=extra_claims,
+        agent_id=agent_id, ttl_seconds=ttl,
+        extra_claims=extra_claims if extra_claims else None,
     )
     _log.info(
         "local /auth/token issued sub=%s iss=%s kid=%s ttl=%ds dpop=%s",

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -935,6 +935,31 @@ async def set_config(key: str, value: str) -> None:
         )
 
 
+async def set_config_if_absent(key: str, value: str) -> bool:
+    """Insert a config row only when the key is absent. Returns ``True``
+    when the value was inserted, ``False`` when the row already existed.
+
+    Used by multi-worker initialisation paths that mint a once-and-only-
+    once secret (e.g. the Mastio Intermediate CA): if two workers race
+    to mint at lifespan boot, only the winner's value lands in the DB
+    and the losers re-read the winning value via ``get_config`` instead
+    of overwriting it. Prevents the cert/key pair drift that the
+    plain ``set_config`` upsert otherwise produces between workers.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """INSERT INTO proxy_config (key, value) VALUES (:key, :value)
+                   ON CONFLICT(key) DO NOTHING"""
+            ),
+            {"key": key, "value": value},
+        )
+        # rowcount is 1 when the INSERT actually wrote, 0 when the
+        # ON CONFLICT branch fired. Both SQLite and Postgres asyncpg
+        # report it consistently here.
+        return (getattr(result, "rowcount", 0) or 0) > 0
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Mastio keys (ADR-012 Phase 2.0 multi-key store, issue #261)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1547,6 +1547,17 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
     ):
         if key in row.keys():
             out[key] = row[key]
+    # ADR-034 §2 — principal_type column (migration 0041). Optional at
+    # read time so legacy fixtures pre-migration don't blow up; the
+    # auth deps (``client_cert.py``, ``local_agent_dep.py``) fall back
+    # to the dataclass default ``"agent"`` when absent. Without this
+    # entry, ``get_agent()`` was silently dropping the column even
+    # though the SQL ``SELECT *`` returned it — every downstream
+    # consumer that called ``record.get("principal_type")`` got
+    # ``None`` and the F-001 gate on ``/v1/principals/csr`` refused
+    # workload-typed Frontdesk callers. Sandbox dogfood caught this.
+    if "principal_type" in row.keys() and row["principal_type"]:
+        out["principal_type"] = row["principal_type"]
     return out
 
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -1711,7 +1711,54 @@ class AgentManager:
         # whatever they were licensed for). Falls back to direct
         # proxy_config write for back-compat in tests / dev that lack
         # the at-rest master key (``MCP_PROXY_DB_ENCRYPTION_KEY``).
-        await self._persist_intermediate_ca(key_pem, cert_pem)
+        #
+        # F0.1 multi-worker race: under ``--workers 4`` (Mastio bundle
+        # default), every uvicorn worker runs the lifespan in parallel
+        # and would otherwise upsert its own ``mastio_ca_{key,cert}``
+        # pair, leaving the winning worker's cert next to a losing
+        # worker's key — and any leaf the loser signs verifies against
+        # the winner's cert with a different public key, ECDSA invalid.
+        # The persist helper now uses ``set_config_if_absent`` on the
+        # legacy path and the KMS providers do the same atomic write
+        # in their backends; either way only the first writer's pair
+        # lands. After persist, re-read from the source-of-truth so
+        # losers update their in-memory state to the winning pair
+        # before they sign any leaves. Sandbox-frontdesk dogfood
+        # caught this — the leaf the Connector enrolled with did not
+        # verify against its own intermediate.
+        winner_inserted = await self._persist_intermediate_ca(key_pem, cert_pem)
+
+        if not winner_inserted:
+            # Another worker won the race. Re-read the persisted pair
+            # and adopt it as our in-memory state.
+            from mcp_proxy.kms import get_kms_provider
+            persisted_key_pem: str | None = None
+            persisted_cert_pem: str | None = None
+            try:
+                loaded = await get_kms_provider().load_intermediate_ca()
+                if loaded is not None:
+                    persisted_key_pem, persisted_cert_pem = loaded
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.warning(
+                    "post-mint KMS reload failed: %s — falling back to "
+                    "legacy proxy_config rows", exc,
+                )
+            if not persisted_key_pem or not persisted_cert_pem:
+                persisted_key_pem = await get_config("mastio_ca_key")
+                persisted_cert_pem = await get_config("mastio_ca_cert")
+            if persisted_key_pem and persisted_cert_pem:
+                self._mastio_ca_key = serialization.load_pem_private_key(
+                    persisted_key_pem.encode(), password=None,
+                )
+                self._mastio_ca_cert = x509.load_pem_x509_certificate(
+                    persisted_cert_pem.encode(),
+                )
+                logger.info(
+                    "Mastio Intermediate CA mint race lost — adopted "
+                    "the winning worker's pair (CN=%s)",
+                    self._mastio_ca_cert.subject.rfc4514_string(),
+                )
+                return
 
         self._mastio_ca_key = mastio_ca_key
         self._mastio_ca_cert = mastio_ca_cert
@@ -1720,8 +1767,16 @@ class AgentManager:
             mastio_ca_subject, INTERMEDIATE_CA_VALIDITY_DAYS,
         )
 
-    async def _persist_intermediate_ca(self, key_pem: str, cert_pem: str) -> None:
+    async def _persist_intermediate_ca(
+        self, key_pem: str, cert_pem: str,
+    ) -> bool:
         """Store the Mastio Intermediate CA via the configured KMS provider.
+
+        Returns ``True`` when this worker won the persistence race
+        (the candidate pair landed in the source-of-truth), ``False``
+        when another worker had already persisted a pair first and the
+        caller should adopt the existing pair instead. See the F0.1
+        race note in ``_mint_mastio_ca``.
 
         Dev-only fallback: if the PKI at-rest master key is missing
         (``MCP_PROXY_DB_ENCRYPTION_KEY`` unset) AND the KMS backend is
@@ -1748,11 +1803,28 @@ class AgentManager:
                 "MCP_PROXY_DB_ENCRYPTION_KEY to land the Intermediate "
                 "under Fernet at-rest.",
             )
-            await set_config("mastio_ca_key", key_pem)
-            await set_config("mastio_ca_cert", cert_pem)
-            return
+            # ``set_config_if_absent`` is the multi-worker-safe
+            # primitive — only the first writer wins, the rest report
+            # back ``False`` and the mint flow adopts the persisted
+            # pair. Both rows must be coupled atomically: we only
+            # accept the "winner" outcome when BOTH inserts wrote;
+            # if just one wrote we treat it as a race and re-read.
+            from mcp_proxy.db import set_config_if_absent
+            wrote_key = await set_config_if_absent(
+                "mastio_ca_key", key_pem,
+            )
+            wrote_cert = await set_config_if_absent(
+                "mastio_ca_cert", cert_pem,
+            )
+            return wrote_key and wrote_cert
 
+        # KMS providers (Vault / AWS-KMS / Azure-KV / etc) implement
+        # their own atomic-insert semantics under
+        # ``store_intermediate_ca``; if the provider doesn't expose a
+        # winner signal we assume win-on-success and leave the
+        # race-safe behaviour to the provider plugin.
         await provider.store_intermediate_ca(key_pem, cert_pem)
+        return True
 
     async def _mint_mastio_leaf(self, now: datetime) -> None:
         """Mint a fresh EC P-256 leaf under the existing intermediate CA.

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -274,20 +274,28 @@ async def sign_user_csr(
         raise RuntimeError(
             "Org CA not loaded on this proxy — cannot sign principal CSRs",
         )
-    ca_key = agent_manager._org_ca_key  # type: ignore[attr-defined]
-    if ca_key is None:
-        raise RuntimeError("Org CA key missing despite ca_loaded=True")
-    # Use the *real* Org CA cert subject as the issuer so the resulting
-    # cert chains cleanly through nginx's ``ssl_verify_client``. The
-    # fallback ``_build_issuer`` would emit a synthetic
-    # ``CN=Cullis Mastio Broker CA, O=<org>`` Name that does NOT match
-    # the registered org_ca subject; OpenSSL then refuses the chain
-    # with "unable to get issuer cert" and nginx returns the generic
-    # 400 SSL certificate error page. Caught dogfooding 2026-05-06.
-    ca_cert = agent_manager._org_ca_cert  # type: ignore[attr-defined]
-    issuer_name = ca_cert.subject if ca_cert is not None else _build_issuer(
-        expected_org,
-    )
+    # Three-tier PKI hardening (audit 2026-05-18) — user-principal
+    # certs sign under the **Mastio Intermediate**, NOT the Org Root.
+    # The Org Root key is cold-by-default (unsealed only briefly to
+    # mint the Intermediate then scrubbed from memory); reaching for
+    # ``agent_manager._org_ca_key`` here returned ``None`` at steady
+    # state and the endpoint replied 503 ``Org CA temporarily
+    # unavailable`` for every Connector user-CSR call. Sandbox
+    # dogfood caught this. Mirror the ``sign_external_pubkey``
+    # pattern (``agent_manager._mastio_ca_key`` /
+    # ``agent_manager._mastio_ca_cert``) so user certs chain
+    # ``leaf → Mastio Intermediate → Org Root`` and nginx's
+    # ``ssl_client_certificate`` (Org Root) verifies them via the
+    # intermediate the Connector ships in ``x5c`` /
+    # ``ssl_client_certificate_chain``.
+    ca_key = agent_manager._mastio_ca_key  # type: ignore[attr-defined]
+    ca_cert = agent_manager._mastio_ca_cert  # type: ignore[attr-defined]
+    if ca_key is None or ca_cert is None:
+        raise RuntimeError(
+            "Mastio Intermediate CA not loaded — ensure_mastio_identity() "
+            "must complete before user-principal CSRs can be signed",
+        )
+    issuer_name = ca_cert.subject
 
     now = datetime.now(timezone.utc)
     not_before = now - CLOCK_SKEW

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -211,5 +211,37 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # The nginx-static SPA inside cullis-chat emits absolute
+        # ``Location: http://<Host>:8080/...`` redirects on dir-norm
+        # 301s (``/login`` → ``/login/``) because the upstream port
+        # is baked into the static container's config and it has no
+        # idea what port the bundle is published on. Rewrite to a
+        # path-only Location so the browser resolves the redirect
+        # against the current origin (whatever host:port the operator
+        # actually picked). Memory:
+        # feedback_nginx_static_absolute_redirects. The TLS sidecar
+        # does the same rewrite via
+        # ``proxy_redirect http://$host:8080/ https://$http_host/``
+        # when ``--tls`` is on; this directive is the HTTP-only
+        # counterpart so the bundle works whether or not the sidecar
+        # profile is enabled. Caught by sandbox-frontdesk dogfood
+        # 2026-05-19 — without it, ``open http://localhost:18080/login``
+        # bounces the browser to ``http://localhost:8080/login/``
+        # (the upstream container port) and the user sees ``connection
+        # refused``.
+        # The SPA's nginx emits Location with the *request* Host's
+        # hostname (stripped of incoming port) plus its own internal
+        # 8080 listen port — so a curl with ``Host: localhost:18080``
+        # gets ``Location: http://localhost:8080/login/`` and a curl
+        # with ``Host: cullis-chat:8080`` gets
+        # ``Location: http://cullis-chat:8080/login/``. A
+        # static-string ``proxy_redirect http://cullis-chat:8080/``
+        # only catches the second shape. Match ANY upstream
+        # ``http://<host>[:port]<path>`` and rewrite back to the
+        # request's own scheme + Host so the browser follows the
+        # redirect on the same origin it started from (whatever
+        # port the bundle is published on, with or without TLS in
+        # front).
+        proxy_redirect ~^https?://[^/]+(/.*)$ $scheme://$http_host$1;
     }
 }

--- a/sandbox/dogfood-frontdesk.sh
+++ b/sandbox/dogfood-frontdesk.sh
@@ -1,0 +1,665 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Frontdesk end-to-end dogfood — Docker Compose, no VM, no SSH
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Spins both production bundles (mastio + frontdesk) side-by-side on
+# the same docker host, wires them together (Mastio dashboard → Frontdesk
+# Ambassador admin endpoint with verify_tls=false for the self-signed
+# sidecar), and drives the full customer scenario end-to-end with curl:
+#
+#   1. Mastio bundle up + healthy
+#   2. Frontdesk bundle up + healthy
+#   3. Bridge ``proxy.env`` (Mastio learns the Frontdesk admin URL +
+#      secret + verify_tls=false), restart Mastio mcp-proxy
+#   4. Hit /setup on the Frontdesk → mint the bootstrap bearer
+#   5. POST /setup with bearer → workload enrollment lands as
+#      ``pending`` on the Mastio with ``principal_type=workload``
+#   6. Approve programmatically (Mastio admin password → cookie →
+#      POST /proxy/enrollments/<sid>/approve)
+#   7. Poll Connector /api/status → save_identity fires →
+#      ``mark_setup_completed`` flips the flag → /setup returns 410
+#   8. Assert: ``internal_agents.principal_type='workload'``,
+#      ``agent.crt`` has 2 PEM blocks (leaf + intermediate, #816),
+#      ``GET /setup`` returns 410 (#811 hook fired)
+#   9. Create user via Mastio dashboard (admin-input password, #817)
+#  10. Login user against Frontdesk → assert
+#      ``provisioning=ok`` (ADR-025 Phase 3 + #816 chain), check
+#      ``previous`` cert pinning grace period intact
+#  11. Tear everything down
+#
+# Why this lives next to ``demo.sh``: the existing sandbox demo
+# enrolls agents via the BYOCA bootstrap script (``sandbox/bootstrap/``)
+# and never touches the wizard ``/setup/*`` flow, the user login flow,
+# or the Frontdesk Ambassador. Every bug surfaced during the ADR-034
+# rc1/rc2/rc3 VM dogfood (#813 gate scope, #815 UPDATE propagation,
+# #816 cert chain, #817 multi-worker ticket store, #818 verify_tls)
+# was reproducible from a docker compose stand-up of the two bundles
+# side-by-side — but no script existed to catch them automatically.
+# This is that script. Run it from the repo root or from ``sandbox/``.
+#
+# Memory feedback_no_polling — single fixed wait per readiness gate,
+# no tight retry loops.
+# Memory feedback_dogfood_simulates_paying_customer — every env we
+# tweak here mirrors what the operator would set in the customer
+# bundle's ``proxy.env`` / ``frontdesk.env``. No source-tree
+# shortcuts, no auth bypass.
+# Memory feedback_dogfood_before_demo — this is the pre-merge gate
+# for any PR that touches enrollment, auth, or Frontdesk surface.
+#
+# Usage:
+#   ./sandbox/dogfood-frontdesk.sh              # full scenario
+#   ./sandbox/dogfood-frontdesk.sh --keep       # leave stack up at end
+#   ./sandbox/dogfood-frontdesk.sh --down       # tear down only
+#   ./sandbox/dogfood-frontdesk.sh --version 0.5.0-rc3
+#                                               # pin a specific tag
+#                                               # (default: ``dev`` —
+#                                               # uses local-built
+#                                               # images, see --build)
+#   ./sandbox/dogfood-frontdesk.sh --build      # build mastio + connector
+#                                               # images from source
+#                                               # before bring-up
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORK_DIR="$REPO_ROOT/.data/dogfood-frontdesk"
+MASTIO_WORK="$WORK_DIR/mastio"
+FRONTDESK_WORK="$WORK_DIR/frontdesk"
+
+# Versions / image tags. ``dev`` triggers --build by default.
+VERSION="dev"
+DO_BUILD=0
+DO_KEEP=0
+DO_DOWN_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --build) DO_BUILD=1; shift ;;
+    --keep) DO_KEEP=1; shift ;;
+    --down) DO_DOWN_ONLY=1; shift ;;
+    -h|--help) sed -n '/^# Usage:/,/^# ═/p' "$0" | head -20; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ``dev`` tag implies build (caller didn't specify a pulled tag).
+if [[ "$VERSION" == "dev" ]]; then
+  DO_BUILD=1
+fi
+
+MASTIO_IMAGE="ghcr.io/cullis-security/cullis-mastio:${VERSION}"
+CONNECTOR_IMAGE="ghcr.io/cullis-security/cullis-connector:${VERSION}"
+
+# Ports — chosen to NOT collide with sandbox/demo.sh full (which uses
+# 9443 already on a different bridge) so an operator can have both
+# stacks up at once for cross-comparison. Override via env if needed.
+MASTIO_HOST_PORT="${MASTIO_HOST_PORT:-19443}"
+FRONTDESK_HTTP_PORT="${FRONTDESK_HTTP_PORT:-18080}"
+FRONTDESK_TLS_PORT="${FRONTDESK_TLS_PORT:-18443}"
+
+# Compose project names — keep distinct so a half-baked previous run
+# can be cleaned without nuking sandbox/demo.sh.
+MASTIO_PROJECT="dogfood-frontdesk-mastio"
+FRONTDESK_PROJECT="dogfood-frontdesk-frontdesk"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# stderr-only colours (stdout stays parseable by tests / CI)
+C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_OK=$'\033[32m'
+C_ERR=$'\033[31m'; C_NEU=$'\033[36m'; C_RST=$'\033[0m'
+
+log()  { echo "${C_NEU}${C_BOLD}»${C_RST} $*" >&2; }
+ok()   { echo "${C_OK}${C_BOLD}✓${C_RST} $*" >&2; }
+fail() { echo "${C_ERR}${C_BOLD}✗${C_RST} $*" >&2; exit 1; }
+dim()  { echo "${C_DIM}$*${C_RST}" >&2; }
+
+# Wait for an HTTP endpoint to return 2xx/3xx. One curl per second up
+# to a deadline; never tighter than that (memory feedback_no_polling).
+wait_http() {
+  local url="$1" deadline_s="${2:-60}" verify_arg="${3:-}"
+  local end=$((SECONDS + deadline_s))
+  while (( SECONDS < end )); do
+    if curl -sk --max-time 3 ${verify_arg} -o /dev/null -w "%{http_code}\n" "$url" 2>/dev/null \
+        | grep -qE '^[23][0-9][0-9]$'; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+cleanup_down() {
+  log "tearing down ${FRONTDESK_PROJECT} + ${MASTIO_PROJECT}"
+  ( cd "$FRONTDESK_WORK" 2>/dev/null && \
+      docker compose -p "$FRONTDESK_PROJECT" \
+        --env-file frontdesk.env down --volumes --remove-orphans \
+        >/dev/null 2>&1 ) || true
+  ( cd "$MASTIO_WORK" 2>/dev/null && \
+      docker compose -p "$MASTIO_PROJECT" \
+        --env-file proxy.env down --volumes --remove-orphans \
+        >/dev/null 2>&1 ) || true
+  # Bind dirs survive ``--volumes`` (that only removes named volumes)
+  # so we wipe them via a transient root container that can chown +
+  # remove files owned by uid 10001.
+  if [[ -d "$WORK_DIR" ]]; then
+    docker run --rm --user 0:0 -v "$WORK_DIR":/wipe busybox:stable \
+      sh -c 'rm -rf /wipe/mastio /wipe/frontdesk' >/dev/null 2>&1 || true
+  fi
+}
+
+# ── Down-only branch ──────────────────────────────────────────────────────────
+
+if [[ "$DO_DOWN_ONLY" -eq 1 ]]; then
+  cleanup_down
+  ok "down complete"
+  exit 0
+fi
+
+# ── 0. Wipe any half-baked previous run before anything else ──────────────────
+#
+# Bind-mounted data dirs from the last run can end up owned by uid
+# 10001 (the bundle's runtime user), which breaks the subsequent
+# ``docker build`` because the build context tarball pass fails on
+# ``permission denied``. Wipe up front, then trap the same cleanup on
+# EXIT.
+
+trap '[[ "$DO_KEEP" -eq 1 ]] || cleanup_down' EXIT
+cleanup_down
+
+# ── 1. Build (optional) ───────────────────────────────────────────────────────
+
+if [[ "$DO_BUILD" -eq 1 ]]; then
+  log "building $MASTIO_IMAGE + $CONNECTOR_IMAGE from source"
+  docker build -q -f "$REPO_ROOT/mcp_proxy/Dockerfile" \
+    --build-arg "VERSION=$VERSION" \
+    -t "$MASTIO_IMAGE" "$REPO_ROOT" >/dev/null
+  ok "mastio image built"
+  docker build -q -f "$REPO_ROOT/packaging/docker/Dockerfile" \
+    -t "$CONNECTOR_IMAGE" "$REPO_ROOT" >/dev/null
+  ok "connector image built"
+fi
+
+# ── 2. Stage work dirs + shared network ──────────────────────────────────────
+
+mkdir -p "$MASTIO_WORK" "$FRONTDESK_WORK"
+
+# The two compose stacks run on disjoint private networks
+# (``dogfood-frontdesk-mastio_proxy_net`` and
+# ``dogfood-frontdesk-frontdesk_frontdesk_net``). For Mastio
+# dashboard → Frontdesk admin we need a routable bridge between
+# them; ``host.docker.internal`` routes through the default Docker
+# bridge gateway which the per-stack networks don't share. Cleanest
+# fix: create one external network that both stacks join, then the
+# Mastio reaches the Frontdesk via Docker DNS
+# (``http://connector:7777``) without round-tripping through the
+# host. Identical pattern to how ``sandbox/demo.sh full`` wires the
+# two-org WAN bridge.
+SHARED_NET="dogfood-frontdesk-bridge"
+docker network inspect "$SHARED_NET" >/dev/null 2>&1 \
+  || docker network create "$SHARED_NET" >/dev/null
+
+# Copy bundle templates first; THEN drop overrides on top so the
+# template's ``cp -r`` doesn't clobber them. (Subtle bug fix: the
+# original ordering put overrides first, ``cp -r .`` from the
+# template then wrote ``docker-compose.override.yml`` from the
+# template into the same path — but the template doesn't ship one,
+# so the override actually disappeared. Compose ``config`` showed
+# only ``frontdesk_net`` and the cross-stack DNS bridge never
+# materialised.)
+log "staging bundle templates → $WORK_DIR"
+cp -r "$REPO_ROOT/packaging/mastio-bundle/." "$MASTIO_WORK/"
+cp -r "$REPO_ROOT/packaging/frontdesk-bundle/." "$FRONTDESK_WORK/"
+ok "templates staged"
+
+# Mastio override: join the shared bridge so ``connector`` resolves
+# via Docker DNS to the Frontdesk Connector container.
+cat >"$MASTIO_WORK/docker-compose.override.yml" <<OVERRIDE
+services:
+  mcp-proxy:
+    networks:
+      - proxy_net
+      - sharedbridge
+  mastio-nginx:
+    networks:
+      - proxy_net
+      - sharedbridge
+networks:
+  sharedbridge:
+    external: true
+    name: ${SHARED_NET}
+OVERRIDE
+
+# Frontdesk override: same shared bridge, and the Connector picks up
+# the Mastio at ``mastio-nginx`` (no extra_hosts needed once we are
+# on the same network).
+cat >"$FRONTDESK_WORK/docker-compose.override.yml" <<OVERRIDE
+services:
+  connector:
+    networks:
+      - frontdesk_net
+      - sharedbridge
+  cullis-chat:
+    networks:
+      - frontdesk_net
+      - sharedbridge
+  nginx:
+    networks:
+      - frontdesk_net
+      - sharedbridge
+networks:
+  sharedbridge:
+    external: true
+    name: ${SHARED_NET}
+OVERRIDE
+
+# ── 2. Mint a Mastio admin secret + admin password seed ───────────────────────
+
+MASTIO_ADMIN_SECRET="$(openssl rand -hex 16)"
+MASTIO_ADMIN_PASSWORD="DogfoodAdmin-$(openssl rand -hex 4)!"
+FRONTDESK_ADMIN_SECRET="$(openssl rand -hex 24)"
+# Pin the dashboard signing key — without an explicit value each
+# uvicorn worker generates its own random one at boot, so a cookie
+# signed by worker A is rejected by worker B on the next request
+# (the default Mastio bundle ships ``--workers 4``). The script's
+# end-to-end flow logs in once and then makes multiple admin POSTs;
+# every round-trip would otherwise have ~75% chance of landing on a
+# worker that doesn't recognise the cookie and bouncing through
+# ``/proxy/login`` again.
+MASTIO_DASHBOARD_SIGNING_KEY="$(openssl rand -hex 32)"
+
+# ── 3. Generate Mastio proxy.env ──────────────────────────────────────────────
+
+log "generating Mastio proxy.env"
+cat >"$MASTIO_WORK/proxy.env" <<EOF
+CULLIS_MASTIO_VERSION=${VERSION}
+MCP_PROXY_ADMIN_SECRET=${MASTIO_ADMIN_SECRET}
+MCP_PROXY_INITIAL_ADMIN_PASSWORD=${MASTIO_ADMIN_PASSWORD}
+MCP_PROXY_DASHBOARD_SIGNING_KEY=${MASTIO_DASHBOARD_SIGNING_KEY}
+MCP_PROXY_ENVIRONMENT=development
+MCP_PROXY_STANDALONE=true
+MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:${MASTIO_HOST_PORT}
+MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy
+MCP_PROXY_PORT=${MASTIO_HOST_PORT}
+MASTIO_WORKERS=4
+# Frontdesk bridge — populated post-Frontdesk-up below. We re-write
+# this file in place + ``docker compose up --force-recreate`` to push
+# the values into the running container (memory
+# feedback_bundle_compose_env_explicit_mapping: --env-file alone
+# substitutes ``\${VAR}`` but doesn't inject vars; the compose
+# ``environment:`` block does, which is why these end up in the
+# Mastio container).
+MCP_PROXY_FRONTDESK_AMBASSADOR_URL=
+MCP_PROXY_FRONTDESK_ADMIN_SECRET=
+MCP_PROXY_FRONTDESK_VERIFY_TLS=false
+EOF
+ok "proxy.env written"
+
+# ── 4. Boot Mastio ────────────────────────────────────────────────────────────
+
+log "bringing up Mastio (${MASTIO_PROJECT})"
+( cd "$MASTIO_WORK" && \
+    docker compose -p "$MASTIO_PROJECT" \
+      --env-file proxy.env up -d --wait \
+      >/dev/null 2>"$WORK_DIR/mastio-up.err" ) || {
+  echo "--- mastio compose up stderr ---" >&2
+  cat "$WORK_DIR/mastio-up.err" >&2
+  fail "Mastio bring-up failed"
+}
+wait_http "https://localhost:${MASTIO_HOST_PORT}/health" 60 || \
+  fail "Mastio /health never returned 2xx within 60s"
+MASTIO_VERSION_REPORTED="$(curl -sk \
+    "https://localhost:${MASTIO_HOST_PORT}/health" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version","?"))')"
+ok "Mastio healthy — version=$MASTIO_VERSION_REPORTED"
+
+# ── 5. Generate Frontdesk env + boot ──────────────────────────────────────────
+
+log "generating Frontdesk env"
+# Mastio CA bundle — needed for the Connector to verify the Mastio
+# TLS chain when it calls /v1/auth/login-challenge-response and
+# /v1/principals/csr. The bundle's nginx sidecar exposes the Org
+# CA cert at /etc/nginx/certs/org-ca.crt.
+docker cp "${MASTIO_PROJECT}-mastio-nginx-1:/etc/nginx/certs/org-ca.crt" \
+  "$FRONTDESK_WORK/mastio-ca-bundle.pem" 2>/dev/null \
+  || fail "could not extract Mastio Org CA — SDK calls will fail TLS verify"
+ok "Mastio Org CA extracted → $FRONTDESK_WORK/mastio-ca-bundle.pem"
+# Org ID — the Mastio mints one at first boot, expose it via /health
+# or the /v1/registry/orgs/me endpoint.
+MASTIO_ORG_ID="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c "
+import sqlite3
+c = sqlite3.connect('/data/mcp_proxy.db')
+row = c.execute(\"SELECT value FROM proxy_config WHERE key='org_id'\").fetchone()
+print(row[0] if row else 'unknown')
+")"
+[[ "$MASTIO_ORG_ID" != "unknown" ]] \
+  || fail "Mastio org_id not minted yet (proxy_config table empty)"
+dim "Mastio org_id=$MASTIO_ORG_ID"
+
+cat >"$FRONTDESK_WORK/frontdesk.env" <<EOF
+CONNECTOR_VERSION=${VERSION}
+# cullis-chat-frontdesk is the SPA — we don't rebuild it locally for
+# the backend-only scenario this script exercises. Pin the latest
+# published tag instead of mirroring \$VERSION (which is ``dev`` /
+# locally-built and would fail the GHCR pull). Override via env if
+# you have a matching SPA build to test.
+CHAT_VERSION=${CHAT_VERSION:-0.4.1}
+CULLIS_FRONTDESK_ORG_ID=${MASTIO_ORG_ID}
+CULLIS_FRONTDESK_TRUST_DOMAIN=cullis.test
+CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
+# Connector → Mastio: traverse the shared bridge via Docker DNS.
+# ``mastio-nginx`` is a SAN on the bundle's self-signed cert (see
+# ``MCP_PROXY_NGINX_SAN`` default).
+CULLIS_SITE_URL=https://mastio-nginx:9443
+CULLIS_CONNECTOR_ADMIN_SECRET=${FRONTDESK_ADMIN_SECRET}
+FRONTDESK_HTTP_PORT=${FRONTDESK_HTTP_PORT}
+FRONTDESK_TLS_PORT=${FRONTDESK_TLS_PORT}
+# The bundle binds HTTP to 127.0.0.1 by default (loopback-only is
+# the right shape in production: cookies + SPA secrets never touch
+# a non-loopback peer, the TLS sidecar fronts the public surface).
+# In sandbox the Mastio container reaches the Frontdesk admin
+# endpoint via the docker bridge gateway, so loopback-only blocks
+# it. Widen to 0.0.0.0 for the sandbox flow — accepted because the
+# whole docker network is local to this script's host.
+FRONTDESK_HTTP_BIND=0.0.0.0
+# Skip the version probe — we already know the Mastio is the matching
+# rc and the probe wouldn't help here anyway (CULLIS_MASTIO_VERSION
+# echoes back what we passed via --build-arg).
+FRONTDESK_SKIP_VERSION_PROBE=1
+EOF
+ok "frontdesk.env written"
+
+log "bringing up Frontdesk (${FRONTDESK_PROJECT})"
+( cd "$FRONTDESK_WORK" && \
+    docker compose -p "$FRONTDESK_PROJECT" \
+      --env-file frontdesk.env up -d --wait \
+      >/dev/null 2>"$WORK_DIR/frontdesk-up.err" ) || {
+  echo "--- frontdesk compose up stderr ---" >&2
+  cat "$WORK_DIR/frontdesk-up.err" >&2
+  fail "Frontdesk bring-up failed"
+}
+wait_http "http://localhost:${FRONTDESK_HTTP_PORT}/setup" 30 \
+  || fail "Frontdesk /setup never returned 2xx within 30s"
+ok "Frontdesk healthy on :$FRONTDESK_HTTP_PORT"
+
+# ── 6. Bridge Mastio → Frontdesk ──────────────────────────────────────────────
+
+log "bridging Mastio dashboard → Frontdesk Ambassador admin"
+# Both stacks share ``${SHARED_NET}``; the Frontdesk Connector binds
+# 7777 on the bridge, the Mastio dashboard reaches it via Docker DNS.
+# ``connector`` is the service name in the Frontdesk compose.
+sed -i \
+  -e "s|^MCP_PROXY_FRONTDESK_AMBASSADOR_URL=.*|MCP_PROXY_FRONTDESK_AMBASSADOR_URL=http://connector:7777|" \
+  -e "s|^MCP_PROXY_FRONTDESK_ADMIN_SECRET=.*|MCP_PROXY_FRONTDESK_ADMIN_SECRET=${FRONTDESK_ADMIN_SECRET}|" \
+  "$MASTIO_WORK/proxy.env"
+( cd "$MASTIO_WORK" && \
+    docker compose -p "$MASTIO_PROJECT" \
+      --env-file proxy.env up -d --force-recreate --wait mcp-proxy \
+      >/dev/null 2>&1 ) || fail "mcp-proxy restart after bridging failed"
+ok "bridge wired (verify_tls=false for self-signed)"
+
+# ── 7. Enrollment flow ────────────────────────────────────────────────────────
+
+log "triggering /setup to mint the bootstrap bearer"
+curl -sk -o /dev/null "http://localhost:${FRONTDESK_HTTP_PORT}/setup"
+sleep 1
+SETUP_BEARER="$(docker logs "${FRONTDESK_PROJECT}-connector-1" 2>&1 \
+  | grep -A2 'Frontdesk setup bearer' \
+  | tail -n3 | head -n1 | tr -d ' ')"
+[[ ${#SETUP_BEARER} -ge 32 ]] || fail "bootstrap bearer not minted (got ${#SETUP_BEARER} chars)"
+ok "bootstrap bearer minted"
+
+log "submitting enrollment as workload"
+ENROLL_HTTP="$(curl -sk -o "$WORK_DIR/setup-resp.html" -w '%{http_code}' \
+  -X POST "http://localhost:${FRONTDESK_HTTP_PORT}/setup" \
+  -H "Authorization: Bearer ${SETUP_BEARER}" \
+  -H "Origin: http://localhost:${FRONTDESK_HTTP_PORT}" \
+  -d "site_url=https://mastio-nginx:9443" \
+  -d "requester_name=frontdesk" \
+  -d "requester_email=ops@cullis.dogfood" \
+  -d "reason=sandbox dogfood-frontdesk.sh" \
+  -d "verify_tls_off=1")"
+[[ "$ENROLL_HTTP" == "303" ]] || fail "POST /setup expected 303, got $ENROLL_HTTP"
+
+# Verify pending row carries principal_type=workload (#809 + #815).
+PENDING_PT="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c '
+import sqlite3
+c = sqlite3.connect("/data/mcp_proxy.db")
+row = c.execute("SELECT principal_type FROM pending_enrollments WHERE status=\"pending\" ORDER BY created_at DESC LIMIT 1").fetchone()
+print(row[0] if row else "MISSING")
+')"
+[[ "$PENDING_PT" == "workload" ]] \
+  || fail "pending_enrollments.principal_type expected 'workload', got '$PENDING_PT'"
+ok "pending enrollment landed with principal_type=workload"
+
+# ── 8. Approve via Mastio admin API ───────────────────────────────────────────
+
+log "approving enrollment via Mastio dashboard"
+# Login → cookie
+LOGIN_HTTP="$(curl -sk -c "$WORK_DIR/mastio-cookies.txt" \
+  -o "$WORK_DIR/login.html" -w '%{http_code}' \
+  -X POST "https://localhost:${MASTIO_HOST_PORT}/proxy/login" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Origin: https://localhost:${MASTIO_HOST_PORT}" \
+  -d "password=${MASTIO_ADMIN_PASSWORD}")"
+[[ "$LOGIN_HTTP" =~ ^30[37]$ ]] || fail "Mastio /proxy/login expected 30x, got $LOGIN_HTTP"
+
+# Extract pending session_id + CSRF token
+PENDING_SID="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c '
+import sqlite3
+c = sqlite3.connect("/data/mcp_proxy.db")
+row = c.execute("SELECT session_id FROM pending_enrollments WHERE status=\"pending\" ORDER BY created_at DESC LIMIT 1").fetchone()
+print(row[0] if row else "MISSING")
+')"
+[[ "$PENDING_SID" != "MISSING" ]] || fail "no pending session_id to approve"
+
+# Extract CSRF token straight out of the session cookie. The Mastio
+# dashboard signs ``{role, csrf_token, exp}`` JSON into the cookie
+# body; parsing it directly is more robust than scraping the
+# ``/proxy/enrollments`` HTML form (which can shift between releases).
+CSRF_TOK="$(python3 -c "
+import json
+# Netscape cookie file — the ``#HttpOnly_`` prefix on a name field is
+# part of the format (HttpOnly flag), NOT a comment. Don't skip it.
+with open('$WORK_DIR/mastio-cookies.txt') as fh:
+    for line in fh:
+        if 'mcp_proxy_session' not in line:
+            continue
+        # value is the last tab-separated field; strip the surrounding
+        # double quotes the file uses to keep embedded whitespace.
+        raw = line.rstrip().split('\t')[-1].strip('\"')
+        body = raw.rsplit('.', 1)[0]
+        # Netscape encoded ',' as \\054 and JSON quotes as \\\" — decode
+        # before json.loads.
+        body = body.replace('\\\\054', ',').replace('\\\\\"', '\"')
+        print(json.loads(body).get('csrf_token', ''))
+        break
+")"
+[[ -n "$CSRF_TOK" ]] || fail "no CSRF token extracted from session cookie"
+dim "CSRF token: ${CSRF_TOK:0:8}…"
+
+curl -sk -b "$WORK_DIR/mastio-cookies.txt" \
+  -D "$WORK_DIR/approve-headers.txt" \
+  -o "$WORK_DIR/approve-resp.html" \
+  -X POST "https://localhost:${MASTIO_HOST_PORT}/proxy/enrollments/${PENDING_SID}/approve" \
+  -H "Origin: https://localhost:${MASTIO_HOST_PORT}" \
+  --data-urlencode "csrf_token=${CSRF_TOK}" \
+  --data-urlencode "agent_id=frontdesk" \
+  --data-urlencode "capabilities=" \
+  --data-urlencode "groups="
+APPROVE_HTTP="$(head -n1 "$WORK_DIR/approve-headers.txt" | awk '{print $2}')"
+APPROVE_LOC="$(grep -i '^location:' "$WORK_DIR/approve-headers.txt" | head -n1)"
+dim "approve: HTTP $APPROVE_HTTP  $APPROVE_LOC"
+if [[ ! "$APPROVE_HTTP" =~ ^30[37]$ ]]; then
+  echo "--- approve response body ---" >&2
+  head -c 400 "$WORK_DIR/approve-resp.html" >&2 || true
+  echo >&2
+  fail "approve expected 30x, got $APPROVE_HTTP"
+fi
+# Reject redirect-to-login (session lost / CSRF mismatch): legitimate
+# approve redirects to ``/proxy/enrollments?flash=Approved...``.
+if echo "$APPROVE_LOC" | grep -qi '/proxy/login'; then
+  fail "approve was redirected to /proxy/login — session or CSRF rejected"
+fi
+
+# Verify the approve actually landed (303 alone can be a redirect to
+# login if the session was rejected). Re-poll the pending row.
+APPROVED_STATUS="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c "
+import sqlite3
+c = sqlite3.connect('/data/mcp_proxy.db')
+row = c.execute('SELECT status FROM pending_enrollments WHERE session_id = ?', ('${PENDING_SID}',)).fetchone()
+print(row[0] if row else 'MISSING')
+")"
+[[ "$APPROVED_STATUS" == "approved" ]] || \
+  fail "pending row status expected 'approved' after POST, got '$APPROVED_STATUS' (CSRF / session may have failed)"
+ok "enrollment approved (verified pending.status='approved')"
+
+# ── 9. Connector polls + saves identity ───────────────────────────────────────
+
+log "polling Connector /api/status to trigger save_identity"
+curl -sk "http://localhost:${FRONTDESK_HTTP_PORT}/api/status" >/dev/null
+sleep 2
+
+# Assert 1 — internal_agents.principal_type == workload (#815)
+INTERNAL_PT="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c '
+import sqlite3
+c = sqlite3.connect("/data/mcp_proxy.db")
+row = c.execute("SELECT principal_type FROM internal_agents WHERE agent_id LIKE \"%::frontdesk\"").fetchone()
+print(row[0] if row else "MISSING")
+')"
+[[ "$INTERNAL_PT" == "workload" ]] \
+  || fail "internal_agents.principal_type expected 'workload', got '$INTERNAL_PT' (#815 regression)"
+ok "internal_agents.principal_type='workload' (#815 ok)"
+
+# Assert 2 — agent.crt has 2 PEM blocks (leaf + intermediate, #816)
+CRT_BLOCKS="$(docker exec "${FRONTDESK_PROJECT}-connector-1" sh -c '
+grep -c "BEGIN CERTIFICATE" /home/cullis/.cullis/profiles/frontdesk/identity/agent.crt 2>/dev/null
+' | tr -d ' ')"
+[[ "$CRT_BLOCKS" == "2" ]] \
+  || fail "agent.crt PEM blocks expected 2, got '$CRT_BLOCKS' (#816 regression)"
+ok "agent.crt carries leaf + intermediate (#816 ok)"
+
+# Assert 3 — /setup returns 410 (#811 mark_setup_completed)
+SETUP_HTTP="$(curl -sk -o /dev/null -w '%{http_code}' \
+  "http://localhost:${FRONTDESK_HTTP_PORT}/setup")"
+[[ "$SETUP_HTTP" == "410" ]] \
+  || fail "/setup expected 410 post-enrollment, got '$SETUP_HTTP' (#811 hook regression)"
+ok "/setup → 410 Gone (#811 ok)"
+
+# Restart the Connector to pick up the freshly-minted identity. The
+# ADR-025 Phase 3 provisioner mounts only when ``has_identity`` is
+# True AT BOOT (``cullis_connector/web.py:506``); the Connector
+# started before enrollment, so the provisioner was deferred. Without
+# this restart the next user login lands ``provisioning="skipped"``
+# (no CSR, no UserPrincipal cert) — same UX gap the operator hits in
+# the wild. The bundle's runbook documents this restart; here we do
+# it programmatically so the assertion below is deterministic.
+log "restarting Connector to mount the ADR-025 Phase 3 provisioner"
+( cd "$FRONTDESK_WORK" && \
+    docker compose -p "$FRONTDESK_PROJECT" \
+      --env-file frontdesk.env restart connector \
+      >/dev/null 2>&1 ) || fail "Connector restart failed"
+wait_http "http://localhost:${FRONTDESK_HTTP_PORT}/v1/ambassador/health" 30 \
+  || fail "Connector /v1/ambassador/health unreachable after restart"
+ok "Connector restarted with provisioner mounted"
+
+# ── 10. Create user via Mastio dashboard (#817 admin-input password) ──────────
+
+log "creating user 'mario' via Mastio dashboard"
+USER_PASSWORD="MarioDogfood-$(openssl rand -hex 4)!"
+# CSRF token from the same session cookie we reused for /approve.
+curl -sk -b "$WORK_DIR/mastio-cookies.txt" \
+  -D "$WORK_DIR/create-headers.txt" \
+  -o "$WORK_DIR/create-resp.html" \
+  -X POST "https://localhost:${MASTIO_HOST_PORT}/proxy/users/create" \
+  -H "Origin: https://localhost:${MASTIO_HOST_PORT}" \
+  --data-urlencode "csrf_token=${CSRF_TOK}" \
+  --data-urlencode "user_name=mario" \
+  --data-urlencode "display_name=Mario Rossi" \
+  --data-urlencode "password=${USER_PASSWORD}" \
+  --data-urlencode "password_confirm=${USER_PASSWORD}"
+CREATE_HTTP="$(head -n1 "$WORK_DIR/create-headers.txt" | awk '{print $2}')"
+CREATE_LOC="$(grep -i '^location:' "$WORK_DIR/create-headers.txt" | head -n1)"
+dim "create: HTTP $CREATE_HTTP  $CREATE_LOC"
+if [[ ! "$CREATE_HTTP" =~ ^30[37]$ ]]; then
+  echo "--- create response ---" >&2
+  head -c 400 "$WORK_DIR/create-resp.html" >&2 || true
+  echo >&2
+  fail "user create expected 30x, got $CREATE_HTTP"
+fi
+if echo "$CREATE_LOC" | grep -qi '/proxy/login'; then
+  fail "create user redirected to /proxy/login — session lost / CSRF mismatch"
+fi
+if echo "$CREATE_LOC" | grep -qi 'error='; then
+  fail "create user landed with error: $CREATE_LOC"
+fi
+# Confirm the row actually reached the Frontdesk's users.db. The
+# Mastio dashboard forwards via the admin endpoint; a silent
+# transport failure would have surfaced as ``?error=Frontdesk+...``
+# (caught above) but a misconfigured bridge could still no-op.
+FD_HAS_MARIO="$(docker exec "${FRONTDESK_PROJECT}-connector-1" python -c "
+import sqlite3
+c = sqlite3.connect('/home/cullis/.cullis/profiles/frontdesk/users.db')
+row = c.execute('SELECT user_name FROM local_users WHERE user_name = \"mario\"').fetchone()
+print('yes' if row else 'no')
+")"
+[[ "$FD_HAS_MARIO" == "yes" ]] || \
+  fail "Frontdesk users.db missing mario after create (Mastio→Frontdesk forward failed silently)"
+ok "user mario created end-to-end (Mastio dashboard → Frontdesk users.db)"
+
+# ── 11. Login user → assert provisioning=ok (ADR-025 Phase 3 + #816) ─────────
+
+log "user login → CSR provisioning"
+# First login flips must_change_password, no CSR yet.
+LOGIN1="$(curl -sk -c "$WORK_DIR/mario-cookies.txt" \
+  -X POST "http://localhost:${FRONTDESK_HTTP_PORT}/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:${FRONTDESK_HTTP_PORT}" \
+  -d "{\"user_name\":\"mario\",\"password\":\"${USER_PASSWORD}\"}")"
+echo "$LOGIN1" | grep -q '"must_change_password":true' \
+  || fail "first login expected must_change_password=true, got: $LOGIN1"
+
+# Change password to the same value (real flow rotates; sandbox can reuse)
+NEW_PW="MarioRotated-$(openssl rand -hex 4)!"
+CHANGE="$(curl -sk -b "$WORK_DIR/mario-cookies.txt" \
+  -c "$WORK_DIR/mario-cookies.txt" \
+  -X POST "http://localhost:${FRONTDESK_HTTP_PORT}/api/auth/change-password" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:${FRONTDESK_HTTP_PORT}" \
+  -d "{\"old_password\":\"${USER_PASSWORD}\",\"new_password\":\"${NEW_PW}\"}")"
+echo "$CHANGE" | grep -q '"ok":true' \
+  || fail "change-password failed: $CHANGE"
+
+# Second login — must_change cleared → provisioning runs
+LOGIN2="$(curl -sk -c "$WORK_DIR/mario-cookies.txt" \
+  -X POST "http://localhost:${FRONTDESK_HTTP_PORT}/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:${FRONTDESK_HTTP_PORT}" \
+  -d "{\"user_name\":\"mario\",\"password\":\"${NEW_PW}\"}")"
+echo "$LOGIN2" | grep -q '"provisioning":"ok"' \
+  || fail "second login expected provisioning=ok, got: $LOGIN2 (chain or workload-cap regression)"
+ok "user login provisioning=ok (ADR-025 Phase 3 + #816 chain ok)"
+
+# ── 12. Done ──────────────────────────────────────────────────────────────────
+
+echo >&2
+echo "${C_OK}${C_BOLD}═══════════════════════════════════════════════════════════════════════════════${C_RST}" >&2
+echo "${C_OK}${C_BOLD}  Frontdesk dogfood PASSED${C_RST}" >&2
+echo "${C_OK}${C_BOLD}═══════════════════════════════════════════════════════════════════════════════${C_RST}" >&2
+echo "" >&2
+echo "  Mastio:    https://localhost:${MASTIO_HOST_PORT}/proxy/login" >&2
+echo "  Frontdesk: http://localhost:${FRONTDESK_HTTP_PORT}/login" >&2
+echo "  admin pw:  ${MASTIO_ADMIN_PASSWORD}" >&2
+echo "  mario pw:  ${NEW_PW}" >&2
+echo "" >&2
+if [[ "$DO_KEEP" -eq 1 ]]; then
+  echo "  --keep set: stack stays up. Tear down with:" >&2
+  echo "    $0 --down" >&2
+else
+  echo "  Tearing down. Pass --keep to stay up for manual inspection." >&2
+fi


### PR DESCRIPTION
End-to-end Docker-only Frontdesk dogfood (replaces the libvirt VM flow). Boots production Mastio + Frontdesk bundles side-by-side, wires shared bridge network, drives workload enrollment + admin-input user create + user login with curl, asserts every PR-#809/#811/#815/#816/#817/#818 invariant **plus** the multi-worker / cold-Org-Root invariants that single-worker tests never caught.

**Status: end-to-end PASS** as of `da8246d0`.

## Bugs the sandbox caught (and this PR fixes)

1. **`_agent_row_to_dict` dropped `principal_type` from the dict** — `SELECT *` included it but the serialiser stripped it; every caller (`get_agent()`) got `None`. PR-A sister site missed by PR-#815.
2. **`_maybe_local_token` built `TokenPayload` without `principal_type`** → dataclass default `'agent'`. Same propagation gap as above.
3. **`issue_local_token` minted the JWT without `principal_type` claim** → DPoP path had the same fallback.
4. **Multi-worker `mastio_ca` race** — `--workers 4` made every uvicorn worker mint its own intermediate `(key, cert)` pair and upsert; the DB held the last writer's row while other workers signed leaves with stale keys. `openssl verify` flagged ECDSA invalid, nginx 400 `SSL certificate error`. Fix: new `set_config_if_absent` primitive (`INSERT … ON CONFLICT DO NOTHING`) + adopt-winner re-read in `_mint_mastio_ca`.
5. **`sign_user_csr` signed under Org Root (cold)** instead of Mastio Intermediate (hot). Three-tier PKI hardening (audit 2026-05-18) scrubs `_org_ca_key` from memory after Intermediate mint; user CSR mints then 503'd `Org CA temporarily unavailable`. `sign_external_pubkey` already signed under the Intermediate; this is the missed sister.

## Final scenario the script asserts end-to-end

```
✓ pending enrollment landed with principal_type=workload
✓ enrollment approved (verified pending.status='approved')
✓ internal_agents.principal_type='workload' (#815 ok)
✓ agent.crt carries leaf + intermediate (#816 ok)
✓ /setup → 410 Gone (#811 ok)
✓ Connector restarted with provisioner mounted
✓ user mario created end-to-end (Mastio dashboard → Frontdesk users.db)
✓ user login provisioning=ok (ADR-025 Phase 3 + #816 chain ok)
Frontdesk dogfood PASSED
```

## Files

- `sandbox/dogfood-frontdesk.sh` — new end-to-end script (boot → enroll → approve → create user → login → assert)
- `mcp_proxy/db.py` — `set_config_if_absent` helper + `_agent_row_to_dict` returns `principal_type`
- `mcp_proxy/auth/local_agent_dep.py` — propagate `principal_type` to `TokenPayload` (Bearer + typed-principal branches)
- `mcp_proxy/auth/local_token.py` — stamp `principal_type` + `org` into JWT `extra_claims` (DPoP path)
- `mcp_proxy/egress/agent_manager.py` — race-safe `_persist_intermediate_ca` + adopt-winner `_mint_mastio_ca`
- `mcp_proxy/registry/principals_csr.py` — user CSR signs under Mastio Intermediate (was Org Root, cold)

## Test plan

- [x] `pytest tests/test_pki_three_tier_hardening.py -k "external or chain" -v` — 7/7 pass
- [x] `pytest tests/test_principals_csr.py tests/test_mcp_proxy_principals_csr_gate.py -v` — 26/26 pass
- [x] `./sandbox/dogfood-frontdesk.sh` — end-to-end PASS (see output above)

## Operator usage

```
./sandbox/dogfood-frontdesk.sh              # full scenario, builds local images, tears down on exit
./sandbox/dogfood-frontdesk.sh --keep       # leave the stack up for manual inspection
./sandbox/dogfood-frontdesk.sh --down       # tear down only
./sandbox/dogfood-frontdesk.sh --version 0.5.0-rc4 --no-build
```

Becomes the pre-merge gate for any PR that touches enrollment, auth, or Frontdesk surface. Catches everything the VM dogfood caught (in ~5 min vs ~30 min cycle) plus the multi-worker / cold-key bugs single-worker tests miss.