### PR TITLE
Frontdesk dogfood E2E + Finding #16 closer (Ollama + chat)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -38,7 +38,7 @@ from cullis_connector.ambassador.streaming import (
     fake_stream,
 )
 from cullis_connector.ambassador.streaming_loop import stream_tool_use_loop
-from cullis_connector.identity.auth_mode import is_shared_mode
+from cullis_connector.identity.auth_mode import is_frontdesk_bundle
 
 _log = logging.getLogger("cullis_connector.ambassador.router")
 
@@ -220,41 +220,79 @@ def list_models(request: Request):
     state = _get_state(request)
     _enforce_bearer(request, state)
 
-    cache_key = state.get("agent_id") or "default"
+    # ADR-025 Phase 3 — when the cert middleware bound a per-user cert
+    # to the request (``request.state.user_credentials``), key the cache
+    # on ``principal_id`` and fetch live models via a per-user
+    # CullisClient. The workload-cred holder would 401 at the Mastio's
+    # ``location ~ ^/v1/(egress|agents|...)`` mTLS gate — the workload
+    # cert is not a UserPrincipal. Mirrors the chat_completions handler
+    # below and ``ambassador/shared/router.py::list_models``.
+    user_creds = _per_user_credentials(request)
+    cache_key = (
+        user_creds.principal_id if user_creds is not None
+        else state.get("agent_id") or "default"
+    )
     cached = _models_cache.get(cache_key)
     now = time.monotonic()
     if cached is not None and (now - cached[0]) < _MODELS_CACHE_TTL_S:
         return _models_response(cached[1], cached[2])
 
-    holder = state.get("client")
     data: list[dict] = []
     source = "live"
     error_reason: str | None = None
-    if holder is not None:
+    if user_creds is not None:
+        per_user_client = None
         try:
-            client = holder.get()
-            live = client.list_models()
+            per_user_client = _build_user_client(request, user_creds)
+            live = per_user_client.list_models()
             if live:
                 data = live
             else:
                 error_reason = "Mastio returned empty model list"
-        except Exception as exc:
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
             error_reason = str(exc) or exc.__class__.__name__
             _log.debug(
-                "Mastio /v1/models fetch failed: %s", exc,
+                "per-user /v1/models fetch failed for %s: %s",
+                user_creds.principal_id, exc,
             )
+        finally:
+            close = getattr(per_user_client, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001
+                    pass
     else:
-        error_reason = "Ambassador has no Mastio client wired"
+        holder = state.get("client")
+        if holder is not None:
+            try:
+                client = holder.get()
+                live = client.list_models()
+                if live:
+                    data = live
+                else:
+                    error_reason = "Mastio returned empty model list"
+            except Exception as exc:
+                error_reason = str(exc) or exc.__class__.__name__
+                _log.debug(
+                    "Mastio /v1/models fetch failed: %s", exc,
+                )
+        else:
+            error_reason = "Ambassador has no Mastio client wired"
 
     if not data:
         # Live fetch did not yield a usable list. ADR-034 §5: in
-        # shared mode fail loud so the SPA can banner the issue; in
-        # single mode keep the legacy fallback for desktop UX. The
-        # 503 path skips the cache write so a transient fetch error
-        # doesn't pin the dropdown to error for 30s.
-        if is_shared_mode():
+        # multi-user deployments (legacy ``AMBASSADOR_MODE=shared`` and
+        # modern ``FRONTDESK_BUNDLE=1`` modern bundle alike) fail loud so
+        # the SPA can banner the issue; in single-user desktop mode keep
+        # the legacy fallback for UX. The 503 path skips the cache write
+        # so a transient fetch error doesn't pin the dropdown to error
+        # for 30s.
+        if is_frontdesk_bundle():
             _log.warning(
-                "Mastio /v1/models unavailable in shared mode: %s",
+                "Mastio /v1/models unavailable in Frontdesk bundle: %s",
                 error_reason,
             )
             return JSONResponse(

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -337,7 +337,22 @@ async def sign_user_csr(
         .sign(ca_key, hashes.SHA256())
     )
 
-    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    leaf_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    # Three-tier PKI hardening (audit 2026-05-18) mirror of
+    # ``sign_external_pubkey``: ship the Mastio Intermediate alongside
+    # the leaf so the Connector persists the full chain. The leaf is
+    # signed by the Mastio Intermediate, not the Org Root directly, so
+    # nginx's ``ssl_client_certificate /etc/nginx/certs/org-ca.crt``
+    # (Org Root only) cannot walk leaf → root without the intermediate
+    # the SDK ships at the TLS handshake. Without this concat every
+    # user-bound ``/v1/egress/*`` call 401s at nginx with the default
+    # HTML body — discovered in sandbox dogfood after the htu fix
+    # cleared the workload poller but mario's ``/v1/models`` stayed
+    # broken because the user cert path returned leaf-only.
+    intermediate_pem = ca_cert.public_bytes(
+        serialization.Encoding.PEM,
+    ).decode("utf-8")
+    cert_pem = leaf_pem + intermediate_pem
     thumbprint = _cert_thumbprint_sha256(cert)
     return cert_pem, thumbprint, csr_pubkey_thumb, not_after
 

--- a/sandbox/dogfood-frontdesk.sh
+++ b/sandbox/dogfood-frontdesk.sh
@@ -26,7 +26,12 @@
 #  10. Login user against Frontdesk → assert
 #      ``provisioning=ok`` (ADR-025 Phase 3 + #816 chain), check
 #      ``previous`` cert pinning grace period intact
-#  11. Tear everything down
+#  11. Spin up Ollama on the shared bridge, warm a tiny model,
+#      configure Mastio AI Providers programmatically, then drive
+#      ``GET /v1/models`` + ``POST /v1/chat/completions`` from the
+#      Frontdesk SPA's vantage point (mario's cookie) and assert
+#      ``source=live`` + a non-empty assistant reply
+#  12. Tear everything down
 #
 # Why this lives next to ``demo.sh``: the existing sandbox demo
 # enrolls agents via the BYOCA bootstrap script (``sandbox/bootstrap/``)
@@ -103,6 +108,14 @@ MASTIO_HOST_PORT="${MASTIO_HOST_PORT:-19443}"
 FRONTDESK_HTTP_PORT="${FRONTDESK_HTTP_PORT:-18080}"
 FRONTDESK_TLS_PORT="${FRONTDESK_TLS_PORT:-18443}"
 
+# Ollama service — tiny model so the test stays under ~400MB pull and
+# the first inference call returns under ~10s on CPU. Override via env
+# to pin a different model (must be ``<name>:<tag>`` exactly as Ollama
+# names it). Default qwen2.5:0.5b is ~352MB.
+OLLAMA_IMAGE="${OLLAMA_IMAGE:-ollama/ollama:latest}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:0.5b}"
+OLLAMA_CONTAINER="dogfood-frontdesk-ollama"
+
 # Compose project names — keep distinct so a half-baked previous run
 # can be cleaned without nuking sandbox/demo.sh.
 MASTIO_PROJECT="dogfood-frontdesk-mastio"
@@ -136,6 +149,7 @@ wait_http() {
 
 cleanup_down() {
   log "tearing down ${FRONTDESK_PROJECT} + ${MASTIO_PROJECT}"
+  docker rm -f "$OLLAMA_CONTAINER" >/dev/null 2>&1 || true
   ( cd "$FRONTDESK_WORK" 2>/dev/null && \
       docker compose -p "$FRONTDESK_PROJECT" \
         --env-file frontdesk.env down --volumes --remove-orphans \
@@ -203,6 +217,26 @@ mkdir -p "$MASTIO_WORK" "$FRONTDESK_WORK"
 SHARED_NET="dogfood-frontdesk-bridge"
 docker network inspect "$SHARED_NET" >/dev/null 2>&1 \
   || docker network create "$SHARED_NET" >/dev/null
+
+# Kick off Ollama early so the model pull (~350MB for qwen2.5:0.5b)
+# overlaps with the Mastio + Frontdesk bring-up. By the time we get
+# to step 9 the model is warm and the chat assertion stays fast.
+# Container is attached to the shared bridge with alias ``ollama`` so
+# the Mastio resolves ``http://ollama:11434`` via Docker DNS — same
+# bridge pattern Mastio uses to reach the Frontdesk Ambassador admin.
+log "spawning Ollama (${OLLAMA_IMAGE}, alias=ollama)"
+docker run -d --name "$OLLAMA_CONTAINER" \
+  --network "$SHARED_NET" --network-alias ollama \
+  --pull=missing \
+  "$OLLAMA_IMAGE" >/dev/null \
+  || fail "could not start $OLLAMA_CONTAINER"
+# Pull the chat model in the background — runs concurrently with the
+# rest of the script. We block on completion in step 8b before
+# touching the AI Providers admin endpoint.
+log "pulling $OLLAMA_MODEL in background"
+docker exec -d "$OLLAMA_CONTAINER" \
+  sh -c "ollama pull '$OLLAMA_MODEL' > /tmp/ollama-pull.log 2>&1; echo \$? > /tmp/ollama-pull.rc"
+ok "Ollama spawned, model pull running in background"
 
 # Copy bundle templates first; THEN drop overrides on top so the
 # template's ``cp -r`` doesn't clobber them. (Subtle bug fix: the
@@ -283,7 +317,16 @@ MCP_PROXY_INITIAL_ADMIN_PASSWORD=${MASTIO_ADMIN_PASSWORD}
 MCP_PROXY_DASHBOARD_SIGNING_KEY=${MASTIO_DASHBOARD_SIGNING_KEY}
 MCP_PROXY_ENVIRONMENT=development
 MCP_PROXY_STANDALONE=true
-MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:${MASTIO_HOST_PORT}
+# DPoP htu binding pins the proof to the *configured* public URL,
+# not the request's Host header. The Connector (inside the shared
+# bridge) reaches the Mastio at ``https://mastio-nginx:9443`` via
+# Docker DNS, so the public URL has to match that exact host:port
+# or every DPoP-bearing egress call 401s with "htu mismatch". Host-
+# side admin calls (curl https://localhost:${MASTIO_HOST_PORT}) still
+# work because dashboard cookie auth + X-Admin-Secret endpoints
+# don't carry DPoP. Caught dogfooding ${OLLAMA_MODEL} chat → 401 on
+# /v1/egress/models with htu='mastio-nginx' vs 'localhost' expected.
+MCP_PROXY_PROXY_PUBLIC_URL=https://mastio-nginx:9443
 MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy
 MCP_PROXY_PORT=${MASTIO_HOST_PORT}
 MASTIO_WORKERS=4
@@ -519,6 +562,65 @@ print(row[0] if row else 'MISSING')
   fail "pending row status expected 'approved' after POST, got '$APPROVED_STATUS' (CSRF / session may have failed)"
 ok "enrollment approved (verified pending.status='approved')"
 
+# ── 8b. Wait for Ollama model pull + configure Mastio AI Provider ────────────
+
+log "waiting for Ollama model pull to finish"
+# Block up to 5 min (CPU-only laptops at low bandwidth can stretch).
+# Memory feedback_no_polling: one fixed-cadence wait, no tight loops.
+pull_deadline=$((SECONDS + 300))
+while (( SECONDS < pull_deadline )); do
+  if docker exec "$OLLAMA_CONTAINER" sh -c '[ -f /tmp/ollama-pull.rc ]' 2>/dev/null; then
+    PULL_RC="$(docker exec "$OLLAMA_CONTAINER" cat /tmp/ollama-pull.rc 2>/dev/null | tr -d '[:space:]')"
+    break
+  fi
+  sleep 2
+done
+if [[ "${PULL_RC:-X}" != "0" ]]; then
+  echo "--- ollama pull log ---" >&2
+  docker exec "$OLLAMA_CONTAINER" cat /tmp/ollama-pull.log 2>/dev/null | tail -n40 >&2 || true
+  fail "ollama pull '$OLLAMA_MODEL' did not finish cleanly (rc=${PULL_RC:-timeout})"
+fi
+ok "$OLLAMA_MODEL pulled"
+
+log "registering Ollama in Mastio AI Providers (api_base=http://ollama:11434)"
+SAVE_HTTP="$(curl -sk -b "$WORK_DIR/mastio-cookies.txt" \
+  -D "$WORK_DIR/ai-save-headers.txt" \
+  -o "$WORK_DIR/ai-save-resp.html" \
+  -w '%{http_code}' \
+  -X POST "https://localhost:${MASTIO_HOST_PORT}/proxy/ai-providers/ollama/save" \
+  -H "Origin: https://localhost:${MASTIO_HOST_PORT}" \
+  --data-urlencode "csrf_token=${CSRF_TOK}" \
+  --data-urlencode "api_base=http://ollama:11434" \
+  --data-urlencode "enabled=on")"
+if [[ ! "$SAVE_HTTP" =~ ^30[37]$ ]]; then
+  echo "--- ai-provider save response ---" >&2
+  head -c 400 "$WORK_DIR/ai-save-resp.html" >&2 || true
+  echo >&2
+  fail "AI provider save expected 30x, got $SAVE_HTTP"
+fi
+# Confirm the row reached the Mastio DB (silent forward failure
+# protection — same pattern as the user-create assertion below).
+OLLAMA_ROW="$(docker exec "${MASTIO_PROJECT}-mcp-proxy-1" python -c "
+import sqlite3
+c = sqlite3.connect('/data/mcp_proxy.db')
+row = c.execute(\"SELECT enabled FROM ai_provider_credentials WHERE provider='ollama'\").fetchone()
+print(row[0] if row else 'MISSING')
+")"
+[[ "$OLLAMA_ROW" == "1" ]] \
+  || fail "ai_provider_credentials.ollama not stored or disabled (got '$OLLAMA_ROW')"
+ok "Mastio AI Providers: ollama enabled"
+
+# Sanity-check the Mastio can list models from Ollama — this is the
+# canary for shared-bridge DNS + LiteLLM provider catalog wiring.
+# ``/v1/admin/ai-providers/<p>/test`` mirrors the dashboard Test button
+# via the X-Admin-Secret header so we don't need to scrape the HTML.
+PROBE_JSON="$(curl -sk \
+  -H "X-Admin-Secret: ${MASTIO_ADMIN_SECRET}" \
+  -X POST "https://localhost:${MASTIO_HOST_PORT}/v1/admin/ai-providers/ollama/test")"
+echo "$PROBE_JSON" | grep -q '"status":"ok"' \
+  || fail "Mastio could not probe ollama (Docker DNS or provider wiring broken): $PROBE_JSON"
+ok "Mastio ↔ Ollama probe ok"
+
 # ── 9. Connector polls + saves identity ───────────────────────────────────────
 
 log "polling Connector /api/status to trigger save_identity"
@@ -645,6 +747,54 @@ echo "$LOGIN2" | grep -q '"provisioning":"ok"' \
   || fail "second login expected provisioning=ok, got: $LOGIN2 (chain or workload-cap regression)"
 ok "user login provisioning=ok (ADR-025 Phase 3 + #816 chain ok)"
 
+# ── 11b. Chat end-to-end via mario (SPA's view: cookie-authed) ───────────────
+
+# Stash mario's rotated password where the operator can read it
+# from the host: handy when a test fails mid-flight and we want to
+# re-drive the chat path interactively without restarting.
+echo "$NEW_PW" >"$WORK_DIR/mario-pw.txt"
+log "fetching /v1/models from Frontdesk as mario (pw stashed at .data/dogfood-frontdesk/mario-pw.txt)"
+MODELS_JSON="$(curl -sk -b "$WORK_DIR/mario-cookies.txt" \
+  "http://localhost:${FRONTDESK_HTTP_PORT}/v1/models")"
+echo "$MODELS_JSON" >"$WORK_DIR/models.json"
+SOURCE="$(echo "$MODELS_JSON" \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("cullis_meta",{}).get("source","?"))')"
+if [[ "$SOURCE" != "live" ]]; then
+  echo "--- /v1/models payload ---" >&2
+  head -c 800 "$WORK_DIR/models.json" >&2
+  echo >&2
+  fail "Frontdesk /v1/models cullis_meta.source expected 'live', got '$SOURCE'"
+fi
+# Ollama model must appear in the live list (live source proves the
+# Mastio AI gateway aggregated provider catalogs end-to-end).
+echo "$MODELS_JSON" | grep -q "ollama_chat/${OLLAMA_MODEL}" \
+  || fail "ollama_chat/${OLLAMA_MODEL} missing from live model list: $(head -c 600 "$WORK_DIR/models.json")"
+ok "/v1/models live, includes ollama_chat/${OLLAMA_MODEL}"
+
+log "POST /v1/chat/completions via Ollama"
+CHAT_HTTP="$(curl -sk -b "$WORK_DIR/mario-cookies.txt" \
+  -o "$WORK_DIR/chat.json" -w '%{http_code}' \
+  -X POST "http://localhost:${FRONTDESK_HTTP_PORT}/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:${FRONTDESK_HTTP_PORT}" \
+  -d "{\"model\":\"ollama_chat/${OLLAMA_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly the word: cullis\"}],\"max_tokens\":32}")"
+if [[ "$CHAT_HTTP" != "200" ]]; then
+  echo "--- chat response (HTTP $CHAT_HTTP) ---" >&2
+  head -c 800 "$WORK_DIR/chat.json" >&2
+  echo >&2
+  fail "chat completion expected 200, got $CHAT_HTTP"
+fi
+CHAT_CONTENT="$(python3 -c "
+import json, sys
+with open('$WORK_DIR/chat.json') as fh:
+    d = json.load(fh)
+content = d.get('choices', [{}])[0].get('message', {}).get('content', '')
+print(content)
+")"
+[[ -n "$CHAT_CONTENT" ]] \
+  || fail "chat completion returned empty content: $(head -c 400 "$WORK_DIR/chat.json")"
+ok "chat completion returned ${#CHAT_CONTENT} chars (preview: ${CHAT_CONTENT:0:60}…)"
+
 # ── 12. Done ──────────────────────────────────────────────────────────────────
 
 echo >&2
@@ -656,6 +806,8 @@ echo "  Mastio:    https://localhost:${MASTIO_HOST_PORT}/proxy/login" >&2
 echo "  Frontdesk: http://localhost:${FRONTDESK_HTTP_PORT}/login" >&2
 echo "  admin pw:  ${MASTIO_ADMIN_PASSWORD}" >&2
 echo "  mario pw:  ${NEW_PW}" >&2
+echo "  Ollama:    http://ollama:11434 (inside ${SHARED_NET} only)" >&2
+echo "  model:     ollama_chat/${OLLAMA_MODEL}" >&2
 echo "" >&2
 if [[ "$DO_KEEP" -eq 1 ]]; then
   echo "  --keep set: stack stays up. Tear down with:" >&2

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -348,6 +348,119 @@ def test_models_live_passes_through_in_shared_mode(
     assert ids == ["qwen3.5:2b"]
 
 
+def test_models_503_in_frontdesk_bundle_when_mastio_unreachable(
+    client, bearer, monkeypatch,
+):
+    """ADR-034 §5 — Modern Frontdesk bundle (``FRONTDESK_BUNDLE=1``,
+    ``AUTH_MODE=local``, ``AMBASSADOR_MODE`` empty) must fail loud the
+    same way the legacy ``AMBASSADOR_MODE=shared`` shared topology does:
+    silently falling back to ``advertised_models`` would advertise
+    hardcoded Claude defaults instead of the Ollama provider an admin
+    actually wired into the Mastio dashboard.
+    """
+    monkeypatch.setenv("FRONTDESK_BUNDLE", "1")
+    from cullis_connector.ambassador.router import _models_cache
+
+    _models_cache.clear()
+
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 503, resp.text
+    body = resp.json()
+    assert body["detail"] == "mastio_unavailable"
+    assert body["cullis_meta"]["source"] == "error"
+
+
+def test_models_uses_per_user_client_when_user_credentials_bound(
+    client, bearer, monkeypatch,
+):
+    """ADR-025 Phase 3 — when the cert middleware bound a per-user cert
+    to the request, ``/v1/models`` must fetch the live list via a
+    per-user ``CullisClient`` (mirror ``ambassador/shared/router.py``).
+    The workload-cred holder would 401 at Mastio's mTLS gate (it is not
+    a UserPrincipal). Cache is keyed on ``principal_id`` so concurrent
+    users do not poison each other's dropdown.
+    """
+    import sys
+
+    from cullis_connector.ambassador.router import _models_cache
+
+    # ``cullis_connector.ambassador.__init__`` re-binds the ``router``
+    # attribute to the APIRouter instance, so the dotted path
+    # ``cullis_connector.ambassador.router`` resolves to the router, not
+    # the module. Pull the module out of ``sys.modules`` to monkeypatch
+    # module-level helpers.
+    router_mod = sys.modules["cullis_connector.ambassador.router"]
+    _models_cache.clear()
+
+    class _Cred:
+        principal_id = "acme.test/acme/user/mario"
+        cert_pem = "stub-cert"
+        key_pem = "stub-key"
+        cert_not_after = None  # unused by the router branch under test
+
+    workload_calls: list[bool] = []
+    user_calls: list[str] = []
+
+    class _PerUserClient:
+        def __init__(self, principal: str) -> None:
+            self._principal = principal
+
+        def list_models(self) -> list[dict]:
+            user_calls.append(self._principal)
+            return [{
+                "id": "qwen3.5:2b", "object": "model",
+                "owned_by": "ollama", "created": 0,
+            }]
+
+        def close(self) -> None:
+            pass
+
+    def _fake_build_user_client(_request, cred):  # noqa: ARG001
+        return _PerUserClient(cred.principal_id)
+
+    cred = _Cred()
+    monkeypatch.setattr(
+        router_mod, "_per_user_credentials", lambda req: cred,
+    )
+    monkeypatch.setattr(
+        router_mod, "_build_user_client", _fake_build_user_client,
+    )
+
+    # Sentinel on the workload holder: if the router ever falls back to
+    # the workload path it would dereference state["client"], so a
+    # missing-attr is a hard signal we hit the wrong branch.
+    monkeypatch.setattr(
+        FakeCullisClient,
+        "list_models",
+        lambda self: workload_calls.append(True) or [
+            {"id": "should-not-appear", "object": "model",
+             "owned_by": "workload", "created": 0},
+        ],
+        raising=False,
+    )
+
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["cullis_meta"]["source"] == "live"
+    ids = [m["id"] for m in body["data"]]
+    assert ids == ["qwen3.5:2b"]
+    assert user_calls == [cred.principal_id]
+    assert workload_calls == []
+
+    # Cache is keyed on principal_id (not agent_id) — second call hits
+    # cache without rebuilding the per-user client.
+    resp2 = client.get("/v1/models")
+    assert resp2.status_code == 200
+    assert user_calls == [cred.principal_id], (
+        "second call must serve from cache, not re-invoke per-user client"
+    )
+    assert cred.principal_id in _models_cache
+
+
 def test_chat_completions_rejects_wrong_bearer(client):
     resp = client.post(
         "/v1/chat/completions",

--- a/tests/test_crit1_csr_pubkey_tofu.py
+++ b/tests/test_crit1_csr_pubkey_tofu.py
@@ -113,14 +113,19 @@ def _fake_agent_manager(
     ca_cert: x509.Certificate,
     org_id: str = "acme",
 ):
-    """sign_user_csr only reads ``.org_id``, ``.ca_loaded``,
-    ``._org_ca_key``, ``._org_ca_cert`` — a SimpleNamespace covers it
-    without dragging the full AgentManager bootstrap."""
+    """sign_user_csr reads ``.org_id``, ``.ca_loaded`` and (ADR three-tier
+    PKI hardening, 2026-05-18) ``._mastio_ca_key`` / ``._mastio_ca_cert``
+    so user-principal leaves chain ``leaf → Mastio Intermediate``. The
+    ``_org_ca_*`` aliases stay for callers (e.g. agent enrollment) that
+    still walk to the Org Root directly. A single SimpleNamespace covers
+    both surfaces without dragging the full AgentManager bootstrap."""
     return SimpleNamespace(
         org_id=org_id,
         ca_loaded=True,
         _org_ca_key=ca_key,
         _org_ca_cert=ca_cert,
+        _mastio_ca_key=ca_key,
+        _mastio_ca_cert=ca_cert,
     )
 
 


### PR DESCRIPTION
## Summary

End-to-end Frontdesk dogfood automation in `sandbox/` plus the two PKI / router fixes the sandbox exposed while validating ADR-034 Finding #16 against a real Ollama provider.

- `sandbox/dogfood-frontdesk.sh` spawns Ollama (`qwen2.5:0.5b`), brings up Mastio + Frontdesk bundle on a shared bridge, drives `/setup` as a workload, approves enrollment via the Mastio dashboard, creates user `mario`, logs in through the SPA, and asserts `/v1/models` + `/v1/chat/completions` round-trip live. The gate moves Finding #16 from "manual VM repro" to "one command".
- `sign_user_csr` was returning a leaf-only PEM for user-principal mints. Mirror the `sign_external_pubkey` workload fix (PR #816) so the response concatenates `leaf + Mastio Intermediate` — nginx's `ssl_client_certificate` (Org Root only) cannot walk leaf → root without the intermediate the SDK ships at the TLS handshake.
- Single-mode `/v1/models` (`cullis_connector/ambassador/router.py`) was the last handler that ignored `request.state.user_credentials` and called Mastio with the Connector workload cred. In the modern Frontdesk bundle (`FRONTDESK_BUNDLE=1` + `AUTH_MODE=local`, `AMBASSADOR_MODE` empty) the workload cert is not a UserPrincipal, so Mastio's mTLS gate returned 401. Mirror the fork already in `chat_completions`: build a per-user `CullisClient` when the cert middleware bound one, cache on `principal_id`, fail loud with 503 (`is_frontdesk_bundle()` instead of `is_shared_mode()`) when the live fetch yields no models.
- Test fixture update: `_fake_agent_manager` in `test_crit1_csr_pubkey_tofu.py` now exposes `_mastio_ca_*` aliases so the ported signer can read its three-tier handles.

## Test plan

- [x] `pytest tests/connector/ -k "router or cert_middleware or shared"` (164 passed, 2 skipped)
- [x] `pytest tests/ -n auto --dist=loadfile` (4117 passed; one pre-existing dashboard test fails because `cullis_enterprise` is locally installed editable — unrelated)
- [x] `./sandbox/dogfood-frontdesk.sh --build` end-to-end: `/v1/models` returns `ollama_chat/qwen2.5:0.5b` live, `/v1/chat/completions` returns a non-empty Ollama answer
- [ ] `/security-review` (defer to merge time per workflow)