### PR TITLE
fix(mastio-bundle): --upgrade defaults to bundle refresh

### DIFF
--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -280,23 +280,24 @@ Fix: allinea `MCP_PROXY_PROXY_PUBLIC_URL` al valore corretto, esegui
 
 ## Updating
 
-**Recommended — full bundle refresh (ADR-030):**
+**Default — full bundle refresh (ADR-030):**
 
 ```bash
-./deploy.sh --upgrade-bundle 0.4.0
+./deploy.sh --upgrade 0.5.0          # alias of --upgrade-bundle
+./deploy.sh --upgrade-bundle 0.5.0   # explicit
 ```
 
 Downloads the released tarball from GitHub, backs up `proxy.env` + `./data/` + `./nginx-certs/` to `./backups/pre-upgrade-<ts>/`, extracts the new bundle scripts in place (without touching your state), bumps `CULLIS_MASTIO_VERSION`, pulls the matching image, and restarts the stack with `compose up -d --wait`. The dashboard's "update available" banner shows the same command as a one-liner you can paste into the host shell.
 
-**Image-only bump (scripts stay at the bundle's original version):**
+**Image-only bump (advanced, scripts stay at the bundle's original version):**
 
 ```bash
-./deploy.sh --upgrade 0.4.0
+./deploy.sh --upgrade 0.5.0 --image-only
 # or:
 ./deploy.sh --pull
 ```
 
-Use this if you trust the new image but want to keep your current `deploy.sh` / compose / scripts. Note: future env vars introduced by a release will NOT reach `proxy.env` until you do a full bundle refresh.
+Use only on air-gapped / forked deploys where the bundle files are managed out-of-band and you've already synced them by hand. Env vars added by a newer release are silently dropped when the compose file does not propagate them — that is why this is the opt-in path, not the default.
 
 **Migrate from legacy named volumes (one-shot, v0.3.x → v0.4.x):**
 

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -496,12 +496,22 @@ Options:
                               re-enroll. Mirrors ``docker compose down
                               --volumes`` semantics for bind mounts.
   --pull                      Force-pull the image before starting.
-  --upgrade <version>         Image-only bump: pin CULLIS_MASTIO_VERSION
-                              in proxy.env to <version>, pull the new
-                              image, recreate containers in-place. Bind-
-                              mount data is preserved. Scripts stay at
-                              the bundle's original version — use
-                              --upgrade-bundle for a full bundle refresh.
+  --upgrade <version>         Full upgrade (image + bundle files). Now
+                              an alias for --upgrade-bundle so the
+                              docker-compose.yml + helper scripts on
+                              disk stay in sync with the target image's
+                              expected surface (env vars, compose
+                              keys). Bind-mount data + proxy.env are
+                              preserved. Pair with --image-only below
+                              if you already synced the bundle files
+                              manually.
+  --image-only                Modifier for --upgrade. Skip the file
+                              refresh and only bump CULLIS_MASTIO_VERSION
+                              in proxy.env + pull the new image. Use
+                              only on air-gapped / forked deploys where
+                              the bundle files are managed out-of-band.
+                              Mismatched files vs image silently drop
+                              env vars added by newer releases.
   --upgrade-bundle <version>  Full bundle refresh: download the released
                               tarball, extract over the current bundle
                               (preserving proxy.env, ./data, ./nginx-
@@ -548,8 +558,9 @@ Examples:
   CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh        # pinned version
   ./deploy.sh --shared-broker                    # join Court on same host
   ./deploy.sh --prod                             # standalone, prod safety
-  ./deploy.sh --upgrade 0.4.2                    # image-only bump
-  ./deploy.sh --upgrade-bundle 0.4.2             # full bundle refresh
+  ./deploy.sh --upgrade 0.4.2                    # full bundle + image
+  ./deploy.sh --upgrade 0.4.2 --image-only       # legacy image-only bump
+  ./deploy.sh --upgrade-bundle 0.4.2             # explicit bundle refresh
   ./deploy.sh --migrate-volumes                  # one-shot bind migration
   ./deploy.sh --down                             # stop + remove (keep state)
   ./deploy.sh --down -v                          # stop + wipe bind dirs (reset)
@@ -562,6 +573,12 @@ SHARED_BROKER=0
 FORCE_PULL=0
 UPGRADE_TO=""
 UPGRADE_BUNDLE_TO=""
+# ``--image-only`` opts back into the legacy ``--upgrade`` semantics:
+# bump ``CULLIS_MASTIO_VERSION``, pull the image, recreate containers.
+# Operator promises the on-disk bundle (docker-compose.yml, deploy.sh,
+# helpers) is already aligned with the target version. Default is now
+# the safer ``--upgrade-bundle`` flow — see the dispatcher block below.
+UPGRADE_IMAGE_ONLY=0
 FROM_BANNER=0
 ACCEPT_DATA_LOSS=0
 # ``--down -v`` (alias ``--volumes`` / ``--wipe-data``) mirrors the
@@ -607,6 +624,7 @@ while [[ $# -gt 0 ]]; do
             ACTION="upgrade_bundle"
             shift
             ;;
+        --image-only)      UPGRADE_IMAGE_ONLY=1; shift ;;
         --migrate-volumes) ACTION="migrate_volumes"; shift ;;
         --from-banner)     FROM_BANNER=1; shift ;;
         --accept-data-loss) ACCEPT_DATA_LOSS=1; shift ;;
@@ -643,6 +661,22 @@ fi
 if [[ "$ACTION" == "migrate_volumes" ]]; then
     _cmd_migrate_volumes
     exit 0
+fi
+# ``--upgrade <version>`` now defaults to a full bundle refresh. The
+# legacy image-only behaviour kept docker-compose.yml + helpers frozen
+# at the bundle's original version, so any env passthrough added by the
+# target release (e.g. PR #818's MCP_PROXY_FRONTDESK_VERIFY_TLS) was
+# silently dropped: ``proxy.env`` carried the new var, the compose file
+# never propagated it, and the upgrade booted with the new image but
+# the old surface. Operators only learned at the next ``Frontdesk
+# unreachable`` flash. Promote to ``--upgrade-bundle`` here; keep the
+# image-only path reachable behind ``--upgrade --image-only`` for
+# operators who already syncronised the files by hand (e.g. air-gapped
+# deploys, custom forks).
+if [[ -n "$UPGRADE_TO" && $UPGRADE_IMAGE_ONLY -eq 0 ]]; then
+    UPGRADE_BUNDLE_TO="$UPGRADE_TO"
+    UPGRADE_TO=""
+    ACTION="upgrade_bundle"
 fi
 if [[ "$ACTION" == "upgrade_bundle" ]]; then
     _cmd_upgrade_bundle "$UPGRADE_BUNDLE_TO"
@@ -766,7 +800,10 @@ fi
 # does too — operators don't expect the version to silently revert if they
 # forget the env var on a later restart.
 if [[ -n "$UPGRADE_TO" ]]; then
-    step "Upgrading Cullis Mastio to ${UPGRADE_TO}"
+    step "Upgrading Cullis Mastio to ${UPGRADE_TO} (image-only)"
+    warn "  Bundle files (docker-compose.yml, helpers) stay at the current"
+    warn "  on-disk version. Drop --image-only to refresh them from the"
+    warn "  released tarball."
     if [[ ! -f "$SCRIPT_DIR/proxy.env" ]]; then
         die "proxy.env not found — run ./deploy.sh once before --upgrade"
     fi


### PR DESCRIPTION
## Summary

\`./deploy.sh --upgrade <ver>\` was a footgun: it pinned the new \`CULLIS_MASTIO_VERSION\`, pulled the matching image, and recreated the containers — but left \`docker-compose.yml\` + helpers frozen at whatever version the operator originally installed. Any env passthrough added between releases was silently dropped at the compose-expansion layer.

Today's symptom on the v0.5.0 upgrade: PR #818 added \`MCP_PROXY_FRONTDESK_VERIFY_TLS\` and \`MCP_PROXY_FRONTDESK_CA_BUNDLE\` to the bundle's compose file. Operator set both in \`proxy.env\` and ran \`./deploy.sh --upgrade 0.5.0\`. The new vars stayed in \`proxy.env\` but the old compose file did not enumerate them under the \`mcp-proxy\` service \`environment:\` block, so \`docker exec ... env | grep FRONTDESK\` showed only \`URL\` + \`ADMIN_SECRET\`. The verify-TLS knob defaulted back to \`True\`, httpx refused the self-signed Frontdesk cert, and the dashboard surfaced "Frontdesk unreachable" on every cross-VM operation.

## Fix

- \`--upgrade <ver>\` is now an alias for \`--upgrade-bundle <ver>\` (which already existed and did the right thing).
- New opt-in \`--upgrade <ver> --image-only\` keeps the legacy behaviour for air-gapped / forked deploys with a stderr warning that bundle files will not refresh.
- README + \`--help\` describe the new default + the opt-in.

## Migration impact

- Existing operators: \`--upgrade 0.5.1\` will now download the tarball + extract bundle files. Same flow they would have gotten via \`--upgrade-bundle\`. No data movement, no breaking change for the dashboard banner (\`install_command\` string is unchanged).
- Air-gapped / forked deploys that intentionally diverged the bundle: add \`--image-only\` to the upgrade invocation.

## Test plan

- [x] \`bash -n packaging/mastio-bundle/deploy.sh\` syntax check
- [x] \`./deploy.sh --help\` renders the new copy
- [x] Repro path verified live on the dogfood VM mastio-demo: \`docker-compose.yml\` shipped in v0.5.0 has the FRONTDESK env passthrough, the on-disk one was v0.4.5 and missed it. After applying this fix in a follow-up bundle refresh, the bridge call to Frontdesk succeeds.
- [ ] Post-merge, ship v0.5.1 with this deploy.sh so future operators get the safe default without manual intervention.