### PR TITLE
fix(frontdesk-bundle): auto-derive TLS SAN from CULLIS_FRONTDESK_PUBLIC_URL

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -420,6 +420,41 @@ TLS_MODE="${TLS_MODE_RAW:-enabled}"
 TLS_PORT="$(_load_env FRONTDESK_TLS_PORT)";           TLS_PORT="${TLS_PORT:-8443}"
 TLS_BIND="$(_load_env FRONTDESK_TLS_BIND)";           TLS_BIND="${TLS_BIND:-0.0.0.0}"
 TLS_SAN="${CLI_TLS_SAN:-$(_load_env FRONTDESK_TLS_SAN)}"
+# Auto-derive a SAN entry from ``CULLIS_FRONTDESK_PUBLIC_URL`` so the
+# bundle mints a cert that matches the URL employees actually reach
+# (mirror of the Mastio bundle's ``MCP_PROXY_PROXY_PUBLIC_URL`` →
+# ``MCP_PROXY_NGINX_SAN`` derivation in ``packaging/mastio-bundle/
+# deploy.sh``). Without this, the customer has to remember to set
+# ``FRONTDESK_TLS_SAN`` or pass ``--tls-san`` at every deploy; if
+# they forget, the cert carries only the default ``localhost`` +
+# docker hostnames and every browser on the LAN urla "hostname
+# mismatch". Strip scheme + port like the Mastio path does. Skip
+# the default hostnames + IP loopback (they're already in the
+# default SAN list inside ``mint-tls-cert.sh``).
+_frontdesk_public_url="$(_load_env CULLIS_FRONTDESK_PUBLIC_URL)"
+if [[ -n "$_frontdesk_public_url" ]]; then
+    _frontdesk_public_host="$(echo "$_frontdesk_public_url" | sed -E 's|^https?://||; s|:[0-9]+$||; s|/.*$||')"
+    if [[ -n "$_frontdesk_public_host" ]] \
+       && [[ "$_frontdesk_public_host" != "localhost" ]] \
+       && [[ "$_frontdesk_public_host" != "host.docker.internal" ]] \
+       && [[ "$_frontdesk_public_host" != "frontdesk.local" ]] \
+       && [[ "$_frontdesk_public_host" != "127.0.0.1" ]]; then
+        # Already in TLS_SAN? Skip — operator-pinned SAN list wins,
+        # we only add when missing. Crude substring match is enough:
+        # entries are comma-separated, the host name does not contain
+        # commas.
+        case ",${TLS_SAN}," in
+            *",${_frontdesk_public_host},"*) ;;
+            *)
+                if [[ -n "$TLS_SAN" ]]; then
+                    TLS_SAN="${TLS_SAN},${_frontdesk_public_host}"
+                else
+                    TLS_SAN="$_frontdesk_public_host"
+                fi
+                ;;
+        esac
+    fi
+fi
 # Export FRONTDESK_TLS_* so docker compose substitution picks them up
 # (compose reads from the process env *and* --env-file; we resolved
 # the precedence above and re-export the winners).

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -113,16 +113,24 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # host that talks loopback.
 # FRONTDESK_TLS_BIND=0.0.0.0
 
+# The public URL employees reach the Frontdesk at. ``deploy.sh``
+# extracts the hostname from this URL and auto-appends it to the
+# TLS cert SAN list (mirror of the Mastio bundle's
+# ``MCP_PROXY_PROXY_PUBLIC_URL`` → ``MCP_PROXY_NGINX_SAN`` derivation).
+# Set this and the cert will match without remembering ``--tls-san``
+# at every redeploy.
+# CULLIS_FRONTDESK_PUBLIC_URL=https://frontdesk.acme.local:8443
+
 # Extra Subject Alternative Names (comma-separated DNS hostnames + IP
 # literals) baked into the self-signed cert. The default SAN list
 # already covers ``localhost``, ``host.docker.internal``,
 # ``frontdesk.local``, ``cullis-frontdesk-nginx``, ``127.0.0.1``,
-# ``::1``. Add the public hostname / VPS IP your employees reach the
-# bundle at so the browser cert validation succeeds without warning
-# after the operator imports ``tls/frontdesk-ca.crt`` as a trust
-# anchor. Set this BEFORE the first deploy (or pass ``--tls-san`` to
-# deploy.sh and re-mint).
-# FRONTDESK_TLS_SAN=frontdesk.acme.example.com,1.2.3.4
+# ``::1``. The hostname derived from ``CULLIS_FRONTDESK_PUBLIC_URL``
+# (above) is added automatically; use this to layer in additional
+# names not covered by the public URL (extra LAN IPs, alternate
+# hostnames the same Frontdesk is reachable at, etc.). ``--tls-san``
+# on the deploy.sh CLI overrides this.
+# FRONTDESK_TLS_SAN=192.168.1.42,frontdesk-backup.acme.example.com
 
 # Show the dev audit panel inside the SPA. Off by default — the audit
 # chain belongs to the Mastio admin dashboard, not the end user surface.


### PR DESCRIPTION
Mirror of the Mastio bundle's PR #801 ergonomic. The Frontdesk bundle was the last surface where the operator had to remember `--tls-san "frontdesk.acme.local"` (or pre-populate `FRONTDESK_TLS_SAN`) at every deploy or the self-signed cert came out with only the default SAN list. Browsers on the LAN urlavano "hostname does not match" until the operator figured out the right flag and re-minted.

## Fix

Set `CULLIS_FRONTDESK_PUBLIC_URL=https://frontdesk.acme.local:8443` in `frontdesk.env` once. `./deploy.sh` now extracts the host (same `sed` pipeline as Mastio: strip scheme + port + path) and appends it to the SAN list passed to `mint-tls-cert.sh`. Skips already-default hostnames + loopback. Operator-pinned `FRONTDESK_TLS_SAN` and `--tls-san` CLI flag still win for layered additional names.

## Foundation, not a workaround

This survives the future ADR-035 (Mastio Frontdesks management page) where the dashboard will layer runtime-editable config on top. The env stays as the bootstrap default for the first-boot path (before the bridge enrollment with Mastio is established).

## Test plan

- [x] 9-case derivation test (localhost skip, host.docker.internal skip, IP + DNS merge, deduplication, path strip, empty no-op, real dogfood case `192.168.1.73,frontdesk.cullis.local`)
- [x] `bash -n` syntax check
- [ ] Manual dogfood post-merge on VM frontdesk-demo: set the env, redeploy, verify SAN in `tls/frontdesk-server.crt`