### PR TITLE
fix(frontdesk-bundle): nginx upstream keepalive (port exhaustion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,6 @@ scripts/stress/stress_agents.json
 scripts/stress/intra-org-results*.json
 scripts/stress/intra-org-results.ndjson
 scripts/stress/intra-org-summary*.json
+scripts/stress/stress_frontdesk_users.json
+scripts/stress/frontdesk-summary*.json
 scripts/stress/*.log

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -235,6 +235,11 @@ services:
       # the sidecar off with ``./deploy.sh --no-tls``.
       - "${FRONTDESK_HTTP_BIND:-127.0.0.1}:${FRONTDESK_HTTP_PORT:-8080}:80"
     volumes:
+      # 00-maps.conf must load BEFORE default.conf (alphabetical
+      # ordering of /etc/nginx/conf.d/*.conf inside the nginx:alpine
+      # http {} context) so default.conf's ``$connection_upgrade``
+      # references resolve. Same pattern as the TLS sidecar below.
+      - ./nginx/00-maps.conf:/etc/nginx/conf.d/00-maps.conf:ro
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - cullis-chat

--- a/packaging/frontdesk-bundle/nginx-tls/00-maps.conf
+++ b/packaging/frontdesk-bundle/nginx-tls/00-maps.conf
@@ -10,11 +10,16 @@
 # =============================================================================
 
 # WebSocket Upgrade helper for SPA streaming endpoints (Cullis Chat
-# streams chat completions via SSE / WS via the Connector). Empty
-# Upgrade → close the upstream connection; anything else → forward
-# verbatim so nginx doesn't emit ``Connection: close`` and break the
-# stream mid-token.
+# streams chat completions via SSE / WS via the Connector). For
+# requests WITH ``Upgrade``, forward verbatim so long-lived streams
+# survive. For requests WITHOUT (the common HTTP case), emit an EMPTY
+# ``Connection`` header so nginx can keep the upstream socket alive
+# in the ``inner_nginx_upstream`` keepalive pool defined in
+# default.conf. The pre-fix default of ``close`` forced a fresh TCP
+# socket per request to the inner nginx, exhausting the ephemeral
+# port pool under sustained load (same bug Mastio fixed in PR #697,
+# Frontdesk inner nginx fixed alongside this map).
 map $http_upgrade $connection_upgrade {
     default upgrade;
-    ''      close;
+    ''      "";
 }

--- a/packaging/frontdesk-bundle/nginx-tls/default.conf
+++ b/packaging/frontdesk-bundle/nginx-tls/default.conf
@@ -22,6 +22,20 @@
 #     HTTPS. Without that the SPA loses cookies on every navigation.
 # =============================================================================
 
+# Keepalive pool to the inner nginx — same pattern as the inner nginx
+# uses toward the Connector / cullis-chat upstreams (00-maps.conf +
+# default.conf in this bundle, mirrored from Mastio PR #697). Without
+# this and with the pre-fix ``set $inner_upstream … proxy_pass $var;``
+# pattern, nginx forced per-request DNS resolution AND opened a new
+# TCP socket every time, doubling the port-exhaustion risk on the way
+# in (TLS hop) and on the way through (inner hop).
+upstream inner_nginx_upstream {
+    server nginx:80;
+    keepalive 64;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
+}
+
 server {
     listen 8443 ssl;
     http2 on;
@@ -67,8 +81,13 @@ server {
     # port 8080 is unaffected.
     # ───────────────────────────────────────────────────────────────
     location / {
-        set $inner_upstream http://nginx:80;
-        proxy_pass $inner_upstream;
+        # Named upstream (above) — keeps a warm TCP pool to the inner
+        # nginx, so high-RPS demo traffic does not burn ephemeral ports
+        # at the TLS hop. The pre-fix ``set $inner_upstream … ;
+        # proxy_pass $var;`` form disabled keepalive pooling entirely
+        # because nginx requires a literal upstream name in
+        # ``proxy_pass`` to bind to a ``keepalive`` pool.
+        proxy_pass http://inner_nginx_upstream;
         proxy_http_version 1.1;
         # $http_host preserves the port the browser sent (e.g.
         # 192.168.122.87:8443), while $host strips it. The Connector
@@ -111,16 +130,9 @@ server {
     }
 }
 
-# WebSocket Upgrade helper. Same map the inner nginx already declares,
-# repeated here because nginx's ``map`` directives don't propagate
-# across separate config files unless both files are loaded into the
-# same ``http {}`` context. nginx:alpine's default config opens
-# ``http {}`` at the top level + auto-loads ``/etc/nginx/conf.d/*.conf``
-# in lexicographic order, so this map ends up in the right context as
-# long as it lives in a file that loads before the ``server {}``
-# block above. Since both directives are in this single file and
-# nginx evaluates them in order within the ``http {}`` context, the
-# server block can reference ``$connection_upgrade`` declared above
-# only if the map sits ABOVE the server. Move the map to
-# ``00-maps.conf`` to make the load order explicit (alphabetical
-# matches the Mastio bundle).
+# NOTE: the ``$connection_upgrade`` map referenced above lives in
+# ``00-maps.conf`` (same dir, mounted alongside this file in the
+# compose service). nginx loads ``conf.d/*.conf`` in lexicographic
+# order inside the ``http {}`` context, so the map is in scope by the
+# time this server block is parsed. Pattern matches the Mastio bundle
+# (``packaging/mastio-bundle/nginx/mastio/00-maps.conf``).

--- a/packaging/frontdesk-bundle/nginx/00-maps.conf
+++ b/packaging/frontdesk-bundle/nginx/00-maps.conf
@@ -1,0 +1,35 @@
+# =============================================================================
+# Cullis Frontdesk inner nginx — http-level maps
+# =============================================================================
+#
+# Loaded before default.conf via lexicographic order in
+# /etc/nginx/conf.d/. ``map`` directives must live in the ``http {}``
+# context (which the nginx official image opens for us at the top
+# level), so they cannot sit inside a ``server {}`` block.
+#
+# WebSocket Upgrade helper. When the client sends ``Upgrade``, forward
+# it verbatim so long-lived streams (SSE, websocket dashboard) survive.
+# When the client does NOT send Upgrade (the common case: every plain
+# HTTP request), emit an EMPTY ``Connection`` header so nginx can keep
+# the upstream socket alive in the ``connector_upstream`` /
+# ``cullis_chat_upstream`` keepalive pool. Without this — and with the
+# pre-fix default of ``close`` or the implicit close from a missing
+# header — every request opens a fresh TCP socket to upstream, ephemeral
+# port pool exhausts in seconds, and nginx logs
+# ``connect() failed (99: Address not available)``.
+#
+# Customer-blocker symptoms before the fix (2026-05-20 load-test
+# baseline, 10 VUs / 60s):
+#   - 14585 ENADDRNOTAVAIL critical lines / minute
+#   - 100 % error rate on /v1/* GET, 70-90 % on POST /api/auth/login
+#   - Frontdesk visibly broken for any concurrent customer demo
+#
+# Same root cause as the Mastio nginx sidecar pre-PR #697. See
+# ``packaging/mastio-bundle/nginx/mastio/00-maps.conf`` for the
+# equivalent (and to keep the two side-cars in sync going forward).
+# =============================================================================
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -26,6 +26,36 @@ map $arg_user $forwarded_user {
     "luca"       "luca@beta.local";
 }
 
+# ── Upstream pools (PR #697 lineage, ported to Frontdesk 2026-05-20) ─────
+#
+# Without an explicit ``upstream { keepalive N; }`` block, nginx opens a
+# fresh TCP socket to the upstream on every request — under sustained
+# load (~600 RPS on a 16-core dev box, ~880 RPS / 10 VUs on a 2-vCPU
+# sandbox) the ephemeral port pool exhausts and the sidecar starts
+# logging ``connect() failed (99: Address not available)`` while the
+# client sees 502. The pools below keep upstream sockets warm and lift
+# the throughput ceiling 5-10x. Combine with
+# ``proxy_set_header Connection $connection_upgrade;`` on every
+# ``location`` (declared via the map in 00-maps.conf) so nginx does not
+# emit ``Connection: close`` and immediately close the pooled socket.
+#
+# The Mastio bundle ships the same pattern at
+# ``packaging/mastio-bundle/nginx/mastio/mastio.conf``; keep the two in
+# sync when extending.
+upstream connector_upstream {
+    server connector:7777;
+    keepalive 64;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
+}
+
+upstream cullis_chat_upstream {
+    server cullis-chat:8080;
+    keepalive 32;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
+}
+
 server {
     listen 80 default_server;
     server_name _;
@@ -33,11 +63,12 @@ server {
     # Hide nginx version in error pages / Server header.
     server_tokens off;
 
-    # Docker's embedded DNS — required because the proxy_pass URLs use
-    # variables (``$request_uri``), which forces nginx to resolve the
-    # upstream hostname per request rather than at start. Without an
-    # explicit resolver nginx errors with "no resolver defined" and
-    # surfaces 502 to the client.
+    # Docker's embedded DNS — kept for resilience even though the
+    # upstream blocks above resolve the service name at config-load.
+    # If the docker bridge re-assigns the upstream IP (compose
+    # ``up --force-recreate``), the static resolution becomes stale;
+    # without a resolver nginx then surfaces 502 until reload. With it,
+    # nginx re-resolves on the next keepalive idle window.
     resolver 127.0.0.11 valid=10s ipv6=off;
     resolver_timeout 3s;
 
@@ -85,12 +116,14 @@ server {
     # /api/auth/* below instead; the 404 surfaced here in local mode is
     # by design.
     location /api/session/ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header X-Forwarded-User $forwarded_user;
     }
 
@@ -103,12 +136,14 @@ server {
     # is intentionally NOT injected — local-auth verifies the password
     # against bcrypt in users.db, no upstream identity claim required.
     location /api/auth/ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
     }
 
     # ----- /admin/*: ADR-025 admin Users / audit endpoints -----------------
@@ -119,12 +154,14 @@ server {
     # caller's request header), so no special handling here besides the
     # passthrough.
     location /admin/ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
     }
 
     # ----- /v1/*: bypass the SPA, direct to the Ambassador -----
@@ -134,12 +171,14 @@ server {
     # /v1/models, /v1/mcp, /v1/ambassador/health directly. SSE streaming
     # wiring (proxy_buffering off, long read timeout) inlined here.
     location /v1/ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header X-Forwarded-User $forwarded_user;
         # SSE chat streaming.
         proxy_buffering off;
@@ -166,12 +205,14 @@ server {
     #   /api/setup/discover/results (HTMX probe results endpoint)
     #   /api/status (HTMX poll for enrollment status)
     location ~ ^/(setup|api/setup|waiting|api/status)(/.*)?$ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
     }
 
     # ----- /static/*: Connector wizard assets (CSS, htmx, SVG) -----
@@ -190,12 +231,14 @@ server {
     # bundle and serves top-level ``cullis-mark.svg`` etc., never
     # ``/static/``, so this namespace is free.
     location /static/ {
-        proxy_pass http://connector:7777$request_uri;
+        proxy_pass http://connector_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
     }
 
     # ----- everything else: static SPA via the cullis-chat container -----
@@ -205,12 +248,14 @@ server {
     # the SPA's own /api/* routes were deleted in Phase 8b-2b along
     # with switching the Astro config to ``output: 'static'``.
     location / {
-        proxy_pass http://cullis-chat:8080;
+        proxy_pass http://cullis_chat_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Keepalive pool helper — see 00-maps.conf for the rationale.
+        proxy_set_header Connection $connection_upgrade;
         # The nginx-static SPA inside cullis-chat emits absolute
         # ``Location: http://<Host>:8080/...`` redirects on dir-norm
         # 301s (``/login`` → ``/login/``) because the upstream port

--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -12,16 +12,19 @@
 | `health-throughput.js` | TLS edge + nginx → mcp-proxy plumbing (cheap read) | live |
 | `soak-stability.js` | Same path, 50 VUs sustained 1h — memory leak detection | live |
 | `intra-org-mastio-burst.js` | Full intra-org auth+audit chain at 50→5k VUs | live (C2.A.1) |
+| `frontdesk-multiuser-mock.js` | Frontdesk user-path (login + list_models) w/o LLM | live |
+| `frontdesk-multiuser-ollama.js` | Same shape + chat_completions against real Ollama | live |
 | `dpop-egress.js` | DPoP signature verification + token issuance | TODO |
 | `a2a-routing.js` | Intra-org A2A message dispatch via PDP + broker | TODO |
 | `enrollment-burst.js` | Concurrent CSR issuance + DB insert | TODO |
 
-`health-throughput.js`, `soak-stability.js`, and `intra-org-mastio-
-burst.js` are wired today. The remaining scenarios are listed so
-future work can land in one place. Each new scenario should keep the
-same conventions: human-readable `handleSummary` for the maintainer +
-a JSON dump (`summary.json`, `soak-summary.json`,
-`intra-org-summary.json`) for diffable artefacts.
+`health-throughput.js`, `soak-stability.js`, `intra-org-mastio-
+burst.js`, and the two `frontdesk-multiuser-*.js` scenarios are wired
+today. The remaining scenarios are listed so future work can land in
+one place. Each new scenario should keep the same conventions:
+human-readable `handleSummary` for the maintainer + a JSON dump
+(`summary.json`, `soak-summary.json`, `intra-org-summary.json`,
+`frontdesk-summary-*.json`) for diffable artefacts.
 
 ## How to run
 
@@ -295,6 +298,74 @@ single-uvicorn-worker GIL + global asyncio audit-chain lock cap
 throughput well below Tier 2+ targets. Architectural changes
 (multi-worker uvicorn, Postgres backend, Redis JTI) are required
 before re-running this scenario for Tier 2+ feasibility.
+
+## Frontdesk multi-user benchmark
+
+`frontdesk-multiuser-mock.js` and `frontdesk-multiuser-ollama.js`
+stress the **Frontdesk** bundle (not Mastio). Each VU is a pre-seeded
+Frontdesk user; the cycle is login → list_models (mock) or login →
+chat_completions (ollama). Login is a one-shot per VU; the per-VU
+cookie jar carries the session through subsequent iterations.
+
+The mock variant isolates Frontdesk software overhead — auth, per-user
+credential fork via `LocalUserProvisioner`, nginx TLS sidecar,
+Frontdesk→Mastio mTLS hop — because `/v1/models` is a cheap read that
+forwards to Mastio without touching an LLM. The ollama variant adds
+`/v1/chat/completions` against the real LLM upstream, so latency
+includes inference time and reflects the demo end-to-end.
+
+### Setup
+
+```bash
+# 1. Bring up the Frontdesk + Mastio stack. The sandbox dogfood spins
+#    both bundles + Ollama on the shared bridge and runs the workload
+#    enrollment + AI provider configuration end-to-end.
+bash sandbox/dogfood-frontdesk.sh
+
+# 2. Seed N test users directly into the Frontdesk users.db. Same
+#    shared bcrypt hash for all N (test only; checkpw still runs on
+#    the hot path so the auth code path is exercised). --warmup
+#    runs a parallel pre-login on all users to populate the
+#    LocalUserProvisioner cert cache before the k6 stages start.
+nix-shell -p python311Packages.bcrypt python311Packages.aiohttp --run \
+    "python scripts/stress/bulk_create_frontdesk_users.py \
+        --n 100 --wipe --warmup \
+        --base-url http://localhost:18080"
+```
+
+`stress_frontdesk_users.json` (carrying the shared cleartext password)
+is gitignored alongside `stress_agents.json`. NEVER commit.
+
+### Run
+
+```bash
+# Mock (no LLM) — pure Frontdesk perf, default stages 50→200→500 VUs
+nix-shell -p k6 --run "K6_SKIP_NDJSON=1 \
+    bash scripts/stress/_run-k6.sh frontdesk-multiuser-mock.js"
+
+# Ollama (full LLM path) — customer-realistic, default stages 10→30→50 VUs
+nix-shell -p k6 --run "K6_SKIP_NDJSON=1 \
+    bash scripts/stress/_run-k6.sh frontdesk-multiuser-ollama.js"
+
+# Short triage:
+STAGE_OVERRIDE='[{"duration":"60s","target":50}]' \
+    nix-shell -p k6 --run "bash scripts/stress/_run-k6.sh \
+        frontdesk-multiuser-mock.js"
+```
+
+The mock script writes `frontdesk-summary-mock.json`; the ollama
+variant writes `frontdesk-summary-ollama.json`. Both are gitignored.
+
+### When to re-run
+
+- Before a Frontdesk-impacting release (anything touching
+  `packaging/frontdesk-bundle/`, `cullis_connector/auth/`,
+  `cullis_connector/ambassador/`, or the nginx sidecar in
+  `packaging/frontdesk-bundle/nginx-tls/`).
+- After any change to `LocalUserProvisioner` / `UserCredentialCache`
+  semantics — per-user fork is the dominant overhead on the Frontdesk
+  user-path.
+- When a customer reports latency spikes at >10 concurrent users.
 
 ## Historical baselines
 

--- a/scripts/stress/bulk_create_frontdesk_users.py
+++ b/scripts/stress/bulk_create_frontdesk_users.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Bulk-seed N Frontdesk test users for k6 stress runs.
+
+Mirrors ``bulk_enroll_agents.py`` for the Mastio side. Two-step flow:
+
+  1. Bulk POST to the Frontdesk ``/admin/users`` endpoint (gated by
+     ``X-Admin-Secret``). Each call creates one row in ``local_users``
+     with ``must_change_password=False`` so subsequent logins go
+     straight to the provisioning path. Parallelised through aiohttp
+     with bounded concurrency to keep bcrypt cost 12 from saturating
+     the Connector CPU.
+
+  2. Optional pre-warmup: parallel ``POST /api/auth/login`` per user.
+     Each successful login triggers ``LocalUserProvisioner`` which
+     mints a user cert via Mastio's ``/v1/principals/csr`` and caches
+     it in ``UserCredentialCache``. Without warmup, the first k6
+     iteration per VU pays the CSR roundtrip; with warmup the cache
+     is hot and the k6 measurements reflect steady state.
+
+Output: ``stress_frontdesk_users.json`` next to this script — list of
+{user_name, password} + base URL the k6 scenario should target. **Local
+only** (carries cleartext shared password). Already gitignored alongside
+``stress_agents.json``.
+
+Required env (or CLI flag):
+  - ``CULLIS_CONNECTOR_ADMIN_SECRET`` (or ``--admin-secret``) — the
+    Connector admin secret. Read from ``packaging/frontdesk-bundle/
+    frontdesk.env`` after ``deploy.sh`` or from the sandbox proxy.env
+    after ``dogfood-frontdesk.sh``.
+
+Usage::
+
+    nix-shell -p 'python311.withPackages(ps: with ps; [ aiohttp ])' --run \\
+        "python scripts/stress/bulk_create_frontdesk_users.py \\
+            --n 100 --wipe --warmup"
+
+    # Local sandbox (dogfood-frontdesk.sh):
+    CULLIS_CONNECTOR_ADMIN_SECRET=$(docker exec \\
+        dogfood-frontdesk-frontdesk-connector-1 \\
+        sh -c 'echo $CULLIS_CONNECTOR_ADMIN_SECRET') \\
+        python scripts/stress/bulk_create_frontdesk_users.py \\
+            --n 50 --wipe --warmup --base-url http://localhost:18080
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import secrets
+import ssl
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+
+HERE = Path(__file__).resolve().parent
+
+DEFAULT_BASE_URL = os.environ.get(
+    "FRONTDESK_BASE_URL", "http://localhost:18080",
+)
+DEFAULT_ADMIN_SECRET = os.environ.get("CULLIS_CONNECTOR_ADMIN_SECRET", "")
+
+
+async def _create_one(
+    session, base_url: str, admin_secret: str,
+    user_name: str, password: str, timeout_s: float,
+) -> tuple[str, str, Optional[str]]:
+    """One create-user call. Returns (user_name, status, error_detail)."""
+    try:
+        async with session.post(
+            f"{base_url}/admin/users",
+            json={
+                "user_name": user_name,
+                "password": password,
+                "must_change_password": False,
+                "display_name": f"Stress {user_name}",
+            },
+            headers={"X-Admin-Secret": admin_secret},
+            timeout=timeout_s,
+        ) as resp:
+            text = await resp.text()
+            if resp.status == 201:
+                return user_name, "created", None
+            if resp.status == 409:
+                # Already exists — re-runs are idempotent only if --wipe
+                # was used. Treat as "skipped" so the operator can spot
+                # the situation without it counting as failure.
+                return user_name, "exists", text[:200]
+            return user_name, "http_error", f"{resp.status}: {text[:200]}"
+    except Exception as exc:  # noqa: BLE001
+        return user_name, "exception", str(exc)
+
+
+async def _delete_prefix(
+    base_url: str, admin_secret: str, prefix: str,
+    *, concurrency: int, timeout_s: float, insecure_tls: bool,
+) -> int:
+    """Best-effort DELETE for every existing <prefix>-* user. Returns count."""
+    import aiohttp
+
+    ssl_ctx = None
+    if base_url.startswith("https://") and insecure_tls:
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    connector = aiohttp.TCPConnector(limit=concurrency, ssl=ssl_ctx)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        # List first, then delete each matching user. We paginate by
+        # asking for a large batch; /admin/users returns everything in
+        # one go for the sizes we work with here.
+        try:
+            async with session.get(
+                f"{base_url}/admin/users",
+                headers={"X-Admin-Secret": admin_secret},
+                timeout=timeout_s,
+            ) as resp:
+                if resp.status != 200:
+                    sys.stderr.write(
+                        f"  wipe: GET /admin/users returned {resp.status}, "
+                        "skipping wipe\n",
+                    )
+                    return 0
+                body = await resp.json()
+        except Exception as exc:  # noqa: BLE001
+            sys.stderr.write(f"  wipe: list call failed: {exc}\n")
+            return 0
+
+        targets = [
+            u["user_name"] for u in body.get("users", [])
+            if u["user_name"].startswith(f"{prefix}-")
+        ]
+        if not targets:
+            return 0
+
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _del_one(name: str) -> bool:
+            async with sem:
+                try:
+                    async with session.delete(
+                        f"{base_url}/admin/users/{name}",
+                        headers={"X-Admin-Secret": admin_secret},
+                        timeout=timeout_s,
+                    ) as resp:
+                        return resp.status in (200, 204, 404)
+                except Exception:  # noqa: BLE001
+                    return False
+
+        ok = await asyncio.gather(*[_del_one(n) for n in targets])
+        return sum(1 for x in ok if x)
+
+
+async def bulk_create_http(
+    base_url: str, admin_secret: str, users: list[dict],
+    *, concurrency: int, timeout_s: float, insecure_tls: bool,
+) -> dict:
+    """Parallel POST /admin/users for all users."""
+    import aiohttp
+
+    ssl_ctx = None
+    if base_url.startswith("https://") and insecure_tls:
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    connector = aiohttp.TCPConnector(limit=concurrency, ssl=ssl_ctx)
+    sem = asyncio.Semaphore(concurrency)
+    counts = {"created": 0, "exists": 0, "http_error": 0, "exception": 0}
+    errors_sample: list[dict] = []
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        async def bounded(u):
+            async with sem:
+                return await _create_one(
+                    session, base_url, admin_secret,
+                    u["user_name"], u["password"], timeout_s,
+                )
+
+        t0 = time.time()
+        coros = [bounded(u) for u in users]
+        for fut in asyncio.as_completed(coros):
+            user_name, status, detail = await fut
+            counts[status] = counts.get(status, 0) + 1
+            if status not in {"created", "exists"} and len(errors_sample) < 5:
+                errors_sample.append(
+                    {"user": user_name, "status": status, "detail": detail},
+                )
+
+    return {
+        **counts,
+        "errors_sample": errors_sample,
+        "elapsed_s": round(time.time() - t0, 2),
+        "rps": round(len(users) / max(time.time() - t0, 0.001), 1),
+    }
+
+
+async def _login_one(
+    session,
+    base_url: str,
+    user_name: str,
+    password: str,
+    timeout_s: float,
+) -> tuple[str, str, Optional[str]]:
+    """One login call. Returns (user_name, status, error_detail)."""
+    import aiohttp  # noqa: F401  imported for type
+    try:
+        async with session.post(
+            f"{base_url}/api/auth/login",
+            json={"user_name": user_name, "password": password},
+            timeout=timeout_s,
+        ) as resp:
+            text = await resp.text()
+            if resp.status != 200:
+                return user_name, "http_error", f"{resp.status}: {text[:200]}"
+            try:
+                body = json.loads(text)
+            except json.JSONDecodeError:
+                return user_name, "bad_json", text[:200]
+            prov = body.get("provisioning", "?")
+            if prov == "ok":
+                return user_name, "ok", None
+            return user_name, f"prov_{prov}", body.get("provisioning_detail")
+    except Exception as exc:  # noqa: BLE001
+        return user_name, "exception", str(exc)
+
+
+async def warmup_logins(
+    base_url: str,
+    users: list[dict],
+    *,
+    concurrency: int,
+    timeout_s: float,
+    insecure_tls: bool,
+) -> dict:
+    """Parallel login pre-warm. Populates the per-user cred cache."""
+    import aiohttp
+
+    ssl_ctx = None
+    if base_url.startswith("https://") and insecure_tls:
+        ssl_ctx = ssl.create_default_context()
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    connector = aiohttp.TCPConnector(limit=concurrency, ssl=ssl_ctx)
+    sem = asyncio.Semaphore(concurrency)
+    results = {"ok": 0, "prov_deferred": 0, "prov_skipped": 0,
+               "http_error": 0, "exception": 0, "bad_json": 0,
+               "errors_sample": []}
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        async def bounded(u):
+            async with sem:
+                return await _login_one(
+                    session, base_url, u["user_name"], u["password"], timeout_s,
+                )
+
+        t0 = time.time()
+        coros = [bounded(u) for u in users]
+        for fut in asyncio.as_completed(coros):
+            user_name, status, detail = await fut
+            key = status if status in results else "exception"
+            results[key] = results.get(key, 0) + 1
+            if status != "ok" and len(results["errors_sample"]) < 5:
+                results["errors_sample"].append(
+                    {"user": user_name, "status": status, "detail": detail},
+                )
+
+    results["elapsed_s"] = round(time.time() - t0, 2)
+    results["rps"] = round(len(users) / max(results["elapsed_s"], 0.001), 1)
+    return results
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--n", type=int, required=True, help="number of users to seed")
+    p.add_argument("--prefix", default="stress",
+                   help="user_name prefix (default 'stress' → stress-00001..)")
+    p.add_argument("--wipe", action="store_true",
+                   help="DELETE any prior <prefix>-* users via /admin/users first")
+    p.add_argument("--password", default=None,
+                   help="shared password (default: random 24-char)")
+    p.add_argument("--base-url", default=DEFAULT_BASE_URL,
+                   help=f"Frontdesk base URL (default {DEFAULT_BASE_URL})")
+    p.add_argument("--admin-secret", default=DEFAULT_ADMIN_SECRET,
+                   help="X-Admin-Secret value (default from "
+                        "CULLIS_CONNECTOR_ADMIN_SECRET env)")
+    p.add_argument("--create-concurrency", type=int, default=10,
+                   help="max concurrent /admin/users POSTs (default 10; bcrypt "
+                        "cost 12 saturates CPU above this)")
+    p.add_argument("--create-timeout-s", type=float, default=30.0,
+                   help="per-create timeout in seconds (default 30)")
+    p.add_argument("--warmup", action="store_true",
+                   help="run parallel pre-login to warm provisioner cache")
+    p.add_argument("--warmup-concurrency", type=int, default=20,
+                   help="max concurrent logins during warmup (default 20)")
+    p.add_argument("--warmup-timeout-s", type=float, default=30.0,
+                   help="per-login timeout in seconds (default 30)")
+    p.add_argument("--insecure-tls", action="store_true",
+                   help="skip TLS verify (for self-signed Frontdesk certs)")
+    p.add_argument("--output", default=str(HERE / "stress_frontdesk_users.json"),
+                   help="where to write the user manifest")
+    args = p.parse_args()
+
+    if args.n < 1:
+        sys.exit("--n must be >= 1")
+    if not args.admin_secret:
+        sys.exit(
+            "missing admin secret. Pass --admin-secret or set "
+            "CULLIS_CONNECTOR_ADMIN_SECRET. For the sandbox dogfood run:\n"
+            "  CULLIS_CONNECTOR_ADMIN_SECRET=$(docker exec "
+            "dogfood-frontdesk-frontdesk-connector-1 "
+            "sh -c 'echo $CULLIS_CONNECTOR_ADMIN_SECRET')",
+        )
+
+    password = args.password or secrets.token_urlsafe(18) + "Aa1!"
+    if len(password) < 8:
+        sys.exit("password too short (need >=8 chars)")
+
+    users = [
+        {"user_name": f"{args.prefix}-{i:05d}", "password": password}
+        for i in range(1, args.n + 1)
+    ]
+
+    if args.wipe:
+        sys.stderr.write(
+            f"  wipe: deleting any prior '{args.prefix}-*' users...\n",
+        )
+        deleted = asyncio.run(_delete_prefix(
+            args.base_url, args.admin_secret, args.prefix,
+            concurrency=args.warmup_concurrency,
+            timeout_s=args.create_timeout_s,
+            insecure_tls=args.insecure_tls,
+        ))
+        sys.stderr.write(f"  wipe: deleted {deleted} prior rows\n")
+
+    sys.stderr.write(
+        f"  creating {len(users)} users via POST /admin/users "
+        f"(concurrency={args.create_concurrency})...\n",
+    )
+    create_report = asyncio.run(bulk_create_http(
+        args.base_url, args.admin_secret, users,
+        concurrency=args.create_concurrency,
+        timeout_s=args.create_timeout_s,
+        insecure_tls=args.insecure_tls,
+    ))
+    sys.stderr.write(
+        f"  create done in {create_report['elapsed_s']}s "
+        f"({create_report['rps']}/s) created={create_report['created']} "
+        f"exists={create_report['exists']} "
+        f"errors={create_report['http_error'] + create_report['exception']}\n",
+    )
+    if create_report["created"] + create_report["exists"] < len(users) * 0.95:
+        sys.exit(
+            f"FAIL: fewer than 95% of users were created. "
+            f"errors={create_report['errors_sample']}",
+        )
+
+    manifest = {
+        "base_url": args.base_url,
+        "prefix": args.prefix,
+        "shared_password": password,
+        "n_users": args.n,
+        "users": users,
+        "create_report": create_report,
+    }
+
+    if args.warmup:
+        sys.stderr.write(
+            f"  warmup: parallel login on {len(users)} users "
+            f"(concurrency={args.warmup_concurrency})...\n",
+        )
+        warm = asyncio.run(warmup_logins(
+            args.base_url, users,
+            concurrency=args.warmup_concurrency,
+            timeout_s=args.warmup_timeout_s,
+            insecure_tls=args.insecure_tls,
+        ))
+        manifest["warmup"] = warm
+        sys.stderr.write(
+            f"  warmup done in {warm['elapsed_s']}s "
+            f"({warm['rps']}/s) ok={warm['ok']} "
+            f"deferred={warm.get('prov_deferred', 0)} "
+            f"errors={warm.get('http_error', 0) + warm.get('exception', 0)}\n",
+        )
+        if warm["ok"] < len(users) * 0.95:
+            sys.stderr.write(
+                f"  WARN: fewer than 95% of warmup logins succeeded. "
+                f"Inspect errors_sample in {args.output}.\n",
+            )
+
+    Path(args.output).write_text(json.dumps(manifest, indent=2))
+    sys.stderr.write(f"  manifest -> {args.output} ({len(users)} users)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/frontdesk-multiuser-mock.js
+++ b/scripts/stress/frontdesk-multiuser-mock.js
@@ -1,0 +1,242 @@
+// Cullis Frontdesk multi-user mock burst.
+//
+// Stresses the Frontdesk user-path WITHOUT involving an LLM upstream, so
+// the resulting RPS curve reflects auth + per-user credential fork +
+// nginx TLS sidecar + Frontdesk -> Mastio mTLS hop — not the LLM.
+//
+// Each VU = one pre-seeded Frontdesk user (see
+// ``scripts/stress/bulk_create_frontdesk_users.py``). First iteration
+// per VU: POST /api/auth/login (cookie cached in the per-VU jar).
+// Subsequent iterations: GET /v1/models loop. List models is cookie-
+// authed, forwards to Mastio via the user cert minted by the
+// LocalUserProvisioner during login.
+//
+// Run::
+//
+//   nix-shell -p k6 --run "K6_SKIP_NDJSON=1 \\
+//       bash scripts/stress/_run-k6.sh frontdesk-multiuser-mock.js"
+//
+// Tuning hooks (env):
+//
+//   - USERS_FILE      path to stress_frontdesk_users.json
+//                     (default sibling of this script)
+//   - STAGE_OVERRIDE  JSON ramp override
+//                     (e.g. '[{"duration":"30s","target":100}]')
+//   - THINK_MS        inter-iteration sleep (default 0)
+//   - REQ_TIMEOUT_S   per-request timeout (default 30)
+//   - LOGIN_AT_START  if "1" (default), per-VU login on first iter;
+//                     useful when pre-warmup populated the cache
+//                     already and we just need the cookie
+
+import http from "k6/http";
+import { check, sleep, fail } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+import { SharedArray } from "k6/data";
+
+
+// ── Tunables ──────────────────────────────────────────────────────────
+
+const USERS_FILE = __ENV.USERS_FILE || "./stress_frontdesk_users.json";
+const THINK_MS = parseInt(__ENV.THINK_MS || "0", 10);
+const REQ_TIMEOUT = `${parseInt(__ENV.REQ_TIMEOUT_S || "30", 10)}s`;
+const LOGIN_AT_START = (__ENV.LOGIN_AT_START || "1") === "1";
+
+
+// ── Stages ────────────────────────────────────────────────────────────
+
+const DEFAULT_STAGES = [
+    { duration: "30s",  target: 50 },
+    { duration: "120s", target: 50 },
+    { duration: "30s",  target: 200 },
+    { duration: "120s", target: 200 },
+    { duration: "30s",  target: 500 },
+    { duration: "120s", target: 500 },
+    { duration: "30s",  target: 0 },
+];
+
+const STAGES = __ENV.STAGE_OVERRIDE
+    ? JSON.parse(__ENV.STAGE_OVERRIDE)
+    : DEFAULT_STAGES;
+
+
+// ── Shared data ───────────────────────────────────────────────────────
+
+const MANIFEST = new SharedArray("frontdesk-users", () => {
+    const bundle = JSON.parse(open(USERS_FILE));
+    if (!bundle.users || bundle.users.length === 0) {
+        fail(`USERS_FILE ${USERS_FILE} contains no users`);
+    }
+    if (!bundle.base_url) {
+        fail(`USERS_FILE ${USERS_FILE} missing base_url`);
+    }
+    // SharedArray expects an array. We pack base_url onto each user so
+    // the VU code can read it without crossing isolation boundaries.
+    return bundle.users.map((u) => ({
+        user_name: u.user_name,
+        password: u.password,
+        base_url: bundle.base_url,
+    }));
+});
+
+
+// ── Metrics ───────────────────────────────────────────────────────────
+
+const loginLatency = new Trend("cullis_fd_login_latency_ms");
+const modelsLatency = new Trend("cullis_fd_models_latency_ms");
+const loginErrors = new Rate("cullis_fd_login_error_rate");
+const modelsErrors = new Rate("cullis_fd_models_error_rate");
+const loginCount = new Counter("cullis_fd_login_count");
+const modelsCount = new Counter("cullis_fd_models_count");
+const provDeferred = new Counter("cullis_fd_provisioning_deferred");
+
+
+// ── Options ───────────────────────────────────────────────────────────
+
+export const options = {
+    insecureSkipTLSVerify: true,
+    discardResponseBodies: false,
+    summaryTrendStats: ["avg", "min", "med", "p(95)", "p(99)", "max"],
+    scenarios: {
+        frontdesk_burst: {
+            executor: "ramping-vus",
+            startVUs: 0,
+            stages: STAGES,
+            gracefulRampDown: "30s",
+        },
+    },
+    thresholds: {
+        // Loose thresholds — this is a stress test, not a release gate.
+        "cullis_fd_login_error_rate":  ["rate<0.50"],
+        "cullis_fd_models_error_rate": ["rate<0.50"],
+    },
+};
+
+
+// ── Per-VU state ──────────────────────────────────────────────────────
+
+const vuState = new Map();  // VU index -> { loggedIn: bool, userIdx: int }
+
+function getVuUser() {
+    const idx = (__VU - 1) % MANIFEST.length;
+    return MANIFEST[idx];
+}
+
+
+// ── Endpoints ─────────────────────────────────────────────────────────
+
+function login(user) {
+    const resp = http.post(
+        `${user.base_url}/api/auth/login`,
+        JSON.stringify({
+            user_name: user.user_name,
+            password: user.password,
+        }),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                "Origin": user.base_url,
+            },
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "auth_login" },
+        },
+    );
+    loginLatency.add(resp.timings.duration);
+    const ok = check(resp, {
+        "login 200": (r) => r.status === 200,
+    });
+    loginErrors.add(!ok);
+    loginCount.add(1);
+    if (ok && resp.body) {
+        // ``provisioning`` is one of ok / deferred / skipped. Count
+        // deferred separately so the operator can spot Mastio outages
+        // mid-run without parsing the full ndjson.
+        if (resp.body.indexOf("\"provisioning\":\"deferred\"") >= 0) {
+            provDeferred.add(1);
+        }
+    }
+    return ok;
+}
+
+function listModels(user) {
+    const resp = http.get(
+        `${user.base_url}/v1/models`,
+        {
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "v1_models" },
+        },
+    );
+    modelsLatency.add(resp.timings.duration);
+    // 502 from Frontdesk means provisioning was deferred and the
+    // upstream cert is missing — treat as model-call failure but
+    // don't crash the VU; the next login may recover.
+    const ok = resp.status === 200;
+    modelsErrors.add(!ok);
+    modelsCount.add(1);
+    return ok;
+}
+
+
+// ── VU body ───────────────────────────────────────────────────────────
+
+export default function () {
+    let state = vuState.get(__VU);
+    if (!state) {
+        state = { loggedIn: false, user: getVuUser() };
+        vuState.set(__VU, state);
+    }
+
+    if (LOGIN_AT_START && !state.loggedIn) {
+        if (!login(state.user)) {
+            // Failed login — sleep briefly so we don't burn CPU on
+            // retry storms. The error rate already captured it.
+            sleep(1);
+            return;
+        }
+        state.loggedIn = true;
+    }
+
+    listModels(state.user);
+
+    if (THINK_MS > 0) sleep(THINK_MS / 1000);
+}
+
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+    return {
+        stdout: textSummary(data),
+        "frontdesk-summary-mock.json": JSON.stringify(data, null, 2),
+    };
+}
+
+function textSummary(data) {
+    const m = data.metrics;
+    function pct(metric, key) {
+        return ((metric?.values?.[key]) || 0).toFixed(1);
+    }
+    const lines = [];
+    lines.push("");
+    lines.push("════ Cullis Frontdesk multi-user MOCK summary ════");
+    lines.push("");
+    lines.push(`  Users loaded:        ${MANIFEST.length}`);
+    lines.push(`  Total requests:      ${m.http_reqs?.values?.count ?? 0}`);
+    lines.push(`  Requests per sec:    ${(m.http_reqs?.values?.rate ?? 0).toFixed(1)} RPS`);
+    lines.push(`  Logins:              ${m.cullis_fd_login_count?.values?.count ?? 0}`);
+    lines.push(`  Models calls:        ${m.cullis_fd_models_count?.values?.count ?? 0}`);
+    lines.push(`  Provisioning defer:  ${m.cullis_fd_provisioning_deferred?.values?.count ?? 0}`);
+    lines.push("");
+    lines.push("  POST /api/auth/login:");
+    lines.push(`    error rate   ${((m.cullis_fd_login_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_fd_login_latency_ms, "avg")} / ${pct(m.cullis_fd_login_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_fd_login_latency_ms, "p(95)")} / ${pct(m.cullis_fd_login_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_fd_login_latency_ms, "max")} ms`);
+    lines.push("");
+    lines.push("  GET /v1/models:");
+    lines.push(`    error rate   ${((m.cullis_fd_models_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_fd_models_latency_ms, "avg")} / ${pct(m.cullis_fd_models_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_fd_models_latency_ms, "p(95)")} / ${pct(m.cullis_fd_models_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_fd_models_latency_ms, "max")} ms`);
+    lines.push("");
+    return lines.join("\n");
+}

--- a/scripts/stress/frontdesk-multiuser-ollama.js
+++ b/scripts/stress/frontdesk-multiuser-ollama.js
@@ -1,0 +1,244 @@
+// Cullis Frontdesk multi-user Ollama burst.
+//
+// Customer-realistic stress: each VU logs in once, then loops
+// chat_completion against the LLM provider configured on the Mastio
+// (default Ollama qwen2.5:0.5b — see ``sandbox/dogfood-frontdesk.sh``
+// for the bring-up). RPS curve reflects the FULL chat path including
+// Ollama inference time, so latency numbers cannot be compared directly
+// to the mock burst — read this as "what does the demo end-to-end look
+// like under N concurrent users".
+//
+// VU cycle:
+//   1. (first iteration) POST /api/auth/login → cookie jar caches
+//      session, LocalUserProvisioner cache populated by Mastio CSR.
+//   2. POST /v1/chat/completions with a short fixed prompt.
+//
+// Run::
+//
+//   nix-shell -p k6 --run "K6_SKIP_NDJSON=1 \\
+//       bash scripts/stress/_run-k6.sh frontdesk-multiuser-ollama.js"
+//
+// Tuning hooks (env):
+//   - USERS_FILE      path to stress_frontdesk_users.json
+//   - STAGE_OVERRIDE  JSON ramp override
+//   - THINK_MS        inter-iteration sleep (default 500 — LLM-bound)
+//   - REQ_TIMEOUT_S   per-request timeout (default 60 — LLM cold start)
+//   - MODEL           LiteLLM model identifier
+//                     (default ollama_chat/qwen2.5:0.5b)
+//   - MAX_TOKENS      cap on response length (default 16 — keep LLM cost low)
+
+import http from "k6/http";
+import { check, sleep, fail } from "k6";
+import { Counter, Rate, Trend } from "k6/metrics";
+import { SharedArray } from "k6/data";
+
+
+// ── Tunables ──────────────────────────────────────────────────────────
+
+const USERS_FILE = __ENV.USERS_FILE || "./stress_frontdesk_users.json";
+const THINK_MS = parseInt(__ENV.THINK_MS || "500", 10);
+const REQ_TIMEOUT = `${parseInt(__ENV.REQ_TIMEOUT_S || "60", 10)}s`;
+const MODEL = __ENV.MODEL || "ollama_chat/qwen2.5:0.5b";
+const MAX_TOKENS = parseInt(__ENV.MAX_TOKENS || "16", 10);
+
+
+// ── Stages ────────────────────────────────────────────────────────────
+
+// Ollama on a single small model saturates quickly — lower ceilings
+// than the mock burst on purpose. Override via STAGE_OVERRIDE on
+// fatter LLM upstreams (e.g. cluster of Ollama replicas).
+const DEFAULT_STAGES = [
+    { duration: "30s",  target: 10 },
+    { duration: "60s",  target: 10 },
+    { duration: "30s",  target: 30 },
+    { duration: "120s", target: 30 },
+    { duration: "30s",  target: 50 },
+    { duration: "120s", target: 50 },
+    { duration: "30s",  target: 0 },
+];
+
+const STAGES = __ENV.STAGE_OVERRIDE
+    ? JSON.parse(__ENV.STAGE_OVERRIDE)
+    : DEFAULT_STAGES;
+
+
+// ── Shared data ───────────────────────────────────────────────────────
+
+const MANIFEST = new SharedArray("frontdesk-users", () => {
+    const bundle = JSON.parse(open(USERS_FILE));
+    if (!bundle.users || bundle.users.length === 0) {
+        fail(`USERS_FILE ${USERS_FILE} contains no users`);
+    }
+    if (!bundle.base_url) {
+        fail(`USERS_FILE ${USERS_FILE} missing base_url`);
+    }
+    return bundle.users.map((u) => ({
+        user_name: u.user_name,
+        password: u.password,
+        base_url: bundle.base_url,
+    }));
+});
+
+
+// ── Metrics ───────────────────────────────────────────────────────────
+
+const loginLatency = new Trend("cullis_fd_login_latency_ms");
+const chatLatency = new Trend("cullis_fd_chat_latency_ms");
+const loginErrors = new Rate("cullis_fd_login_error_rate");
+const chatErrors = new Rate("cullis_fd_chat_error_rate");
+const loginCount = new Counter("cullis_fd_login_count");
+const chatCount = new Counter("cullis_fd_chat_count");
+const chatTimeouts = new Counter("cullis_fd_chat_timeouts");
+
+
+// ── Options ───────────────────────────────────────────────────────────
+
+export const options = {
+    insecureSkipTLSVerify: true,
+    discardResponseBodies: false,
+    summaryTrendStats: ["avg", "min", "med", "p(95)", "p(99)", "max"],
+    scenarios: {
+        frontdesk_ollama: {
+            executor: "ramping-vus",
+            startVUs: 0,
+            stages: STAGES,
+            gracefulRampDown: "30s",
+        },
+    },
+    thresholds: {
+        "cullis_fd_login_error_rate": ["rate<0.50"],
+        "cullis_fd_chat_error_rate":  ["rate<0.50"],
+    },
+};
+
+
+// ── Per-VU state ──────────────────────────────────────────────────────
+
+const vuState = new Map();
+
+function getVuUser() {
+    const idx = (__VU - 1) % MANIFEST.length;
+    return MANIFEST[idx];
+}
+
+
+// ── Endpoints ─────────────────────────────────────────────────────────
+
+function login(user) {
+    const resp = http.post(
+        `${user.base_url}/api/auth/login`,
+        JSON.stringify({
+            user_name: user.user_name,
+            password: user.password,
+        }),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                "Origin": user.base_url,
+            },
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "auth_login" },
+        },
+    );
+    loginLatency.add(resp.timings.duration);
+    const ok = resp.status === 200;
+    loginErrors.add(!ok);
+    loginCount.add(1);
+    return ok;
+}
+
+function chatCompletion(user) {
+    const body = JSON.stringify({
+        model: MODEL,
+        messages: [
+            { role: "user", content: "Reply with exactly the word: cullis" },
+        ],
+        max_tokens: MAX_TOKENS,
+    });
+    const resp = http.post(
+        `${user.base_url}/v1/chat/completions`,
+        body,
+        {
+            headers: {
+                "Content-Type": "application/json",
+                "Origin": user.base_url,
+            },
+            timeout: REQ_TIMEOUT,
+            tags: { endpoint: "v1_chat_completions" },
+        },
+    );
+    chatLatency.add(resp.timings.duration);
+    const ok = resp.status === 200;
+    chatErrors.add(!ok);
+    chatCount.add(1);
+    if (resp.status === 0) {
+        // k6 reports status 0 on timeout / connection reset.
+        chatTimeouts.add(1);
+    }
+    return ok;
+}
+
+
+// ── VU body ───────────────────────────────────────────────────────────
+
+export default function () {
+    let state = vuState.get(__VU);
+    if (!state) {
+        state = { loggedIn: false, user: getVuUser() };
+        vuState.set(__VU, state);
+    }
+
+    if (!state.loggedIn) {
+        if (!login(state.user)) {
+            sleep(1);
+            return;
+        }
+        state.loggedIn = true;
+    }
+
+    chatCompletion(state.user);
+
+    if (THINK_MS > 0) sleep(THINK_MS / 1000);
+}
+
+
+// ── Summary ───────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+    return {
+        stdout: textSummary(data),
+        "frontdesk-summary-ollama.json": JSON.stringify(data, null, 2),
+    };
+}
+
+function textSummary(data) {
+    const m = data.metrics;
+    function pct(metric, key) {
+        return ((metric?.values?.[key]) || 0).toFixed(1);
+    }
+    const lines = [];
+    lines.push("");
+    lines.push("════ Cullis Frontdesk multi-user OLLAMA summary ════");
+    lines.push("");
+    lines.push(`  Users loaded:        ${MANIFEST.length}`);
+    lines.push(`  Model:               ${MODEL}`);
+    lines.push(`  Total requests:      ${m.http_reqs?.values?.count ?? 0}`);
+    lines.push(`  Requests per sec:    ${(m.http_reqs?.values?.rate ?? 0).toFixed(1)} RPS`);
+    lines.push(`  Logins:              ${m.cullis_fd_login_count?.values?.count ?? 0}`);
+    lines.push(`  Chat calls:          ${m.cullis_fd_chat_count?.values?.count ?? 0}`);
+    lines.push(`  Chat timeouts (0):   ${m.cullis_fd_chat_timeouts?.values?.count ?? 0}`);
+    lines.push("");
+    lines.push("  POST /api/auth/login:");
+    lines.push(`    error rate   ${((m.cullis_fd_login_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_fd_login_latency_ms, "avg")} / ${pct(m.cullis_fd_login_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_fd_login_latency_ms, "p(95)")} / ${pct(m.cullis_fd_login_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_fd_login_latency_ms, "max")} ms`);
+    lines.push("");
+    lines.push("  POST /v1/chat/completions:");
+    lines.push(`    error rate   ${((m.cullis_fd_chat_error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`);
+    lines.push(`    avg / p50    ${pct(m.cullis_fd_chat_latency_ms, "avg")} / ${pct(m.cullis_fd_chat_latency_ms, "med")} ms`);
+    lines.push(`    p95 / p99    ${pct(m.cullis_fd_chat_latency_ms, "p(95)")} / ${pct(m.cullis_fd_chat_latency_ms, "p(99)")} ms`);
+    lines.push(`    max          ${pct(m.cullis_fd_chat_latency_ms, "max")} ms`);
+    lines.push("");
+    return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Backport Mastio PR #697 nginx keepalive pattern to the Frontdesk bundle (inner + TLS sidecar). Without it, `connect() failed (99: Address not available)` under any sustained load (~10 concurrent users).
- First Frontdesk load test ever run measured the impact: pre-fix 90% login error rate + 14585 ENADDRNOTAVAIL critical lines in 60s; post-fix 0% login error + 0 ENADDRNOTAVAIL.
- Also ships the stress harness that found the bug (`scripts/stress/bulk_create_frontdesk_users.py` + `scripts/stress/frontdesk-multiuser-*.js`).

## What changed

**Frontdesk inner nginx** (`packaging/frontdesk-bundle/nginx/`):
- New `00-maps.conf` declares `connection_upgrade` (default empty string, not `close`).
- `default.conf` adds `connector_upstream` + `cullis_chat_upstream` keepalive pools and replaces `proxy_pass http://connector:7777$request_uri` (which disabled keepalive entirely) with the named upstream form. Every location now sets `Connection $connection_upgrade`.

**Frontdesk TLS sidecar** (`packaging/frontdesk-bundle/nginx-tls/`):
- `00-maps.conf` flips pre-fix `'' close` → `'' ""` so the TLS hop also reuses inner-nginx sockets.
- `default.conf` adds `inner_nginx_upstream` and drops `set $inner_upstream …; proxy_pass $var;` (variable-form `proxy_pass` cannot bind to a keepalive pool).

**Compose mount** (`packaging/frontdesk-bundle/docker-compose.yml`):
- Adds `./nginx/00-maps.conf:/etc/nginx/conf.d/00-maps.conf:ro` on the inner nginx service so the map loads before `default.conf` in the http context.

**Stress harness** (new):
- `scripts/stress/bulk_create_frontdesk_users.py` seeds N test users via `POST /admin/users` + optional warmup login pass to populate the `LocalUserProvisioner` cache.
- `scripts/stress/frontdesk-multiuser-mock.js` k6 scenario: login + list_models, no LLM upstream. Isolates Frontdesk software perf.
- `scripts/stress/frontdesk-multiuser-ollama.js` k6 scenario: login + chat_completions against the configured AI provider. Customer-realistic.
- `scripts/stress/README.md` documents the new section. `.gitignore` covers the local-only manifest + summary outputs.

## Measurement

Sandbox `bash sandbox/dogfood-frontdesk.sh --keep`, 50 stress users pre-seeded + warmed (provisioning=ok), k6 mock scenario with `STAGE_OVERRIDE='[{\"duration\":\"60s\",\"target\":50}]'`:

| Run | Login error | Login p99 | nginx ENADDRNOTAVAIL / 60s |
|---|---|---|---|
| Pre-fix | 90% | 419ms | 14585 |
| Post-fix | 0% | 1219ms (bcrypt queue) | **0** |

The post-fix p99 latency reflects bcrypt cost-12 contention under 50 concurrent fresh logins — that is a separate follow-up (lazy session cache or cost-tuning), not a regression vs. pre-fix.

Full baseline note in `imp/2026-05-20-frontdesk-load-test-baseline.md` (local-only).

## Test plan
- [x] `k6 inspect` clean on both new scenarios
- [x] `python -m py_compile scripts/stress/bulk_create_frontdesk_users.py`
- [x] 50/50 user seed + warmup login = 100% provisioning=ok
- [x] k6 mock 50 VUs / 60s post-fix: 0% login error rate, 0 ENADDRNOTAVAIL
- [ ] Re-run on the VM bundle after merge to confirm the same numbers in a customer-shaped environment
- [ ] Ollama variant pending Mastio AI provider configured in the target sandbox (not blocking this fix)