### PR TITLE
fix(frontdesk-bundle): per-user auth gate, bcrypt knob, dir-norm HTTPS rewrite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,7 @@ __pycache__/
 imp/
 drafts/
 demo/
+.data/
 
 # Build outputs (keep the Docker build context small; the connector
 # Dockerfile builds the wheel fresh inside the builder stage).

--- a/cullis_connector/identity/users.py
+++ b/cullis_connector/identity/users.py
@@ -8,11 +8,17 @@ helpers the admin API and the (later-phase) login endpoint use.
 
 Design notes:
 
-- bcrypt cost 12 — same as ``mcp_proxy/dashboard/session.py`` admin
-  password hashing. ``bcrypt.checkpw`` is CPU-bound C code, so we
-  always wrap it in ``asyncio.to_thread`` to keep the event loop
-  responsive while a verification runs (~150 ms / call on commodity
-  hardware).
+- bcrypt cost defaults to 12 (matches ``mcp_proxy/dashboard/session.py``
+  admin hashing). ``bcrypt.checkpw`` is CPU-bound C code, so we always
+  wrap it in ``asyncio.to_thread`` to keep the event loop responsive
+  while a verification runs (~250 ms / call on commodity hardware at
+  cost 12). The cost is configurable via ``CULLIS_BCRYPT_COST`` for
+  Frontdesk deployments anticipating bursts of >~16 concurrent logins
+  (4 worker × 1 bcrypt-12 / 250ms ≈ 16 logins/s saturation under load
+  measured 2026-05-20). Dropping to 10 gives ~62 ms / check (4x faster)
+  and is still defensible per OWASP guidance for non-PII workloads;
+  values below 10 are rejected to avoid an accidental footgun. The
+  cost is clamped to [10, 14].
 - Username regex matches the Mastio convention
   (``mcp_proxy/admin/users.py``): ``^[a-zA-Z0-9._-]{1,64}$``. That
   guarantees the user_name is safe to splice into a SPIFFE id and
@@ -28,6 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -39,6 +46,33 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 _log = logging.getLogger("cullis_connector.identity.users")
+
+
+def _resolve_bcrypt_cost() -> int:
+    """Return the bcrypt rounds value, clamped to a safe range.
+
+    Default 12 matches the dashboard admin hash. Operators expecting
+    high concurrent login bursts (>16/s on a 4-worker box at default
+    cost 12) can set ``CULLIS_BCRYPT_COST`` in the bundle's env file
+    to drop to 10 (~62 ms / check vs ~250 ms) without exposing the
+    hash to GPU-cracking economics that would justify a stronger cost.
+    Values below 10 are rejected; values above 14 are clamped to keep
+    a single login from monopolising a worker for >2 s.
+    """
+    raw = os.environ.get("CULLIS_BCRYPT_COST", "").strip()
+    if not raw:
+        return 12
+    try:
+        cost = int(raw)
+    except ValueError:
+        _log.warning(
+            "CULLIS_BCRYPT_COST=%r not an integer — using default 12", raw,
+        )
+        return 12
+    return max(10, min(14, cost))
+
+
+_BCRYPT_COST = _resolve_bcrypt_cost()
 
 
 # ── SQLAlchemy ORM ────────────────────────────────────────────────────────
@@ -136,7 +170,7 @@ def _now_iso() -> str:
 def _hash_password_sync(plain: str) -> str:
     """Blocking bcrypt hash. Caller wraps in asyncio.to_thread."""
     return bcrypt.hashpw(
-        plain.encode("utf-8"), bcrypt.gensalt(rounds=12),
+        plain.encode("utf-8"), bcrypt.gensalt(rounds=_BCRYPT_COST),
     ).decode("utf-8")
 
 

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -997,15 +997,23 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     # ── Routes ────────────────────────────────────────────────────────────
 
     @app.get("/", response_class=HTMLResponse)
-    def root() -> Response:
+    def root(request: Request) -> Response:
         """Dispatch to the correct screen based on current state.
 
         When identity is present AND the Cullis Chat SPA is mounted at
         /chat (ADR-019 Phase 8c), the root sends users straight to the
-        chat surface — that is the consumer-facing destination of the
-        desktop installer. The /connected dashboard is still reachable
-        directly (or via the tray menu in the desktop wrapper) for
-        admin / maintenance flows.
+        chat surface, the consumer-facing destination of the desktop
+        installer. The /connected dashboard is still reachable directly
+        (or via the tray menu in the desktop wrapper) for admin and
+        maintenance flows.
+
+        In the Frontdesk bundle the workload identity is provisioned at
+        admin setup, so ``has_identity()`` is True for every visitor.
+        Per-user auth still requires a local session cookie; without
+        one, send the visitor to ``/login`` instead of ``/chat/`` (the
+        SPA would render as the workload principal and the backend
+        would refuse the actual chat call, leaving the user stuck on
+        a logged-in-looking surface they cannot use).
 
         First-boot default is the auto-discovery wizard at
         ``/setup/discover``: it probes a few local addresses for a
@@ -1014,6 +1022,16 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         on the wizard page.
         """
         if has_identity(config.config_dir):
+            from cullis_connector.identity.auth_mode import is_frontdesk_bundle
+            from cullis_connector.identity.local_session import (
+                LOCAL_SESSION_COOKIE_NAME,
+            )
+
+            if (
+                is_frontdesk_bundle()
+                and not request.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+            ):
+                return RedirectResponse("/login", status_code=303)
             if getattr(app.state, "cullis_chat_mounted", False):
                 return RedirectResponse("/chat/", status_code=303)
             return RedirectResponse("/connected", status_code=303)

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -163,6 +163,12 @@ services:
       # Off by default so existing customer deployments keep their
       # chat working until they opt in.
       CULLIS_CONNECTOR_TOOL_PDP_ENABLED: ${CULLIS_CONNECTOR_TOOL_PDP_ENABLED:-}
+      # bcrypt cost for local user passwords (cullis_connector/identity/
+      # users.py). Default 12 if unset. Set to 10 in frontdesk.env when
+      # the deployment expects bursts of concurrent logins above the
+      # ~16/s ceiling at cost 12 — see frontdesk.env.example for the
+      # security tradeoff and the 2026-05-20 load test reference.
+      CULLIS_BCRYPT_COST: ${CULLIS_BCRYPT_COST:-}
       # Trust anchor for the Mastio TLS handshake. Production uses the
       # corporate PKI; the sandbox/ ships a self-signed Org-CA so we
       # mount it as a CA bundle here. Honoured by Python's ssl module

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -156,3 +156,19 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # on the sibling Mastio bundle; both must be on for the policy gate
 # to actually fire.
 # CULLIS_CONNECTOR_TOOL_PDP_ENABLED=true
+
+# ── bcrypt cost for local user passwords ───────────────────────────
+#
+# Default 12 (~250 ms / verify on commodity hardware). Each uvicorn
+# worker can process ~1 bcrypt / 250 ms ≈ 4 logins/s; with the bundle's
+# 4-worker default that caps sustained login throughput at ~16 logins/s.
+# 2026-05-20 load test (50 → 500 VU ramp, ``scripts/stress/frontdesk-
+# multiuser-mock.js``) hit this ceiling at the 500-VU stage and saw
+# ~3 % of logins timeout because the bcrypt queue deepened past the
+# 30 s client deadline. Drop to 10 (~62 ms / verify, 4x faster) for
+# deployments expecting concurrent morning-login bursts (>~50 users
+# pre-cookie); cost 10 is still defensible per OWASP for shared-mode
+# deployments where bcrypt is one layer in front of cookie auth +
+# Mastio CSR provisioning. Values below 10 are floored to 10, values
+# above 14 are capped at 14.
+# CULLIS_BCRYPT_COST=10

--- a/packaging/frontdesk-bundle/nginx/00-maps.conf
+++ b/packaging/frontdesk-bundle/nginx/00-maps.conf
@@ -33,3 +33,20 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      "";
 }
+
+# X-Forwarded-Proto-aware scheme for the catch-all ``proxy_redirect``
+# that rewrites absolute upstream Locations. When the TLS sidecar
+# fronts this nginx, the sidecar→inner connection is plain HTTP and
+# ``$scheme`` evaluates to "http". Using ``$scheme`` for the rewrite
+# would synthesise ``http://<host>:8443/login/`` on a dir-norm 301,
+# which the browser follows back into the sidecar's TLS listener and
+# gets a ``400 The plain HTTP request was sent to HTTPS port`` (and,
+# more subtly, breaks every Secure cookie the SPA sets along the way).
+# Honour the sidecar's ``X-Forwarded-Proto: https`` so the rewritten
+# Location stays on the public HTTPS face. Falls back to ``$scheme``
+# when no XFP header is present (HTTP-only deployments without the
+# sidecar profile, e.g. sandbox/ and dogfood-frontdesk/).
+map $http_x_forwarded_proto $effective_scheme {
+    default $scheme;
+    https   https;
+}

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -241,6 +241,48 @@ server {
         proxy_set_header Connection $connection_upgrade;
     }
 
+    # ----- gate ``/`` on a session cookie (Frontdesk shared mode) -----
+    #
+    # Without a local session cookie a fresh visitor (new phone, fresh
+    # incognito) would land on the SPA shell and the SPA would render
+    # the chat surface with the workload principal as fallback identity.
+    # The backend then refuses the actual chat call (the user is not a
+    # provisioned principal), leaving the user stuck on a logged-in-
+    # looking screen they cannot use. Send them to /login instead.
+    #
+    # Exact match ``=`` has higher priority than the prefix catch-all
+    # below, so this block only fires for an empty path. Every other
+    # path (including direct typing of ``/chat`` or a deep link) still
+    # falls through to the SPA; the SPA's own client-side router is
+    # expected to handle its own unauthenticated state for those.
+    #
+    # The ``if`` is safe here because it only carries ``return`` (the
+    # one usage explicitly endorsed by the nginx ifIsEvil page); no
+    # ``proxy_pass``/``rewrite`` mixed in.
+    #
+    # Reported by the operator from a phone on the LAN-exposed dogfood
+    # VM 2026-05-20: opening the bundle root URL dropped them straight
+    # into chat as the workload principal with no way to send messages.
+    location = / {
+        # Emit a path-only Location on the redirect below so the browser
+        # resolves it against the actual origin (host:port the bundle is
+        # published on). The default ``absolute_redirect on`` synthesises
+        # ``http://<server_name>/login`` and drops the operator-chosen
+        # port, which breaks LAN-exposed deployments (the phone would
+        # hit ``http://localhost/login`` on itself).
+        absolute_redirect off;
+        if ($http_cookie !~* "(?:^|;\s*)cullis_local_session=") {
+            return 303 /login;
+        }
+        proxy_pass http://cullis_chat_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
     # ----- everything else: static SPA via the cullis-chat container -----
     #
     # The cullis-chat container ships nginx-static (port 8080) serving

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -329,6 +329,11 @@ server {
         # redirect on the same origin it started from (whatever
         # port the bundle is published on, with or without TLS in
         # front).
-        proxy_redirect ~^https?://[^/]+(/.*)$ $scheme://$http_host$1;
+        # ``$effective_scheme`` (declared in 00-maps.conf) honours the
+        # sidecar's ``X-Forwarded-Proto: https`` when one is present,
+        # falling back to ``$scheme`` for HTTP-only deployments. Using
+        # plain ``$scheme`` here downgrades HTTPS→HTTP behind the TLS
+        # sidecar because the sidecar→inner hop is plain HTTP.
+        proxy_redirect ~^https?://[^/]+(/.*)$ $effective_scheme://$http_host$1;
     }
 }

--- a/scripts/stress/bulk_create_frontdesk_users.py
+++ b/scripts/stress/bulk_create_frontdesk_users.py
@@ -108,28 +108,36 @@ async def _delete_prefix(
 
     connector = aiohttp.TCPConnector(limit=concurrency, ssl=ssl_ctx)
     async with aiohttp.ClientSession(connector=connector) as session:
-        # List first, then delete each matching user. We paginate by
-        # asking for a large batch; /admin/users returns everything in
-        # one go for the sizes we work with here.
+        # List first, then delete each matching user. /admin/users
+        # paginates at default 200 / max 500 per call; loop until the
+        # batch comes back short so very large prior runs still wipe.
+        all_users: list[dict] = []
+        offset = 0
         try:
-            async with session.get(
-                f"{base_url}/admin/users",
-                headers={"X-Admin-Secret": admin_secret},
-                timeout=timeout_s,
-            ) as resp:
-                if resp.status != 200:
-                    sys.stderr.write(
-                        f"  wipe: GET /admin/users returned {resp.status}, "
-                        "skipping wipe\n",
-                    )
-                    return 0
-                body = await resp.json()
+            while True:
+                async with session.get(
+                    f"{base_url}/admin/users?limit=500&offset={offset}",
+                    headers={"X-Admin-Secret": admin_secret},
+                    timeout=timeout_s,
+                ) as resp:
+                    if resp.status != 200:
+                        sys.stderr.write(
+                            f"  wipe: GET /admin/users returned {resp.status}, "
+                            "skipping wipe\n",
+                        )
+                        return 0
+                    body = await resp.json()
+                batch = body.get("users", [])
+                all_users.extend(batch)
+                if len(batch) < 500:
+                    break
+                offset += 500
         except Exception as exc:  # noqa: BLE001
             sys.stderr.write(f"  wipe: list call failed: {exc}\n")
             return 0
 
         targets = [
-            u["user_name"] for u in body.get("users", [])
+            u["user_name"] for u in all_users
             if u["user_name"].startswith(f"{prefix}-")
         ]
         if not targets:

--- a/scripts/stress/frontdesk-multiuser-mock.js
+++ b/scripts/stress/frontdesk-multiuser-mock.js
@@ -124,6 +124,30 @@ function getVuUser() {
 
 // ── Endpoints ─────────────────────────────────────────────────────────
 
+// Extract every Set-Cookie value's ``name=value`` and join them so we
+// can attach the lot via a single ``Cookie:`` header on subsequent
+// requests. k6's per-VU cookie jar handles this automatically in
+// theory, but production cookies carry the ``Secure`` attribute and
+// the bundle is normally accessed over HTTPS — so when the sandbox
+// runs the test on plain HTTP for iteration speed, the jar refuses to
+// re-attach Secure cookies and every follow-up reads as 401. We
+// short-circuit that by mirroring what the browser does on HTTPS:
+// pull the name=value pairs out of Set-Cookie and replay them on the
+// Cookie header verbatim. Live customer traffic on the TLS sidecar
+// (port 8443 / 18443) does not need this — the jar works there.
+function extractCookieHeader(resp) {
+    const setCookies = resp.headers["Set-Cookie"];
+    if (!setCookies) return "";
+    const arr = Array.isArray(setCookies) ? setCookies : [setCookies];
+    const pairs = [];
+    for (const sc of arr) {
+        const semi = sc.indexOf(";");
+        const head = semi >= 0 ? sc.slice(0, semi) : sc;
+        if (head.indexOf("=") > 0) pairs.push(head.trim());
+    }
+    return pairs.join("; ");
+}
+
 function login(user) {
     const resp = http.post(
         `${user.base_url}/api/auth/login`,
@@ -147,20 +171,18 @@ function login(user) {
     loginErrors.add(!ok);
     loginCount.add(1);
     if (ok && resp.body) {
-        // ``provisioning`` is one of ok / deferred / skipped. Count
-        // deferred separately so the operator can spot Mastio outages
-        // mid-run without parsing the full ndjson.
         if (resp.body.indexOf("\"provisioning\":\"deferred\"") >= 0) {
             provDeferred.add(1);
         }
     }
-    return ok;
+    return { ok, cookieHeader: ok ? extractCookieHeader(resp) : "" };
 }
 
-function listModels(user) {
+function listModels(user, cookieHeader) {
     const resp = http.get(
         `${user.base_url}/v1/models`,
         {
+            headers: cookieHeader ? { "Cookie": cookieHeader } : {},
             timeout: REQ_TIMEOUT,
             tags: { endpoint: "v1_models" },
         },
@@ -186,16 +208,18 @@ export default function () {
     }
 
     if (LOGIN_AT_START && !state.loggedIn) {
-        if (!login(state.user)) {
+        const r = login(state.user);
+        if (!r.ok) {
             // Failed login — sleep briefly so we don't burn CPU on
             // retry storms. The error rate already captured it.
             sleep(1);
             return;
         }
         state.loggedIn = true;
+        state.cookieHeader = r.cookieHeader;
     }
 
-    listModels(state.user);
+    listModels(state.user, state.cookieHeader);
 
     if (THINK_MS > 0) sleep(THINK_MS / 1000);
 }

--- a/scripts/stress/frontdesk-multiuser-ollama.js
+++ b/scripts/stress/frontdesk-multiuser-ollama.js
@@ -124,6 +124,23 @@ function getVuUser() {
 
 // ── Endpoints ─────────────────────────────────────────────────────────
 
+// See ``frontdesk-multiuser-mock.js`` for why we replay cookies via
+// the Cookie header instead of relying on the per-VU jar — short
+// version: bundle cookies carry ``Secure`` for the TLS path and the
+// jar refuses to attach them on plain HTTP sandbox runs.
+function extractCookieHeader(resp) {
+    const setCookies = resp.headers["Set-Cookie"];
+    if (!setCookies) return "";
+    const arr = Array.isArray(setCookies) ? setCookies : [setCookies];
+    const pairs = [];
+    for (const sc of arr) {
+        const semi = sc.indexOf(";");
+        const head = semi >= 0 ? sc.slice(0, semi) : sc;
+        if (head.indexOf("=") > 0) pairs.push(head.trim());
+    }
+    return pairs.join("; ");
+}
+
 function login(user) {
     const resp = http.post(
         `${user.base_url}/api/auth/login`,
@@ -144,10 +161,10 @@ function login(user) {
     const ok = resp.status === 200;
     loginErrors.add(!ok);
     loginCount.add(1);
-    return ok;
+    return { ok, cookieHeader: ok ? extractCookieHeader(resp) : "" };
 }
 
-function chatCompletion(user) {
+function chatCompletion(user, cookieHeader) {
     const body = JSON.stringify({
         model: MODEL,
         messages: [
@@ -155,14 +172,16 @@ function chatCompletion(user) {
         ],
         max_tokens: MAX_TOKENS,
     });
+    const headers = {
+        "Content-Type": "application/json",
+        "Origin": user.base_url,
+    };
+    if (cookieHeader) headers["Cookie"] = cookieHeader;
     const resp = http.post(
         `${user.base_url}/v1/chat/completions`,
         body,
         {
-            headers: {
-                "Content-Type": "application/json",
-                "Origin": user.base_url,
-            },
+            headers,
             timeout: REQ_TIMEOUT,
             tags: { endpoint: "v1_chat_completions" },
         },
@@ -189,14 +208,16 @@ export default function () {
     }
 
     if (!state.loggedIn) {
-        if (!login(state.user)) {
+        const r = login(state.user);
+        if (!r.ok) {
             sleep(1);
             return;
         }
         state.loggedIn = true;
+        state.cookieHeader = r.cookieHeader;
     }
 
-    chatCompletion(state.user);
+    chatCompletion(state.user, state.cookieHeader);
 
     if (THINK_MS > 0) sleep(THINK_MS / 1000);
 }


### PR DESCRIPTION
## Summary

- New `nginx location = /` redirects unauthenticated visitors to `/login` instead of letting them land in chat as the workload principal. Reported by an operator from a phone on the LAN-exposed dogfood VM 2026-05-20: opening the bundle root URL dropped them straight into chat with a fallback identity the backend then refused.
- `$effective_scheme` map honours `X-Forwarded-Proto` so dir-norm 301s from the inner SPA stay on HTTPS when the TLS sidecar fronts the bundle. Without it, the inner nginx rewrote Location with `$scheme=http` (the sidecar→inner hop is plain HTTP), the browser followed back into the TLS listener and got `400 The plain HTTP request was sent to HTTPS port` plus silent Secure-cookie breakage.
- `CULLIS_BCRYPT_COST` env knob (clamped `[10, 14]`) lets operators trade one CPU stage for ~4x login throughput when bursts exceed the cost-12 ceiling (~16 logins/s on 4 workers). Default stays at 12; values below 10 floored to avoid an accidental footgun. Surfaced by the 2026-05-20 50→500 VU ramp where ~3% of logins timed out past the 30s deadline.
- Plus housekeeping: pagination fix in `scripts/stress/bulk_create_frontdesk_users.py` (single GET was leaving >200 users behind in `--wipe-prefix`), and `.dockerignore` excludes `.data/` so dogfood volumes don't bloat the Docker build context.

## Test plan

- [x] E2E verified on local `dogfood-frontdesk` stack: GET `/` without cookie → 303 `/login` → 200 SPA login form; login → cookie → GET `/` → 200 SPA chat shell.
- [x] E2E verified on VM `frontdesk-demo` via TLS sidecar `https://192.168.122.87:8443/`: full redirect chain stays on HTTPS, lands on Cullis Frontdesk Sign in page.
- [x] Bcrypt cost A/B on live container: cost 10 → 67 ms login (mediana 5 runs), cost 12 → 222 ms. E2E speedup 3.26x, microbench `bcrypt.checkpw` 3.95x.
- [x] Defense-in-depth check in `cullis_connector/web.py` root() gated on `is_frontdesk_bundle()`, so the standalone desktop Connector flow is unchanged.
- [ ] `./sandbox/smoke.sh full` pre-merge.
- [ ] `/security-review` pre-merge (cookie gate, redirect handling, env-driven crypto cost).