### PR TITLE
fix(frontdesk-bundle,connector): follow-up to PR #827 security review

### DIFF
--- a/cullis_connector/admin/users_router.py
+++ b/cullis_connector/admin/users_router.py
@@ -150,11 +150,12 @@ async def list_users_endpoint(
     q: str = Query("", max_length=128),
     disabled: Optional[bool] = Query(None),
     limit: int = Query(200, ge=1, le=500),
+    offset: int = Query(0, ge=0),
 ) -> UserListResponse:
     config_dir = _config_dir(request)
     async with get_users_session(config_dir) as session:
         users = await list_users(
-            session, q=q, disabled=disabled, limit=limit,
+            session, q=q, disabled=disabled, limit=limit, offset=offset,
         )
     items = [_to_out(u) for u in users]
     return UserListResponse(users=items, total=len(items))

--- a/cullis_connector/identity/users.py
+++ b/cullis_connector/identity/users.py
@@ -239,12 +239,18 @@ async def list_users(
     q: str = "",
     disabled: Optional[bool] = None,
     limit: int = 200,
+    offset: int = 0,
 ) -> list[User]:
-    """Return up to ``limit`` users, newest-first.
+    """Return up to ``limit`` users, newest-first, skipping ``offset``.
 
     ``q`` does a case-insensitive substring match on ``user_name``
     and ``display_name``. ``disabled`` filters by status when set;
-    ``None`` returns both enabled and disabled rows.
+    ``None`` returns both enabled and disabled rows. ``offset``
+    lets callers paginate through deployments with more rows than
+    ``limit`` (the stress harness wipe path walks the table in 500-
+    row pages); the sort key is stable since ``created_at`` is
+    indexed and unique-enough in practice for the dev-time scripts
+    that consume this endpoint.
     """
     stmt = select(LocalUser)
     if q:
@@ -255,7 +261,11 @@ async def list_users(
         )
     if disabled is not None:
         stmt = stmt.where(LocalUser.disabled == (1 if disabled else 0))
-    stmt = stmt.order_by(LocalUser.created_at.desc()).limit(int(limit))
+    stmt = (
+        stmt.order_by(LocalUser.created_at.desc())
+        .offset(int(offset))
+        .limit(int(limit))
+    )
     result = await session.execute(stmt)
     rows = result.scalars().all()
     return [_row_to_user(r) for r in rows]

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -271,7 +271,15 @@ server {
         # port, which breaks LAN-exposed deployments (the phone would
         # hit ``http://localhost/login`` on itself).
         absolute_redirect off;
-        if ($http_cookie !~* "(?:^|;\s*)cullis_local_session=") {
+        # Require a non-empty cookie value, not just the name + ``=``.
+        # The downstream Python gate at cullis_connector/web.py root()
+        # treats ``Cookie: cullis_local_session=`` (empty value) as
+        # unauthenticated; the nginx match must agree, otherwise a
+        # trivially-crafted empty cookie tunnels past the gate into
+        # the SPA shell and the visitor lands on the broken logged-in-
+        # looking surface the gate was added to eliminate. Pattern:
+        # any non-``;`` non-whitespace character right after the ``=``.
+        if ($http_cookie !~* "(?:^|;\s*)cullis_local_session=[^;\s]") {
             return 303 /login;
         }
         proxy_pass http://cullis_chat_upstream;


### PR DESCRIPTION
## Summary

Follow-up to PR #827 closing the two minor findings raised by `/security-review` (one MED, one LOW). Both were already noted in the test plan of #827 and are addressed here as a separate housekeeping PR so the originating fix-bundle merged cleanly.

- **M1 — nginx cookie gate accepted empty value** (`packaging/frontdesk-bundle/nginx/default.conf`). The new `location = /` regex `(?:^|;\s*)cullis_local_session=` let `Cookie: cullis_local_session=` (empty value) through to the SPA shell, reproducing exactly the broken logged-in-looking surface the gate was added to eliminate. Python gate in `web.py:1030-1034` was already strict. Tightened to `cullis_local_session=[^;\s]` so the two gates agree. Not an auth bypass — the backend `/api/auth` and `/v1` paths re-validate the HMAC.
- **L2 — `/admin/users` endpoint silently dropped the `offset` query** (`cullis_connector/admin/users_router.py` + `cullis_connector/identity/users.py`). The wipe path in `scripts/stress/bulk_create_frontdesk_users.py` (added by #827) walks the table in 500-row pages, but the endpoint only accepted `q` / `disabled` / `limit`, so every iteration returned the same first 500 rows and the loop never terminated on deployments with more than 500 matching users. Dev-only script gated by `X-Admin-Secret`, so no external blast radius — but self-DoS. Add `offset: int = Query(0, ge=0)` and pass through to `list_users(..., offset=int(offset))` (applied as `.offset()` before `.limit()` on the ordered query).

## Test plan

- [x] M1: matrix verified on `dogfood-frontdesk`: no cookie → 303 /login; `Cookie: cullis_local_session=` → 303 /login (was 200, the bug); cookie with value → 200; name-collision `foocullis_local_session=value` → 303.
- [x] L2: seeded 5 users, walked `?limit=2&offset=0/2/4`, each page returned distinct rows.
- [ ] `/security-review` re-run on this delta (recommended).