### PR TITLE
release: Connector v0.5.1 + Frontdesk bundle v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,71 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+## [Connector v0.5.1] — Per-user auth gate, bcrypt knob, dir-norm HTTPS — 2026-05-20
+
+### Fixed
+
+- **Per-user auth gate at the Frontdesk root URL** (#827, #828). A fresh
+  visitor (new phone on the LAN, fresh incognito tab) used to land on
+  the chat surface as the workload principal — the backend refused
+  every actual chat call, leaving the user stuck on a logged-in-looking
+  shell. The Connector now redirects to `/login` when no
+  `cullis_local_session` cookie is present (defence-in-depth alongside
+  the nginx gate in the bundle below). Standalone desktop Connector
+  unchanged (`is_frontdesk_bundle()` gates the new branch).
+- **`/admin/users` paginates** (#828). The endpoint now accepts
+  `offset: int = Query(0, ge=0)` and passes it through to
+  `list_users(..., offset=int(offset))`, so dev scripts walking the
+  table in 500-row pages (`scripts/stress/bulk_create_frontdesk_users.py`)
+  actually advance instead of returning the same first 500 rows
+  forever.
+
+### Added
+
+- **`CULLIS_BCRYPT_COST` env knob** (#827), clamped `[10, 14]`, default
+  `12`. Drop to `10` (~62 ms vs ~250 ms / verify, ~4x faster) when the
+  deployment expects bursts of concurrent morning logins above the
+  ~16 logins/s ceiling on a 4-worker box at cost 12. Verified
+  end-to-end: cost 10 → 67 ms login mediana, cost 12 → 222 ms. Floor
+  at 10 to avoid an accidental footgun, cap at 14 to bound worker
+  monopoly. Values are read once at module import; bundle env file
+  carries an example commented block.
+
+[Connector v0.5.1]: https://github.com/cullis-security/cullis/releases/tag/connector-v0.5.1
+
+## [Frontdesk bundle v0.2.10] — Cookie gate, $effective_scheme, bcrypt knob passthrough — 2026-05-20
+
+### Fixed
+
+- **Inner nginx `location = /` gates on the session cookie** (#827, #828).
+  Without a non-empty `cullis_local_session` cookie value, the inner
+  nginx now returns `303 /login` instead of proxying the visitor to the
+  static SPA shell. Path-only `Location` header (`absolute_redirect
+  off`) so the redirect resolves against the operator's actual host:port
+  (LAN deployments where the published port differs from the default).
+  Tightened in #828 to require a non-empty value after `=` so an empty
+  cookie does not tunnel past the gate.
+- **`$effective_scheme` map honours `X-Forwarded-Proto: https`** (#827).
+  The catch-all `proxy_redirect` that rewrites absolute upstream
+  `Location` headers from the SPA's dir-norm 301s now stays on HTTPS
+  when the TLS sidecar fronts the bundle. Previously the rewrite used
+  `$scheme` which evaluated to `http` (the sidecar→inner hop is plain
+  HTTP), producing `http://<host>:8443/login/` and a `400 The plain
+  HTTP request was sent to HTTPS port` on the follow-up.
+
+### Changed
+
+- **`CULLIS_BCRYPT_COST` passthrough** in the bundle's
+  `docker-compose.yml`. Drop to 10 in `frontdesk.env` when expecting
+  morning-login bursts above the cost-12 ceiling. See
+  `frontdesk.env.example` for the security tradeoff and the
+  2026-05-20 load-test reference.
+- **`deploy.sh` defaults to `CONNECTOR_VERSION=0.5.1`** (was `0.4.6`,
+  stale since the v0.5.0 release). Fresh installs now pull the new
+  Connector image without needing the operator to override the env.
+
+[Frontdesk bundle v0.2.10]: https://github.com/cullis-security/cullis/releases/tag/frontdesk-bundle-v0.2.10
+
 ## [v0.5.1] — Mastio bundle: `--upgrade` defaults to bundle refresh — 2026-05-20
 
 ### Fixed

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = ["__version__"]

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -155,7 +155,7 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.6)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.5.1)
   CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.4.1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
@@ -407,7 +407,7 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.6}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.5.1}"
 CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.4.1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Coordinated release of Connector v0.5.1 + Frontdesk bundle v0.2.10. Both ship the auth-gate hardening from PR #827 (per-user gate, dir-norm HTTPS, bcrypt knob, defence-in-depth `web.py` cookie check) and the M1+L2 follow-ups from PR #828 (empty-cookie tighter regex, `/admin/users` offset pagination). Bundle also bumps the stale `CONNECTOR_VERSION=0.4.6` default in `deploy.sh` to `0.5.1` so fresh installs pull the new image automatically.

See `CHANGELOG.md` for the per-component release notes.

## Post-merge build/push checklist

This repo no longer ships release workflows (`.github/workflows/` was removed in PR #782). After merge:

- [ ] `docker build -f Dockerfile -t ghcr.io/cullis-security/cullis-connector:0.5.1 -t ghcr.io/cullis-security/cullis-connector:latest .`
- [ ] `docker push ghcr.io/cullis-security/cullis-connector:0.5.1 && docker push ghcr.io/cullis-security/cullis-connector:latest` (no `v` prefix on the image tag, per the existing `mastio-vX.Y.Z` convention)
- [ ] `git tag -a connector-v0.5.1 -m "Connector v0.5.1" <merge-sha> && git push origin connector-v0.5.1`
- [ ] `gh release create connector-v0.5.1 --title "Cullis Connector v0.5.1" --notes "$(awk '/^## \[Connector v0.5.1\]/,/^## /' CHANGELOG.md | sed '\$d')"`
- [ ] Stage bundle tarball via the allowlist pattern from `feedback_bundle_staging_cp_allowlist.md` (memory)
- [ ] `git tag -a frontdesk-bundle-v0.2.10 -m "Frontdesk bundle v0.2.10" <merge-sha> && git push origin frontdesk-bundle-v0.2.10`
- [ ] `gh release create frontdesk-bundle-v0.2.10 --title "Cullis Frontdesk Bundle v0.2.10" --notes "$(awk '/^## \[Frontdesk bundle v0.2.10\]/,/^## /' CHANGELOG.md | sed '\$d')" cullis-frontdesk-bundle.tar.gz`
- [ ] Optional: PyPI publish `python -m build packaging/pypi/ && twine upload packaging/pypi/dist/*0.5.1*`