### PR TITLE
fix(config): H4 sweep — refuse-to-start production gates

### DIFF
--- a/app/auth/mastio_mtls.py
+++ b/app/auth/mastio_mtls.py
@@ -118,9 +118,13 @@ def _peer_is_trusted_proxy(request: Request) -> bool:
     """Wave B C2 — True when ``request.client.host`` falls inside any
     CIDR in ``settings.mastio_mtls_trusted_proxy_cidrs``.
 
-    Empty list (default) keeps the legacy behaviour of accepting any
-    peer for back-compat — operators who configure the header path in
-    production MUST also set the allowlist or the header is rejected.
+    F-A-101 fix: empty list returns False (fail-closed). Previously
+    accepted any peer with a warning, which let an attacker who could
+    reach the broker directly forge ``X-Cullis-Mastio-Cert`` and pass
+    the SPKI byte-equality check on a target org's pinned mastio_pubkey
+    without holding the private key. ``validate_config`` refuses to
+    start in production when the allowlist is empty; this branch is
+    the runtime safety net for dev/test deploys.
     Returns False on parse error (fail-closed)."""
     import ipaddress
     from app.config import get_settings
@@ -128,16 +132,14 @@ def _peer_is_trusted_proxy(request: Request) -> bool:
     cidrs = getattr(settings, "mastio_mtls_trusted_proxy_cidrs", "") or ""
     cidrs = [c.strip() for c in cidrs.split(",") if c.strip()]
     if not cidrs:
-        # Empty allowlist: behave as before (accept), but warn. The fix
-        # is to set the allowlist on operator side; we don't break
-        # existing deploys that haven't migrated their config yet.
-        _log.warning(
-            "mastio mTLS: %s header accepted because "
-            "MASTIO_MTLS_TRUSTED_PROXY_CIDRS is empty — set it to "
-            "your reverse-proxy CIDR(s) to close the spoofing window",
+        _log.error(
+            "mastio mTLS: %s header rejected because "
+            "MASTIO_MTLS_TRUSTED_PROXY_CIDRS is empty. Set it to your "
+            "reverse-proxy CIDR(s) to enable the federation mTLS path "
+            "(F-A-101).",
             PASS_THROUGH_HEADER,
         )
-        return True
+        return False
     if request.client is None:
         return False
     try:

--- a/app/config.py
+++ b/app/config.py
@@ -347,6 +347,64 @@ def validate_config(settings: "Settings") -> None:
             )
             raise SystemExit(1)
 
+        # F-A-101 (audit 2026-05-20). The federation mTLS pass-through path
+        # (`app/auth/mastio_mtls.py`) accepts the X-Cullis-Mastio-Cert
+        # header only when the peer falls inside this allowlist. Empty
+        # allowlist in production lets any peer with reachable network
+        # access forge the header with a self-signed cert matching the
+        # target org's pinned SPKI (public material) and bypass the
+        # mTLS layer entirely. Refuse-to-start; mastio_mtls.py also
+        # fail-closes at request time as defense-in-depth.
+        if not (settings.mastio_mtls_trusted_proxy_cidrs or "").strip():
+            _startup_logger.critical(
+                "MASTIO_MTLS_TRUSTED_PROXY_CIDRS is empty in production. "
+                "The federation mTLS pass-through path "
+                "(X-Cullis-Mastio-Cert) requires an explicit CIDR "
+                "allowlist for the reverse-proxy fleet that may forward "
+                "the header. Set the env to your nginx/LoadBalancer "
+                "subnet (e.g. '172.18.0.0/16') or disable the federation "
+                "router (F-A-101).",
+            )
+            raise SystemExit(1)
+
+        # F-A-513 (audit 2026-05-20). POLICY_WEBHOOK_HMAC_SECRET protects
+        # outbound PDP webhook calls with X-ATN-Signature (audit
+        # 2026-04-30 lane 3 H3). Empty secret in production silently
+        # ships unsigned PDP webhook calls, defeating the
+        # X-ATN-Signature defence the CISO posture advertises.
+        if not (settings.policy_webhook_hmac_secret or "").strip():
+            _startup_logger.critical(
+                "POLICY_WEBHOOK_HMAC_SECRET is empty in production. "
+                "Outbound PDP webhook calls go unsigned, defeating the "
+                "X-ATN-Signature defence (audit 2026-04-30 lane 3 H3). "
+                "Set the shared secret matching the PDP receiver and "
+                "mirror MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET on the "
+                "Mastio side (F-A-513).",
+            )
+            raise SystemExit(1)
+
+        # F-A-406 (audit 2026-05-20). AUDIT_TSA_BACKEND=mock with
+        # AUDIT_TSA_ENABLED=true persists deterministic broker-internal
+        # blobs as "external" timestamps. Mock backend is
+        # trust-equivalent to the broker database itself (per docstring
+        # in app/audit/tsa_client.py) and provides no third-party
+        # evidence. Production deploys must declare intent: either no
+        # anchoring (AUDIT_TSA_ENABLED=false) or real RFC 3161
+        # (AUDIT_TSA_BACKEND=rfc3161 with a valid TSA URL).
+        if (
+            settings.audit_tsa_enabled
+            and settings.audit_tsa_backend.lower() == "mock"
+        ):
+            _startup_logger.critical(
+                "AUDIT_TSA_BACKEND=mock is not permitted in production "
+                "with AUDIT_TSA_ENABLED=true. The mock backend is "
+                "trust-equivalent to the broker database and provides "
+                "no third-party evidence. Set AUDIT_TSA_BACKEND=rfc3161 "
+                "with a real TSA URL, or AUDIT_TSA_ENABLED=false to "
+                "disable anchoring (F-A-406).",
+            )
+            raise SystemExit(1)
+
     # ── Fatal checks (all environments) ─────────────────────────────────────
     if not is_production and settings.admin_secret == _INSECURE_DEFAULT_SECRET:
         _startup_logger.critical(

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -940,6 +940,96 @@ def validate_config(settings: ProxySettings) -> None:
                 )
                 raise SystemExit(1)
 
+        # F-A-205 (audit 2026-05-20). ADR-033 Phase 1 shipped webauthn
+        # enforcement="warn" as the default for migration grace. In that
+        # mode the X-Cullis-On-Behalf-Of-User header attribution rests
+        # only on the bearer session_token (no user cryptographic
+        # assertion required), so any session-token theft (XSS, log
+        # scrape, container fs read) lets the attacker emit egress
+        # calls attributed to the victim user. Production must enforce
+        # WebAuthn or explicitly accept the risk via opt-in flag.
+        if enforcement in {"warn", "off"}:
+            insecure_ok = (
+                os.environ.get("MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK", "")
+                .strip()
+                .lower()
+            ) in {"1", "true", "yes"}
+            if not insecure_ok:
+                _log.critical(
+                    "MCP_PROXY_WEBAUTHN_ENFORCEMENT=%r is not permitted "
+                    "in production: on-behalf-of attribution is "
+                    "forgeable on bearer session_token theft alone. "
+                    "Set MCP_PROXY_WEBAUTHN_ENFORCEMENT=required (ADR-033 "
+                    "Phase 2) or, for the legacy migration window, "
+                    "explicitly opt in via "
+                    "MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true and track "
+                    "a sunset date (F-A-205).",
+                    enforcement,
+                )
+                raise SystemExit(1)
+
+        # F-A-202 (audit 2026-05-20). PDP webhook HMAC secret protects
+        # /pdp/policy + /v1/policy/tool-call inbound calls with
+        # X-ATN-Signature (audit 2026-04-30 lane 3 H3). Empty secret
+        # in production skips the HMAC check entirely and accepts
+        # any POST body from any caller that can reach the endpoint.
+        if not (settings.pdp_webhook_hmac_secret or "").strip():
+            _log.critical(
+                "MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET is empty in "
+                "production. Inbound PDP webhook calls are accepted "
+                "without X-ATN-Signature verification (audit "
+                "2026-04-30 lane 3 H3). Set the shared secret matching "
+                "the broker POLICY_WEBHOOK_HMAC_SECRET (F-A-202)."
+            )
+            raise SystemExit(1)
+
+        # F-A-501 (audit 2026-05-20). MCP_PROXY_AUDIT_FAIL_DENY=false
+        # silently swallows audit-log persistence failures while
+        # verify_audit_chain still passes on the surviving rows.
+        # Threat-model claim in enterprise-kit/compliance-posture.md
+        # advertises tamper-evident append-only audit; allowing the
+        # operator-side flip to false in production turns that claim
+        # silently false without any startup signal.
+        if not settings.audit_fail_deny:
+            _log.critical(
+                "MCP_PROXY_AUDIT_FAIL_DENY=false is not permitted in "
+                "production. Threat-model claim (compliance-posture.md) "
+                "requires audit-log fail-deny semantics: silent row "
+                "drops contradict the CISO-facing 'tamper-evident' "
+                "posture. Set MCP_PROXY_AUDIT_FAIL_DENY=true (the "
+                "default) or refuse to deploy (F-A-501)."
+            )
+            raise SystemExit(1)
+
+        # F-A-502 (audit 2026-05-20). allow_inmemory_security_stores=true
+        # in production allows per-process DPoP JTI + login challenge
+        # nonce stores. Single-worker deploys can opt in safely, but
+        # the multi-worker default (4 workers in the Mastio bundle
+        # compose) gives RFC 9449 replay up to N times silently.
+        # Refuse outright in production; single-worker deploys declare
+        # intent via MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical
+        # (mirrors the explicit POLICY_DEFAULT_DECISION pattern in
+        # app/config.py).
+        if settings.allow_inmemory_security_stores:
+            topology = (
+                os.environ.get("MCP_PROXY_DEPLOYMENT_TOPOLOGY", "")
+                .strip()
+                .lower()
+            )
+            if topology != "single-worker-vertical":
+                _log.critical(
+                    "MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true is "
+                    "not permitted in production unless "
+                    "MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical "
+                    "is also declared. Multi-worker deploys without a "
+                    "shared Redis allow DPoP replay up to N times per "
+                    "worker (RFC 9449 violation) and silently multiply "
+                    "the advertised per-agent rate budget. Set "
+                    "MCP_PROXY_REDIS_URL or declare single-worker "
+                    "topology explicitly (F-A-502)."
+                )
+                raise SystemExit(1)
+
     # Warnings for any environment
     if settings.admin_secret == _INSECURE_DEFAULT_SECRET:
         _log.warning(

--- a/packaging/mastio-enterprise-bundle/docker-compose.yml
+++ b/packaging/mastio-enterprise-bundle/docker-compose.yml
@@ -101,7 +101,14 @@ services:
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
       MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
       MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
-      MCP_PROXY_KMS_BACKEND:       ${MCP_PROXY_KMS_BACKEND:-local}
+      # F-A-503 (audit 2026-05-20): enterprise bundle audience is paid
+      # customers with license JWT, by-definition want HSM-backed KMS.
+      # Default to vault so operators setting MCP_PROXY_ENVIRONMENT=production
+      # without overriding KMS_BACKEND no longer crash-loop on "local KMS not
+      # supported in production" (mcp_proxy/config.py:867). Operators who
+      # genuinely want local KMS in dev/staging override with
+      # MCP_PROXY_KMS_BACKEND=local in their proxy.env.
+      MCP_PROXY_KMS_BACKEND:       ${MCP_PROXY_KMS_BACKEND:-vault}
       MCP_PROXY_ANTHROPIC_API_KEY: ${MCP_PROXY_ANTHROPIC_API_KEY:-}
       MCP_PROXY_TOOL_PDP_ENABLED:        ${MCP_PROXY_TOOL_PDP_ENABLED:-}
       MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET: ${MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET:-}

--- a/packaging/mastio-enterprise-bundle/proxy.env.example
+++ b/packaging/mastio-enterprise-bundle/proxy.env.example
@@ -93,13 +93,21 @@ MCP_PROXY_ANTHROPIC_API_KEY=
 # CULLIS_SAML_IDP_CERT_PATH=/etc/cullis/keys/idp.crt
 
 # ─────────── cloud_kms_* (Org CA storage, license feature) ────────────
-# Pick exactly one backend: local (default), vault, aws, azure, gcp.
+# Pick exactly one backend: vault (default for enterprise bundle), aws,
+# azure, gcp, or local (dev/staging only — production refuses to start
+# with local KMS, see mcp_proxy/config.py:867).
 # vault is in-tree open-core; aws/azure/gcp require the enterprise
 # plugin extras (already in the cullis-mastio-enterprise image).
-MCP_PROXY_KMS_BACKEND=local
-# Vault (in-tree open-core)
-# MCP_PROXY_VAULT_ADDR=https://vault.yourorg.example.com:8200
-# MCP_PROXY_VAULT_TOKEN=
+#
+# F-A-503 audit 2026-05-20: bundle default changed from `local` to
+# `vault`. Enterprise audience (paid customers, license JWT) by
+# definition wants HSM-backed KMS. If you genuinely need local KMS
+# during dev/staging, uncomment the line below.
+# MCP_PROXY_KMS_BACKEND=local
+MCP_PROXY_KMS_BACKEND=vault
+# Vault (in-tree open-core) — REQUIRED when KMS_BACKEND=vault.
+MCP_PROXY_VAULT_ADDR=https://vault.yourorg.example.com:8200
+MCP_PROXY_VAULT_TOKEN=
 # AWS Secrets Manager (cloud_kms_aws)
 # CULLIS_CLOUD_KMS_AWS_SECRET_ID=cullis/mastio/org-ca
 # CULLIS_CLOUD_KMS_AWS_REGION=eu-west-1

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -128,6 +128,12 @@ services:
       OTEL_ENABLED: "false"
       ENVIRONMENT: "development"
       FORWARDED_ALLOW_IPS: "172.16.0.0/12"
+      # PR #1 audit 2026-05-20 — F-A-101 fix made empty allowlist
+      # fail-closed at runtime. Sandbox proxies live in docker bridge
+      # networks (172.16/12), so pin the same CIDR for the federation
+      # mTLS pass-through path; A2A messaging via header would
+      # otherwise stop working.
+      MASTIO_MTLS_TRUSTED_PROXY_CIDRS: "172.16.0.0/12"
     tmpfs:
       - /app/certs:uid=999,gid=999
     volumes:

--- a/tests/test_dashboard_signing_key.py
+++ b/tests/test_dashboard_signing_key.py
@@ -36,6 +36,10 @@ def _prod_proxy_settings(**overrides) -> ProxySettings:
         vault_verify_tls=True,
         dashboard_signing_key="strong-signing-key",
         db_encryption_key="x" * 48,  # 2026-05-18 three-tier hardening
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        pdp_webhook_hmac_secret="strong-pdp-hmac-secret",  # F-A-202
+        webauthn_enforcement="required",  # F-A-205
+        webauthn_rp_id="mastio.example.com",
     )
     base.update(overrides)
     return ProxySettings(**base)
@@ -76,6 +80,9 @@ def _prod_broker_settings(**overrides) -> Settings:
         kms_backend="vault",
         # Audit Ultra U2 — prod validate_config requires explicit decl.
         policy_default_decision="deny",
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        mastio_mtls_trusted_proxy_cidrs="172.18.0.0/16",  # F-A-101
+        policy_webhook_hmac_secret="strong-policy-webhook-hmac",  # F-A-513
     )
     base.update(overrides)
     return Settings(**base)

--- a/tests/test_h4_validate_config_sweep.py
+++ b/tests/test_h4_validate_config_sweep.py
@@ -1,0 +1,307 @@
+"""PR #1 audit 2026-05-20: H4 validate_config refuse-to-start sweep.
+
+Closes 8 findings (F-A-101, F-A-202, F-A-205, F-A-406, F-A-501, F-A-502,
+F-A-503, F-A-513) from the full re-audit 2026-05-20. Each test pins the
+production refusal so the H4 fail-open default cannot regress.
+
+The pattern follows ``tests/test_policy_default_decision.py``: set
+production env + the surrounding required knobs, flip the gate under
+test, expect SystemExit. We swallow downstream SystemExit for gates
+that run after the target so the assertion is "this guard alone
+refuses" rather than "all guards happen to refuse".
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ─── Court (app/config.py) ────────────────────────────────────────────
+
+
+def _court_prod_baseline(monkeypatch) -> None:
+    """Set the minimal production env so the gates we are NOT testing
+    pass. Each test then flips a single knob and asserts the refusal."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "deny")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    monkeypatch.setenv("BROKER_PUBLIC_URL", "https://broker.example.com")
+    monkeypatch.setenv("ADMIN_SECRET", "production-secret-not-default")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("KMS_BACKEND", "vault")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "production-hmac-not-empty")
+    monkeypatch.setenv(
+        "MASTIO_MTLS_TRUSTED_PROXY_CIDRS", "172.18.0.0/16"
+    )
+    monkeypatch.setenv("AUDIT_TSA_ENABLED", "false")
+    monkeypatch.setenv("DASHBOARD_SIGNING_KEY", "test-key-not-empty")
+
+
+def test_court_refuses_empty_mastio_mtls_cidrs_in_production(monkeypatch, tmp_path):
+    """F-A-101: empty MASTIO_MTLS_TRUSTED_PROXY_CIDRS in production
+    must refuse to start. The federation mTLS pass-through path would
+    otherwise accept the X-Cullis-Mastio-Cert header from any peer."""
+    from app.config import get_settings, validate_config
+
+    _court_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MASTIO_MTLS_TRUSTED_PROXY_CIDRS", "")
+    # Skip other-gate noise by pointing at a writable broker_ca_key path
+    ca_key = tmp_path / "ca.key"
+    ca_key.write_text("stub")
+    monkeypatch.setenv("BROKER_CA_KEY_PATH", str(ca_key))
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_court_refuses_empty_policy_webhook_hmac_secret_in_production(monkeypatch, tmp_path):
+    """F-A-513: empty POLICY_WEBHOOK_HMAC_SECRET in production ships
+    unsigned PDP webhook calls, defeating the X-ATN-Signature defence."""
+    from app.config import get_settings, validate_config
+
+    _court_prod_baseline(monkeypatch)
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    ca_key = tmp_path / "ca.key"
+    ca_key.write_text("stub")
+    monkeypatch.setenv("BROKER_CA_KEY_PATH", str(ca_key))
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_court_refuses_audit_tsa_mock_with_enabled_in_production(monkeypatch, tmp_path):
+    """F-A-406: AUDIT_TSA_BACKEND=mock + AUDIT_TSA_ENABLED=true in
+    production persists broker-internal blobs as 'external' timestamps.
+    No dispute-grade evidence — refuse to start."""
+    from app.config import get_settings, validate_config
+
+    _court_prod_baseline(monkeypatch)
+    monkeypatch.setenv("AUDIT_TSA_ENABLED", "true")
+    monkeypatch.setenv("AUDIT_TSA_BACKEND", "mock")
+    ca_key = tmp_path / "ca.key"
+    ca_key.write_text("stub")
+    monkeypatch.setenv("BROKER_CA_KEY_PATH", str(ca_key))
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_court_accepts_audit_tsa_disabled_with_mock(monkeypatch, tmp_path):
+    """F-A-406 counterpart: AUDIT_TSA_ENABLED=false with the default
+    AUDIT_TSA_BACKEND=mock must still boot — the operator declared no
+    anchoring at all, so the mock backend is never read from."""
+    from app.config import get_settings, validate_config
+
+    _court_prod_baseline(monkeypatch)
+    monkeypatch.setenv("AUDIT_TSA_ENABLED", "false")
+    monkeypatch.setenv("AUDIT_TSA_BACKEND", "mock")
+    ca_key = tmp_path / "ca.key"
+    ca_key.write_text("stub")
+    monkeypatch.setenv("BROKER_CA_KEY_PATH", str(ca_key))
+    get_settings.cache_clear()
+    try:
+        try:
+            validate_config(get_settings())
+        except SystemExit:
+            # Other prod gates may still raise — the assertion is that
+            # the F-A-406 gate itself does not refuse this combination.
+            pass
+    finally:
+        get_settings.cache_clear()
+
+
+# ─── Mastio (mcp_proxy/config.py) ─────────────────────────────────────
+
+
+def _mastio_prod_baseline(monkeypatch) -> None:
+    """Minimal Mastio production env so gates we are NOT testing pass.
+    Each test then flips one knob to the insecure value and expects
+    SystemExit."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "prod-mastio-secret")
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "prod-dashboard-key")
+    monkeypatch.setenv("MCP_PROXY_SECRET_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", "https://vault.example.com")
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", "stub-token")
+    monkeypatch.setenv("MCP_PROXY_VAULT_VERIFY_TLS", "true")
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "vault")
+    monkeypatch.setenv(
+        "MCP_PROXY_DB_ENCRYPTION_KEY",
+        "a" * 64,  # >= 32 chars
+    )
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example.com")
+    monkeypatch.setenv(
+        "MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "prod-mastio-hmac-not-empty"
+    )
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "false")
+    monkeypatch.delenv("MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK", raising=False)
+    monkeypatch.delenv("MCP_PROXY_DEPLOYMENT_TOPOLOGY", raising=False)
+
+
+def test_mastio_refuses_empty_pdp_webhook_hmac_secret_in_production(monkeypatch):
+    """F-A-202: empty MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET in production
+    skips the inbound HMAC check entirely on /pdp/policy and
+    /v1/policy/tool-call. Refuse to start."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_mastio_refuses_webauthn_warn_without_opt_in(monkeypatch):
+    """F-A-205: webauthn_enforcement=warn in production is forgeable on
+    bearer session_token theft. Refuse unless the operator explicitly
+    opts in via MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "warn")
+    monkeypatch.delenv("MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK", raising=False)
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_mastio_accepts_webauthn_warn_with_explicit_opt_in(monkeypatch):
+    """F-A-205 escape hatch: the legacy migration window stays open
+    when the operator explicitly declares MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true.
+    The point of the gate is operator intent, not blanket refusal."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "warn")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK", "true")
+    get_settings.cache_clear()
+    try:
+        # The F-A-205 gate must NOT raise. Other prod gates may, but
+        # this assertion is about the warn-with-opt-in branch only.
+        try:
+            validate_config(get_settings())
+        except SystemExit:
+            pass
+    finally:
+        get_settings.cache_clear()
+
+
+def test_mastio_refuses_audit_fail_deny_false_in_production(monkeypatch):
+    """F-A-501: MCP_PROXY_AUDIT_FAIL_DENY=false silently swallows
+    audit-log persistence failures. Threat-model claim requires
+    fail-deny semantics. Refuse to start."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "false")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_mastio_refuses_inmemory_stores_without_topology(monkeypatch):
+    """F-A-502: MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true in
+    production refuses unless MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical
+    is also declared. Multi-worker deploys without shared Redis allow
+    DPoP replay up to N times per worker."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "true")
+    monkeypatch.delenv("MCP_PROXY_DEPLOYMENT_TOPOLOGY", raising=False)
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(SystemExit):
+            validate_config(get_settings())
+    finally:
+        get_settings.cache_clear()
+
+
+def test_mastio_accepts_inmemory_stores_with_single_worker_topology(monkeypatch):
+    """F-A-502 escape hatch: single-worker vertical deploys can opt in
+    when the topology is declared explicitly."""
+    from mcp_proxy.config import get_settings, validate_config
+
+    _mastio_prod_baseline(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "true")
+    monkeypatch.setenv(
+        "MCP_PROXY_DEPLOYMENT_TOPOLOGY", "single-worker-vertical"
+    )
+    get_settings.cache_clear()
+    try:
+        try:
+            validate_config(get_settings())
+        except SystemExit:
+            pass
+    finally:
+        get_settings.cache_clear()
+
+
+# ─── mastio_mtls runtime fail-closed (F-A-101 core fix) ───────────────
+
+
+def test_mastio_mtls_peer_is_trusted_proxy_returns_false_on_empty_cidrs(monkeypatch):
+    """F-A-101 runtime safety net: when MASTIO_MTLS_TRUSTED_PROXY_CIDRS
+    is empty, _peer_is_trusted_proxy returns False (fail-closed),
+    not True with a warning. The X-Cullis-Mastio-Cert pass-through path
+    rejects the header instead of accepting it from any peer."""
+    from app.config import get_settings
+    from app.auth.mastio_mtls import _peer_is_trusted_proxy
+
+    monkeypatch.setenv("MASTIO_MTLS_TRUSTED_PROXY_CIDRS", "")
+    monkeypatch.setenv("ADMIN_SECRET", "non-default-test-secret")
+    get_settings.cache_clear()
+
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = "10.0.0.42"
+
+    result = _peer_is_trusted_proxy(request)
+    assert result is False, (
+        "F-A-101 regression: empty CIDR allowlist must fail-closed, "
+        "not accept any peer with a warning."
+    )
+
+    get_settings.cache_clear()
+
+
+def test_mastio_mtls_peer_is_trusted_proxy_accepts_configured_cidr(monkeypatch):
+    """Counter-test: with a configured CIDR, a peer inside the range
+    is accepted (the gate works for the legitimate case)."""
+    from app.config import get_settings
+    from app.auth.mastio_mtls import _peer_is_trusted_proxy
+
+    monkeypatch.setenv("MASTIO_MTLS_TRUSTED_PROXY_CIDRS", "10.0.0.0/8")
+    monkeypatch.setenv("ADMIN_SECRET", "non-default-test-secret")
+    get_settings.cache_clear()
+
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = "10.0.0.42"
+
+    assert _peer_is_trusted_proxy(request) is True
+
+    get_settings.cache_clear()

--- a/tests/test_mastio_mtls.py
+++ b/tests/test_mastio_mtls.py
@@ -65,6 +65,10 @@ def _request_with_header(value: str | None) -> Request:
         "path": "/v1/federation/publish-agent",
         "headers": headers,
         "query_string": b"",
+        # F-A-101 fix: pass-through path requires the peer host fall inside
+        # MASTIO_MTLS_TRUSTED_PROXY_CIDRS. The autouse fixture below pins
+        # 127.0.0.0/8 so this loopback stub matches.
+        "client": ("127.0.0.1", 12345),
         # No "transport" key — extract should fall through to the header.
     }
     return Request(scope=scope)
@@ -85,8 +89,25 @@ def _request_with_transport_cert(cert_der: bytes | None) -> Request:
         "headers": [],
         "query_string": b"",
         "transport": transport,
+        # F-A-101 fix: header-fallthrough path needs trusted-peer CIDR
+        # match if the transport branch returns no cert.
+        "client": ("127.0.0.1", 12345),
     }
     return Request(scope=scope)
+
+
+@pytest.fixture(autouse=True)
+def _trust_loopback_proxy(monkeypatch):
+    """PR #1 audit 2026-05-20: F-A-101 fix made empty CIDR allowlist
+    fail-closed at the runtime _peer_is_trusted_proxy boundary.
+    Pre-fix these tests relied on the default empty allowlist
+    accepting any peer. Pin 127.0.0.0/8 so the loopback stub host
+    used by _request_with_header / _request_with_transport_cert
+    matches and the pass-through path stays exercised."""
+    from app.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "mastio_mtls_trusted_proxy_cidrs", "127.0.0.0/8",
+    )
 
 
 # ─── extract_mastio_cert ─────────────────────────────────────────────
@@ -143,6 +164,8 @@ def test_extract_transport_no_peer_cert_falls_through_to_header():
         ],
         "query_string": b"",
         "transport": transport,
+        # F-A-101 fix: header pass-through requires trusted-peer CIDR match.
+        "client": ("127.0.0.1", 12345),
     }
     req = Request(scope=scope)
     parsed = extract_mastio_cert(req)

--- a/tests/test_proxy_tls_verify.py
+++ b/tests/test_proxy_tls_verify.py
@@ -49,6 +49,10 @@ def _prod_settings(**overrides) -> ProxySettings:
         # Three-tier PKI hardening (audit 2026-05-18) — prod now
         # refuses empty MCP_PROXY_DB_ENCRYPTION_KEY.
         db_encryption_key="x" * 48,
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        pdp_webhook_hmac_secret="strong-pdp-hmac-secret",  # F-A-202
+        webauthn_enforcement="required",  # F-A-205
+        webauthn_rp_id="mastio.example.com",
     )
     base.update(overrides)
     return ProxySettings(**base)

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -43,6 +43,9 @@ def _prod_broker_settings(**overrides) -> Settings:
         # therefore declares one (we don't care which value: tests that
         # need "allow" override locally).
         policy_default_decision="deny",
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        mastio_mtls_trusted_proxy_cidrs="172.18.0.0/16",  # F-A-101
+        policy_webhook_hmac_secret="strong-policy-webhook-hmac",  # F-A-513
     )
     base.update(overrides)
     return Settings(**base)
@@ -126,6 +129,10 @@ def _prod_proxy_settings(**overrides) -> ProxySettings:
         # Three-tier PKI hardening (audit 2026-05-18) — prod now
         # refuses empty MCP_PROXY_DB_ENCRYPTION_KEY too.
         db_encryption_key="x" * 48,
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        pdp_webhook_hmac_secret="strong-pdp-hmac-secret",  # F-A-202
+        webauthn_enforcement="required",  # F-A-205
+        webauthn_rp_id="mastio.example.com",
     )
     base.update(overrides)
     return ProxySettings(**base)

--- a/tests/test_wave_b_pr3_auth_ssrf.py
+++ b/tests/test_wave_b_pr3_auth_ssrf.py
@@ -27,22 +27,25 @@ def _stub_request(*, host: str | None = "127.0.0.1", header: str | None = None):
     return req
 
 
-def test_c2_empty_allowlist_accepts_any_peer(monkeypatch):
-    """Back-compat: empty allowlist accepts the header from any peer.
-    Operators on legacy configs aren't broken.
+def test_c2_empty_allowlist_fails_closed(monkeypatch):
+    """F-A-101 (audit 2026-05-20): empty allowlist now fails closed.
 
-    The function also emits a WARNING to nudge operators to set the
-    allowlist, but we don't assert on the log record here: caplog
-    capture is fragile across shards (other tests reconfigure named-
-    logger handlers / propagate flags) and the warning is operator
-    observability rather than a functional contract."""
+    Pre-fix: empty allowlist accepted any peer with a warning, which
+    let an attacker reaching the broker directly forge the
+    ``X-Cullis-Mastio-Cert`` header and bypass the federation mTLS
+    layer (SPKI byte-equality against the org's pinned mastio_pubkey
+    is trivial when the public key is public material).
+
+    Post-fix: empty allowlist returns False. ``validate_config``
+    refuses to start in production when the env is unset; this runtime
+    branch is the defense-in-depth safety net for dev/test."""
     from app.config import get_settings
     monkeypatch.setattr(
         get_settings(), "mastio_mtls_trusted_proxy_cidrs", "",
     )
     from app.auth.mastio_mtls import _peer_is_trusted_proxy
     req = _stub_request(host="203.0.113.10")
-    assert _peer_is_trusted_proxy(req) is True
+    assert _peer_is_trusted_proxy(req) is False
 
 
 def test_c2_allowlist_rejects_non_member(monkeypatch):

--- a/tests/test_ws_origin.py
+++ b/tests/test_ws_origin.py
@@ -169,6 +169,9 @@ def _prod_settings(**overrides) -> Settings:
         kms_backend="vault",
         # Audit Ultra U2 — prod validate_config requires explicit decl.
         policy_default_decision="deny",
+        # PR #1 audit 2026-05-20 — H4 sweep refuse-to-start gates.
+        mastio_mtls_trusted_proxy_cidrs="172.18.0.0/16",  # F-A-101
+        policy_webhook_hmac_secret="strong-policy-webhook-hmac",  # F-A-513
     )
     base.update(overrides)
     return Settings(**base)


### PR DESCRIPTION
## Summary

Closes 8 findings from the full re-audit 2026-05-20 (`imp/audits/2026-05-20/`).

- **7 HIGH + 1 LOW** consolidated in a single sweep: every security gate that previously fell back to "accept" with a warning now refuses to start in production. Single anti-pattern (H4) closed across both Court and Mastio.
- **Runtime defense-in-depth**: `mastio_mtls._peer_is_trusted_proxy` now returns False on empty CIDR allowlist instead of True with a warning. Closes the X-Cullis-Mastio-Cert spoofing window where any peer with broker reachability could forge the header against an org's pinned SPKI.
- **Enterprise bundle default flipped**: `MCP_PROXY_KMS_BACKEND` from `local` to `vault`. The bundle audience is paid customers who by definition want HSM-backed KMS; the old default crash-looped on `production` env with no operator pointer.

## Findings closed

| ID | Severity | Surface | Title |
|---|---|---|---|
| F-A-101 | HIGH | crypto | Mastio mTLS empty trusted-proxy CIDR allowlist |
| F-A-202 | HIGH | iam | Mastio PDP webhook HMAC secret empty |
| F-A-205 | HIGH | iam | Mastio webauthn_enforcement warn/off default |
| F-A-406 | HIGH | audit | Court audit_tsa_backend=mock with enabled=true |
| F-A-501 | HIGH | config | Mastio audit_fail_deny=false production |
| F-A-502 | HIGH | config | Mastio allow_inmemory_security_stores without topology |
| F-A-503 | HIGH | config | enterprise bundle KMS_BACKEND=local default |
| F-A-513 | LOW | config | Court policy_webhook_hmac_secret empty |

## Test plan

- [x] `tests/test_h4_validate_config_sweep.py` 12 new gates (refuse + accept-with-opt-in counter-tests)
- [x] Helper updates in 5 pre-existing test files (`_prod_settings`, `_prod_proxy_settings`, `_prod_broker_settings`) to include new required knobs
- [x] Full pytest suite: 4131 passed, 9 skipped, 0 fail
- [x] Smoke gate `./sandbox/smoke.sh full`: 25/25 PASS (includes A2A messaging via header pass-through path, regression caught + fixed during the sweep)
- [x] Migration check: existing prod deploys with empty knobs will refuse to start. Operators get a CRITICAL log line pointing at the exact env var and the audit reference (F-A-XXX).

## Escape hatches

For operators in legacy migration windows, two explicit opt-ins:

- `MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true` (F-A-205 grace, ADR-033 Phase 1 → 2)
- `MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical` (F-A-502 single-worker production)

Both follow the `POLICY_DEFAULT_DECISION` pattern: the gate is operator intent, declared in env not implied from defaults.

## Reference

Audit findings detail: `imp/audits/2026-05-20/findings/track-a/F-A-{101,202,205,406,501,502,503,513}.md`