### PR TITLE
feat(security): SSRF shared helper assert_safe_outbound_url

### DIFF
--- a/app/policy/webhook.py
+++ b/app/policy/webhook.py
@@ -90,20 +90,36 @@ def _validate_response_ip(resp: httpx.Response) -> None:
 
     httpx does not expose the remote IP in all transports; when unavailable,
     we rely on the pre-request DNS validation as a best-effort defense.
+
+    F-A-204 (audit 2026-05-20) fix: distinguish "cannot determine the
+    server address" (accept, defer to pre-request validation) from
+    "address determined and unsafe" (raise). The previous broad
+    ``except (TypeError, ValueError, IndexError)`` clause was swallowing
+    the very ``ValueError`` this function raises on a private-IP hit,
+    turning the post-request belt-and-braces into a no-op.
     """
     if _allow_private_webhooks():
         return
-    # httpx stores network info in response.extensions when using httpcore
     network_stream = resp.extensions.get("network_stream")
-    if network_stream is not None:
-        try:
-            server_addr = network_stream.get_extra_info("server_addr")
-            if server_addr:
-                ip = ipaddress.ip_address(server_addr[0])
-                if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-                    raise ValueError(f"Response came from private/reserved IP: {ip}")
-        except (TypeError, ValueError, IndexError):
-            pass  # cannot determine — fall through to pre-request validation
+    if network_stream is None:
+        return
+    # Stage 1: extract the peer address. Broad except: any failure here
+    # means "cannot determine", which is the documented accept path.
+    try:
+        server_addr = network_stream.get_extra_info("server_addr")
+    except (TypeError, AttributeError):
+        return
+    if not server_addr:
+        return
+    # Stage 2: parse the address. Malformed → cannot determine → accept.
+    try:
+        ip = ipaddress.ip_address(server_addr[0])
+    except (ValueError, IndexError, TypeError):
+        return
+    # Stage 3: refuse private/reserved. ValueError raised here is the
+    # safety signal the caller must surface — do NOT catch it locally.
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+        raise ValueError(f"Response came from private/reserved IP: {ip}")
 
 
 def _validate_and_resolve_webhook_url(url: str) -> str:

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -221,6 +221,15 @@ class ProxySettings(BaseSettings):
     # the broker via ``POLICY_WEBHOOK_HMAC_SECRET`` to enable.
     pdp_webhook_hmac_secret: str = ""
 
+    # SSRF escape hatch — PR #2 audit 2026-05-20.
+    # When False (the production default) outbound URL helpers
+    # (mcp_proxy/utils/url_safety.assert_safe_outbound_url) refuse any
+    # hostname that resolves to private/loopback/link-local/reserved
+    # ranges. Set to True ONLY for local docker compose / e2e / sandbox
+    # stacks where the Mastio reaches a service on the same private
+    # network (federation PDP, MCP resources on the docker bridge, etc.).
+    policy_webhook_allow_private_ips: bool = False
+
     # ADR-029 Phase C, tool-level PDP gate. When true, exposes the
     # POST /v1/policy/tool-call endpoint that the Connector ambassador
     # calls before executing each MCP tool the model emits in a chat

--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -95,12 +95,31 @@ def _parse_allowed_domains(raw: str) -> list[str]:
 
 
 def _validate_endpoint_url(url: str) -> str:
+    """F-A-301 (audit 2026-05-20): refuse SSRF endpoints (cloud metadata,
+    RFC 1918, loopback) at the dashboard CRUD boundary.
+
+    Pre-fix the dashboard only checked the http(s) scheme — an org
+    admin (or compromised admin role) could register an MCP resource
+    pointing at 169.254.169.254 and have the Mastio fire a POST against
+    cloud IMDS on every tool invocation. ``allow_private`` is wired to
+    the Mastio escape ``policy_webhook_allow_private_ips`` so dev /
+    sandbox stacks reaching MCP servers on the docker bridge keep
+    working.
+    """
+    from mcp_proxy.utils.url_safety import (
+        UnsafeUrlError,
+        assert_safe_outbound_url,
+    )
+    from mcp_proxy.config import get_settings
+
     url = url.strip()
-    if not url.startswith(("http://", "https://")):
-        raise HTTPException(
-            status_code=400,
-            detail="endpoint_url must start with http:// or https://",
-        )
+    allow_private = bool(
+        getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+    )
+    try:
+        assert_safe_outbound_url(url, allow_private=allow_private)
+    except UnsafeUrlError as exc:
+        raise HTTPException(status_code=400, detail=f"endpoint_url: {exc}") from exc
     return url
 
 

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -189,6 +189,13 @@ def validate_creds(provider: str, creds: dict[str, Any]) -> dict[str, str]:
     """Strip unknown keys, enforce required ones, return a clean dict.
 
     The returned dict is what the admin endpoint stores in the DB.
+
+    F-A-302 (audit 2026-05-20): the ``api_base`` override on OpenAI /
+    Ollama / similar providers is admin-supplied and travels with the
+    API key into LiteLLM. Pre-fix, an admin (or compromised admin role)
+    could point ``api_base`` at cloud metadata / RFC 1918 and leak the
+    upstream API key plus user prompts on every chat call. The SSRF
+    helper refuses those URLs at admin-write time.
     """
     spec = get_spec(provider)
     if spec is None:
@@ -207,6 +214,26 @@ def validate_creds(provider: str, creds: dict[str, Any]) -> dict[str, str]:
                 f"{provider}.{fld.name} must be a string, got {type(raw).__name__}",
             )
         cleaned[fld.name] = raw.strip()
+
+    # F-A-302: SSRF gate on every URL-shaped field. Today only
+    # ``api_base`` qualifies (OpenAI + Ollama); future providers should
+    # mark their URL fields here too.
+    if "api_base" in cleaned and cleaned["api_base"]:
+        from mcp_proxy.utils.url_safety import (
+            UnsafeUrlError,
+            assert_safe_outbound_url,
+        )
+        from mcp_proxy.config import get_settings
+
+        allow_private = bool(
+            getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+        )
+        try:
+            assert_safe_outbound_url(cleaned["api_base"], allow_private=allow_private)
+        except UnsafeUrlError as exc:
+            raise InvalidCredentialsError(
+                f"{provider}.api_base refused: {exc}"
+            ) from exc
     return cleaned
 
 
@@ -326,9 +353,32 @@ async def fetch_ollama_models(api_base: str, *, timeout_s: float = 2.0) -> list[
     Returns ``[]`` (and logs a debug line) on any failure: the dashboard
     treats Ollama as "not reachable" and the admin can hit the Test
     button for a verbose error.
+
+    F-A-302 (audit 2026-05-20): defense-in-depth SSRF gate on the
+    runtime path. ``validate_creds`` already refuses unsafe URLs at
+    admin-write time; this re-check catches drift (DB row predating
+    the helper, manual SQL, schema migration) before the model-list
+    refresh fires a GET against the saved endpoint.
     """
     if not api_base:
         return []
+    from mcp_proxy.utils.url_safety import (
+        UnsafeUrlError,
+        assert_safe_outbound_url,
+    )
+    from mcp_proxy.config import get_settings
+
+    allow_private = bool(
+        getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+    )
+    try:
+        assert_safe_outbound_url(api_base, allow_private=allow_private)
+    except UnsafeUrlError as exc:
+        _log.warning(
+            "ollama tag fetch refused unsafe api_base %s: %s", api_base, exc,
+        )
+        return []
+
     url = api_base.rstrip("/") + "/api/tags"
     try:
         async with httpx.AsyncClient(timeout=timeout_s) as client:

--- a/mcp_proxy/policy/federation.py
+++ b/mcp_proxy/policy/federation.py
@@ -77,6 +77,35 @@ async def call_remote_tool_call_policy(
         ).hexdigest()
         headers["X-ATN-Signature"] = sig
 
+    # F-A-203 (audit 2026-05-20). Validate the federation URL against
+    # the SSRF block list before issuing the POST. An operator-configured
+    # entry pointing at cloud metadata or internal services would
+    # otherwise leak cross-org principal_id / tool_name / model id to
+    # the attacker-controlled destination on every PDP call.
+    from mcp_proxy.utils.url_safety import (
+        UnsafeUrlError,
+        assert_safe_outbound_url,
+    )
+    from mcp_proxy.config import get_settings
+
+    allow_private = bool(
+        getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+    )
+    try:
+        assert_safe_outbound_url(federation_url, allow_private=allow_private)
+    except UnsafeUrlError as exc:
+        _log.warning(
+            "federation tool-call refused unsafe URL target=%s url=%s err=%s",
+            target_org, federation_url, exc,
+        )
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' refused: unsafe URL",
+            ),
+            reached_remote=False,
+        )
+
     try:
         async with httpx.AsyncClient(
             timeout=_FEDERATION_TIMEOUT, follow_redirects=False,

--- a/mcp_proxy/tools/http_whitelist.py
+++ b/mcp_proxy/tools/http_whitelist.py
@@ -42,6 +42,32 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
             raise ToolExecutionError(
                 f"Domain '{hostname}' not in whitelist: {sorted(self._allowed)}"
             )
+        # F-A-301 (audit 2026-05-20): defense-in-depth IP block on top of
+        # the hostname allowlist. The dashboard already refuses SSRF
+        # endpoints at registration, but the per-request check guards
+        # against allowlist entries that resolve to internal IPs (an
+        # operator who whitelists ``internal-mcp`` and forgets it points
+        # to a cloud-metadata side-channel).
+        from mcp_proxy.utils.url_safety import (
+            UnsafeUrlError,
+            assert_safe_outbound_url,
+        )
+        from mcp_proxy.config import get_settings
+
+        allow_private = bool(
+            getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+        )
+        try:
+            assert_safe_outbound_url(str(request.url), allow_private=allow_private)
+        except UnsafeUrlError as exc:
+            _log.warning(
+                "WhitelistedTransport refused unsafe URL %s: %s",
+                request.url, exc,
+            )
+            raise ToolExecutionError(
+                f"Refused URL {request.url!s}: {exc}"
+            ) from exc
+
         return await super().handle_async_request(request)
 
     def _is_allowed(self, hostname: str) -> bool:

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -73,8 +73,34 @@ async def _fetch_upstream_schema(endpoint_url: str, tool_name: str) -> dict | No
     advertises ``{sql: string}``). Without this, the proxy aggregator
     advertises an empty inputSchema and the LLM has no idea how to
     invoke the tool.
+
+    F-A-301 (audit 2026-05-20): re-validate the endpoint URL here too.
+    The dashboard CRUD validates at registration but a row in the DB
+    (sandbox migration, manual insert, schema drift) may bypass it;
+    this is defence-in-depth on the startup-time fetch path. The
+    forwarder (mcp_resource_forwarder) hits the same URL on every
+    tool invocation so the dashboard gate is the primary defense
+    on the runtime path.
     """
     import httpx as _httpx
+    from mcp_proxy.utils.url_safety import (
+        UnsafeUrlError,
+        assert_safe_outbound_url,
+    )
+    from mcp_proxy.config import get_settings
+
+    allow_private = bool(
+        getattr(get_settings(), "policy_webhook_allow_private_ips", False)
+    )
+    try:
+        assert_safe_outbound_url(endpoint_url, allow_private=allow_private)
+    except UnsafeUrlError as exc:
+        _log.warning(
+            "upstream schema fetch refused unsafe endpoint %s: %s",
+            endpoint_url, exc,
+        )
+        return None
+
     try:
         async with _httpx.AsyncClient(timeout=3.0) as client:
             r = await client.post(

--- a/mcp_proxy/utils/url_safety.py
+++ b/mcp_proxy/utils/url_safety.py
@@ -1,0 +1,213 @@
+"""Outbound URL safety helper (PR #2 audit 2026-05-20).
+
+Closes F-A-203, F-A-301, F-A-302 by centralising SSRF defence at every
+admin-supplied / operator-supplied URL boundary in the Mastio. The
+sister implementation in ``app/policy/webhook.py`` (Court) is the
+reference; this module is the Mastio mirror to avoid cross-project
+imports (Court does not depend on Mastio and vice versa).
+
+Usage::
+
+    from mcp_proxy.utils.url_safety import assert_safe_outbound_url
+
+    try:
+        pinned_ip = assert_safe_outbound_url(url, allow_private=False)
+    except UnsafeUrlError as exc:
+        raise HTTPException(400, str(exc))
+
+The helper refuses:
+- non-http(s) schemes
+- IP literals or hostnames that resolve into private/loopback/link-local
+  / reserved / cloud-metadata / shared (CGNAT) ranges
+- malformed URLs / unresolvable hostnames
+
+The override hatch ``allow_private`` is for dev/sandbox stacks where
+the Mastio legitimately reaches a service on a docker-compose network.
+The env-driven host allowlist ``MCP_PROXY_INTERNAL_HOST_ALLOWLIST``
+lets on-prem operators opt in specific internal MCP servers
+(comma-separated FQDN list) without flipping the entire dev escape.
+"""
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from urllib.parse import urlparse
+
+__all__ = [
+    "UnsafeUrlError",
+    "assert_safe_outbound_url",
+    "is_safe_ip",
+]
+
+_log = logging.getLogger(__name__)
+
+# Blocked address-space catalogue. Documented inline so the matrix is
+# visible without chasing CIDR libraries.
+_BLOCK_REASONS = {
+    "is_loopback": "loopback (127.0.0.0/8, ::1)",
+    "is_link_local": "link-local (169.254.0.0/16, fe80::/10) — cloud metadata",
+    "is_private": "private (RFC 1918, RFC 4193)",
+    "is_reserved": "reserved",
+    "is_unspecified": "unspecified (0.0.0.0, ::)",
+    "is_multicast": "multicast",
+}
+
+# 100.64.0.0/10 (RFC 6598 — carrier-grade NAT) is NOT in ipaddress.is_private
+# but matters in cloud (AWS uses it for internal services).
+_CGNAT_V4 = ipaddress.ip_network("100.64.0.0/10")
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when an outbound URL fails SSRF safety checks."""
+
+
+def is_safe_ip(ip_str: str, *, allow_private: bool = False) -> tuple[bool, str | None]:
+    """Return ``(safe, reason)`` for a parsed IP literal.
+
+    ``allow_private=True`` permits RFC 1918 + loopback (dev/sandbox).
+    Cloud-metadata (169.254/16) and CGNAT (100.64/10) are NEVER allowed
+    even with the dev escape — the IMDS attack surface is the whole point
+    of this defence.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except (ValueError, TypeError) as exc:
+        return False, f"malformed IP {ip_str!r}: {exc}"
+
+    # Cloud metadata and CGNAT are always refused.
+    if ip.is_link_local:
+        return False, _BLOCK_REASONS["is_link_local"]
+    if ip.version == 4 and ip in _CGNAT_V4:
+        return False, "CGNAT (100.64.0.0/10) — AWS internal range"
+
+    if allow_private:
+        # Dev/sandbox path: loopback + RFC 1918 OK, the cloud-metadata
+        # / CGNAT block above still applies.
+        if ip.is_multicast or ip.is_unspecified:
+            return False, _BLOCK_REASONS["is_multicast" if ip.is_multicast else "is_unspecified"]
+        return True, None
+
+    # Production posture: refuse anything not globally routable.
+    for attr in ("is_loopback", "is_private", "is_reserved", "is_unspecified", "is_multicast"):
+        if getattr(ip, attr):
+            return False, _BLOCK_REASONS[attr]
+    return True, None
+
+
+def _internal_host_allowlist() -> frozenset[str]:
+    """Parse MCP_PROXY_INTERNAL_HOST_ALLOWLIST (comma-separated FQDNs).
+
+    Hostnames listed here skip the IP-block check entirely. Use for
+    explicit internal MCP servers (e.g. ``internal-mcp.corp.example``)
+    that the operator has audited and trusts."""
+    raw = os.environ.get("MCP_PROXY_INTERNAL_HOST_ALLOWLIST", "")
+    return frozenset(
+        host.strip().lower() for host in raw.split(",") if host.strip()
+    )
+
+
+def assert_safe_outbound_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+) -> str:
+    """Validate ``url`` is safe to fetch and return the pinned IP.
+
+    The pinned IP can be passed to a custom transport so the actual
+    socket connect goes to that address (defends against DNS rebinding
+    where a later resolve flips to an internal address).
+
+    Raises ``UnsafeUrlError`` on:
+    - non-http(s) scheme
+    - missing hostname
+    - hostname in the cloud-metadata or CGNAT family
+    - hostname resolves to a private/loopback/reserved address (when
+      ``allow_private=False``)
+    - unresolvable hostname
+
+    The ``MCP_PROXY_INTERNAL_HOST_ALLOWLIST`` env (comma-separated)
+    bypasses the IP block for explicit operator-trusted FQDNs (still
+    returns the first resolved IP for pinning).
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeUrlError("URL is empty")
+
+    parsed = urlparse(url.strip())
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        raise UnsafeUrlError(
+            f"URL scheme {scheme!r} not allowed (only http/https accepted)"
+        )
+
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        raise UnsafeUrlError("URL has no hostname")
+
+    # Bypass IP-block for explicit operator-trusted FQDNs (still resolve
+    # for pinning).
+    in_allowlist = hostname in _internal_host_allowlist()
+
+    # Early refuse: explicit loopback names (operator can override via
+    # allow_private=True for sandbox / docker compose).
+    if not allow_private and not in_allowlist and hostname in {
+        "localhost", "ip6-localhost", "ip6-loopback",
+    }:
+        raise UnsafeUrlError(f"hostname {hostname!r} is loopback (set allow_private for dev)")
+
+    # IP-literal hostname: validate directly without DNS.
+    try:
+        ipaddress.ip_address(hostname)
+        is_literal = True
+    except ValueError:
+        is_literal = False
+
+    if is_literal:
+        safe, reason = is_safe_ip(hostname, allow_private=allow_private)
+        if not safe and not in_allowlist:
+            raise UnsafeUrlError(
+                f"URL IP literal {hostname!r} is blocked: {reason}"
+            )
+        return hostname
+
+    # Hostname: resolve and check every returned address.
+    try:
+        addr_infos = socket.getaddrinfo(
+            hostname,
+            parsed.port or (443 if scheme == "https" else 80),
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise UnsafeUrlError(
+            f"cannot resolve hostname {hostname!r}: {exc}"
+        ) from exc
+
+    if not addr_infos:
+        raise UnsafeUrlError(f"hostname {hostname!r} resolved to no addresses")
+
+    pinned_ip: str | None = None
+    for _family, _type, _proto, _canonname, sockaddr in addr_infos:
+        ip_str = sockaddr[0]
+        # Strip IPv6 zone id (e.g. "fe80::1%eth0") before validation.
+        ip_str_clean = ip_str.split("%", 1)[0]
+        safe, reason = is_safe_ip(ip_str_clean, allow_private=allow_private)
+        if not safe:
+            if in_allowlist:
+                _log.warning(
+                    "url_safety: %s resolves to %s (%s) but is in "
+                    "MCP_PROXY_INTERNAL_HOST_ALLOWLIST — allowing",
+                    hostname, ip_str_clean, reason,
+                )
+            else:
+                raise UnsafeUrlError(
+                    f"hostname {hostname!r} resolves to {ip_str_clean} which is blocked: {reason}"
+                )
+        if pinned_ip is None:
+            pinned_ip = ip_str_clean
+
+    if pinned_ip is None:
+        # Should be unreachable given the empty-list check above.
+        raise UnsafeUrlError(f"hostname {hostname!r} produced no usable address")
+
+    return pinned_ip

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -339,6 +339,11 @@ services:
       # and the cross-org federation against proxy-b.
       MCP_PROXY_TOOL_PDP_ENABLED: "true"
       MCP_PROXY_TOOL_PDP_FEDERATION_URLS: '{"orgb": "http://proxy-b:9100/v1/policy/tool-call"}'
+      # PR #2 audit 2026-05-20 — F-A-203 SSRF gate refuses RFC 1918
+      # federation URLs by default. Sandbox proxies live on docker bridge
+      # (172.x.x.x); enable the dev escape so the federation tool-PDP
+      # path stays exercised.
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
     volumes:
       - proxy-a-data:/data
       - mastio-a-nginx-certs:/var/lib/mastio/nginx-certs:rw
@@ -658,6 +663,8 @@ services:
       # and the cross-org federation against proxy-a.
       MCP_PROXY_TOOL_PDP_ENABLED: "true"
       MCP_PROXY_TOOL_PDP_FEDERATION_URLS: '{"orga": "http://proxy-a:9100/v1/policy/tool-call"}'
+      # PR #2 audit 2026-05-20 — F-A-203 SSRF gate (see proxy-a comment).
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
     volumes:
       - proxy-b-data:/data
       - mastio-b-nginx-certs:/var/lib/mastio/nginx-certs:rw

--- a/tests/test_proxy_dashboard_mcp_resources.py
+++ b/tests/test_proxy_dashboard_mcp_resources.py
@@ -24,6 +24,11 @@ async def proxy_logged_in(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
     monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    # PR #2 audit 2026-05-20: SSRF helper refuses RFC 1918 endpoints
+    # at registration unless the dev escape is set. These tests use
+    # 10.0.0.5 stubs in docker-bridge style addresses; flip the dev
+    # flag so the dashboard CRUD accepts them.
+    monkeypatch.setenv("MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
 
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
@@ -54,11 +59,11 @@ async def _create_resource(
     client,
     *,
     name: str,
-    endpoint_url: str = "http://mcp-svc:8080/",
+    endpoint_url: str = "http://10.0.0.5:8080/",
     auth_type: str = "none",
     org_id: str = "acme",
     enabled: str = "1",
-    allowed_domains: str = '["mcp-svc:8080"]',
+    allowed_domains: str = '["10.0.0.5:8080"]',
     required_capability: str = "",
     auth_secret_ref: str = "",
     description: str = "",
@@ -129,7 +134,7 @@ async def test_list_page_renders_empty(proxy_logged_in):
 async def test_create_resource_persists(proxy_logged_in):
     resp = await _create_resource(
         proxy_logged_in, name="github-mcp",
-        endpoint_url="https://api.example.com/mcp",
+        endpoint_url="http://10.0.0.6:8080/mcp",
         auth_type="bearer", auth_secret_ref="env://GH_TOKEN",
     )
     assert resp.status_code == 303
@@ -141,7 +146,7 @@ async def test_create_resource_persists(proxy_logged_in):
                  "FROM local_mcp_resources WHERE name='github-mcp'")
         )).mappings().first()
     assert row is not None
-    assert row["endpoint_url"] == "https://api.example.com/mcp"
+    assert row["endpoint_url"] == "http://10.0.0.6:8080/mcp"
     assert row["auth_type"] == "bearer"
     assert row["auth_secret_ref"] == "env://GH_TOKEN"
     assert row["enabled"] == 1
@@ -196,7 +201,7 @@ async def test_update_changes_fields(proxy_logged_in):
         data={
             "csrf_token": csrf,
             "description": "updated",
-            "endpoint_url": "https://new.example.com/mcp",
+            "endpoint_url": "http://10.0.0.7:8080/mcp",
             "auth_type": "api_key",
             "auth_secret_ref": "env://NEW",
             "required_capability": "x.read",
@@ -214,7 +219,7 @@ async def test_update_changes_fields(proxy_logged_in):
             {"r": rid},
         )).mappings().first()
     assert row["description"] == "updated"
-    assert row["endpoint_url"] == "https://new.example.com/mcp"
+    assert row["endpoint_url"] == "http://10.0.0.7:8080/mcp"
     assert row["auth_type"] == "api_key"
     assert row["required_capability"] == "x.read"
 

--- a/tests/test_ssrf_shared_helper.py
+++ b/tests/test_ssrf_shared_helper.py
@@ -1,0 +1,305 @@
+"""PR #2 audit 2026-05-20: SSRF shared helper + callsite gates.
+
+Closes 4 findings (F-A-203, F-A-204, F-A-301, F-A-302). Each test
+exercises one boundary:
+
+- F-A-203: federation tool-PDP URL refused on private IP
+- F-A-204: Court ``_validate_response_ip`` raises (not swallows) on
+  server addr in private range
+- F-A-301: MCP resource registration refused on IMDS endpoint
+- F-A-302: provider catalog validate_creds refuses Ollama / OpenAI
+  api_base on cloud metadata
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from mcp_proxy.utils.url_safety import (
+    UnsafeUrlError,
+    assert_safe_outbound_url,
+    is_safe_ip,
+)
+
+
+# ─── helper unit tests ────────────────────────────────────────────────
+
+
+class TestUrlSafetyHelper:
+    def test_refuses_imds_link_local(self):
+        with pytest.raises(UnsafeUrlError, match="link-local|169.254"):
+            assert_safe_outbound_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_refuses_imds_link_local_even_with_allow_private(self):
+        """Cloud metadata is NEVER allowed even with the dev escape."""
+        with pytest.raises(UnsafeUrlError, match="link-local|169.254"):
+            assert_safe_outbound_url(
+                "http://169.254.169.254/latest/meta-data/",
+                allow_private=True,
+            )
+
+    def test_refuses_loopback(self):
+        with pytest.raises(UnsafeUrlError, match="loopback|127"):
+            assert_safe_outbound_url("http://127.0.0.1:8080/x")
+
+    def test_refuses_rfc1918(self):
+        with pytest.raises(UnsafeUrlError, match="private|10\\."):
+            assert_safe_outbound_url("http://10.0.0.5/x")
+
+    def test_refuses_localhost_name(self):
+        with pytest.raises(UnsafeUrlError, match="loopback"):
+            assert_safe_outbound_url("http://localhost:8080/x")
+
+    def test_refuses_non_http_scheme(self):
+        with pytest.raises(UnsafeUrlError, match="scheme"):
+            assert_safe_outbound_url("file:///etc/passwd")
+
+    def test_refuses_missing_host(self):
+        with pytest.raises(UnsafeUrlError, match="hostname"):
+            assert_safe_outbound_url("http:///path")
+
+    def test_refuses_empty(self):
+        with pytest.raises(UnsafeUrlError):
+            assert_safe_outbound_url("")
+
+    def test_refuses_cgnat(self):
+        """100.64.0.0/10 is RFC 6598 CGNAT, used by AWS for internal services."""
+        with pytest.raises(UnsafeUrlError, match="CGNAT"):
+            assert_safe_outbound_url("http://100.64.1.1/x")
+
+    def test_accepts_public_ip_literal(self):
+        pinned = assert_safe_outbound_url("http://1.1.1.1/")
+        assert pinned == "1.1.1.1"
+
+    def test_allow_private_accepts_rfc1918(self):
+        """Dev escape: docker compose service IPs in RFC 1918 OK with flag."""
+        pinned = assert_safe_outbound_url(
+            "http://10.0.0.5:9100/pdp", allow_private=True,
+        )
+        assert pinned == "10.0.0.5"
+
+    def test_allow_private_accepts_loopback(self):
+        """Dev escape: 127.0.0.1 OK with explicit allow_private."""
+        pinned = assert_safe_outbound_url(
+            "http://127.0.0.1:8080/", allow_private=True,
+        )
+        assert pinned == "127.0.0.1"
+
+    def test_is_safe_ip_refuses_imds_even_with_private_allowed(self):
+        safe, reason = is_safe_ip("169.254.169.254", allow_private=True)
+        assert safe is False
+        assert "link-local" in (reason or "")
+
+    def test_is_safe_ip_refuses_malformed(self):
+        safe, reason = is_safe_ip("not-an-ip")
+        assert safe is False
+        assert "malformed" in (reason or "")
+
+    def test_internal_host_allowlist_bypasses_block(self, monkeypatch):
+        """Operator-trusted FQDN bypasses the IP block (still resolves)."""
+        # Allowlist a hostname that would resolve via DNS to a private IP;
+        # 'localhost' is a stable stand-in (loopback) that any system can
+        # resolve. With the allowlist, it must NOT raise.
+        monkeypatch.setenv(
+            "MCP_PROXY_INTERNAL_HOST_ALLOWLIST", "localhost",
+        )
+        pinned = assert_safe_outbound_url("http://localhost:8080/")
+        # The literal-name short-circuit refuses 'localhost' for safety;
+        # allowlist still applies — check pin is non-empty.
+        assert pinned in {"127.0.0.1", "::1"}
+
+
+# ─── F-A-203: federation tool-PDP SSRF ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_federation_refuses_imds_url(monkeypatch):
+    """F-A-203: cross-org tool PDP call refuses cloud metadata endpoints."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from mcp_proxy.policy.federation import call_remote_tool_call_policy
+
+    result = await call_remote_tool_call_policy(
+        target_org="competitor",
+        federation_url="http://169.254.169.254/latest/meta-data/",
+        payload={"principal_id": "alice", "tool_name": "list_files"},
+        hmac_secret="stub-secret",
+    )
+    assert result.reached_remote is False
+    assert "unsafe" in result.decision.reason.lower()
+    assert result.decision.allowed is False
+
+
+# ─── F-A-204: Court response IP check raises (not swallows) ───────────
+
+
+def test_court_validate_response_ip_raises_on_private(monkeypatch):
+    """F-A-204: when the post-request server_addr is private,
+    _validate_response_ip raises ValueError (not swallowed by the
+    surrounding except clause)."""
+    from app.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from app.policy.webhook import _validate_response_ip
+
+    # Mock httpx response with network_stream.get_extra_info returning
+    # a private IP.
+    network_stream = MagicMock()
+    network_stream.get_extra_info = MagicMock(
+        return_value=("127.0.0.1", 8080),
+    )
+    response = MagicMock(spec=httpx.Response)
+    response.extensions = {"network_stream": network_stream}
+
+    with pytest.raises(ValueError, match="private/reserved IP"):
+        _validate_response_ip(response)
+
+
+def test_court_validate_response_ip_accepts_when_unavailable(monkeypatch):
+    """F-A-204 counter-test: when server_addr cannot be determined,
+    accept (legitimate path for transports that don't expose it)."""
+    from app.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from app.policy.webhook import _validate_response_ip
+
+    network_stream = MagicMock()
+    network_stream.get_extra_info = MagicMock(
+        side_effect=TypeError("not supported by this transport"),
+    )
+    response = MagicMock(spec=httpx.Response)
+    response.extensions = {"network_stream": network_stream}
+
+    # Must NOT raise — defers to pre-request validation.
+    _validate_response_ip(response)
+
+
+# ─── F-A-301: MCP resource registration ───────────────────────────────
+
+
+def test_mcp_resource_dashboard_refuses_imds(monkeypatch):
+    """F-A-301: _validate_endpoint_url refuses IMDS endpoints."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from fastapi import HTTPException
+    from mcp_proxy.dashboard.mcp_resources import _validate_endpoint_url
+
+    with pytest.raises(HTTPException) as exc:
+        _validate_endpoint_url(
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+        )
+    assert exc.value.status_code == 400
+    assert "endpoint_url" in exc.value.detail
+
+
+def test_mcp_resource_dashboard_refuses_loopback(monkeypatch):
+    """F-A-301: loopback endpoint refused at registration."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from fastapi import HTTPException
+    from mcp_proxy.dashboard.mcp_resources import _validate_endpoint_url
+
+    with pytest.raises(HTTPException) as exc:
+        _validate_endpoint_url("http://localhost:9000/mcp")
+    assert exc.value.status_code == 400
+
+
+def test_mcp_resource_dashboard_accepts_public(monkeypatch):
+    """F-A-301: public endpoint must still register. Uses IP literal
+    so the test doesn't depend on DNS being reachable from the test
+    runner (NixOS sandbox isolates network)."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from mcp_proxy.dashboard.mcp_resources import _validate_endpoint_url
+
+    url = _validate_endpoint_url("https://1.1.1.1/mcp")
+    assert url == "https://1.1.1.1/mcp"
+
+
+def test_mcp_resource_dashboard_dev_escape_accepts_rfc1918(monkeypatch):
+    """F-A-301 escape hatch: sandbox / docker compose stacks with the
+    dev flag set accept private docker network endpoints. Uses IP
+    literal to keep the test offline."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", True,
+    )
+    from mcp_proxy.dashboard.mcp_resources import _validate_endpoint_url
+
+    url = _validate_endpoint_url("http://10.0.0.5:8080/")
+    assert url == "http://10.0.0.5:8080/"
+
+
+# ─── F-A-302: provider catalog api_base SSRF ──────────────────────────
+
+
+def test_openai_api_base_refuses_imds(monkeypatch):
+    """F-A-302: openai api_base override refused on cloud metadata."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from mcp_proxy.egress.provider_catalog import (
+        InvalidCredentialsError,
+        validate_creds,
+    )
+
+    with pytest.raises(InvalidCredentialsError, match="api_base"):
+        validate_creds("openai", {
+            "api_key": "sk-real",
+            "api_base": "http://169.254.169.254/latest/meta-data/",
+        })
+
+
+def test_ollama_api_base_refuses_loopback(monkeypatch):
+    """F-A-302: ollama api_base refused on loopback in production."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from mcp_proxy.egress.provider_catalog import (
+        InvalidCredentialsError,
+        validate_creds,
+    )
+
+    with pytest.raises(InvalidCredentialsError, match="api_base"):
+        validate_creds("ollama", {"api_base": "http://127.0.0.1:11434"})
+
+
+def test_ollama_api_base_accepts_loopback_with_dev_escape(monkeypatch):
+    """F-A-302 escape hatch: dev/sandbox can point at loopback Ollama."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", True,
+    )
+    from mcp_proxy.egress.provider_catalog import validate_creds
+
+    cleaned = validate_creds("ollama", {"api_base": "http://127.0.0.1:11434"})
+    assert cleaned["api_base"] == "http://127.0.0.1:11434"
+
+
+@pytest.mark.asyncio
+async def test_fetch_ollama_models_refuses_imds_runtime(monkeypatch):
+    """F-A-302 defense-in-depth: runtime fetch refuses even if DB row
+    predates the validate_creds gate."""
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "policy_webhook_allow_private_ips", False,
+    )
+    from mcp_proxy.egress.provider_catalog import fetch_ollama_models
+
+    # Pre-existing DB row pointing at IMDS — runtime must refuse.
+    result = await fetch_ollama_models("http://169.254.169.254/x")
+    assert result == []

--- a/tests/test_tool_call_pdp_federation.py
+++ b/tests/test_tool_call_pdp_federation.py
@@ -35,9 +35,14 @@ async def proxy_app(tmp_path, monkeypatch):
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
     monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
     monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")
+    # PR #2 audit 2026-05-20: federation URL is mock-transported (never
+    # hits the wire), but the SSRF helper validates the URL before
+    # dispatching. Use IP literal in a sandboxed range + flip the dev
+    # escape so the test doesn't depend on DNS resolution.
+    monkeypatch.setenv("MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
     monkeypatch.setenv(
         "MCP_PROXY_TOOL_PDP_FEDERATION_URLS",
-        json.dumps({"competitor": "https://mastio.competitor.local/v1/policy/tool-call"}),
+        json.dumps({"competitor": "http://10.0.0.10:9100/v1/policy/tool-call"}),
     )
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
@@ -66,6 +71,7 @@ async def proxy_app_phaseg(tmp_path, monkeypatch):
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
     monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
     monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")
+    monkeypatch.setenv("MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
     monkeypatch.setenv("MCP_PROXY_TOOL_PDP_FEDERATION_URLS", "{}")
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
@@ -425,9 +431,9 @@ async def test_phaseg_court_catalog_publishes_url(proxy_app_phaseg, monkeypatch)
         if url.endswith("/v1/federation/orgs/competitor/mastio-url"):
             return httpx.Response(200, json={
                 "org_id": "competitor",
-                "mastio_url": "https://mastio.competitor.dynamic/v1/policy/tool-call",
+                "mastio_url": "https://10.0.0.11:9100/v1/policy/tool-call",
             })
-        if "mastio.competitor.dynamic" in url:
+        if "10.0.0.11:9100" in url:
             captured["peer_url"] = url
             captured["peer_body"] = json.loads(request.content)
             return httpx.Response(200, json={
@@ -460,7 +466,7 @@ async def test_phaseg_court_catalog_publishes_url(proxy_app_phaseg, monkeypatch)
     body = resp.json()
     assert body["decision"] == "allow", body
     # The catalog-resolved peer received the call.
-    assert "mastio.competitor.dynamic" in captured["peer_url"]
+    assert "10.0.0.11:9100" in captured["peer_url"]
     assert captured["peer_body"]["target"]["org"] == "competitor"
 
 


### PR DESCRIPTION
## Summary

Closes 4 HIGH findings from the full re-audit 2026-05-20.

- **F-A-203**: cross-org federation tool-PDP call now refuses cloud metadata / RFC 1918 endpoints before dispatching
- **F-A-204**: Court PDP webhook response-IP check restructured to actually raise on private IPs (was swallowing its own ValueError)
- **F-A-301**: MCP resource registration refuses IMDS / loopback endpoints at dashboard CRUD + `_fetch_upstream_schema` + per-request transport defense-in-depth
- **F-A-302**: Ollama discovery + OpenAI api_base override refuses unsafe URLs at validate_creds + runtime fetch

## Architecture note

`mcp_proxy/utils/url_safety.py` is a Mastio-side mirror of the SSRF logic already in `app/policy/webhook.py` (Court). Court does not import from Mastio and vice versa, so the helper is duplicated rather than lifted — sister-file pattern documented in CLAUDE.md. Both surfaces share the same gate semantics.

## Findings closed

| ID | Severity | Surface | Title |
|---|---|---|---|
| F-A-203 | HIGH | iam | Cross-org federation tool-PDP no SSRF defence |
| F-A-204 | HIGH | iam | PDP webhook response-IP fails open on parse |
| F-A-301 | HIGH | mcp-egress | MCP resource registration SSRF |
| F-A-302 | HIGH | mcp-egress | Ollama / OpenAI api_base SSRF |

## Escape hatches

- `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=true` (existing Court flag mirrored to Mastio) — dev/sandbox docker-bridge stacks
- `MCP_PROXY_INTERNAL_HOST_ALLOWLIST=fqdn1,fqdn2` (new) — explicit operator-trusted internal MCP servers

Cloud metadata (169.254.0.0/16) and CGNAT (100.64.0.0/10) are NEVER allowed even with the dev escape — the IMDS attack surface is the whole point of this defence.

## Test plan

- [x] 26 new gates in `tests/test_ssrf_shared_helper.py` covering helper unit + callsite integration
- [x] URL stub updates in `test_proxy_dashboard_mcp_resources.py` + `test_tool_call_pdp_federation.py` (IP literals replace hostnames that require DNS in CI sandbox)
- [x] Full pytest: 4145 passed, 9 skipped, 0 fail
- [x] Smoke gate `./sandbox/smoke.sh full`: 25/25 PASS
- [x] Sandbox compose patched: `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=true` on proxy-a + proxy-b so federation tool-PDP stays exercised on the docker bridge

## Reference

Audit findings detail: `imp/audits/2026-05-20/findings/track-a/F-A-{203,204,301,302}.md`