### PR TITLE
fix(security): Court CSR TOFU pubkey pin (CRITICAL F-A-201)

### DIFF
--- a/alembic/versions/u1p2q3r4s5t6_user_pubkey.py
+++ b/alembic/versions/u1p2q3r4s5t6_user_pubkey.py
@@ -1,0 +1,55 @@
+"""F-A-201 (CRITICAL) — TOFU pubkey_thumbprint on Court user_principals.
+
+Revision ID: u1p2q3r4s5t6_user_pubkey
+Revises: t0o1p2q3r4s5_idx_thumb
+Create Date: 2026-05-20 14:00:00.000000
+
+Ports the Mastio CRIT-1 TOFU defence
+(``local_user_principals.pubkey_thumbprint``,
+``mcp_proxy/registry/principals_csr.py:247-269``) to the Court so that
+``/v1/principals/csr`` refuses to mint a fresh user-principal cert
+keyed to a different SPKI than the one already bound to that
+principal_id.
+
+Pre-fix the broker signs any well-formed user-CSR a workload token
+presents, even one keyed to an attacker's keypair, so a compromised
+workload escalates to arbitrary user identity in its org
+(F-A-201 audit 2026-05-20).
+
+Column is nullable to preserve TOFU semantics: legacy rows that
+predate this migration sit with ``pubkey_thumbprint=NULL`` until the
+next CSR roundtrip, at which point ``sign_user_csr`` records the
+presented SPKI digest and every subsequent CSR must match.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "u1p2q3r4s5t6_user_pubkey"
+down_revision = "t0o1p2q3r4s5_idx_thumb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_principals",
+        sa.Column(
+            "pubkey_thumbprint",
+            sa.String(length=64),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "idx_user_principals_pubkey_thumbprint",
+        "user_principals",
+        ["pubkey_thumbprint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_user_principals_pubkey_thumbprint",
+        table_name="user_principals",
+    )
+    op.drop_column("user_principals", "pubkey_thumbprint")

--- a/app/registry/principals_csr.py
+++ b/app/registry/principals_csr.py
@@ -160,20 +160,46 @@ def _cert_thumbprint_sha256(cert: x509.Certificate) -> str:
     return hashlib.sha256(der).hexdigest()
 
 
+def pubkey_thumbprint_sha256(public_key) -> str:
+    """F-A-201 (audit 2026-05-20). SHA-256 hex of a public key's
+    SubjectPublicKeyInfo (SPKI) DER.
+
+    Used for TOFU pinning of user principals (port of the Mastio
+    CRIT-1 fix). The cert rotates every USER_CERT_TTL but the
+    Ambassador re-uses its keypair across refreshes, so the SPKI
+    digest is the stable identifier. Compatible across RSA/EC public
+    keys (both expose ``public_bytes(SubjectPublicKeyInfo, DER)``).
+    """
+    spki_der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(spki_der).hexdigest()
+
+
 async def sign_user_csr(
     csr_pem: str,
     principal_id: str,
     *,
     ttl: timedelta = USER_CERT_TTL,
-) -> tuple[str, str, datetime]:
+) -> tuple[str, str, str, datetime]:
     """Sign a user-principal CSR with the broker CA.
 
-    Returns ``(cert_pem, cert_thumbprint_sha256, cert_not_after)``.
+    Returns ``(cert_pem, cert_thumbprint_sha256, pubkey_thumbprint_sha256,
+    cert_not_after)``.
+
+    The third-element ``pubkey_thumbprint_sha256`` is the stable TOFU
+    binding (F-A-201 audit 2026-05-20). The caller persists it on
+    first signature via ``attach_pubkey_thumbprint`` and this function
+    refuses subsequent CSRs that present a different SPKI for the same
+    principal_id.
 
     Raises:
         ValueError: principal_id malformed.
         CsrValidationError: CSR malformed, weak key, missing SAN,
-            wrong SPIFFE URI, signature invalid.
+            wrong SPIFFE URI, signature invalid, OR pubkey does not
+            match the previously-pinned pubkey for this principal
+            (TOFU mismatch — F-A-201 defence).
     """
     spiffe_expected, expected_org = parse_principal_id_to_spiffe(principal_id)
 
@@ -194,6 +220,33 @@ async def sign_user_csr(
 
     # Catch malformed paths early so signing failures surface as 400.
     spiffe_to_principal(spiffe_expected)
+
+    # F-A-201 (audit 2026-05-20) — TOFU pubkey check. Compute SPKI
+    # digest from the CSR public key, look up the principal's stored
+    # thumbprint, and refuse if they disagree. Without this, any
+    # workload-bound JWT can mint a 1h cert for
+    # ``<org>::user::<arbitrary-name>`` with the caller's own keypair,
+    # then present that cert at ``/v1/auth/token`` with
+    # ``principal_type=user`` to bypass the ADR-009 mastio counter-
+    # signature and the mTLS gate. Ports the Mastio CRIT-1 defence
+    # (``mcp_proxy/registry/principals_csr.py:247-269``).
+    csr_pubkey_thumb = pubkey_thumbprint_sha256(csr.public_key())
+    parts = principal_id.split("/")
+    if len(parts) == 4 and parts[2] == "user":
+        # Slash-form principal_id (``<td>/<org>/user/<name>``) is the
+        # wire form. The DB row keys on the ``::``-separated short id.
+        short_pid = f"{parts[1]}::user::{parts[3]}"
+        from app.db.database import AsyncSessionLocal
+        from app.registry import user_principals as up
+        async with AsyncSessionLocal() as session:
+            _exists, stored_thumb = await up.get_pubkey_thumbprint(
+                session, short_pid,
+            )
+        if stored_thumb is not None and stored_thumb != csr_pubkey_thumb:
+            raise CsrValidationError(
+                "CSR public key does not match the pubkey already bound "
+                f"to {principal_id!r} (TOFU mismatch, refuse to sign)",
+            )
 
     kms = get_kms_provider()
     ca_key_pem = await kms.get_broker_private_key_pem()
@@ -243,7 +296,7 @@ async def sign_user_csr(
 
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
     thumbprint = _cert_thumbprint_sha256(cert)
-    return cert_pem, thumbprint, not_after
+    return cert_pem, thumbprint, csr_pubkey_thumb, not_after
 
 
 __all__ = [

--- a/app/registry/user_principals.py
+++ b/app/registry/user_principals.py
@@ -66,6 +66,13 @@ class UserPrincipalRecord(Base):
             "idx_user_principals_cert_thumbprint",
             "cert_thumbprint",
         ),
+        # F-A-201 audit 2026-05-20 — pubkey TOFU lookup index. Mirrors
+        # the cert_thumbprint index pattern; nullable so legacy rows
+        # are silently skipped.
+        Index(
+            "idx_user_principals_pubkey_thumbprint",
+            "pubkey_thumbprint",
+        ),
     )
 
     principal_id     = Column(String(255), primary_key=True)
@@ -74,6 +81,14 @@ class UserPrincipalRecord(Base):
     display_name     = Column(String(255), nullable=True)
     cert_thumbprint  = Column(String(64),  nullable=True)
     cert_not_after   = Column(DateTime(timezone=True), nullable=True)
+    # F-A-201 (audit 2026-05-20). TOFU pubkey pin: SHA-256 of the CSR's
+    # SubjectPublicKeyInfo DER. Stable across cert rotations (the
+    # Ambassador re-uses its keypair). sign_user_csr records this on
+    # first signature and refuses subsequent CSRs that present a
+    # different SPKI for the same principal_id. NULL = first-touch
+    # window before any CSR has landed; nullable to preserve TOFU
+    # semantics on legacy rows that predate migration u1p2q3r4s5t6.
+    pubkey_thumbprint = Column(String(64), nullable=True)
     kms_backend      = Column(String(32),  nullable=False)
     kms_key_handle   = Column(String(255), nullable=False)
     provisioned_at   = Column(
@@ -255,6 +270,60 @@ async def attach_cert(
             cert_thumbprint=cert_thumbprint,
             cert_not_after=cert_not_after,
         ),
+    )
+    if cur.rowcount == 0:
+        return None
+    await session.flush()
+    return await get_by_principal_id(session, principal_id)
+
+
+async def get_pubkey_thumbprint(
+    session: AsyncSession,
+    principal_id: str,
+) -> tuple[bool, Optional[str]]:
+    """F-A-201 (audit 2026-05-20). TOFU pubkey lookup for a user
+    principal, mirroring the Mastio
+    ``mcp_proxy.db.get_user_principal_pubkey_thumbprint``.
+
+    Returns ``(exists, pubkey_thumbprint)``:
+      - ``(False, None)`` — no row for ``principal_id``. Caller
+        (``sign_user_csr``) treats this as first-touch and persists the
+        CSR's SPKI digest after signature.
+      - ``(True, None)`` — row exists but no pubkey pinned yet (legacy
+        row predating migration u1p2q3r4s5t6, or admin-pre-created).
+        First CSR roundtrip records the SPKI.
+      - ``(True, "<sha256_hex>")`` — pinned. Caller compares to the
+        presented CSR pubkey and refuses on mismatch.
+    """
+    row = await session.execute(
+        select(UserPrincipalRecord.pubkey_thumbprint)
+        .where(UserPrincipalRecord.principal_id == principal_id),
+    )
+    first = row.first()
+    if first is None:
+        return (False, None)
+    return (True, first[0])
+
+
+async def attach_pubkey_thumbprint(
+    session: AsyncSession,
+    *,
+    principal_id: str,
+    pubkey_thumbprint: str,
+) -> Optional[UserPrincipalView]:
+    """F-A-201 (audit 2026-05-20). Persist the CSR's SPKI digest on
+    first signature so subsequent CSRs are TOFU-checked.
+
+    Idempotent on the column value: re-attaching the same thumbprint is
+    a no-op write. Mismatch is caller's job (``sign_user_csr`` raises
+    ``CsrValidationError`` before reaching this helper).
+    """
+    if not pubkey_thumbprint or len(pubkey_thumbprint) > 64:
+        raise ValueError("pubkey_thumbprint must be 1-64 chars")
+    cur = await session.execute(
+        update(UserPrincipalRecord)
+        .where(UserPrincipalRecord.principal_id == principal_id)
+        .values(pubkey_thumbprint=pubkey_thumbprint),
     )
     if cur.rowcount == 0:
         return None

--- a/app/registry/user_principals_router.py
+++ b/app/registry/user_principals_router.py
@@ -204,7 +204,7 @@ async def sign_csr(
         )
 
     try:
-        cert_pem, thumbprint, not_after = await sign_user_csr(
+        cert_pem, thumbprint, pubkey_thumb, not_after = await sign_user_csr(
             csr_pem=body.csr_pem,
             principal_id=body.principal_id,
         )
@@ -216,6 +216,36 @@ async def sign_csr(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="CSR validation failed",
         ) from exc
+
+    # F-A-201 (audit 2026-05-20). Persist the SPKI digest on first
+    # signature so subsequent CSRs are TOFU-checked. Slash-form
+    # principal_id is the wire/protocol id; the DB stores the
+    # ``::``-separated short id. Best-effort — if the row does not
+    # exist yet (admin has not run /v1/admin/users yet, legacy seed,
+    # etc.) the attach is a no-op and the next signature has a fresh
+    # TOFU window. The Mastio side has the same lazy-create semantics.
+    short_pid_parts = body.principal_id.split("/")
+    if len(short_pid_parts) == 4 and short_pid_parts[2] == "user":
+        from app.db.database import AsyncSessionLocal
+        from app.registry import user_principals as up
+        short_pid = f"{short_pid_parts[1]}::user::{short_pid_parts[3]}"
+        try:
+            async with AsyncSessionLocal() as session:
+                await up.attach_pubkey_thumbprint(
+                    session,
+                    principal_id=short_pid,
+                    pubkey_thumbprint=pubkey_thumb,
+                )
+                await session.commit()
+        except Exception as exc:
+            # Persisting is opportunistic: if the principal row is
+            # missing or the DB layer raises, we still return the
+            # signed cert (the TOFU window stays open for the next
+            # call). Log so operators see when this happens.
+            _log.warning(
+                "principals.csr: attach_pubkey_thumbprint(%s) failed: %s",
+                short_pid, exc,
+            )
 
     _log.info(
         "principals.csr signed principal_id=%s thumbprint=%s not_after=%s",

--- a/tests/test_cert_thumbprint_index.py
+++ b/tests/test_cert_thumbprint_index.py
@@ -94,12 +94,16 @@ def test_alembic_upgrade_creates_thumbprint_indices():
     finally:
         con.close()
 
+    # PR #3 audit 2026-05-20: downgrade to the revision BEFORE the
+    # thumbprint-index migration (t0o1p2q3r4s5_idx_thumb). Using a
+    # named revision rather than ``-1`` keeps the test stable as more
+    # migrations land on top.
     r = subprocess.run(
-        cmd + ["downgrade", "-1"],
+        cmd + ["downgrade", "s9n0o1p2q3r4_replica"],
         capture_output=True, text=True, env=env, cwd=cwd,
     )
     assert r.returncode == 0, (
-        f"alembic downgrade -1 failed: stderr={r.stderr[-1500:]}"
+        f"alembic downgrade failed: stderr={r.stderr[-1500:]}"
     )
 
     con = sqlite3.connect(db_path.name)

--- a/tests/test_court_csr_tofu_pin.py
+++ b/tests/test_court_csr_tofu_pin.py
@@ -1,0 +1,178 @@
+"""PR #3 audit 2026-05-20: F-A-201 Court CSR TOFU pubkey pin (CRITICAL).
+
+The Mastio sister endpoint already enforces this (PR #730/CRIT-1
+audit). Court was the missing leg — any compromised workload token in
+the org could mint a 1h user-principal cert keyed to its OWN keypair,
+then present it at /v1/auth/token with principal_type=user and bypass
+the ADR-009 counter-signature gate plus the mTLS gate.
+
+These tests pin the TOFU semantics so the gap cannot regress:
+- First CSR signs and persists the SPKI thumbprint
+- Second CSR with the SAME keypair is accepted (rotation case)
+- Second CSR with a DIFFERENT keypair for the same principal_id is
+  refused (the attack F-A-201 describes)
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from app.registry.principals_csr import (
+    CsrValidationError,
+    pubkey_thumbprint_sha256,
+    sign_user_csr,
+)
+
+
+def _make_csr(spiffe_uri: str, *, key_type: str = "ec"):
+    if key_type == "ec":
+        key = ec.generate_private_key(ec.SECP256R1())
+    else:
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")])
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.UniformResourceIdentifier(spiffe_uri)]
+            ),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode()
+    return key, csr_pem
+
+
+# ─── pubkey_thumbprint_sha256 unit ────────────────────────────────────
+
+
+def test_pubkey_thumbprint_stable_across_csrs_same_key():
+    """Same keypair → same SPKI digest regardless of CSR shape."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    thumb1 = pubkey_thumbprint_sha256(key.public_key())
+    thumb2 = pubkey_thumbprint_sha256(key.public_key())
+    assert thumb1 == thumb2
+    assert len(thumb1) == 64
+
+
+def test_pubkey_thumbprint_differs_across_keys():
+    """Different keypairs → different SPKI digest."""
+    key_a = ec.generate_private_key(ec.SECP256R1())
+    key_b = ec.generate_private_key(ec.SECP256R1())
+    assert pubkey_thumbprint_sha256(key_a.public_key()) != \
+        pubkey_thumbprint_sha256(key_b.public_key())
+
+
+# ─── sign_user_csr returns 4-tuple including SPKI digest ─────────────
+
+
+@pytest.mark.asyncio
+async def test_sign_user_csr_returns_pubkey_thumbprint():
+    """F-A-201: signed cert response carries the SPKI digest so the
+    caller can persist it via attach_pubkey_thumbprint."""
+    key, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    cert_pem, cert_thumb, pubkey_thumb, _ = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    expected = pubkey_thumbprint_sha256(key.public_key())
+    assert pubkey_thumb == expected
+    assert "BEGIN CERTIFICATE" in cert_pem
+
+
+# ─── TOFU refusal on key mismatch (the F-A-201 attack) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_csr_with_different_key_refused_when_thumbprint_pinned(
+    monkeypatch,
+):
+    """F-A-201 attack chain: a workload token mints a cert for
+    <org>::user::mario using key K_attacker. With a pinned SPKI digest
+    that doesn't match K_attacker, sign_user_csr must refuse."""
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+
+    # Stub: pretend a different SPKI is already pinned for this principal.
+    pinned_thumb = "0" * 64
+    async def _stub_lookup(session, short_pid):
+        assert short_pid == "acme::user::mario"
+        return (True, pinned_thumb)
+
+    monkeypatch.setattr(
+        "app.registry.user_principals.get_pubkey_thumbprint",
+        _stub_lookup,
+    )
+
+    with pytest.raises(CsrValidationError, match="TOFU mismatch"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+@pytest.mark.asyncio
+async def test_csr_with_same_key_accepted_when_thumbprint_pinned(monkeypatch):
+    """F-A-201 counter-test: cert rotation (same keypair, new CSR)
+    must succeed because the SPKI digest matches the pinned value."""
+    key, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    pinned_thumb = pubkey_thumbprint_sha256(key.public_key())
+
+    async def _stub_lookup(session, short_pid):
+        return (True, pinned_thumb)
+
+    monkeypatch.setattr(
+        "app.registry.user_principals.get_pubkey_thumbprint",
+        _stub_lookup,
+    )
+
+    cert_pem, _, pubkey_thumb, _ = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    assert pubkey_thumb == pinned_thumb
+    assert "BEGIN CERTIFICATE" in cert_pem
+
+
+@pytest.mark.asyncio
+async def test_csr_first_touch_accepted_when_no_pin_yet(monkeypatch):
+    """F-A-201 first-touch path: no pinned thumbprint for this
+    principal yet — sign and return the SPKI digest to be persisted
+    by the router."""
+    key, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+
+    async def _stub_lookup(session, short_pid):
+        # Row exists but no pubkey pinned yet (the migration-legacy case).
+        return (True, None)
+
+    monkeypatch.setattr(
+        "app.registry.user_principals.get_pubkey_thumbprint",
+        _stub_lookup,
+    )
+
+    _, _, pubkey_thumb, _ = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    assert pubkey_thumb == pubkey_thumbprint_sha256(key.public_key())
+
+
+@pytest.mark.asyncio
+async def test_csr_no_principal_row_accepted_first_touch(monkeypatch):
+    """F-A-201 first-touch path: principal row does not exist yet
+    (admin has not pre-created via /v1/admin/users). The signer still
+    accepts and returns the SPKI digest so the router can lazy-create."""
+    key, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+
+    async def _stub_lookup(session, short_pid):
+        return (False, None)
+
+    monkeypatch.setattr(
+        "app.registry.user_principals.get_pubkey_thumbprint",
+        _stub_lookup,
+    )
+
+    _, _, pubkey_thumb, _ = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    assert pubkey_thumb == pubkey_thumbprint_sha256(key.public_key())

--- a/tests/test_principals_csr.py
+++ b/tests/test_principals_csr.py
@@ -105,11 +105,12 @@ def test_parse_principal_id_unknown_type_raises():
 
 async def test_sign_user_csr_happy_ec_p256():
     _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
-    cert_pem, thumbprint, not_after = await sign_user_csr(
+    cert_pem, thumbprint, pubkey_thumb, not_after = await sign_user_csr(
         csr_pem, "acme.test/acme/user/mario",
     )
     assert "BEGIN CERTIFICATE" in cert_pem
     assert len(thumbprint) == 64  # sha256 hex
+    assert len(pubkey_thumb) == 64  # F-A-201 SPKI digest, hex
     assert not_after > datetime.now(timezone.utc)
     # Parse the returned cert and check its SAN.
     cert = x509.load_pem_x509_certificate(cert_pem.encode())
@@ -130,7 +131,7 @@ async def test_sign_user_csr_happy_rsa_2048():
     _, csr_pem = _make_csr(
         "spiffe://acme.test/acme/user/mario", key_type="rsa", key_size=2048,
     )
-    cert_pem, thumbprint, _ = await sign_user_csr(
+    cert_pem, thumbprint, _, _ = await sign_user_csr(
         csr_pem, "acme.test/acme/user/mario",
     )
     assert "BEGIN CERTIFICATE" in cert_pem


### PR DESCRIPTION
## Summary

Closes **F-A-201 (CRITICAL)** from the full re-audit 2026-05-20.

This is the only CRITICAL the audit found. Pre-fix, any compromised workload token in an org could escalate to arbitrary user identity in its org by minting a 1h user-principal cert keyed to its own keypair via Court `/v1/principals/csr`, then presenting it at `/v1/auth/token` with `principal_type=user` — which skips the ADR-009 counter-signature gate plus the mTLS gate.

The Mastio sister endpoint (`mcp_proxy/registry/principals_csr.py`) already ships the CRIT-1 TOFU defence (PR #730). The Court half was never ported. Documented systemic risk: dual-tier Court↔Mastio sister-file gap. This is the third instance of the same pattern (memory `feedback_mcp_proxy_csr_gate_f001_missing`).

## Changes

- **Migration** `u1p2q3r4s5t6_user_pubkey`: adds `pubkey_thumbprint VARCHAR(64) NULLABLE` to `user_principals` + index. Nullable to preserve TOFU semantics on legacy rows.
- **Model + helpers** in `app/registry/user_principals.py`:
  - new `pubkey_thumbprint` column on `UserPrincipalRecord`
  - new `get_pubkey_thumbprint(session, principal_id)` mirroring `mcp_proxy.db.get_user_principal_pubkey_thumbprint`
  - new `attach_pubkey_thumbprint(session, principal_id, pubkey_thumbprint)` for the first-touch persist
- **Signer** in `app/registry/principals_csr.py`:
  - new `pubkey_thumbprint_sha256(public_key)` helper (SPKI DER → SHA-256)
  - `sign_user_csr` now returns a **4-tuple** `(cert_pem, cert_thumbprint, pubkey_thumb, not_after)` and refuses on TOFU mismatch
- **Router** in `app/registry/user_principals_router.py`:
  - unpacks the 4-tuple
  - persists the SPKI digest via `attach_pubkey_thumbprint` after signing (best-effort, lazy-create semantics matching the Mastio side)

## TOFU semantics

| State | get_pubkey_thumbprint returns | sign_user_csr behaviour |
|---|---|---|
| Row missing | `(False, None)` | Sign, return SPKI digest for caller-side lazy persist |
| Row exists, no pin | `(True, None)` | Sign, return SPKI digest for first-touch persist |
| Row exists, pinned, match | `(True, "<sha256>")` | Sign (rotation case) |
| Row exists, pinned, mismatch | `(True, "<sha256>")` | Refuse with `CsrValidationError("TOFU mismatch")` |

## Test plan

- [x] 7 new gates in `tests/test_court_csr_tofu_pin.py` covering helper + TOFU paths
- [x] `tests/test_principals_csr.py` updated for the new 4-tuple signature
- [x] `tests/test_cert_thumbprint_index.py` downgrade target updated (named revision so adding more migrations on top stays stable)
- [x] Full pytest: 4126 passed, 9 skipped, 0 fail
- [x] Smoke gate `./sandbox/smoke.sh full`: 25/25 PASS

## Migration safety

- Column is **nullable** — no data migration needed, no down-time
- Alembic revision id 22 chars (under the 32-char Postgres VARCHAR cap, see memory `feedback_alembic_revision_length`)
- Single head verified: `t0o1p2q3r4s5_idx_thumb` → `u1p2q3r4s5t6_user_pubkey`
- Downgrade tested via `test_alembic_upgrade_creates_thumbprint_indices`

## Reference

Audit finding detail: `imp/audits/2026-05-20/findings/track-a/F-A-201.md`