### PR TITLE
fix(audit): Mastio audit_log append-only trigger + hash v2

### DIFF
--- a/mcp_proxy/alembic/versions/0042_audit_log_v2.py
+++ b/mcp_proxy/alembic/versions/0042_audit_log_v2.py
@@ -1,0 +1,138 @@
+"""F-A-402 + F-A-403 — Mastio audit_log append-only trigger + hash v2.
+
+Revision ID: 0042_audit_log_v2
+Revises: 0041_agents_principal_type
+Create Date: 2026-05-20 15:00:00.000000
+
+Audit ref: imp/audits/2026-05-20/findings/track-a/F-A-{402,403}.md
+
+Closes two sister-file gaps on the Mastio primary audit chain:
+
+F-A-402 (HIGH): ``audit_log`` had hash chain semantics
+(``chain_seq``, ``prev_hash``, ``row_hash``) but no BEFORE UPDATE/DELETE
+trigger. The Court ``audit_log`` (migration r8m9n0o1p2q3) and the
+Mastio ``local_audit`` (migration 0031) both have the trigger. An
+attacker with DB write could UPDATE a row, recompute every
+subsequent ``row_hash`` (no signing key, just SHA-256 over data they
+control), and ``verify_audit_chain`` would still pass.
+
+F-A-403 (HIGH): ``compute_audit_row_hash`` canonical excluded
+``dpop_jkt`` (ADR-014 DPoP binding) and ``on_behalf_of_user_id``
+(ADR-032 OBO principal attribution). Both columns were added by
+later migrations (0033, 0034) without bumping the hash format.
+Result: an attacker could swap ``on_behalf_of_user_id='attacker'``
+to ``'victim'`` on a high-value row and ``verify_audit_chain`` would
+not notice. The Court ``compute_entry_hash_v2`` already binds
+``principal_type``, so this is sister-file divergence (third instance
+of the dual-tier gap, see ``feedback_mcp_proxy_csr_gate_f001_missing``).
+
+This migration:
+1. Installs the BEFORE UPDATE/DELETE trigger on ``audit_log`` (Postgres
+   CREATE FUNCTION + CREATE TRIGGER; SQLite CREATE TRIGGER ... RAISE).
+2. Adds ``hash_format`` TEXT NULL column. ``log_audit`` sets it to
+   ``'v2'`` for new rows; legacy rows stay NULL and ``verify_audit_chain``
+   verifies them with the v1 canonical (preserve historical chain).
+
+The v2 canonical extends the v1 canonical with ``|{dpop_jkt or ''}|{
+on_behalf_of_user_id or ''}`` so both attribution columns are bound
+to the chain.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0042_audit_log_v2"
+down_revision: Union[str, Sequence[str], None] = "0041_agents_principal_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "audit_log"
+
+
+_PG_TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION audit_log_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION
+        'audit_log is append-only (F-A-402): % is not permitted',
+        TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_PG_TRIGGER = """
+CREATE TRIGGER audit_log_no_update_or_delete
+BEFORE UPDATE OR DELETE ON audit_log
+FOR EACH ROW EXECUTE FUNCTION audit_log_no_mutate();
+"""
+
+_SQLITE_TRIGGER_UPDATE = """
+CREATE TRIGGER IF NOT EXISTS audit_log_no_update
+BEFORE UPDATE ON audit_log
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_log is append-only (F-A-402): UPDATE not permitted');
+END;
+"""
+
+_SQLITE_TRIGGER_DELETE = """
+CREATE TRIGGER IF NOT EXISTS audit_log_no_delete
+BEFORE DELETE ON audit_log
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_log is append-only (F-A-402): DELETE not permitted');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _TABLE not in existing:
+        return
+
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if "hash_format" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("hash_format", sa.Text(), nullable=True),
+        )
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(_PG_TRIGGER_FN)
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_log_no_update_or_delete ON audit_log"
+        )
+        op.execute(_PG_TRIGGER)
+    elif dialect == "sqlite":
+        op.execute(_SQLITE_TRIGGER_UPDATE)
+        op.execute(_SQLITE_TRIGGER_DELETE)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _TABLE not in existing:
+        return
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_log_no_update_or_delete ON audit_log"
+        )
+        op.execute("DROP FUNCTION IF EXISTS audit_log_no_mutate()")
+    elif dialect == "sqlite":
+        op.execute("DROP TRIGGER IF EXISTS audit_log_no_update")
+        op.execute("DROP TRIGGER IF EXISTS audit_log_no_delete")
+
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if "hash_format" in cols:
+        op.drop_column(_TABLE, "hash_format")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -369,20 +369,41 @@ def compute_audit_row_hash(
     detail: str | None,
     request_id: str | None,
     prev_hash: str,
+    dpop_jkt: str | None = None,
+    on_behalf_of_user_id: str | None = None,
+    hash_format: str | None = None,
 ) -> str:
     """SHA-256 over a canonical encoding of every authoritative field.
 
-    Any tamper to the row — including changing tool_name from ``None``
-    to ``""`` — invalidates the hash. The encoding mirrors the Court
+    Any tamper to the row, including changing tool_name from ``None``
+    to ``""``, invalidates the hash. The encoding mirrors the Court
     pattern in ``app/db/audit.py``: pipe-delimited with empty-string
     sentinels for NULLs and a ``genesis`` literal for the head of the
     chain.
+
+    F-A-403 (audit 2026-05-20). ``hash_format`` dispatches:
+      - NULL / "v1" (legacy rows): v1 canonical, no dpop_jkt or
+        on_behalf_of_user_id binding. Kept so existing chain rows
+        keep verifying after the migration ships.
+      - "v2" (new rows from migration 0042 onward): canonical is
+        prefixed with the literal ``"v2|"`` and extended with
+        ``|{dpop_jkt or ''}|{on_behalf_of_user_id or ''}`` so the
+        ADR-014 DPoP binding and ADR-032 OBO attribution are bound
+        to chain integrity.
     """
-    canonical = (
-        f"{chain_seq}|{timestamp}|{agent_id}|{action}|"
-        f"{tool_name or ''}|{status}|{detail or ''}|"
-        f"{request_id or ''}|{prev_hash}"
-    )
+    if hash_format == "v2":
+        canonical = (
+            f"v2|{chain_seq}|{timestamp}|{agent_id}|{action}|"
+            f"{tool_name or ''}|{status}|{detail or ''}|"
+            f"{request_id or ''}|{dpop_jkt or ''}|"
+            f"{on_behalf_of_user_id or ''}|{prev_hash}"
+        )
+    else:
+        canonical = (
+            f"{chain_seq}|{timestamp}|{agent_id}|{action}|"
+            f"{tool_name or ''}|{status}|{detail or ''}|"
+            f"{request_id or ''}|{prev_hash}"
+        )
     return _hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -517,6 +538,8 @@ async def log_audit(
             async with get_db() as conn:
                 last_seq, prev_hash = await _audit_chain_head(conn)
                 chain_seq = last_seq + 1
+                # F-A-403 (audit 2026-05-20): new rows go in as v2,
+                # binding dpop_jkt + on_behalf_of_user_id to the chain.
                 row_hash = compute_audit_row_hash(
                     chain_seq=chain_seq,
                     timestamp=ts,
@@ -527,6 +550,9 @@ async def log_audit(
                     detail=detail,
                     request_id=request_id,
                     prev_hash=prev_hash,
+                    dpop_jkt=dpop_jkt,
+                    on_behalf_of_user_id=on_behalf_of_user_id,
+                    hash_format="v2",
                 )
                 try:
                     await conn.execute(
@@ -535,12 +561,12 @@ async def log_audit(
                                    timestamp, agent_id, action, tool_name,
                                    status, detail, request_id, duration_ms,
                                    chain_seq, prev_hash, row_hash, dpop_jkt,
-                                   on_behalf_of_user_id
+                                   on_behalf_of_user_id, hash_format
                                ) VALUES (
                                    :timestamp, :agent_id, :action, :tool_name,
                                    :status, :detail, :request_id, :duration_ms,
                                    :chain_seq, :prev_hash, :row_hash, :dpop_jkt,
-                                   :on_behalf_of_user_id
+                                   :on_behalf_of_user_id, :hash_format
                                )"""
                         ),
                         {
@@ -557,6 +583,7 @@ async def log_audit(
                             "row_hash": row_hash,
                             "dpop_jkt": dpop_jkt,
                             "on_behalf_of_user_id": on_behalf_of_user_id,
+                            "hash_format": "v2",
                         },
                     )
                     return
@@ -606,9 +633,14 @@ async def verify_audit_chain(
     Pre-migration rows (``chain_seq IS NULL``) are skipped.
     """
     async with get_db() as conn:
+        # F-A-403 (audit 2026-05-20): SELECT also the v2 attribution
+        # columns and ``hash_format`` so the dispatch below can verify
+        # legacy and new rows with the right canonical.
         stmt = (
             "SELECT chain_seq, prev_hash, row_hash, timestamp, agent_id, "
-            "action, tool_name, status, detail, request_id FROM audit_log "
+            "action, tool_name, status, detail, request_id, dpop_jkt, "
+            "on_behalf_of_user_id, hash_format "
+            "FROM audit_log "
             "WHERE chain_seq IS NOT NULL AND chain_seq >= :start "
             "ORDER BY chain_seq ASC"
         )
@@ -637,6 +669,8 @@ async def verify_audit_chain(
                 return False, chain_seq, f"chain_seq gap: expected {expected_seq}"
             if expected_prev is not None and prev_hash != expected_prev:
                 return False, chain_seq, "prev_hash mismatch with previous row"
+        # F-A-403 dispatch: v2 rows feed dpop_jkt + on_behalf_of_user_id
+        # into the canonical; v1/NULL rows verify with the legacy form.
         recomputed = compute_audit_row_hash(
             chain_seq=chain_seq,
             timestamp=str(row[3]),
@@ -647,6 +681,9 @@ async def verify_audit_chain(
             detail=row[8],
             request_id=row[9],
             prev_hash=prev_hash,
+            dpop_jkt=row[10],
+            on_behalf_of_user_id=row[11],
+            hash_format=row[12],
         )
         if recomputed != stored_hash:
             return False, chain_seq, "row_hash mismatch — row tampered"

--- a/tests/test_audit_api.py
+++ b/tests/test_audit_api.py
@@ -80,7 +80,12 @@ async def seeded_agents(proxy_app):
             request_id=request_id,
             duration_ms=duration,
         )
+        # F-A-402 (audit 2026-05-20): migration 0042 installs an
+        # append-only trigger on audit_log. The seed helper backfills
+        # timestamps for deterministic test ordering, which is a
+        # legitimate test-only override of the production gate.
         async with get_db() as conn:
+            await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_no_update"))
             await conn.execute(
                 text(
                     "UPDATE audit_log SET timestamp = :ts "

--- a/tests/test_h4_audit_chain.py
+++ b/tests/test_h4_audit_chain.py
@@ -104,7 +104,13 @@ async def test_verify_chain_catches_detail_tamper(proxy_app):
 
     # Rewrite row 3's detail without touching row_hash — the kind of
     # mutation an operator with DB write access could do.
+    # F-A-402 (audit 2026-05-20): migration 0042 installs a
+    # BEFORE UPDATE/DELETE trigger on audit_log. Drop it locally to
+    # simulate the threat model "attacker with DB write that bypasses
+    # the schema gate" — the test asserts verify_audit_chain catches
+    # the tamper as the second layer of defence.
     async with get_db() as conn:
+        await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_no_update"))
         await conn.execute(
             text("UPDATE audit_log SET detail = 'rewritten' WHERE chain_seq = 3"),
         )
@@ -126,6 +132,8 @@ async def test_verify_chain_catches_dropped_row(proxy_app):
                         detail=f"row-{i}")
 
     async with get_db() as conn:
+        # F-A-402: simulate attacker bypassing the schema trigger.
+        await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_no_delete"))
         await conn.execute(
             text("DELETE FROM audit_log WHERE chain_seq = 3"),
         )
@@ -156,10 +164,16 @@ async def test_verify_chain_catches_prev_hash_tamper(proxy_app):
     # leave row 4's prev_hash untouched. The chain walker should
     # flag row 4 as the break point.
     async with get_db() as conn:
+        # F-A-402: simulate attacker bypassing the schema trigger.
+        # F-A-403: recompute with the same v2 inputs the live row has
+        # so we exercise the prev_hash-mismatch detection on row 4.
+        await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_no_update"))
         row3 = (await conn.execute(
             text(
                 "SELECT timestamp, agent_id, action, tool_name, status, "
-                "detail, request_id, prev_hash FROM audit_log WHERE chain_seq = 3",
+                "detail, request_id, prev_hash, dpop_jkt, "
+                "on_behalf_of_user_id, hash_format "
+                "FROM audit_log WHERE chain_seq = 3",
             ),
         )).first()
         new_hash = compute_audit_row_hash(
@@ -172,6 +186,9 @@ async def test_verify_chain_catches_prev_hash_tamper(proxy_app):
             detail="rewritten",
             request_id=row3[6],
             prev_hash=str(row3[7]),
+            dpop_jkt=row3[8],
+            on_behalf_of_user_id=row3[9],
+            hash_format=row3[10],
         )
         await conn.execute(
             text(

--- a/tests/test_mastio_audit_log_v2.py
+++ b/tests/test_mastio_audit_log_v2.py
@@ -1,0 +1,174 @@
+"""PR #4 audit 2026-05-20: Mastio audit_log v2 + append-only trigger.
+
+Closes F-A-402 (BEFORE UPDATE/DELETE trigger missing on the Mastio
+primary audit_log) and F-A-403 (canonical hash excluded dpop_jkt +
+on_behalf_of_user_id, so attribution was forgeable via UPDATE).
+
+These tests pin both gates so the dual-tier Court↔Mastio sister-file
+pattern cannot regress on this surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.db import compute_audit_row_hash
+
+
+# ─── F-A-403 v2 canonical includes dpop_jkt + on_behalf_of_user_id ────
+
+
+def test_v2_canonical_includes_dpop_jkt():
+    """Same v1 inputs, different dpop_jkt → different row_hash under v2.
+    Pre-fix the two were equal because the canonical ignored the column."""
+    base = dict(
+        chain_seq=1,
+        timestamp="2026-05-20T15:00:00Z",
+        agent_id="acme::frontdesk",
+        action="tool_call",
+        tool_name="search",
+        status="ok",
+        detail="",
+        request_id="req-1",
+        prev_hash="genesis",
+        on_behalf_of_user_id="alice",
+        hash_format="v2",
+    )
+    h_a = compute_audit_row_hash(**{**base, "dpop_jkt": "thumb_a"})
+    h_b = compute_audit_row_hash(**{**base, "dpop_jkt": "thumb_b"})
+    assert h_a != h_b, "v2 must bind dpop_jkt into the canonical"
+
+
+def test_v2_canonical_includes_on_behalf_of_user_id():
+    """Same v1 inputs, different on_behalf_of_user_id → different
+    row_hash under v2. Pre-fix the attacker could swap victim_user
+    for attacker_user without detection."""
+    base = dict(
+        chain_seq=1,
+        timestamp="2026-05-20T15:00:00Z",
+        agent_id="acme::frontdesk",
+        action="tool_call",
+        tool_name="search",
+        status="ok",
+        detail="",
+        request_id="req-1",
+        prev_hash="genesis",
+        dpop_jkt="thumb",
+        hash_format="v2",
+    )
+    h_alice = compute_audit_row_hash(
+        **{**base, "on_behalf_of_user_id": "alice"},
+    )
+    h_eve = compute_audit_row_hash(
+        **{**base, "on_behalf_of_user_id": "eve"},
+    )
+    assert h_alice != h_eve, (
+        "v2 must bind on_behalf_of_user_id (the F-A-403 attack)"
+    )
+
+
+def test_v1_canonical_unchanged_for_legacy_rows():
+    """Legacy rows (hash_format=NULL or 'v1') must verify with the
+    v1 canonical regardless of dpop_jkt / on_behalf_of_user_id values
+    passed at recompute time. Backward compat invariant."""
+    base = dict(
+        chain_seq=1,
+        timestamp="2026-05-20T15:00:00Z",
+        agent_id="acme::frontdesk",
+        action="tool_call",
+        tool_name="search",
+        status="ok",
+        detail="",
+        request_id="req-1",
+        prev_hash="genesis",
+    )
+    # hash_format=None (legacy) — dpop_jkt + obo ignored.
+    h_legacy_no_dpop = compute_audit_row_hash(
+        **base, dpop_jkt=None, on_behalf_of_user_id=None,
+    )
+    h_legacy_with_dpop = compute_audit_row_hash(
+        **base, dpop_jkt="thumb", on_behalf_of_user_id="alice",
+    )
+    assert h_legacy_no_dpop == h_legacy_with_dpop, (
+        "v1 must not bind the new columns (legacy rows precede the migration)"
+    )
+
+    # Explicit "v1" string also takes the legacy path.
+    h_explicit_v1 = compute_audit_row_hash(
+        **base, dpop_jkt="thumb", on_behalf_of_user_id="alice",
+        hash_format="v1",
+    )
+    assert h_explicit_v1 == h_legacy_no_dpop
+
+
+def test_v2_prefix_differs_from_v1_for_same_v1_inputs():
+    """A v2 row with NO attribution columns set still produces a
+    different hash from its v1 equivalent, because the canonical is
+    prefixed with the literal ``v2|``. Prevents downgrade-style
+    attacks: an attacker who knows the v1 inputs cannot precompute
+    the v2 hash without knowing the format discriminator."""
+    base = dict(
+        chain_seq=1,
+        timestamp="2026-05-20T15:00:00Z",
+        agent_id="acme::frontdesk",
+        action="tool_call",
+        tool_name="search",
+        status="ok",
+        detail="",
+        request_id="req-1",
+        prev_hash="genesis",
+    )
+    h_v1 = compute_audit_row_hash(**base)
+    h_v2 = compute_audit_row_hash(
+        **base, dpop_jkt=None, on_behalf_of_user_id=None, hash_format="v2",
+    )
+    assert h_v1 != h_v2
+
+
+# ─── F-A-402 append-only trigger ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_log_update_blocked_by_trigger(tmp_path):
+    """F-A-402: a raw SQL UPDATE on audit_log must be rejected by the
+    schema trigger. Mirrors the parity test for local_audit
+    (tests/test_proxy_local_audit_chain.py) and the Court equivalent
+    (r8m9n0o1p2q3)."""
+    from sqlalchemy import text
+    from mcp_proxy.db import dispose_db, init_db, get_db, log_audit
+
+    db_file = tmp_path / "audit_v2.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    try:
+        await log_audit(
+            agent_id="acme::test",
+            action="tool_call",
+            tool_name="search",
+            status="ok",
+            detail="seed",
+        )
+
+        async with get_db() as conn:
+            with pytest.raises(Exception) as exc:
+                await conn.execute(
+                    text(
+                        "UPDATE audit_log SET detail = 'tampered' "
+                        "WHERE id = 1"
+                    ),
+                )
+            assert "append-only" in str(exc.value).lower() or (
+                "f-a-402" in str(exc.value).lower()
+            ), f"Expected append-only trigger raise, got: {exc.value}"
+
+        async with get_db() as conn:
+            with pytest.raises(Exception) as exc:
+                await conn.execute(
+                    text("DELETE FROM audit_log WHERE id = 1"),
+                )
+            assert "append-only" in str(exc.value).lower() or (
+                "f-a-402" in str(exc.value).lower()
+            ), (
+                f"Expected append-only trigger raise on DELETE, got: {exc.value}"
+            )
+    finally:
+        await dispose_db()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0041_agents_principal_type",)]
+    assert rows == [("0042_audit_log_v2",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0041_agents_principal_type",)]
+    assert version == [("0042_audit_log_v2",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0041_agents_principal_type"
+HEAD_REVISION = "0042_audit_log_v2"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0041_agents_principal_type"
+HEAD_REVISION = "0042_audit_log_v2"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0041_agents_principal_type"
+HEAD_REVISION = "0042_audit_log_v2"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

Closes 2 HIGH findings from the full re-audit 2026-05-20.

**F-A-402 (HIGH)**: Mastio primary `audit_log` had hash chain semantics but no BEFORE UPDATE/DELETE trigger. The Court `audit_log` and the Mastio `local_audit` both ship the trigger; this was the third sister table that missed the ratification (dual-tier sister-file pattern, see memory `feedback_mcp_proxy_csr_gate_f001_missing`).

**F-A-403 (HIGH)**: `compute_audit_row_hash` canonical excluded `dpop_jkt` (ADR-014 DPoP binding) and `on_behalf_of_user_id` (ADR-032 OBO attribution). An attacker with DB write could swap `on_behalf_of_user_id` from attacker to victim on a high-value row and `verify_audit_chain` would not notice.

## Changes

- **Migration** `0042_audit_log_v2` (Mastio): installs the BEFORE UPDATE/DELETE trigger on `audit_log` + adds `hash_format` TEXT NULL column. Postgres CREATE FUNCTION + CREATE TRIGGER, SQLite CREATE TRIGGER + RAISE.
- **`compute_audit_row_hash`** accepts `dpop_jkt`, `on_behalf_of_user_id`, `hash_format` params:
  - `hash_format=NULL` / `"v1"` → legacy canonical (backward compat invariant)
  - `hash_format="v2"` → prefixed canonical that binds both attribution columns
- **`log_audit`** writes new rows with `hash_format="v2"` so the chain rolls forward.
- **`verify_audit_chain`** SELECTs the additional columns and dispatches per row.

## Findings closed

| ID | Severity | Surface | Title |
|---|---|---|---|
| F-A-402 | HIGH | audit | Mastio audit_log missing BEFORE UPDATE/DELETE trigger |
| F-A-403 | HIGH | audit | Mastio audit_log hash canonical excludes dpop_jkt + OBO |

## Test plan

- [x] 5 new gates in `tests/test_mastio_audit_log_v2.py`:
  - v2 canonical binds `dpop_jkt`
  - v2 canonical binds `on_behalf_of_user_id` (the F-A-403 attack)
  - v1 backward compat (legacy rows ignore new columns)
  - v2 prefix differs from v1 for the same v1 inputs
  - Schema trigger refuses UPDATE + DELETE
- [x] `test_h4_audit_chain.py` tamper tests updated to DROP TRIGGER locally (simulates attacker bypassing the schema gate)
- [x] `test_audit_api.py` seed helper drops trigger for test-only backfill
- [x] HEAD_REVISION bumped to `0042_audit_log_v2` in 4 migration test files
- [x] Full pytest: 4123 passed, 9 skipped, 1 known timing flake (`test_sweeper_expires_ttl_rows`)
- [x] Smoke gate `./sandbox/smoke.sh full`: 25/25 PASS

## Migration safety

- `hash_format` is nullable — no data migration needed, no down-time
- Legacy rows keep verifying with v1 canonical
- Single head verified
- Postgres + SQLite trigger implementations parity (mirror of 0031)

## Reference

Audit findings: `imp/audits/2026-05-20/findings/track-a/F-A-{402,403}.md`