### PR TITLE
fix(connector): atomic 0600 secret writes (F-B-401)

### DIFF
--- a/cullis_connector/_atomic_write.py
+++ b/cullis_connector/_atomic_write.py
@@ -1,0 +1,103 @@
+"""Atomic + permission-correct secret writes (audit F-B-401).
+
+Several Connector call sites used the ``open(..., "w") + chmod 0600``
+idiom. POSIX ``open(2)`` applies the default umask (typically 0644) to
+the file at creation time; ``chmod`` runs after the bytes touch the
+disk. The window between the two is microseconds but mechanically
+observable on any multi-user box — Frontdesk container, sandbox with
+multiple developer processes, any host where a daemon shares a
+filesystem with non-root users.
+
+This helper closes the window: ``tempfile.mkstemp`` creates the file
+with mode 0600 by default, we then ``os.fchmod`` to the requested mode
+(idempotent if it was already 0600), write the bytes, and ``os.replace``
+atomically into the destination. Crash safety is preserved (replace is
+atomic on POSIX) and no readable-by-other window ever opens.
+
+Use:
+
+    from cullis_connector._atomic_write import write_with_mode
+
+    write_with_mode(
+        path,
+        data=b"...",
+        mode=0o600,
+    )
+
+Or, when the existing call uses text + encoding:
+
+    write_with_mode(
+        path,
+        data=text.encode("utf-8"),
+        mode=0o600,
+    )
+
+All call sites in the Connector that write secret material (Bearer
+tokens, PEM private keys, cookie secrets) must use this helper.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+_log = logging.getLogger("cullis_connector._atomic_write")
+
+
+def write_with_mode(path: Path, *, data: bytes, mode: int) -> None:
+    """Atomically write ``data`` to ``path`` with file mode ``mode``.
+
+    Implementation steps:
+
+      1. ``tempfile.mkstemp`` creates a fresh file *in the same
+         directory* with permissions 0600 (the tempfile default).
+         Same-dir ensures ``os.replace`` is atomic (POSIX requires the
+         tmp file and the destination live on the same filesystem).
+      2. ``os.fchmod`` brings the mode to the caller-requested value.
+         For 0600 this is a no-op; for other modes (e.g. 0644 for a
+         non-secret config sibling) it adjusts before any byte hits.
+      3. Write the bytes through the fd.
+      4. ``os.replace`` swaps the tmp into the destination atomically.
+
+    On Windows ``mkstemp`` ignores the POSIX mode and ``os.fchmod``
+    raises NotImplementedError. We catch + warn rather than fail —
+    the trust boundary on Windows is the OS user account, not the
+    file ACL.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(dir=str(parent), prefix=path.name + ".", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        try:
+            os.fchmod(fd, mode)
+        except (NotImplementedError, OSError) as exc:
+            _log.info(
+                "could not fchmod %o on %s (filesystem may not support it): %s",
+                mode, tmp_path, exc,
+            )
+        with os.fdopen(fd, "wb") as fh:
+            fd = -1  # ownership transferred to the file object
+            fh.write(data)
+        os.replace(tmp_path, path)
+    except Exception:
+        # Clean up the temp file on any failure path. If we transferred
+        # ownership to the file object, fdopen's context manager already
+        # closed the fd; only unlink is left.
+        if fd != -1:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def write_text_with_mode(path: Path, *, text: str, mode: int, encoding: str = "utf-8") -> None:
+    """Convenience wrapper for text payloads. Encodes then delegates."""
+    write_with_mode(path, data=text.encode(encoding), mode=mode)

--- a/cullis_connector/ambassador/auth.py
+++ b/cullis_connector/ambassador/auth.py
@@ -76,23 +76,23 @@ def rotate_local_token(config_dir: Path) -> str:
 
 
 def _write_new_local_token(config_dir: Path, *, reason: str) -> str:
-    """Generate a fresh token, write it 0600, return it.
+    """Generate a fresh token, write it 0600 atomically, return it.
 
     Shared body for ``ensure_local_token`` first-create path and the
     ``rotate_local_token`` explicit overwrite path. ``reason`` is only
     used for the log line.
+
+    Audit F-B-401 — uses ``cullis_connector._atomic_write.write_text_with_mode``
+    so the file is created 0600 atomically (tempfile.mkstemp → fchmod
+    → os.replace). The pre-fix ``write_text + chmod`` idiom left a
+    microsecond window during which the 64-char hex Bearer hit the
+    disk world-readable.
     """
+    from cullis_connector._atomic_write import write_text_with_mode
+
     token = secrets.token_hex(32)
-    config_dir.mkdir(parents=True, exist_ok=True)
     token_path = config_dir / LOCAL_TOKEN_FILENAME
-    token_path.write_text(token + "\n", encoding="utf-8")
-    try:
-        token_path.chmod(0o600)
-    except OSError:
-        # Some filesystems (e.g. on Windows) ignore chmod. Logged at
-        # info, not warning, because the local trust boundary is the
-        # OS user not the file mode in those environments.
-        _log.info("could not chmod 0600 on %s (filesystem may not support it)", token_path)
+    write_text_with_mode(token_path, text=token + "\n", mode=0o600)
     _log.info("%s local token at %s", reason, token_path)
     return token
 

--- a/cullis_connector/ambassador/shared/keystore.py
+++ b/cullis_connector/ambassador/shared/keystore.py
@@ -113,10 +113,11 @@ class UserKeyStore:
             priv = ec.generate_private_key(ec.SECP256R1())
             pem = _key_pem_from_priv(priv)
             self._base_dir.mkdir(parents=True, exist_ok=True)
-            tmp = path.with_suffix(path.suffix + ".tmp")
-            tmp.write_text(pem, encoding="utf-8")
-            os.chmod(tmp, 0o600)
-            os.replace(tmp, path)
+            # Audit F-B-401 — atomic 0600 write so the PEM never hits
+            # disk under the default umask before chmod closes the
+            # window. Same helper used by the single-mode keystore.
+            from cullis_connector._atomic_write import write_text_with_mode
+            write_text_with_mode(path, text=pem, mode=0o600)
             _log.info(
                 "keystore created principal_id=%s path=%s",
                 principal_id, path,

--- a/cullis_connector/ambassador/shared/wire.py
+++ b/cullis_connector/ambassador/shared/wire.py
@@ -79,15 +79,12 @@ def bootstrap_cookie_secret(config_dir: Path) -> bytes:
             "regenerating", path, len(raw),
         )
     secret = secrets.token_bytes(SECRET_LEN_BYTES)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_bytes(secret)
-    try:
-        os.chmod(tmp, 0o600)
-    except OSError:
-        _log.info(
-            "could not chmod 0600 on %s (filesystem may not support it)", tmp,
-        )
-    os.replace(tmp, path)
+    # Audit F-B-401 — the cookie secret is the HMAC key for every
+    # Frontdesk shared-mode session cookie. Atomic 0600 write so the
+    # 64 random bytes don't sit on disk world-readable for the chmod
+    # window.
+    from cullis_connector._atomic_write import write_with_mode
+    write_with_mode(path, data=secret, mode=0o600)
     _log.info("shared cookie secret generated at %s (0600)", path)
     return secret
 

--- a/cullis_connector/identity/store.py
+++ b/cullis_connector/identity/store.py
@@ -15,6 +15,7 @@ where it matters (POSIX only — Windows NTFS ACLs are out of scope for v1).
 from __future__ import annotations
 
 import json
+import logging
 import os
 import stat
 from dataclasses import dataclass
@@ -24,6 +25,8 @@ from pathlib import Path
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+
+_log = logging.getLogger("cullis_connector.identity.store")
 
 CERT_FILENAME = "agent.crt"
 KEY_FILENAME = "agent.key"
@@ -213,24 +216,50 @@ def load_identity(config_dir: Path) -> IdentityBundle:
 
 
 def _write_atomic(path: Path, data: bytes, *, mode: int) -> None:
-    """Write ``data`` to ``path`` via a tmp file + rename for crash safety."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with open(tmp, "wb") as fh:
-        fh.write(data)
-    os.chmod(tmp, mode)
-    os.replace(tmp, path)
+    """Write ``data`` to ``path`` atomically with the requested file mode.
+
+    Audit F-B-401 — delegates to
+    ``cullis_connector._atomic_write.write_with_mode`` which uses
+    ``tempfile.mkstemp`` (creates 0600 by default) + ``os.fchmod`` +
+    ``os.replace`` so the bytes never hit disk under the default umask
+    permissions. Pre-fix the open-then-chmod idiom left a microsecond
+    window during which agent private keys (PEM) and DPoP jwk material
+    were readable by any other UID on the box.
+    """
+    from cullis_connector._atomic_write import write_with_mode
+
+    write_with_mode(path, data=data, mode=mode)
 
 
 def _ensure_private_key_permissions(path: Path) -> None:
-    """Best-effort check on POSIX that the key file is not world-readable."""
+    """Defence-in-depth: warn loudly if a key file is found with loose
+    perms; only fix silently when explicitly opted in.
+
+    Audit F-B-401 recommendation — the pre-2026-05-20 version silently
+    chmod'd the file back to 0600. That hid the underlying drift (a
+    backup-restore from a different UID, a packaging bug, an operator
+    copying files with a permissive umask). An operator needs to see
+    the signal, not have it papered over.
+
+    We still chmod the file to close the immediate exposure window —
+    leaving a world-readable key on disk would be worse than fixing it
+    without telling anyone — but the WARNING gives ops a reliable
+    grep target.
+    """
     if os.name != "posix":
         return
     try:
         mode = path.stat().st_mode
     except OSError:
         return
-    # Any group or other read/write/execute bit is too permissive.
     if mode & (stat.S_IRWXG | stat.S_IRWXO):
+        _log.warning(
+            "F-B-401: private key file %s had permissive mode %o "
+            "(group/other readable). Fixing to 0600 — but the underlying "
+            "drift (backup-restore with different UID, packaging bug, "
+            "loose umask) needs investigation.",
+            path, mode & 0o777,
+        )
         os.chmod(path, 0o600)
 
 

--- a/tests/test_connector_atomic_write.py
+++ b/tests/test_connector_atomic_write.py
@@ -1,0 +1,208 @@
+"""Tests for the Connector atomic-write helper + secret-write call sites (F-B-401).
+
+The pre-2026-05-20 idiom ``Path.write_text(...) + chmod(0o600)`` left a
+microsecond window during which the file was readable by other UIDs on
+the box. The fix routes all secret writes through
+``cullis_connector._atomic_write.write_with_mode``, which uses
+``tempfile.mkstemp`` (creates 0600 by default) + ``os.fchmod`` +
+``os.replace``.
+
+We test two things:
+
+  1. The helper itself: file lands with the requested mode, content is
+     correct, no race-window file ever appears with permissive mode,
+     atomic replace works (existing file is overwritten with the new
+     content).
+  2. The migrated call sites (auth.py _write_new_local_token,
+     identity/store.py _write_atomic, shared/keystore.py, shared/wire.py
+     _ensure_cookie_secret) deliver files at mode 0600 first try.
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+
+# ── Helper unit tests ─────────────────────────────────────────────
+
+
+def test_write_with_mode_creates_file_with_requested_mode(tmp_path):
+    """The helper must lay the file down at the requested mode on the
+    first stat. No transient permissive-mode file ever shows up."""
+    from cullis_connector._atomic_write import write_with_mode
+
+    target = tmp_path / "secret.bin"
+    write_with_mode(target, data=b"hello", mode=0o600)
+
+    assert target.read_bytes() == b"hello"
+    # 0600 only — no group or other bit.
+    perm = stat.S_IMODE(target.stat().st_mode)
+    assert perm == 0o600, f"expected 0o600, got {oct(perm)}"
+
+
+def test_write_text_with_mode_encodes_utf8(tmp_path):
+    from cullis_connector._atomic_write import write_text_with_mode
+
+    target = tmp_path / "secret.txt"
+    write_text_with_mode(target, text="cafè\n", mode=0o600)
+
+    assert target.read_text(encoding="utf-8") == "cafè\n"
+    perm = stat.S_IMODE(target.stat().st_mode)
+    assert perm == 0o600
+
+
+def test_write_with_mode_overwrites_existing_atomically(tmp_path):
+    from cullis_connector._atomic_write import write_with_mode
+
+    target = tmp_path / "secret.bin"
+    target.write_bytes(b"old-content")
+    target.chmod(0o644)  # pretend it was created loose by an old version
+
+    write_with_mode(target, data=b"new-content", mode=0o600)
+
+    assert target.read_bytes() == b"new-content"
+    perm = stat.S_IMODE(target.stat().st_mode)
+    assert perm == 0o600
+
+
+def test_write_with_mode_cleans_up_temp_on_failure(tmp_path, monkeypatch):
+    """If os.replace fails, the temp file must not linger in the
+    destination directory — otherwise the next caller sees an extra
+    .tmp file with secret content even on the failure path."""
+    from cullis_connector import _atomic_write
+
+    target = tmp_path / "secret.bin"
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", _boom)
+
+    with pytest.raises(OSError, match="simulated"):
+        _atomic_write.write_with_mode(target, data=b"hello", mode=0o600)
+
+    # No leftover .tmp file in the parent directory.
+    leftover = [p for p in tmp_path.iterdir() if p.name.startswith("secret.bin.")]
+    assert leftover == [], f"temp file leaked on failure path: {leftover}"
+
+
+def test_write_with_mode_creates_parent_directory(tmp_path):
+    from cullis_connector._atomic_write import write_with_mode
+
+    target = tmp_path / "nested" / "deep" / "secret.bin"
+    write_with_mode(target, data=b"x", mode=0o600)
+    assert target.is_file()
+    perm = stat.S_IMODE(target.stat().st_mode)
+    assert perm == 0o600
+
+
+# ── Call site regression: local Bearer token ──────────────────────
+
+
+def test_local_token_file_lands_0600(tmp_path):
+    """The Bearer minted by ``_write_new_local_token`` must hit disk
+    at mode 0600 on first stat — never readable by other UIDs."""
+    from cullis_connector.ambassador.auth import (
+        LOCAL_TOKEN_FILENAME,
+        rotate_local_token,
+    )
+
+    token = rotate_local_token(tmp_path)
+    assert len(token) == 64  # 32 bytes hex
+    token_path = tmp_path / LOCAL_TOKEN_FILENAME
+    assert token_path.is_file()
+    perm = stat.S_IMODE(token_path.stat().st_mode)
+    assert perm == 0o600, f"local Bearer file mode {oct(perm)} — should be 0o600"
+
+
+# ── Call site regression: identity store keys ─────────────────────
+
+
+def test_identity_store_write_atomic_uses_helper(tmp_path):
+    """``_write_atomic`` is the entry point for agent.key + dpop.jwk +
+    metadata. After F-B-401 it delegates to the helper."""
+    from cullis_connector.identity import store
+
+    target = tmp_path / "agent.key"
+    store._write_atomic(target, b"---PRIVATE KEY---", mode=0o600)
+    assert target.read_bytes() == b"---PRIVATE KEY---"
+    perm = stat.S_IMODE(target.stat().st_mode)
+    assert perm == 0o600
+
+
+def test_ensure_private_key_permissions_warns_on_loose_mode(tmp_path, caplog):
+    """Loose-perm detection now logs WARNING (audit F-B-401) rather
+    than silently chmodding. The file still gets fixed — leaving it
+    world-readable would be worse — but ops sees the drift signal."""
+    if os.name != "posix":
+        pytest.skip("posix-only path")
+    from cullis_connector.identity import store
+
+    target = tmp_path / "agent.key"
+    target.write_bytes(b"---PRIVATE KEY---")
+    target.chmod(0o644)  # simulate a backup-restore with loose perms
+
+    import logging
+    captured: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            captured.append(record.getMessage())
+
+    logger = logging.getLogger("cullis_connector.identity.store")
+    h = _Capture()
+    h.setLevel(logging.WARNING)
+    logger.addHandler(h)
+    try:
+        store._ensure_private_key_permissions(target)
+    finally:
+        logger.removeHandler(h)
+
+    # File was tightened.
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    # The drift was reported.
+    assert any("F-B-401" in m for m in captured), (
+        f"expected F-B-401 warning, got {captured!r}"
+    )
+
+
+# ── Call site regression: shared keystore (Frontdesk per-user) ────
+
+
+def test_shared_keystore_persists_user_key_0600(tmp_path):
+    """``shared.keystore.UserKeyStore.get_or_create`` writes the
+    per-user EC private key at 0600. The first-time-provision path is
+    the one F-B-401 fixed."""
+    import asyncio
+
+    from cullis_connector.ambassador.shared.keystore import UserKeyStore
+
+    ks = UserKeyStore(base_dir=tmp_path)
+    pem = asyncio.run(ks.get_or_create("acme/user/alice"))
+    assert "BEGIN" in pem and "PRIVATE KEY" in pem
+
+    # Find the file (UserKeyStore hashes the principal_id for the filename)
+    keys = [p for p in tmp_path.iterdir() if p.is_file() and not p.name.endswith(".tmp")]
+    assert len(keys) == 1, f"expected exactly one key file, got {keys}"
+    perm = stat.S_IMODE(keys[0].stat().st_mode)
+    assert perm == 0o600
+
+
+# ── Call site regression: shared cookie secret ───────────────────
+
+
+def test_shared_cookie_secret_lands_0600(tmp_path):
+    """``bootstrap_cookie_secret`` mints the HMAC key for every Frontdesk
+    shared-mode session cookie. Must land 0600."""
+    from cullis_connector.ambassador.shared import wire
+
+    secret = wire.bootstrap_cookie_secret(tmp_path)
+    assert len(secret) == wire.SECRET_LEN_BYTES
+
+    secret_path = tmp_path / wire.COOKIE_SECRET_FILENAME
+    assert secret_path.is_file()
+    perm = stat.S_IMODE(secret_path.stat().st_mode)
+    assert perm == 0o600


### PR DESCRIPTION
## Summary

Sprint 2 Quick-Win 2/2 — closes audit MAJOR F-B-401 (TOCTOU race on secret file writes).

Four Connector call sites used \`Path.write_text(...) + chmod(0o600)\`. POSIX \`open(2)\` applies the default umask (0644) at creation; \`chmod\` runs after the bytes hit the disk. The window is microseconds but mechanically observable on:

- the Frontdesk container (shared filesystem between Connector and operator)
- the sandbox (multiple developer processes on the same login)
- any host where a daemon shares a filesystem with non-root UIDs

Sites:
1. \`cullis_connector/ambassador/auth.py\` — the local Bearer for \`/v1/chat/completions\` etc.
2. \`cullis_connector/identity/store.py\` — agent.key PEM + dpop.jwk
3. \`cullis_connector/ambassador/shared/keystore.py\` — Frontdesk per-user EC keys
4. \`cullis_connector/ambassador/shared/wire.py\` — cookie HMAC secret

## Approach

New \`cullis_connector/_atomic_write.py\`:

\`\`\`python
write_with_mode(path, *, data, mode):
    # tempfile.mkstemp in same dir (creates 0600 by default,
    # keeps os.replace atomic — POSIX requires same filesystem)
    # os.fchmod brings the fd to requested mode (no-op when 0600)
    # write bytes through the fd
    # os.replace atomically into destination
    # on failure: unlink tmp so no .tmp secret lingers
\`\`\`

Plus \`write_text_with_mode\` UTF-8 wrapper. All 4 call sites now go through the helper.

Also tightened \`_ensure_private_key_permissions\`: pre-fix it silently chmodded loose-perm key files (per audit rec 2). Now logs a WARNING tagged \`F-B-401\` so ops sees the drift signal (backup-restore with different UID, packaging bug, loose umask). The chmod still happens — leaving a key world-readable would be worse — but the silent fix-up was masking real failures.

## Test plan

- [x] \`pytest tests/test_connector_atomic_write.py -q\` — 10 passed (5 helper unit + 5 call-site regression)
- [x] \`pytest tests/ --ignore=tests/integration --ignore=tests/e2e --deselect ... -q\` — 4182 passed, 9 skipped, 32 xfailed
- [x] \`./sandbox/demo.sh full && ./sandbox/smoke.sh full\` — 25/25 PASS (B4.7 re-run once, expected)
- [x] Regression: \`test_local_token_file_lands_0600\` asserts the Bearer hits disk at 0600 on first stat
- [x] Regression: \`test_ensure_private_key_permissions_warns_on_loose_mode\` asserts the audit-tagged warning fires
- [x] DCO Signed-off-by
- [x] No \`Co-Authored-By: Claude\`

## Scope

| File | Change |
|---|---|
| \`cullis_connector/_atomic_write.py\` (new) | Helper module |
| \`cullis_connector/ambassador/auth.py\` | _write_new_local_token → write_text_with_mode |
| \`cullis_connector/identity/store.py\` | _write_atomic → write_with_mode + WARN on loose perms |
| \`cullis_connector/ambassador/shared/keystore.py\` | UserKeyStore.get_or_create → write_text_with_mode |
| \`cullis_connector/ambassador/shared/wire.py\` | bootstrap_cookie_secret → write_with_mode |
| \`tests/test_connector_atomic_write.py\` (new) | 10 tests |

## Out of scope

Other Connector / Mastio secret writes that may exist on different paths (oidc_session, statusline_token, ...). The audit specifically flagged the 4 sites above; the helper is now available for a follow-up sweep.

Audit ref: \`imp/audits/2026-05-20/findings/track-b/F-B-401.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)