### PR TITLE
refactor(dashboard): extract Court dashboard helpers + template factory (F-B-202 PR-1/10)

### DIFF
--- a/app/dashboard/_helpers.py
+++ b/app/dashboard/_helpers.py
@@ -1,0 +1,330 @@
+"""Shared helpers for the Court dashboard router (audit F-B-202 PR-1).
+
+Sprint 2 / F-B-202 modularization PR-1 of 10. Extracts the pure-helper
+functions that ``app/dashboard/router.py`` accumulated alongside its
+67 route handlers, with the goal of letting future PRs (one per
+feature area) move endpoints to per-feature sub-routers without
+having to drag the helpers along.
+
+What lives here:
+
+  - ``_safe_redirect`` — open-redirect guard (audit H-IO-1) used by
+    login / logout / OIDC / form-post handlers.
+  - ``_ctx`` — Jinja2 template context builder, threads
+    session, csrf_token, jaeger_url into every render.
+  - sealed-org mutation guard: ``_is_sealed``, ``_require_sealed_reauth``,
+    ``_sealed_mutation_details``, plus the ``_SEALED_DETAIL`` constant
+    (audit F-B-2).
+  - input validators: ``_validate_id``, ``_validate_webhook_url``,
+    plus the ``_ID_PATTERN`` regex.
+  - audit rendering: ``_build_audit_event_dict`` (projects
+    ``AuditLog`` rows for the audit template).
+  - HTMX nav chip: ``_count_chip``.
+  - URL builder: ``_broker_url_from_request``.
+  - dev cert generator: ``_generate_agent_cert`` (used by the
+    download-bundle endpoint).
+
+No router decorators here — the helpers are imported from
+``app.dashboard.router`` (and from future sub-routers as the split
+progresses).
+
+Module-level imports are intentionally kept lean: only the symbols
+every helper actually needs. Heavier deps (``cryptography``,
+``json``) are imported lazily inside their consumer to keep
+import-time cheap for sub-routers that only need a subset.
+"""
+from __future__ import annotations
+
+import datetime
+import re
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request
+
+from app.dashboard.session import DashboardSession, get_session
+from app.registry.org_store import OrganizationRecord
+
+
+# ── Open-redirect guard (audit H-IO-1) ────────────────────────────
+
+
+def _safe_redirect(next_url: object, fallback: str = "/dashboard") -> str:
+    """Validate a caller-supplied redirect target and return a safe local path.
+
+    Rejects anything that could cause an open-redirect (H-IO-1):
+    - non-string values
+    - absolute URLs  (``https://...``)
+    - protocol-relative URLs  (``//evil.example/x``)
+    - backslash-relative URLs  (``/\\evil``)
+    - empty / whitespace-only strings
+
+    Only accepts paths that start with ``/`` and whose parsed ``netloc``
+    is empty (i.e., no host component), which is the standard urllib test
+    for relative-same-origin URLs.
+    """
+    if not isinstance(next_url, str) or not next_url.strip():
+        return fallback
+    # Block protocol-relative (//host) and backslash variants (/\host)
+    if next_url.startswith("//") or next_url.startswith("/\\"):
+        return fallback
+    # Must start with a single slash (no scheme, no authority)
+    if not next_url.startswith("/"):
+        return fallback
+    # Belt-and-suspenders: urlparse must see no scheme and no netloc
+    parsed = urlparse(next_url)
+    if parsed.scheme or parsed.netloc:
+        return fallback
+    return next_url
+
+
+# ── Template context ──────────────────────────────────────────────
+
+
+def _ctx(request: Request, session: DashboardSession, **kwargs) -> dict:
+    """Build template context with session info, CSRF token, and the
+    Jaeger UI link derived from the OTLP endpoint."""
+    from app.config import get_settings
+
+    _s = get_settings()
+    _parsed = urlparse(_s.otel_exporter_otlp_endpoint or "http://localhost:4317")
+    _jaeger_host = _parsed.hostname or "localhost"
+    _jaeger_scheme = _parsed.scheme or "http"
+    jaeger_url = f"{_jaeger_scheme}://{_jaeger_host}:16686"
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "jaeger_url": jaeger_url,
+        **kwargs,
+    }
+
+
+# ── Sealed-org mutation guard (audit F-B-2) ───────────────────────
+#
+# Rationale: the broker dashboard authenticates a single ``admin`` session
+# cookie. Without further scoping, that cookie lets the network operator
+# mutate any tenant's identity plane (CA, bindings, agents, certs) with
+# no cross-check that they actually represent the tenant. The ``sealed``
+# flag on ``organizations`` marks orgs whose proxy claimed ownership via
+# the attach-ca flow; mutations on those orgs require a per-org re-auth
+# challenge stamped on the session cookie within the last
+# ``REAUTH_TTL_SECONDS`` seconds.
+#
+# Guard pattern to apply on every state-changing endpoint scoped to an org:
+#
+#     await _require_sealed_reauth(request, org)  # raises 403 if missing
+#
+# The helper is a no-op for unsealed orgs (legacy behavior preserved).
+
+_SEALED_DETAIL = (
+    "Organization is tenant-sealed. Complete the per-org re-auth challenge "
+    "before retrying this action."
+)
+
+
+def _is_sealed(org: OrganizationRecord | None) -> bool:
+    """Return True iff the org exists and its ``sealed`` flag is True."""
+    return bool(getattr(org, "sealed", False)) if org is not None else False
+
+
+async def _require_sealed_reauth(
+    request: Request, org: OrganizationRecord | None,
+) -> None:
+    """Raise 403 if the org is sealed and the admin session lacks a scope.
+
+    Safe to call with ``org=None`` (treated as unsealed — the caller's
+    existence check handles the not-found case on its own).
+    """
+    if not _is_sealed(org):
+        return
+    session = get_session(request)
+    if not session.is_admin:
+        raise HTTPException(status_code=403, detail=_SEALED_DETAIL)
+    if not session.has_reauth_scope(org.org_id):
+        raise HTTPException(status_code=403, detail=_SEALED_DETAIL)
+
+
+def _sealed_mutation_details(
+    org: OrganizationRecord | None, extra: dict | None = None,
+) -> dict:
+    """Standardize audit log details for sealed-org mutations."""
+    base: dict = {"source": "dashboard_admin"}
+    if _is_sealed(org):
+        base["source"] = "dashboard_admin_with_reauth"
+        base["sealed"] = True
+    if extra:
+        base.update(extra)
+    return base
+
+
+# ── Input validators ──────────────────────────────────────────────
+
+
+# Alphanumeric, hyphens, underscores, colons, dots — max 128 chars
+_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:@\-]{0,127}$")
+
+
+def _validate_id(value: str, field_name: str) -> str | None:
+    """Return an error message if the ID is invalid, else None."""
+    if not value:
+        return None  # emptiness checked elsewhere
+    if not _ID_PATTERN.match(value):
+        return (
+            f"{field_name} must be alphanumeric (hyphens, underscores, colons, "
+            "dots allowed), max 128 characters."
+        )
+    return None
+
+
+def _validate_webhook_url(url: str) -> str | None:
+    """Return an error message if the webhook URL is invalid, else None."""
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme not in ("https", "http"):
+        return "Webhook URL must use https:// or http:// scheme."
+    if not parsed.hostname:
+        return "Webhook URL must have a valid hostname."
+    return None
+
+
+# ── Audit rendering ───────────────────────────────────────────────
+
+
+def _build_audit_event_dict(e) -> dict:
+    """Project an ``AuditLog`` row into the dict shape the audit template
+    consumes, adding a pretty-printed ``details`` string plus a parsed
+    ``recipient`` hint for oneshot/forwarded events so the UI can show
+    who was on the receiving end of the traffic.
+
+    ``details_pretty`` is ``None`` when the original column was empty;
+    non-JSON legacy strings pass through verbatim so nothing is lost.
+    """
+    import json as _json
+    raw = e.details
+    recipient = None
+    details_pretty: str | None = None
+    if raw:
+        try:
+            parsed = _json.loads(raw)
+            details_pretty = _json.dumps(parsed, indent=2, sort_keys=True)
+            if isinstance(parsed, dict):
+                recipient = (
+                    parsed.get("recipient_agent_id")
+                    or parsed.get("target_agent_id")
+                    or parsed.get("recipient")
+                )
+        except (ValueError, TypeError):
+            details_pretty = raw
+    return {
+        "event_type": e.event_type,
+        "result": e.result,
+        "agent_id": e.agent_id,
+        "org_id": e.org_id,
+        "details": e.details,
+        "details_pretty": details_pretty,
+        "recipient": recipient,
+        "created_at": e.timestamp,
+        "entry_hash": e.entry_hash,
+    }
+
+
+# ── HTMX nav chip ─────────────────────────────────────────────────
+
+
+def _count_chip(count: int) -> str:
+    """Neutral count chip used in the principal-type nav badges."""
+    if count <= 0:
+        return ""
+    return (
+        '<span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono '
+        f'bg-gray-700/40 text-gray-400">{count}</span>'
+    )
+
+
+# ── Broker URL builder ────────────────────────────────────────────
+
+
+def _broker_url_from_request(request: Request) -> str:
+    """Compute the broker public URL from request headers."""
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.url.hostname)
+    port = request.url.port
+    if scheme == "https" and port and port != 443:
+        return f"{scheme}://{host}:{port}"
+    elif scheme == "http" and port and port != 80:
+        return f"{scheme}://{host}:{port}"
+    return f"{scheme}://{host}"
+
+
+# ── Dev agent cert generator (used by /agents/<id>/bundle) ────────
+
+
+def _generate_agent_cert(agent_id: str, org_id: str, org_ca_key, org_ca_cert):
+    """Generate agent cert + key in memory. Returns (key_pem, cert_pem).
+
+    Used by the dashboard's deploy-bundle download endpoint. Mints a
+    1-year RSA-2048 leaf cert signed by ``org_ca_key`` with a SPIFFE
+    SAN derived from the agent id. The caller is responsible for
+    persisting the thumbprint pin in the registry.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    _, agent_name = agent_id.split("::", 1)
+    spiffe_id = f"spiffe://cullis.local/{org_id}/{agent_name}"
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(org_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe_id),
+            ]),
+            critical=False,
+        )
+        .sign(org_ca_key, hashes.SHA256())
+    )
+
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    return key_pem, cert_pem
+
+
+__all__ = [
+    "_safe_redirect",
+    "_ctx",
+    "_SEALED_DETAIL",
+    "_is_sealed",
+    "_require_sealed_reauth",
+    "_sealed_mutation_details",
+    "_ID_PATTERN",
+    "_validate_id",
+    "_validate_webhook_url",
+    "_build_audit_event_dict",
+    "_count_chip",
+    "_broker_url_from_request",
+    "_generate_agent_cert",
+]

--- a/app/dashboard/_template_env.py
+++ b/app/dashboard/_template_env.py
@@ -1,0 +1,50 @@
+"""Shared Jinja2Templates factory for Court dashboard sub-routers.
+
+Sprint 2 / F-B-202 PR-1. Mirror of ``mcp_proxy/dashboard/_template_env.py``
+on the Mastio side. The Court dashboard router has historically lived
+as a single 3125-LOC file with templates built inline via
+``Jinja2Templates(directory=...)``. The modularization sprint (10 PR,
+~22h) splits the router into per-feature sub-routers, and every sub-
+router that renders templates must thread through this factory so
+cross-cutting Jinja2 globals (today: none on the Court side; in the
+future: license gates, feature flags) land in one place.
+
+The current implementation is intentionally minimal — no globals are
+registered yet. Future PRs add them here without touching every
+sub-router.
+"""
+from __future__ import annotations
+
+import pathlib
+from typing import Callable
+
+from fastapi.templating import Jinja2Templates
+
+
+def _register_globals(templates: Jinja2Templates) -> None:
+    """Attach Court-wide Jinja2 globals + filters to ``templates``.
+
+    Currently a no-op — the Court dashboard does not need cross-cutting
+    template globals yet (the Mastio side has ``has_feature`` for
+    license gates, but those plugin gates are Mastio-only). The hook
+    is here so a future cross-cutting feature lands in one place.
+    """
+    return
+
+
+def build_templates(
+    template_dir: pathlib.Path | str,
+    *,
+    extra: Callable[[Jinja2Templates], None] | None = None,
+) -> Jinja2Templates:
+    """Construct a ``Jinja2Templates`` with the shared Court dashboard env.
+
+    ``extra`` is an optional callback so a sub-router can add its own
+    filters / globals on top of the shared baseline without duplicating
+    the baseline itself.
+    """
+    templates = Jinja2Templates(directory=str(template_dir))
+    _register_globals(templates)
+    if extra is not None:
+        extra(templates)
+    return templates

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -30,6 +30,25 @@ from app.dashboard.session import (
     get_session, set_session, clear_session, require_login, verify_csrf,
     add_reauth_scope, DashboardSession, REAUTH_TTL_SECONDS,
 )
+# F-B-202 PR-1: pure helpers extracted to a sibling module so the
+# upcoming per-feature sub-routers can import them without dragging
+# the 3000-LOC router.py with them.
+from app.dashboard._helpers import (
+    _safe_redirect,
+    _ctx,
+    _SEALED_DETAIL,
+    _is_sealed,
+    _require_sealed_reauth,
+    _sealed_mutation_details,
+    _ID_PATTERN,
+    _validate_id,
+    _validate_webhook_url,
+    _build_audit_event_dict,
+    _count_chip,
+    _broker_url_from_request,
+    _generate_agent_cert,
+)
+from app.dashboard._template_env import build_templates
 
 from app.db.database import get_db
 from app.db.audit import AuditLog, log_event
@@ -52,38 +71,12 @@ import logging
 _log = logging.getLogger("agent_trust")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+# F-B-202 PR-1: build_templates threads every dashboard sub-router
+# through one Jinja2 env factory so cross-cutting globals (today: none;
+# future: license gates / feature flags) land in one place.
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
-
-
-def _safe_redirect(next_url: object, fallback: str = "/dashboard") -> str:
-    """Validate a caller-supplied redirect target and return a safe local path.
-
-    Rejects anything that could cause an open-redirect (H-IO-1):
-    - non-string values
-    - absolute URLs  (``https://...``)
-    - protocol-relative URLs  (``//evil.example/x``)
-    - backslash-relative URLs  (``/\\evil``)
-    - empty / whitespace-only strings
-
-    Only accepts paths that start with ``/`` and whose parsed ``netloc``
-    is empty (i.e., no host component), which is the standard urllib test
-    for relative-same-origin URLs.
-    """
-    if not isinstance(next_url, str) or not next_url.strip():
-        return fallback
-    # Block protocol-relative (//host) and backslash variants (/\host)
-    if next_url.startswith("//") or next_url.startswith("/\\"):
-        return fallback
-    # Must start with a single slash (no scheme, no authority)
-    if not next_url.startswith("/"):
-        return fallback
-    # Belt-and-suspenders: urlparse must see no scheme and no netloc
-    parsed = urlparse(next_url)
-    if parsed.scheme or parsed.netloc:
-        return fallback
-    return next_url
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -516,108 +509,13 @@ async def oidc_callback(
     return response
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Helper — require login on every page
-# ─────────────────────────────────────────────────────────────────────────────
-
-def _ctx(request: Request, session: DashboardSession, **kwargs) -> dict:
-    """Build template context with session info and CSRF token."""
-    from app.config import get_settings
-    _s = get_settings()
-    _parsed = urlparse(_s.otel_exporter_otlp_endpoint or "http://localhost:4317")
-    _jaeger_host = _parsed.hostname or "localhost"
-    _jaeger_scheme = _parsed.scheme or "http"
-    jaeger_url = f"{_jaeger_scheme}://{_jaeger_host}:16686"
-    return {"request": request, "session": session, "csrf_token": session.csrf_token,
-            "jaeger_url": jaeger_url, **kwargs}
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Audit F-B-2 — sealed-org mutation guard.
-#
-# Rationale: the broker dashboard authenticates a single ``admin`` session
-# cookie. Without further scoping, that cookie lets the network operator
-# mutate any tenant's identity plane (CA, bindings, agents, certs) with
-# no cross-check that they actually represent the tenant. The ``sealed``
-# flag on ``organizations`` marks orgs whose proxy claimed ownership via
-# the attach-ca flow; mutations on those orgs require a per-org re-auth
-# challenge stamped on the session cookie within the last
-# ``REAUTH_TTL_SECONDS`` seconds.
-#
-# Guard pattern to apply on every state-changing endpoint scoped to an org:
-#
-#     await _require_sealed_reauth(request, org)  # raises 403 if missing
-#
-# The helper is a no-op for unsealed orgs (legacy behavior preserved).
-# ─────────────────────────────────────────────────────────────────────────────
-
-_SEALED_DETAIL = (
-    "Organization is tenant-sealed. Complete the per-org re-auth challenge "
-    "before retrying this action."
-)
-
-
-def _is_sealed(org: OrganizationRecord | None) -> bool:
-    """Return True iff the org exists and its ``sealed`` flag is True."""
-    return bool(getattr(org, "sealed", False)) if org is not None else False
-
-
-async def _require_sealed_reauth(
-    request: Request, org: OrganizationRecord | None,
-) -> None:
-    """Raise 403 if the org is sealed and the admin session lacks a scope.
-
-    Safe to call with ``org=None`` (treated as unsealed — the caller's
-    existence check handles the not-found case on its own).
-    """
-    if not _is_sealed(org):
-        return
-    session = get_session(request)
-    if not session.is_admin:
-        raise HTTPException(status_code=403, detail=_SEALED_DETAIL)
-    if not session.has_reauth_scope(org.org_id):
-        raise HTTPException(status_code=403, detail=_SEALED_DETAIL)
-
-
-def _sealed_mutation_details(
-    org: OrganizationRecord | None, extra: dict | None = None,
-) -> dict:
-    """Standardize audit log details for sealed-org mutations."""
-    base: dict = {"source": "dashboard_admin"}
-    if _is_sealed(org):
-        base["source"] = "dashboard_admin_with_reauth"
-        base["sealed"] = True
-    if extra:
-        base.update(extra)
-    return base
-
-
-# Alphanumeric, hyphens, underscores, colons, dots — max 128 chars
-_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._:@\-]{0,127}$")
+# Helpers (_ctx, sealed-org guard, validators, ID pattern) live in
+# ``app/dashboard/_helpers.py`` since F-B-202 PR-1. Endpoint-specific
+# size limits below stay here for now; they migrate to per-feature
+# sub-routers as the modularization sprint progresses.
 _DISPLAY_NAME_MAX = 256
 _CAPABILITY_MAX_LEN = 64
 _CAPABILITY_MAX_COUNT = 50
-
-
-def _validate_id(value: str, field_name: str) -> str | None:
-    """Return an error message if the ID is invalid, else None."""
-    if not value:
-        return None  # emptiness checked elsewhere
-    if not _ID_PATTERN.match(value):
-        return f"{field_name} must be alphanumeric (hyphens, underscores, colons, dots allowed), max 128 characters."
-    return None
-
-
-def _validate_webhook_url(url: str) -> str | None:
-    """Return an error message if the webhook URL is invalid, else None."""
-    if not url:
-        return None
-    parsed = urlparse(url)
-    if parsed.scheme not in ("https", "http"):
-        return "Webhook URL must use https:// or http:// scheme."
-    if not parsed.hostname:
-        return "Webhook URL must have a valid hostname."
-    return None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1049,43 +947,8 @@ async def sessions_list(
 
 _AUDIT_LIMIT = 200
 
-
-def _build_audit_event_dict(e) -> dict:
-    """Project an ``AuditLog`` row into the dict shape the audit template
-    consumes, adding a pretty-printed ``details`` string plus a parsed
-    ``recipient`` hint for oneshot/forwarded events so the UI can show
-    who was on the receiving end of the traffic.
-
-    ``details_pretty`` is ``None`` when the original column was empty;
-    non-JSON legacy strings pass through verbatim so nothing is lost.
-    """
-    import json as _json
-    raw = e.details
-    recipient = None
-    details_pretty: str | None = None
-    if raw:
-        try:
-            parsed = _json.loads(raw)
-            details_pretty = _json.dumps(parsed, indent=2, sort_keys=True)
-            if isinstance(parsed, dict):
-                recipient = (
-                    parsed.get("recipient_agent_id")
-                    or parsed.get("target_agent_id")
-                    or parsed.get("recipient")
-                )
-        except (ValueError, TypeError):
-            details_pretty = raw
-    return {
-        "event_type": e.event_type,
-        "result": e.result,
-        "agent_id": e.agent_id,
-        "org_id": e.org_id,
-        "details": e.details,
-        "details_pretty": details_pretty,
-        "recipient": recipient,
-        "created_at": e.timestamp,
-        "entry_hash": e.entry_hash,
-    }
+# ``_build_audit_event_dict`` lives in ``app.dashboard._helpers`` since
+# F-B-202 PR-1.
 
 
 @router.get("/audit", response_class=HTMLResponse)
@@ -1301,14 +1164,7 @@ async def badge_pending_sessions(request: Request, db: AsyncSession = Depends(ge
     return ""
 
 
-def _count_chip(count: int) -> str:
-    """Neutral count chip used in the principal-type nav badges."""
-    if count <= 0:
-        return ""
-    return (
-        '<span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono '
-        f'bg-gray-700/40 text-gray-400">{count}</span>'
-    )
+# ``_count_chip`` lives in ``app.dashboard._helpers`` since F-B-202 PR-1.
 
 
 @router.get("/badge/users-count", response_class=HTMLResponse)
@@ -2280,16 +2136,8 @@ async def agent_delete(request: Request, agent_id: str, db: AsyncSession = Depen
 # Agent Detail — Developer Portal Page
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _broker_url_from_request(request: Request) -> str:
-    """Compute the broker public URL from request headers."""
-    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
-    host = request.headers.get("x-forwarded-host", request.url.hostname)
-    port = request.url.port
-    if scheme == "https" and port and port != 443:
-        return f"{scheme}://{host}:{port}"
-    elif scheme == "http" and port and port != 80:
-        return f"{scheme}://{host}:{port}"
-    return f"{scheme}://{host}"
+# ``_broker_url_from_request`` lives in ``app.dashboard._helpers`` since
+# F-B-202 PR-1.
 
 
 @router.get("/agents/{agent_id:path}", response_class=HTMLResponse)
@@ -2532,51 +2380,8 @@ async def agent_credentials_download(request: Request, agent_id: str,
 # Download Agent Bundle (zip with cert, key, env, scripts, start.sh)
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _generate_agent_cert(agent_id: str, org_id: str, org_ca_key, org_ca_cert):
-    """Generate agent cert + key in memory. Returns (key_pem, cert_pem)."""
-    from cryptography import x509
-    from cryptography.hazmat.primitives import hashes, serialization
-    from cryptography.hazmat.primitives.asymmetric import rsa
-    from cryptography.x509.oid import NameOID
-
-    now = datetime.datetime.now(datetime.timezone.utc)
-    _, agent_name = agent_id.split("::", 1)
-    spiffe_id = f"spiffe://cullis.local/{org_id}/{agent_name}"
-
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    subject = x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
-        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
-    ])
-    cert = (
-        x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(org_ca_cert.subject)
-        .public_key(key.public_key())
-        .serial_number(x509.random_serial_number())
-        .not_valid_before(now)
-        .not_valid_after(now + datetime.timedelta(days=365))
-        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
-        .add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
-            critical=False,
-        )
-        .add_extension(
-            x509.SubjectAlternativeName([
-                x509.UniformResourceIdentifier(spiffe_id),
-            ]),
-            critical=False,
-        )
-        .sign(org_ca_key, hashes.SHA256())
-    )
-
-    key_pem = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
-    return key_pem, cert_pem
+# ``_generate_agent_cert`` lives in ``app.dashboard._helpers`` since
+# F-B-202 PR-1.
 
 
 @router.post("/agents/{agent_id:path}/bundle")


### PR DESCRIPTION
## Summary

Sprint 2 Court modularization PR-1 of 10 — opens the extraction sprint that turns \`app/dashboard/router.py\` (3125 LOC, 67 routes, 14 feature areas, BLOCKER F-B-202) into per-feature sub-routers.

This PR is **pure helper move + Jinja2 factory introduction**, zero behavioural delta. URLs unchanged, response bodies unchanged, no route registrations touched. It lays the groundwork so PR-2 through PR-10 can extract route handlers into sibling files without dragging the helpers along.

## What moves

| New file | LOC | Contents |
|---|---|---|
| \`app/dashboard/_template_env.py\` | 50 | \`build_templates(dir, *, extra)\` factory — mirrors \`mcp_proxy/dashboard/_template_env.py\` on the Mastio side. Hook for future cross-cutting Jinja2 globals (license gates, feature flags). |
| \`app/dashboard/_helpers.py\` | 330 | 13 helpers: \`_safe_redirect\`, \`_ctx\`, sealed-org guard (\`_is_sealed\` / \`_require_sealed_reauth\` / \`_sealed_mutation_details\`), validators (\`_validate_id\` / \`_validate_webhook_url\`), \`_build_audit_event_dict\`, \`_count_chip\`, \`_broker_url_from_request\`, \`_generate_agent_cert\`. |

\`app/dashboard/router.py\`: **3125 → 2930 LOC** (−195). All 13 helpers now imported from the new modules; breadcrumb comments left at the old definition sites.

## What stays

- \`_DISPLAY_NAME_MAX\`, \`_CAPABILITY_MAX_LEN\`, \`_CAPABILITY_MAX_COUNT\`, \`_AUDIT_LIMIT\` constants — endpoint-specific, will move to per-feature sub-routers in PR-2 / 5 / 9.
- All 67 route handlers — they move in PR-2 onward.

## Test plan

- [x] \`pytest tests/test_dashboard*.py -q\` — 202/203 passed (1 pre-existing deselect: \`test_dashboard_approvals_nav::test_badge_approvals_empty_when_plugin_unavailable\`)
- [x] \`pytest tests/ --ignore=tests/integration --ignore=tests/e2e --deselect <known> -q\` — 4209 passed, 10 skipped, 32 xfailed (2 unrelated xdist flakes pass isolated)
- [x] \`./sandbox/demo.sh full && ./sandbox/smoke.sh full\` — 25/25 PASS (B4.7 re-run once)
- [x] DCO Signed-off-by
- [x] No \`Co-Authored-By: Claude\`

## Roadmap (10 PR total, ~22h)

| PR | Extract | Routes | Effort |
|---|---|---|---|
| **PR-1 (this)** | _template_env + _helpers | 0 | 2h ✅ |
| PR-2 | auth_routes (login/logout/register/OIDC) | 9 | 2.5h |
| PR-3 | admin_settings_routes | 3 | 1h |
| PR-4 | overview + badges + sse | 8 | 2h |
| PR-5 | orgs_routes (CRUD + invites + approve/reject/suspend/delete/upload-CA) | 11 | 3h |
| PR-6 | org_onboard + org_seal | 8 | 2.5h |
| PR-7 | agents_lifecycle + agents_credentials | 12 | 4h |
| PR-8 | policies + bindings | 8 | 2.5h |
| PR-9 | sessions + audit + rfq | 6 | 2h |
| PR-10 | agents_demo (ADR-020 demo-cast) | 6 | 1h |

After PR-10, \`app/dashboard/router.py\` becomes a ~100 LOC aggregator that calls \`router.include_router(...)\` for each shard.

Audit ref: \`imp/audits/2026-05-20/findings/track-b/F-B-202.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)