### PR TITLE
fix(connector): CRITICAL — guard /v1/conversations against cross-user data leak

### DIFF
--- a/cullis_connector/auth/cert_middleware.py
+++ b/cullis_connector/auth/cert_middleware.py
@@ -74,6 +74,16 @@ _GUARDED_PREFIXES = (
     # the SDK call to Mastio's ``/v1/egress/message/{send,inbox}`` is
     # authenticated as the user principal, not the Connector-agent.
     "/v1/inbox",
+    # 2026-05-20 CRITICAL — /v1/conversations was unguarded, so the
+    # ``_authenticate`` helper in ``conversations_router.py`` fell
+    # back to the Connector-wide ``agent_id`` for every request, and
+    # all enrolled Frontdesk users collapsed onto the same
+    # ``principal_id``. End result: cross-user READ + WRITE of chat
+    # history. Now guarded so the middleware binds
+    # ``request.state.user_credentials`` from the per-user cookie and
+    # ``conversations_router._authenticate`` resolves the correct
+    # ``creds.principal_id`` per user.
+    "/v1/conversations",
 )
 
 

--- a/tests/connector/test_cert_middleware.py
+++ b/tests/connector/test_cert_middleware.py
@@ -321,3 +321,102 @@ def test_distinct_users_get_distinct_principals(tmp_path):
     # Each user triggers exactly one CSR call.
     seen = sorted(p for p, _ in mastio.calls)
     assert seen == ["td.test/acme/user/anna", "td.test/acme/user/mario"]
+
+
+# ── 2026-05-20 CRITICAL regression: /v1/conversations cross-user leak ──
+
+
+def test_guarded_prefixes_includes_v1_conversations():
+    """Sentinel: ``/v1/conversations`` MUST stay in ``_GUARDED_PREFIXES``.
+
+    Before 2026-05-20 the prefix was missing. Effect: the middleware
+    skipped binding ``request.state.user_credentials`` on
+    ``/v1/conversations*`` requests, so
+    ``conversations_router._authenticate`` fell back to the Connector
+    agent_id (one shared identity for the whole process) for every
+    enrolled Frontdesk user. All chat history collapsed onto the same
+    ``principal_id``, leaking READ + WRITE across users.
+
+    Removing this prefix again would silently re-introduce the leak.
+    """
+    from cullis_connector.auth.cert_middleware import _GUARDED_PREFIXES
+
+    assert "/v1/conversations" in _GUARDED_PREFIXES, (
+        "CRITICAL regression — /v1/conversations dropped from "
+        "_GUARDED_PREFIXES; cross-user chat history leak resurfaces"
+    )
+
+
+def test_v1_conversations_binds_per_user_principal(tmp_path):
+    """End-to-end: with the guard in place, two distinct cookies on
+    ``/v1/conversations`` must resolve to two distinct
+    ``request.state.user_credentials.principal_id``s.
+
+    Pre-fix this test would PASS the gate (no 401 — middleware is
+    silent) but FAIL the assertion because both users got
+    ``principal_id=None`` (middleware skipped the path) and the
+    downstream router's fallback to ``state.agent_id`` would collapse
+    them. Post-fix both users get their own principal_id.
+    """
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+
+    @app.get("/v1/conversations")
+    async def probe_conv(request: Request):
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({
+            "principal_id": cred.principal_id if cred else None,
+        })
+
+    tc_alice = TestClient(app)
+    tc_alice.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("alice"))
+    tc_bob = TestClient(app)
+    tc_bob.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("bob"))
+
+    r_alice = tc_alice.get("/v1/conversations")
+    r_bob = tc_bob.get("/v1/conversations")
+
+    assert r_alice.status_code == 200
+    assert r_bob.status_code == 200
+    pid_alice = r_alice.json()["principal_id"]
+    pid_bob = r_bob.json()["principal_id"]
+    assert pid_alice is not None, (
+        "/v1/conversations not guarded by cert middleware — "
+        "user_credentials not bound"
+    )
+    assert pid_bob is not None
+    assert pid_alice != pid_bob, (
+        "CRITICAL — distinct users got SAME principal_id on "
+        "/v1/conversations (cross-user leak)"
+    )
+    assert pid_alice == "td.test/acme/user/alice"
+    assert pid_bob == "td.test/acme/user/bob"
+
+
+def test_v1_conversations_subpaths_also_guarded(tmp_path):
+    """``/v1/conversations/{id}`` and ``/v1/conversations/{id}/messages``
+    must also be guarded (prefix match)."""
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+
+    @app.get("/v1/conversations/{conv_id}")
+    async def probe_conv_id(conv_id: str, request: Request):
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({
+            "principal_id": cred.principal_id if cred else None,
+        })
+
+    @app.post("/v1/conversations/{conv_id}/messages")
+    async def probe_conv_messages(conv_id: str, request: Request):
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({
+            "principal_id": cred.principal_id if cred else None,
+        })
+
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("carol"))
+
+    r_get = tc.get("/v1/conversations/abc123")
+    r_post = tc.post("/v1/conversations/abc123/messages")
+    assert r_get.json()["principal_id"] == "td.test/acme/user/carol"
+    assert r_post.json()["principal_id"] == "td.test/acme/user/carol"


### PR DESCRIPTION
## Summary

**SEVERITY: CRITICAL** — cross-user READ + WRITE leak of chat history on Frontdesk bundle deployments with multiple enrolled local users (\`AUTH_MODE=local\`).

Discovered 2026-05-20 (maintainer dogfood on \`frontdesk-demo\` + \`mastio-demo\` VMs): 3 users enrolled via local password auth, opened the Cullis Chat SPA from 3 different devices. All three saw each other's full chat history, and a new message written by user A appeared inside user B's conversation thread.

## Root cause (one line)

\`/v1/conversations\` was missing from \`_GUARDED_PREFIXES\` in \`cullis_connector/auth/cert_middleware.py\`. Middleware skipped binding \`request.state.user_credentials\` on that prefix → \`conversations_router._authenticate\` fell back to the Connector-wide \`agent_id\` → all enrolled users' conversations collapsed onto a single \`principal_id\`.

## Fix

One-line addition to the prefix tuple:

\`\`\`python
_GUARDED_PREFIXES = (
    "/v1/chat/completions",
    "/v1/models",
    "/v1/mcp",
    "/v1/inbox",
    "/v1/conversations",   # NEW — closes the cross-user leak
)
\`\`\`

Prefix match covers \`/v1/conversations\`, \`/v1/conversations/{id}\`, and \`/v1/conversations/{id}/messages\` in one entry. The \`_authenticate\` helper on the router side was already correct (it reads \`creds.principal_id\` first, only falls back to \`agent_id\` when creds is None) — post-fix the fallback path is never taken on a Frontdesk multi-user deployment.

## Tests (3 new in \`tests/connector/test_cert_middleware.py\`)

- \`test_guarded_prefixes_includes_v1_conversations\` — sentinel pinning the constant so a future refactor can't drop the prefix without flagging this regression
- \`test_v1_conversations_binds_per_user_principal\` — end-to-end: two distinct cookies on \`/v1/conversations\` resolve to two distinct \`principal_id\`s
- \`test_v1_conversations_subpaths_also_guarded\` — \`/v1/conversations/X\` and \`/v1/conversations/X/messages\` pick up the binding via prefix match

Test results:
- \`pytest tests/connector/test_cert_middleware.py -q\` — 14/14 pass
- \`pytest tests/connector/ -q\` — 725/729 (4 pre-existing skips)
- \`pytest tests/ <full unit suite> -q\` — 4214 passed, 9 skipped, 32 xfailed (1 xdist flake passes isolated, pre-existing)

## Operator impact / hotfix release notes

**No schema migration needed** — the \`conversations.db\` rows already have the correct per-user \`principal_id\` columns; the writes were just always landing on the Connector \`agent_id\` slot. Post-fix:

- New writes land on the correct per-user slot
- Pre-fix leaked rows remain visible on the Connector \`agent_id\` slot
- A separate one-shot cleanup script may be needed for compliance — out of scope for this hotfix

**Recommend**:

- Bump Connector PyPI patch (\`0.5.1 → 0.5.2\`)
- Ship Frontdesk bundle hotfix release
- CHANGELOG entry: \"Pre-fix Frontdesk \`AUTH_MODE=local\` deployments leaked chat history across enrolled users. Update urgently.\"
- Note pre-existing rows on the legacy slot can be cleaned via SQL: \`DELETE FROM messages WHERE conversation_id IN (SELECT id FROM conversations WHERE principal_id = '<connector-agent-id>')\` (after operator review)

## Why this surfaced now (lesson learned)

\`/v1/conversations\` (Sprint 1 Step 6 PR-B) was added after the cert middleware shipped. The route's own \`_authenticate()\` looked correct in isolation — \`principal_id\` scoping was right, fallback to \`agent_id\` was a known degradation path. The missing middleware hookup was invisible at PR review because no integration test exercised middleware + router together.

Same shape as the F-A-401 \`chat_completion\` DPoP pinning bug (memory \`feedback_chat_completion_dpop_pinning_bug\`): missing per-user binding silently degrades to agent-wide identity, smoke 25/25 stays green because the legacy sandbox doesn't exercise the path.

This is exactly the class of bug the \`stack/\` modern smoke (parallel agent, plan in \`imp/plans/sandbox-modern-stack.md\`) is designed to catch — Block 5.8 specifically asserts \"alice + bob in same Frontdesk → audit rows distinguish per principal_id (multi-tenant isolation)\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)