### PR TITLE
release: Connector v0.5.2 + Frontdesk bundle v0.2.11 (CRITICAL hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,81 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+## [Connector v0.5.2] — CRITICAL chat-history cross-user leak — 2026-05-20
+
+### Security
+
+- **CRITICAL — `/v1/conversations` cross-user data leak** (#843).
+  Frontdesk bundle deployments running `AUTH_MODE=local` (default for
+  Frontdesk v0.2.x) leaked chat history across all enrolled users:
+  every user listed, read, AND wrote into the same conversation slot,
+  regardless of which cookie authenticated the request.
+
+  Root cause: the Connector cert middleware
+  (`cullis_connector/auth/cert_middleware.py`) declared the URL
+  prefixes that needed per-user `UserPrincipal` cert binding —
+  `/v1/chat/completions`, `/v1/models`, `/v1/mcp`, `/v1/inbox` — but
+  the prefix list was missing `/v1/conversations`. The
+  conversations router fell back to the Connector-wide `agent_id`
+  on every request, collapsing all per-user `principal_id` scoping.
+
+  Fix: one-line addition to `_GUARDED_PREFIXES`. The router-side
+  `_authenticate` helper was already correct; the missing middleware
+  hookup was the entire bug.
+
+  **All Frontdesk multi-user deployments must update immediately**.
+  Pre-fix `conversations.db` rows already store the correct
+  per-user `principal_id` columns (writes were just always landing
+  on the Connector `agent_id` slot), so no schema migration is
+  required. Operators that need to clean the leaked rows from the
+  shared slot can run, AFTER REVIEW:
+
+  ```sql
+  -- Inside <config_dir>/conversations.db
+  DELETE FROM messages
+   WHERE conversation_id IN (
+     SELECT id FROM conversations
+      WHERE principal_id = '<connector-agent-id>'
+   );
+  DELETE FROM conversations
+   WHERE principal_id = '<connector-agent-id>';
+  ```
+
+  Tests (`tests/connector/test_cert_middleware.py`, 3 new):
+  - `test_guarded_prefixes_includes_v1_conversations` — sentinel
+    pin so a refactor can't drop the prefix silently
+  - `test_v1_conversations_binds_per_user_principal` — two cookies
+    → two distinct `principal_id`s
+  - `test_v1_conversations_subpaths_also_guarded` — `/v1/conversations/{id}`
+    and `/v1/conversations/{id}/messages` also bound via prefix match
+
+  Standalone Connector desktop (single user, `AUTH_MODE` absent) is
+  not affected: only one user exists on the process and the fallback
+  to `agent_id` was the same as the real user's principal.
+
+## [Frontdesk bundle v0.2.11] — CRITICAL Connector hotfix passthrough — 2026-05-20
+
+### Security
+
+- Bumps default `CONNECTOR_VERSION` from `0.5.1` to `0.5.2` so a
+  fresh `./deploy.sh` (or an `./deploy.sh --upgrade`) on a Frontdesk
+  bundle host picks up the Connector cross-user chat history leak
+  fix automatically. Operators that pinned a specific
+  `CONNECTOR_VERSION` in `frontdesk.env` must update the pin
+  manually to `0.5.2` and re-run `./deploy.sh --upgrade`.
+
+### Fixed
+
+- `packaging/frontdesk-bundle/docker-compose.yml` default fallback
+  for `${CONNECTOR_VERSION:-…}` was stuck at the stale `0.4.4` even
+  though `deploy.sh` had been bumped to `0.5.1` in v0.2.10. A
+  deployment that bypassed `deploy.sh` (`docker compose up -d`
+  directly with no env file) would have pulled the year-old
+  Connector image. Aligned to `0.5.2`.
+- `packaging/frontdesk-bundle/frontdesk.env.example` reference
+  comment refreshed from the stale `# CONNECTOR_VERSION=0.4.6` to
+  `# CONNECTOR_VERSION=0.5.2`.
+
 ## [Connector v0.5.1] — Per-user auth gate, bcrypt knob, dir-norm HTTPS — 2026-05-20
 
 ### Fixed

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = ["__version__"]

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -155,7 +155,7 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.5.1)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.5.2)
   CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.4.1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
@@ -407,7 +407,7 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.5.1}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.5.2}"
 CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.4.1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - frontdesk_net
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.4}
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.5.2}
     # ``dashboard`` mounts the local-auth router (ADR-025) by default; the
     # legacy fake-SSO Ambassador shared-mode is reachable by setting
     # ``AMBASSADOR_MODE=shared`` explicitly in frontdesk.env. ADR-025

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -42,7 +42,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.6
+# CONNECTOR_VERSION=0.5.2
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.5.1"
+version = "0.5.2"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

**CRITICAL hotfix release** — ships PR #843 (cross-user chat history leak on \`/v1/conversations\`) to operators.

- **Connector v0.5.1 → v0.5.2**: \`cullis_connector/__init__.py\` + \`packaging/pypi/pyproject.toml\`.
- **Frontdesk bundle v0.2.10 → v0.2.11**: \`deploy.sh\` default + \`docker-compose.yml\` fallback + \`frontdesk.env.example\` comment all bumped to \`0.5.2\`.
- **CHANGELOG.md**: 2 new sections (Connector v0.5.2 security + Frontdesk bundle v0.2.11 passthrough).

## Critical merge order

1. **Merge PR #843 FIRST** (the cert middleware fix). This release commit assumes the fix is on main.
2. **Then merge this PR** (the version bumps + CHANGELOG).
3. From main post-merge, run:
   \`\`\`bash
   git tag connector-v0.5.2
   git tag frontdesk-bundle-v0.2.11
   git push origin connector-v0.5.2 frontdesk-bundle-v0.2.11
   \`\`\`
4. Build + push GHCR image \`ghcr.io/cullis-security/cullis-connector:0.5.2\` (semver no-\`v\`, per memory \`feedback_mastio_release_tag_convention\`).
5. Build + upload PyPI wheel \`cullis-connector==0.5.2\`.

If steps 4-5 are wired through the legacy \`release-connector.yml\` workflow, the tag push in step 3 triggers it. If the workflow was removed in PR #782 (per memory \`feedback_cloud_ci_is_overhead_for_solo_founder\`), run the build manually:

\`\`\`bash
# Connector PyPI
cd packaging/pypi
python -m build
twine upload dist/cullis_connector-0.5.2*

# Connector GHCR
docker build -t ghcr.io/cullis-security/cullis-connector:0.5.2 -f Dockerfile .
docker push ghcr.io/cullis-security/cullis-connector:0.5.2
\`\`\`

## Operator notice (paste into the GitHub Release body)

> **SECURITY — update immediately.** Frontdesk bundle deployments running \`AUTH_MODE=local\` (default for v0.2.x) leaked chat history across all enrolled users. Every user listed, read, and wrote into the same conversation slot regardless of which cookie authenticated the request. Root cause was a missing entry in the Connector cert middleware's URL guard list. Fix is one line + 3 regression tests.
>
> **No schema migration needed**. Pre-fix \`conversations.db\` rows already store the correct per-user \`principal_id\` columns; the writes were just always landing on the Connector \`agent_id\` slot. Operators that need to clean leaked rows from the shared slot can run the SQL in CHANGELOG.md Connector v0.5.2 section (after operator review).
>
> Upgrade path: \`./deploy.sh --upgrade\` on the Frontdesk bundle host pulls the new Connector image automatically. Operators that pinned \`CONNECTOR_VERSION=0.5.1\` in \`frontdesk.env\` must bump the pin to \`0.5.2\` first.

## Files changed

| File | Change |
|---|---|
| \`cullis_connector/__init__.py\` | \`__version__\` \`0.5.1\` → \`0.5.2\` |
| \`packaging/pypi/pyproject.toml\` | \`version\` \`0.5.1\` → \`0.5.2\` |
| \`packaging/frontdesk-bundle/deploy.sh\` | default + docstring \`0.5.1\` → \`0.5.2\` |
| \`packaging/frontdesk-bundle/docker-compose.yml\` | fallback \`0.4.4\` → \`0.5.2\` (incidental stale-default fix) |
| \`packaging/frontdesk-bundle/frontdesk.env.example\` | comment ref \`0.4.6\` → \`0.5.2\` |
| \`CHANGELOG.md\` | +75 lines: Connector v0.5.2 + Frontdesk bundle v0.2.11 sections |

## Test plan

- [x] \`python -c "from cullis_connector import __version__; assert __version__ == '0.5.2'"\` — pass
- [x] \`python -c "import tomllib; tomllib.loads(open('packaging/pypi/pyproject.toml').read())"\` — parse ok
- [x] \`grep -E '0\\.5\\.2' packaging/frontdesk-bundle/{deploy.sh,docker-compose.yml,frontdesk.env.example}\` — 4 hits all on the bumped lines
- [x] DCO Signed-off-by
- [x] No \`Co-Authored-By: Claude\`
- [x] Smoke + unit tests skipped — pure version bump + CHANGELOG, no runtime path change. Fix is on #843; this PR only ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)