### PR TITLE
fix(connector): defence-in-depth — refuse agent_id fallback in Frontdesk multi-user

### DIFF
--- a/cullis_connector/ambassador/conversations_router.py
+++ b/cullis_connector/ambassador/conversations_router.py
@@ -73,9 +73,23 @@ def _authenticate(request: Request) -> str:
     principal_id to scope the operation by.
 
     The principal is the per-user credential when present (ADR-025
-    shared mode), otherwise the Connector agent id (single-user mode).
-    Conversations are always partitioned by principal so a user in
-    Frontdesk shared mode cannot see another user's history.
+    multi-user / Frontdesk bundle path); otherwise the Connector
+    agent id (single-user desktop Cullis Chat path).
+
+    Defence-in-depth for Frontdesk multi-user (2026-05-20 PR #843
+    follow-up): the primary bug was the cert middleware not guarding
+    ``/v1/conversations`` at all, which meant ``creds`` was always
+    None and the fallback to ``state['agent_id']`` collapsed every
+    user onto the Connector identity. PR #843 added the prefix to
+    ``_GUARDED_PREFIXES`` so a valid cookie now binds the per-user
+    creds correctly. This helper closes the residual fail-open: if a
+    Frontdesk multi-user deployment ever reaches this code with
+    ``creds=None`` (cookie missing / expired / tampered, middleware
+    silently passing through), refusing the fallback returns 401
+    instead of silently dumping the request into the Connector-wide
+    agent_id bucket. Single-user Cullis Chat desktop keeps the
+    fallback behaviour — there is only one user on the process and
+    ``state['agent_id']`` IS that user.
     """
     _enforce_loopback(request)
     state = _ambassador_state(request)
@@ -83,6 +97,21 @@ def _authenticate(request: Request) -> str:
     creds = _per_user_credentials(request)
     if creds is not None and getattr(creds, "principal_id", None):
         return creds.principal_id
+
+    # Multi-user mode: refuse fallback to the Connector-wide agent_id.
+    # ``is_frontdesk_bundle`` covers both the modern ``AUTH_MODE=local``
+    # bundle and the legacy ``AMBASSADOR_MODE=shared`` deployment.
+    from cullis_connector.identity.auth_mode import is_frontdesk_bundle
+    if is_frontdesk_bundle():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "missing or invalid session cookie — Frontdesk multi-user "
+                "deployments require a per-user UserPrincipal binding "
+                "for /v1/conversations (audit 2026-05-20 PR #843 follow-up)"
+            ),
+        )
+
     agent_id = state.get("agent_id") or ""
     if not agent_id:
         raise HTTPException(

--- a/tests/connector/test_conversations_router.py
+++ b/tests/connector/test_conversations_router.py
@@ -171,3 +171,60 @@ def test_list_pagination_bounds_validated(client, auth):
     assert client.get("/v1/conversations?limit=0", headers=auth).status_code == 400
     assert client.get("/v1/conversations?limit=101", headers=auth).status_code == 400
     assert client.get("/v1/conversations?offset=-1", headers=auth).status_code == 400
+
+
+# ── 2026-05-20 PR #843 follow-up: refuse fallback in Frontdesk mode ──
+
+
+def test_frontdesk_bundle_refuses_agent_fallback(
+    client, bearer, monkeypatch,
+):
+    """Defence-in-depth (audit 2026-05-20 PR #843 follow-up).
+
+    When the bundle marker ``FRONTDESK_BUNDLE=1`` is set (modern
+    Frontdesk ``AUTH_MODE=local`` bundle or legacy
+    ``AMBASSADOR_MODE=shared``) and the request reaches
+    ``_authenticate`` without a per-user cert binding, the helper
+    MUST return 401 instead of falling back to the Connector-wide
+    agent_id.
+
+    Pre-PR #843 the cert middleware did not guard
+    ``/v1/conversations`` at all so the fallback was hit on every
+    request → all enrolled users collapsed onto the same
+    principal_id (cross-user data leak). PR #843 made the primary
+    binding work; this test pins the residual fail-open path so a
+    future regression (middleware skips the prefix again, cookie
+    fails to parse, etc.) surfaces as a 401 rather than silently
+    rejoining the leak.
+    """
+    monkeypatch.setenv("FRONTDESK_BUNDLE", "1")
+    # No cookie on the request, so _per_user_credentials → None.
+    # Bearer satisfies the legacy gate, but Frontdesk mode now
+    # refuses to serve conversations without a per-user binding.
+    r = client.get(
+        "/v1/conversations",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert r.status_code == 401, (
+        f"Frontdesk multi-user fallback to agent_id was not refused: {r.text}"
+    )
+    assert "Frontdesk multi-user" in r.json().get("detail", "")
+
+
+def test_single_user_desktop_keeps_agent_fallback(
+    client, auth, monkeypatch,
+):
+    """Cullis Chat desktop / standalone PyPI Connector ship without
+    ``FRONTDESK_BUNDLE``. There is only one user on the process and
+    ``state['agent_id']`` IS that user, so the fallback is the
+    correct semantic. Verify the upgrade doesn't regress the
+    single-user path."""
+    monkeypatch.delenv("FRONTDESK_BUNDLE", raising=False)
+    monkeypatch.delenv("AMBASSADOR_MODE", raising=False)
+    r = client.post("/v1/conversations", headers=auth)
+    assert r.status_code == 201, r.text
+    # Listing returns the freshly created conversation under the
+    # Connector agent_id — single-user behaviour preserved.
+    r2 = client.get("/v1/conversations", headers=auth)
+    assert r2.status_code == 200
+    assert len(r2.json()) == 1


### PR DESCRIPTION
## Summary

PR #843 follow-up. PR #843 closed the primary \`/v1/conversations\` cross-user leak by adding the prefix to \`_GUARDED_PREFIXES\`. This PR closes the residual fail-open in the same code path.

## What was still leaky after #843

\`conversations_router._authenticate\` reads \`_per_user_credentials(request)\` and falls back to \`state['agent_id']\` when creds is None. With #843 the middleware binds creds on the happy path (valid cookie), so the fallback is only reachable on the edge cases:

- cookie missing (SPA bug, fresh tab before \`/api/session/init\`)
- cookie expired (1h TTL boundary)
- cookie tampered (parse fails → returns None)

In Frontdesk multi-user deployments, ANY of those edges silently drops the request onto the Connector-wide \`agent_id\`, re-introducing the leak shape for that one request. Improbable on the happy path, but it's exactly the pattern that caused the original bug.

## Fix

\`_authenticate\` now returns 401 instead of falling back, when \`is_frontdesk_bundle()\` is true:

\`\`\`python
from cullis_connector.identity.auth_mode import is_frontdesk_bundle
if is_frontdesk_bundle():
    raise HTTPException(401, "Frontdesk multi-user deployments require ...")
\`\`\`

\`is_frontdesk_bundle()\` covers both topologies (modern \`AUTH_MODE=local\` + legacy \`AMBASSADOR_MODE=shared\`) via the \`FRONTDESK_BUNDLE=1\` env marker the bundle compose sets.

Single-user Cullis Chat desktop / standalone PyPI Connector are **NOT** affected — they ship without \`FRONTDESK_BUNDLE\`, the fallback to \`state['agent_id']\` keeps working, and that IS the correct identity (only one user on the process).

## Tests (2 new in \`tests/connector/test_conversations_router.py\`)

- \`test_frontdesk_bundle_refuses_agent_fallback\` — with \`FRONTDESK_BUNDLE=1\` and no cookie, the endpoint returns 401 with a clear \`"Frontdesk multi-user"\` detail
- \`test_single_user_desktop_keeps_agent_fallback\` — without \`FRONTDESK_BUNDLE\`, single-user path keeps working (create + list flow returns 201 + 200)

Test results: \`pytest tests/connector/test_conversations_router.py -q\` → 11/11. Full unit suite 4213 passed.

## Release coordination

This PR has **no version bump** in itself. Options:

1. **Ship in the same Connector v0.5.2 release as #843** (preferred): merge this PR before #844 (release commit), then amend #844 or open a tiny addendum that re-confirms the merged SHAs cover both PRs.
2. **Ship as v0.5.3** if v0.5.2 has already been tagged. The defence-in-depth gap is a real but second-order issue — the primary leak is closed by #843 alone.

## Why ship both together

\`feedback_h4_convergent_pattern_fallback_insecure_default\` (audit 2026-05-20) made the same point in a different surface: every new gate must have a refuse-to-fall-back path in multi-tenant mode. Shipping #843 without this follow-up means the audit's own anti-pattern rule applies to its own fix. Better to land both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)