### PR TITLE
refactor(dashboard): extract Court sessions + audit + rfq sub-routers (F-B-202 PR-9/10)

### DIFF
--- a/app/dashboard/audit_routes.py
+++ b/app/dashboard/audit_routes.py
@@ -1,0 +1,108 @@
+"""Court dashboard — Audit Log sub-router.
+
+Sprint 2 / F-B-202 PR-9 of 10. Extracts the audit-log table + hash
+chain verification (section 14 of router.py).
+
+Mounted via ``router.include_router(audit_routes.router)``.
+
+Routes (2):
+
+  GET  /dashboard/audit              search + paginate audit table
+  POST /dashboard/audit/verify       run audit-chain integrity check (admin-only)
+
+The verify endpoint is the dispute-grade Track-A control point — it
+walks the hash chain end-to-end and reports the first broken link.
+Admin-only + CSRF gated.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import RedirectResponse
+
+from app.dashboard._helpers import _build_audit_event_dict, _ctx
+from app.dashboard._template_env import build_templates
+from app.dashboard.session import require_login, verify_csrf
+from app.db.audit import AuditLog
+from app.db.database import get_db
+
+_log = logging.getLogger("agent_trust")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-audit"])
+
+_AUDIT_LIMIT = 200
+
+
+@router.get("/audit", response_class=HTMLResponse)
+async def audit_log(
+    request: Request,
+    q: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    query = select(AuditLog).order_by(AuditLog.id.desc())
+
+    if q:
+        q = q[:100]  # Limit search term length to prevent expensive LIKE queries
+        # Escape LIKE wildcards in user input to prevent pattern abuse
+        _escaped = q.replace("%", r"\%").replace("_", r"\_")
+        pattern = f"%{_escaped}%"
+        query = query.where(or_(
+            AuditLog.event_type.ilike(pattern),
+            AuditLog.agent_id.ilike(pattern),
+            AuditLog.org_id.ilike(pattern),
+            AuditLog.result.ilike(pattern),
+            AuditLog.details.ilike(pattern),
+        ))
+
+    query = query.limit(_AUDIT_LIMIT)
+    result = await db.execute(query)
+    events = result.scalars().all()
+
+    event_list = [_build_audit_event_dict(e) for e in events]
+
+    return templates.TemplateResponse("audit.html",
+        _ctx(request, session, active="audit", events=event_list, query=q or "", limit=_AUDIT_LIMIT)
+    )
+
+
+@router.post("/audit/verify", response_class=HTMLResponse)
+async def verify_audit_chain(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Admin-only: verify the cryptographic integrity of the audit log chain."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not session.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from app.db.audit import verify_chain
+    is_valid, total, broken_id = await verify_chain(db)
+
+    verify_result = {"valid": is_valid, "total": total, "broken_id": broken_id}
+
+    # Re-render audit page with verification result
+    query = select(AuditLog).order_by(AuditLog.id.desc()).limit(_AUDIT_LIMIT)
+    result = await db.execute(query)
+    events = result.scalars().all()
+    event_list = [_build_audit_event_dict(e) for e in events]
+
+    return templates.TemplateResponse("audit.html",
+        _ctx(request, session, active="audit", events=event_list, query="",
+             limit=_AUDIT_LIMIT, verify_result=verify_result)
+    )

--- a/app/dashboard/rfq_routes.py
+++ b/app/dashboard/rfq_routes.py
@@ -1,0 +1,155 @@
+"""Court dashboard — RFQ sub-router.
+
+Sprint 2 / F-B-202 PR-9 of 10. Extracts the request-for-quote
+list / detail / approval surface (section 15 of router.py).
+
+Mounted via ``router.include_router(rfq_routes.router)``.
+
+Routes (3):
+
+  GET  /dashboard/rfqs               list (last 100)
+  GET  /dashboard/rfq/{rfq_id}       detail + responses
+  POST /dashboard/rfq/{rfq_id}/approve  approve a quote + mint txn token
+
+The approve endpoint mints a transaction token and pushes it over the
+broker WS to the initiator agent — same path the API uses, kept inline
+here so the dashboard and API stay behaviour-equivalent.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import RedirectResponse
+
+from app.auth.transaction_token import compute_payload_hash, create_transaction_token
+from app.broker.db_models import RfqRecord, RfqResponseRecord
+from app.broker.ws_manager import ws_manager
+from app.dashboard._helpers import _ctx
+from app.dashboard._template_env import build_templates
+from app.dashboard.session import require_login, verify_csrf
+from app.db.audit import log_event
+from app.db.database import get_db
+
+_log = logging.getLogger("agent_trust")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-rfq"])
+
+
+@router.get("/rfqs", response_class=HTMLResponse)
+async def rfq_list(request: Request, db: AsyncSession = Depends(get_db)):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    q = select(RfqRecord).order_by(RfqRecord.created_at.desc()).limit(100)
+    rfqs = (await db.execute(q)).scalars().all()
+
+    return templates.TemplateResponse("rfqs.html",
+        _ctx(request, session, active="rfq", rfqs=rfqs)
+    )
+
+
+@router.get("/rfq/{rfq_id}", response_class=HTMLResponse)
+async def rfq_detail(request: Request, rfq_id: str, db: AsyncSession = Depends(get_db)):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    rfq = (await db.execute(
+        select(RfqRecord).where(RfqRecord.rfq_id == rfq_id)
+    )).scalar_one_or_none()
+    if not rfq:
+        raise HTTPException(status_code=404, detail="RFQ not found")
+
+    responses = (await db.execute(
+        select(RfqResponseRecord).where(RfqResponseRecord.rfq_id == rfq_id)
+    )).scalars().all()
+
+    return templates.TemplateResponse("rfq_detail.html",
+        _ctx(request, session, active="rfq", rfq=rfq, responses=responses,
+             success=None, error=None)
+    )
+
+
+@router.post("/rfq/{rfq_id}/approve", response_class=HTMLResponse)
+async def rfq_approve(request: Request, rfq_id: str, db: AsyncSession = Depends(get_db)):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    rfq = (await db.execute(
+        select(RfqRecord).where(RfqRecord.rfq_id == rfq_id)
+    )).scalar_one_or_none()
+    if not rfq:
+        raise HTTPException(status_code=404, detail="RFQ not found")
+
+    form = await request.form()
+    response_id = form.get("response_id")
+    responder_agent_id = form.get("responder_agent_id", "")
+
+    if not response_id:
+        raise HTTPException(status_code=400, detail="Missing response_id")
+
+    quote = (await db.execute(
+        select(RfqResponseRecord).where(
+            RfqResponseRecord.id == int(response_id),
+            RfqResponseRecord.rfq_id == rfq_id,
+        )
+    )).scalar_one_or_none()
+    if not quote:
+        raise HTTPException(status_code=404, detail="Quote not found")
+
+    payload_hash = compute_payload_hash(quote.payload)
+    token_id, token_record = await create_transaction_token(
+        db,
+        agent_id=rfq.initiator_agent_id,
+        org_id=rfq.initiator_org_id,
+        txn_type="CREATE_ORDER",
+        resource_id=rfq_id,
+        payload_hash=payload_hash,
+        approved_by="admin",
+        rfq_id=rfq_id,
+        target_agent_id=responder_agent_id,
+    )
+
+    rfq.status = "approved"
+    await db.commit()
+
+    try:
+        await ws_manager.send_to_agent(rfq.initiator_agent_id, {
+            "type": "transaction_token",
+            "token_id": token_id,
+            "rfq_id": rfq_id,
+            "txn_type": "CREATE_ORDER",
+            "target_agent_id": responder_agent_id,
+            "payload_hash": payload_hash,
+        })
+    except Exception:
+        _log.warning("Could not deliver transaction token to agent %s via WS",
+                      rfq.initiator_agent_id)
+
+    await log_event(db, "rfq.approved", "ok",
+                    agent_id=rfq.initiator_agent_id, org_id=rfq.initiator_org_id,
+                    details={"rfq_id": rfq_id, "approved_quote_id": response_id,
+                             "responder_agent_id": responder_agent_id, "token_id": token_id})
+
+    responses = (await db.execute(
+        select(RfqResponseRecord).where(RfqResponseRecord.rfq_id == rfq_id)
+    )).scalars().all()
+    await db.refresh(rfq)
+
+    return templates.TemplateResponse("rfq_detail.html",
+        _ctx(request, session, active="rfq", rfq=rfq, responses=responses,
+             success=f"Quote approved. Transaction token issued to agent {rfq.initiator_agent_id}.",
+             error=None)
+    )

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -19,11 +19,11 @@ import zipfile
 import datetime
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Query
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse
-from sqlalchemy import select, func, or_
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dashboard.session import (
@@ -61,9 +61,8 @@ from app.registry.binding_store import (
     BindingRecord, create_binding, approve_binding, revoke_binding,
     get_binding_by_org_agent,
 )
-from app.broker.db_models import SessionRecord, SessionMessageRecord, RfqRecord, RfqResponseRecord
+from app.broker.db_models import SessionRecord
 from app.broker.ws_manager import ws_manager
-from app.auth.transaction_token import create_transaction_token, compute_payload_hash
 from app.dashboard import _demo_cast
 
 import logging
@@ -125,6 +124,15 @@ from app.dashboard import policies_routes as _policies_routes  # noqa: E402
 from app.dashboard import bindings_routes as _bindings_routes  # noqa: E402
 router.include_router(_policies_routes.router)
 router.include_router(_bindings_routes.router)
+
+# F-B-202 PR-9: include sessions (session list), audit (log table +
+# chain verify) and rfq (list + detail + approve). 6 routes total.
+from app.dashboard import sessions_routes as _sessions_routes  # noqa: E402
+from app.dashboard import audit_routes as _audit_routes  # noqa: E402
+from app.dashboard import rfq_routes as _rfq_routes  # noqa: E402
+router.include_router(_sessions_routes.router)
+router.include_router(_audit_routes.router)
+router.include_router(_rfq_routes.router)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -350,249 +358,15 @@ async def federation_view(request: Request):
     ))
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Sessions
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/sessions", response_class=HTMLResponse)
-async def sessions_list(
-    request: Request,
-    status: str | None = Query(default=None),
-    db: AsyncSession = Depends(get_db),
-):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    q = select(SessionRecord).order_by(SessionRecord.created_at.desc())
-    if status:
-        q = q.where(SessionRecord.status == status)
-    q = q.limit(100)
-
-    result = await db.execute(q)
-    sessions = result.scalars().all()
-
-    # Count messages per session
-    msg_counts = {}
-    if sessions:
-        session_ids = [s.session_id for s in sessions]
-        count_q = (
-            select(SessionMessageRecord.session_id, func.count(SessionMessageRecord.id))
-            .where(SessionMessageRecord.session_id.in_(session_ids))
-            .group_by(SessionMessageRecord.session_id)
-        )
-        for row in (await db.execute(count_q)).all():
-            msg_counts[row[0]] = row[1]
-
-    session_list = []
-    for s in sessions:
-        session_list.append({
-            "session_id": s.session_id,
-            "initiator_agent_id": s.initiator_agent_id,
-            "initiator_org_id": s.initiator_org_id,
-            "target_agent_id": s.target_agent_id,
-            "target_org_id": s.target_org_id,
-            "status": s.status,
-            "message_count": msg_counts.get(s.session_id, 0),
-            "created_at": s.created_at,
-        })
-
-    return templates.TemplateResponse("sessions.html",
-        _ctx(request, session, active="sessions", sessions=session_list, status_filter=status)
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Audit Log
-# ─────────────────────────────────────────────────────────────────────────────
-
-_AUDIT_LIMIT = 200
-
-# ``_build_audit_event_dict`` lives in ``app.dashboard._helpers`` since
-# F-B-202 PR-1.
-
-
-@router.get("/audit", response_class=HTMLResponse)
-async def audit_log(
-    request: Request,
-    q: str | None = Query(default=None),
-    db: AsyncSession = Depends(get_db),
-):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    query = select(AuditLog).order_by(AuditLog.id.desc())
-
-    if q:
-        q = q[:100]  # Limit search term length to prevent expensive LIKE queries
-        # Escape LIKE wildcards in user input to prevent pattern abuse
-        _escaped = q.replace("%", r"\%").replace("_", r"\_")
-        pattern = f"%{_escaped}%"
-        query = query.where(or_(
-            AuditLog.event_type.ilike(pattern),
-            AuditLog.agent_id.ilike(pattern),
-            AuditLog.org_id.ilike(pattern),
-            AuditLog.result.ilike(pattern),
-            AuditLog.details.ilike(pattern),
-        ))
-
-    query = query.limit(_AUDIT_LIMIT)
-    result = await db.execute(query)
-    events = result.scalars().all()
-
-    event_list = [_build_audit_event_dict(e) for e in events]
-
-    return templates.TemplateResponse("audit.html",
-        _ctx(request, session, active="audit", events=event_list, query=q or "", limit=_AUDIT_LIMIT)
-    )
-
-
-@router.post("/audit/verify", response_class=HTMLResponse)
-async def verify_audit_chain(
-    request: Request,
-    db: AsyncSession = Depends(get_db),
-):
-    """Admin-only: verify the cryptographic integrity of the audit log chain."""
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not session.is_admin:
-        raise HTTPException(status_code=403, detail="Admin only")
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    from app.db.audit import verify_chain
-    is_valid, total, broken_id = await verify_chain(db)
-
-    verify_result = {"valid": is_valid, "total": total, "broken_id": broken_id}
-
-    # Re-render audit page with verification result
-    query = select(AuditLog).order_by(AuditLog.id.desc()).limit(_AUDIT_LIMIT)
-    result = await db.execute(query)
-    events = result.scalars().all()
-    event_list = [_build_audit_event_dict(e) for e in events]
-
-    return templates.TemplateResponse("audit.html",
-        _ctx(request, session, active="audit", events=event_list, query="",
-             limit=_AUDIT_LIMIT, verify_result=verify_result)
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# RFQ Detail & Approval
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/rfqs", response_class=HTMLResponse)
-async def rfq_list(request: Request, db: AsyncSession = Depends(get_db)):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    q = select(RfqRecord).order_by(RfqRecord.created_at.desc()).limit(100)
-    rfqs = (await db.execute(q)).scalars().all()
-
-    return templates.TemplateResponse("rfqs.html",
-        _ctx(request, session, active="rfq", rfqs=rfqs)
-    )
-
-
-@router.get("/rfq/{rfq_id}", response_class=HTMLResponse)
-async def rfq_detail(request: Request, rfq_id: str, db: AsyncSession = Depends(get_db)):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    rfq = (await db.execute(
-        select(RfqRecord).where(RfqRecord.rfq_id == rfq_id)
-    )).scalar_one_or_none()
-    if not rfq:
-        raise HTTPException(status_code=404, detail="RFQ not found")
-
-    responses = (await db.execute(
-        select(RfqResponseRecord).where(RfqResponseRecord.rfq_id == rfq_id)
-    )).scalars().all()
-
-    return templates.TemplateResponse("rfq_detail.html",
-        _ctx(request, session, active="rfq", rfq=rfq, responses=responses,
-             success=None, error=None)
-    )
-
-
-@router.post("/rfq/{rfq_id}/approve", response_class=HTMLResponse)
-async def rfq_approve(request: Request, rfq_id: str, db: AsyncSession = Depends(get_db)):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    rfq = (await db.execute(
-        select(RfqRecord).where(RfqRecord.rfq_id == rfq_id)
-    )).scalar_one_or_none()
-    if not rfq:
-        raise HTTPException(status_code=404, detail="RFQ not found")
-
-    form = await request.form()
-    response_id = form.get("response_id")
-    responder_agent_id = form.get("responder_agent_id", "")
-
-    if not response_id:
-        raise HTTPException(status_code=400, detail="Missing response_id")
-
-    quote = (await db.execute(
-        select(RfqResponseRecord).where(
-            RfqResponseRecord.id == int(response_id),
-            RfqResponseRecord.rfq_id == rfq_id,
-        )
-    )).scalar_one_or_none()
-    if not quote:
-        raise HTTPException(status_code=404, detail="Quote not found")
-
-    payload_hash = compute_payload_hash(quote.payload)
-    token_id, token_record = await create_transaction_token(
-        db,
-        agent_id=rfq.initiator_agent_id,
-        org_id=rfq.initiator_org_id,
-        txn_type="CREATE_ORDER",
-        resource_id=rfq_id,
-        payload_hash=payload_hash,
-        approved_by="admin",
-        rfq_id=rfq_id,
-        target_agent_id=responder_agent_id,
-    )
-
-    rfq.status = "approved"
-    await db.commit()
-
-    try:
-        await ws_manager.send_to_agent(rfq.initiator_agent_id, {
-            "type": "transaction_token",
-            "token_id": token_id,
-            "rfq_id": rfq_id,
-            "txn_type": "CREATE_ORDER",
-            "target_agent_id": responder_agent_id,
-            "payload_hash": payload_hash,
-        })
-    except Exception:
-        _log.warning("Could not deliver transaction token to agent %s via WS",
-                      rfq.initiator_agent_id)
-
-    await log_event(db, "rfq.approved", "ok",
-                    agent_id=rfq.initiator_agent_id, org_id=rfq.initiator_org_id,
-                    details={"rfq_id": rfq_id, "approved_quote_id": response_id,
-                             "responder_agent_id": responder_agent_id, "token_id": token_id})
-
-    responses = (await db.execute(
-        select(RfqResponseRecord).where(RfqResponseRecord.rfq_id == rfq_id)
-    )).scalars().all()
-    await db.refresh(rfq)
-
-    return templates.TemplateResponse("rfq_detail.html",
-        _ctx(request, session, active="rfq", rfq=rfq, responses=responses,
-             success=f"Quote approved. Transaction token issued to agent {rfq.initiator_agent_id}.",
-             error=None)
-    )
+# Sessions list (/dashboard/sessions) moved to
+# ``app/dashboard/sessions_routes.py`` since F-B-202 PR-9.
+#
+# Audit log (/dashboard/audit + /dashboard/audit/verify) moved to
+# ``app/dashboard/audit_routes.py`` since F-B-202 PR-9.
+#
+# RFQ list / detail / approve (/dashboard/rfqs, /dashboard/rfq/{id},
+# /dashboard/rfq/{id}/approve) moved to
+# ``app/dashboard/rfq_routes.py`` since F-B-202 PR-9.
 
 
 # Badge endpoints moved to ``app/dashboard/badges_routes.py`` and the

--- a/app/dashboard/sessions_routes.py
+++ b/app/dashboard/sessions_routes.py
@@ -1,0 +1,84 @@
+"""Court dashboard — Sessions sub-router.
+
+Sprint 2 / F-B-202 PR-9 of 10. Extracts the session-list page
+(section 13 of router.py).
+
+Mounted via ``router.include_router(sessions_routes.router)``.
+
+Routes (1):
+
+  GET  /dashboard/sessions      list (filter by status, last 100)
+
+Read-only — no CSRF / sealed gate.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import RedirectResponse
+
+from app.broker.db_models import SessionMessageRecord, SessionRecord
+from app.dashboard._helpers import _ctx
+from app.dashboard._template_env import build_templates
+from app.dashboard.session import require_login
+from app.db.database import get_db
+
+_log = logging.getLogger("agent_trust")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-sessions"])
+
+
+@router.get("/sessions", response_class=HTMLResponse)
+async def sessions_list(
+    request: Request,
+    status: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    q = select(SessionRecord).order_by(SessionRecord.created_at.desc())
+    if status:
+        q = q.where(SessionRecord.status == status)
+    q = q.limit(100)
+
+    result = await db.execute(q)
+    sessions = result.scalars().all()
+
+    # Count messages per session
+    msg_counts = {}
+    if sessions:
+        session_ids = [s.session_id for s in sessions]
+        count_q = (
+            select(SessionMessageRecord.session_id, func.count(SessionMessageRecord.id))
+            .where(SessionMessageRecord.session_id.in_(session_ids))
+            .group_by(SessionMessageRecord.session_id)
+        )
+        for row in (await db.execute(count_q)).all():
+            msg_counts[row[0]] = row[1]
+
+    session_list = []
+    for s in sessions:
+        session_list.append({
+            "session_id": s.session_id,
+            "initiator_agent_id": s.initiator_agent_id,
+            "initiator_org_id": s.initiator_org_id,
+            "target_agent_id": s.target_agent_id,
+            "target_org_id": s.target_org_id,
+            "status": s.status,
+            "message_count": msg_counts.get(s.session_id, 0),
+            "created_at": s.created_at,
+        })
+
+    return templates.TemplateResponse("sessions.html",
+        _ctx(request, session, active="sessions", sessions=session_list, status_filter=status)
+    )


### PR DESCRIPTION
Sprint 2 modularization PR-9 of 10 — closing F-B-202 Court dashboard refactor BLOCKER.

## Summary

- Extract `sessions` + `audit` + `rfq` route sections from `app/dashboard/router.py` into three new sibling modules.
- 6 routes total (1 session list + 2 audit + 3 rfq lifecycle).
- Zero behaviour change. Admin-only + CSRF gate on `/audit/verify`, and RFQ approve transaction-token mint + WS push, all preserved.

## Layout

| File | LOC | Routes |
|---|---|---|
| `app/dashboard/sessions_routes.py` (new) | 84 | 1 |
| `app/dashboard/audit_routes.py` (new) | 108 | 2 |
| `app/dashboard/rfq_routes.py` (new) | 155 | 3 |
| `app/dashboard/router.py` | 2071 → 1840 (−231 net) | −6 |

Sub-routers follow the established pattern: `APIRouter(tags=[...])` with **no prefix**, route paths bare. Outer `/dashboard` prefix is prepended by `router.include_router(...)`.

Unused imports trimmed in router.py:
- `Query` (fastapi) — was used in `sessions_list` + `audit_log`.
- `or_` (sqlalchemy) — was used in `audit_log`.
- `SessionMessageRecord, RfqRecord, RfqResponseRecord` (broker.db_models) — `SessionRecord` retained for overview stats.
- `create_transaction_token, compute_payload_hash` (whole `app.auth.transaction_token` import dropped) — was only used in `rfq_approve`.

## Router LOC progress

```
Pre-Sprint 2 : 67 routes, 3125 LOC
Post-PR-1 #839: 67 routes, 2930 LOC   merged
Post-PR-2 #841: 60 routes, 2614 LOC   merged
Post-PR-3 #842: 57 routes, 2528 LOC   merged
Post-PR-4 #847: 50 routes, 2372 LOC   merged
Post-PR-5 #848: 39 routes, 2071 LOC   merged
Post-PR-9 (this, before PR-6/7/8 merged): 33 routes, 1840 LOC
Target post-PR-10: ~3 (aggregator), ~100 LOC
```

## Conflict warning

PR-6 #849 + PR-7 #850 + PR-8 #851 are still open. This PR's sections (13+14+15) have zero line overlap with their sections — rebase clean post-merge in any order. Only contention is the `include_router` stack at top of `router.py` (1-line nest, trivial to resolve).

## Test plan

- [x] `pytest tests/test_dashboard.py tests/test_audit_r2_t1.py tests/test_dashboard_principals.py` — 73/73 PASS
- [x] `pytest tests/test_dashboard*.py tests/test_audit*.py tests/test_rfq*.py tests/test_onboarding.py` — 421/421 PASS (1 pre-existing env-fail deselected: `test_badge_approvals_empty_when_plugin_unavailable` requires `cullis_enterprise` not installed; passes clean in CI).
- [x] Syntax + import smoke OK

## Next

PR-10 (closes F-B-202): `agents_demo` sub-router (sections 11+12) + final aggregator pass. Target ~3 routes, ~100 LOC end-state.