### PR TITLE
refactor(dashboard): extract Court agents_demo (F-B-202 PR-10/10 — closes F-B-202)

### DIFF
--- a/app/dashboard/agents_demo_routes.py
+++ b/app/dashboard/agents_demo_routes.py
@@ -1,0 +1,137 @@
+"""Court dashboard — Agents list + ADR-020 principal-type demo views.
+
+Sprint 2 / F-B-202 PR-10 of 10 — final extraction, closes F-B-202.
+
+Bundles the read-only views that surface registry rows + the
+ADR-020 principal-type sections (Users / Workloads / Resources /
+Federation). The latter ship with hardcoded ``_demo_cast`` data
+because the matching admin REST endpoints (``/v1/admin/users``,
+``/v1/admin/workloads``) are still being wired by the backend
+session; once they are live, swap the ``_demo_cast.*`` calls for
+httpx calls to those routes and delete ``app/dashboard/_demo_cast.py``.
+
+Mounted via ``router.include_router(agents_demo_routes.router)``.
+
+Routes (5):
+
+  GET  /dashboard/agents        agent registry list (with binding + ws)
+  GET  /dashboard/users         ADR-020 user principals (demo)
+  GET  /dashboard/workloads     ADR-020 workload principals (demo)
+  GET  /dashboard/resources     ADR-020 resource principals (demo)
+  GET  /dashboard/federation    federation peers + Court status (demo)
+
+All read-only; no CSRF / sealed gate.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import RedirectResponse
+
+from app.broker.ws_manager import ws_manager
+from app.dashboard import _demo_cast
+from app.dashboard._helpers import _ctx
+from app.dashboard._template_env import build_templates
+from app.dashboard.session import require_login
+from app.db.database import get_db
+from app.registry.binding_store import BindingRecord
+from app.registry.store import AgentRecord
+
+_log = logging.getLogger("agent_trust")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-agents-demo"])
+
+
+@router.get("/agents", response_class=HTMLResponse)
+async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    q = select(AgentRecord).order_by(AgentRecord.org_id, AgentRecord.agent_id)
+    agents = (await db.execute(q)).scalars().all()
+
+    binding_statuses = {}
+    binding_q = select(BindingRecord.agent_id, BindingRecord.status).order_by(BindingRecord.id.desc())
+    for row in (await db.execute(binding_q)).all():
+        if row[0] not in binding_statuses:
+            binding_statuses[row[0]] = row[1]
+
+    agent_list = []
+    for agent in agents:
+        extras = _demo_cast.agent_extras(agent.agent_id)
+        agent_list.append({
+            "agent_id": agent.agent_id,
+            "org_id": agent.org_id,
+            "display_name": agent.display_name,
+            "is_active": agent.is_active,
+            "capabilities": agent.capabilities,
+            "binding_status": binding_statuses.get(agent.agent_id),
+            "ws_connected": ws_manager.is_connected(agent.agent_id),
+            "cert_thumbprint": agent.cert_thumbprint,
+            "enrollment_method": extras.get("enrollment_method"),
+            "automation_type": extras.get("automation_type"),
+        })
+
+    return templates.TemplateResponse("agents.html",
+        _ctx(request, session, active="agents", agents=agent_list)
+    )
+
+
+@router.get("/users", response_class=HTMLResponse)
+async def users_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("users.html", _ctx(
+        request, session, active="users",
+        users=_demo_cast.users_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/workloads", response_class=HTMLResponse)
+async def workloads_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("workloads.html", _ctx(
+        request, session, active="workloads",
+        workloads=_demo_cast.workloads_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/resources", response_class=HTMLResponse)
+async def resources_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("resources.html", _ctx(
+        request, session, active="resources",
+        resources=_demo_cast.resources_cast(),
+    ))
+
+
+@router.get("/federation", response_class=HTMLResponse)
+async def federation_view(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("federation.html", _ctx(
+        request, session, active="federation",
+        peers=_demo_cast.peers_cast(),
+        court_status="Online",
+        court_endpoint="https://court.cullis.test",
+        court_audit_status="Healthy",
+        court_last_anchor="active",
+        court_last_anchor_iso=None,
+    ))

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -134,6 +134,12 @@ router.include_router(_sessions_routes.router)
 router.include_router(_audit_routes.router)
 router.include_router(_rfq_routes.router)
 
+# F-B-202 PR-10 (final): include agents_demo (agents list + ADR-020
+# principal-type demo views: users/workloads/resources/federation).
+# 5 routes — closes F-B-202.
+from app.dashboard import agents_demo_routes as _agents_demo_routes  # noqa: E402
+router.include_router(_agents_demo_routes.router)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Login / Logout
@@ -256,106 +262,9 @@ async def overview(request: Request, db: AsyncSession = Depends(get_db)):
 # since F-B-202 PR-5.
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Agents
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/agents", response_class=HTMLResponse)
-async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    q = select(AgentRecord).order_by(AgentRecord.org_id, AgentRecord.agent_id)
-    agents = (await db.execute(q)).scalars().all()
-
-    binding_statuses = {}
-    binding_q = select(BindingRecord.agent_id, BindingRecord.status).order_by(BindingRecord.id.desc())
-    for row in (await db.execute(binding_q)).all():
-        if row[0] not in binding_statuses:
-            binding_statuses[row[0]] = row[1]
-
-    agent_list = []
-    for agent in agents:
-        extras = _demo_cast.agent_extras(agent.agent_id)
-        agent_list.append({
-            "agent_id": agent.agent_id,
-            "org_id": agent.org_id,
-            "display_name": agent.display_name,
-            "is_active": agent.is_active,
-            "capabilities": agent.capabilities,
-            "binding_status": binding_statuses.get(agent.agent_id),
-            "ws_connected": ws_manager.is_connected(agent.agent_id),
-            "cert_thumbprint": agent.cert_thumbprint,
-            "enrollment_method": extras.get("enrollment_method"),
-            "automation_type": extras.get("automation_type"),
-        })
-
-    return templates.TemplateResponse("agents.html",
-        _ctx(request, session, active="agents", agents=agent_list)
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Users / Workloads / Resources / Federation (ADR-020 principal-type sections)
-#
-# Phase 1 of the SPA rework ships these views with hardcoded demo data
-# from imp/insurance-demo-spec.md. The matching admin REST endpoints
-# (/v1/admin/users, /v1/admin/workloads) are owned by the backend
-# session and land separately. Once they are live, swap the
-# ``_demo_cast.*`` calls below for httpx calls to those routes and
-# delete app/dashboard/_demo_cast.py.
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/users", response_class=HTMLResponse)
-async def users_list(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    return templates.TemplateResponse("users.html", _ctx(
-        request, session, active="users",
-        users=_demo_cast.users_cast(),
-        endpoint_ready=False,
-    ))
-
-
-@router.get("/workloads", response_class=HTMLResponse)
-async def workloads_list(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    return templates.TemplateResponse("workloads.html", _ctx(
-        request, session, active="workloads",
-        workloads=_demo_cast.workloads_cast(),
-        endpoint_ready=False,
-    ))
-
-
-@router.get("/resources", response_class=HTMLResponse)
-async def resources_list(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    return templates.TemplateResponse("resources.html", _ctx(
-        request, session, active="resources",
-        resources=_demo_cast.resources_cast(),
-    ))
-
-
-@router.get("/federation", response_class=HTMLResponse)
-async def federation_view(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    return templates.TemplateResponse("federation.html", _ctx(
-        request, session, active="federation",
-        peers=_demo_cast.peers_cast(),
-        court_status="Online",
-        court_endpoint="https://court.cullis.test",
-        court_audit_status="Healthy",
-        court_last_anchor="active",
-        court_last_anchor_iso=None,
-    ))
+# Agents list (/dashboard/agents) and ADR-020 principal-type demo views
+# (/dashboard/users, /workloads, /resources, /federation) moved to
+# ``app/dashboard/agents_demo_routes.py`` since F-B-202 PR-10.
 
 
 # Sessions list (/dashboard/sessions) moved to


### PR DESCRIPTION
**Closes F-B-202.** Sprint 2 modularization PR-10 of 10 — final extraction in the Court dashboard refactor BLOCKER.

## Summary

- Extract the agents registry list + ADR-020 principal-type demo views (`users`, `workloads`, `resources`, `federation`) into one sibling module.
- 5 routes, all read-only — no CSRF / sealed gate touched.
- Bundled in one file because all five share the `_demo_cast` import (`agent_extras` for the agents list, `*_cast` helpers for the rest). When the matching admin REST endpoints (`/v1/admin/users`, `/v1/admin/workloads`) ship and `_demo_cast.py` is deleted, the change touches one file, not five.

## Layout

| File | LOC | Routes |
|---|---|---|
| `app/dashboard/agents_demo_routes.py` (new) | 137 | 5 |
| `app/dashboard/router.py` | 2071 → 1980 (−91 net on main; full F-B-202 trajectory below) | −5 |

Sub-router follows the rest of Sprint 2: `APIRouter(tags=[...])` with **no prefix**, route paths bare; outer `/dashboard` prefix prepended by `router.include_router(...)`.

## Sprint 2 / F-B-202 FINAL LOC trajectory

```
Pre-Sprint 2 : 67 routes, 3125 LOC
Post-PR-1 #839: 67 routes, 2930 LOC   merged   helpers + template_env
Post-PR-2 #841: 60 routes, 2614 LOC   merged   auth (7 routes)
Post-PR-3 #842: 57 routes, 2528 LOC   merged   admin_settings (3 routes)
Post-PR-4 #847: 50 routes, 2372 LOC   merged   badges + sse (7 routes)
Post-PR-5 #848: 39 routes, 2071 LOC   merged   orgs (11 routes)
Post-PR-6 #849: open                          org_onboard + org_seal (7 routes)
Post-PR-7 #850: open                          agents lifecycle + credentials (12 routes)
Post-PR-8 #851: open                          policies + bindings (8 routes)
Post-PR-9 #852: open                          sessions + audit + rfq (6 routes)
Post-PR-10 (this, before #849-852 merged): 34 routes, 1980 LOC
```

After all PR-6 → PR-10 land sequentially:
  - ~3 inline routes (overview + breadcrumbs only)
  - ~110 LOC aggregator wiring 14 sub-routers via `include_router`

## Conflict warning

PR-6 #849 + PR-7 #850 + PR-8 #851 + PR-9 #852 are still open. This PR's sections (11+12) have zero line overlap with their sections — rebase clean post-merge in any order. Only contention is the `include_router` stack at top of `router.py` (1-line nest, trivial to resolve).

## Test plan

- [x] `pytest tests/test_dashboard.py tests/test_dashboard_principals.py tests/test_dashboard_sealed_org.py tests/test_dashboard_agents_reach.py` — 84/84 PASS
- [x] `pytest tests/test_dashboard*.py tests/test_enrollment.py tests/test_onboarding.py tests/test_policy*.py tests/test_audit*.py tests/test_rfq*.py` — 460/460 PASS (1 pre-existing env-fail deselected: `test_badge_approvals_empty_when_plugin_unavailable` requires `cullis_enterprise` not installed; passes clean in CI)
- [x] Syntax + import smoke OK

Closes F-B-202.