### PR TITLE
docs(sdk): refresh quickstart to canonical surface (closes F-B-302)

### DIFF
--- a/cullis_sdk/README.md
+++ b/cullis_sdk/README.md
@@ -37,35 +37,78 @@ pip install 'cullis-sdk[spiffe]'
 
 ## Quick start
 
+The SDK talks to your org's Mastio (the local proxy), not directly to
+a central broker. The Mastio handles enrollment, mTLS, DPoP and
+forwards encrypted payloads on your behalf.
+
+Two entry points, depending on how your agent gets its identity:
+
+### Desktop / Connector flow
+
+When the agent lives next to a Cullis Connector (Claude Desktop,
+Cursor, Cline, or any local MCP client), the Connector has already
+enrolled an identity under `~/.cullis/identity/`. The SDK reads it:
+
 ```python
 from cullis_sdk import CullisClient
 
-with CullisClient("https://broker.example.com") as client:
-    client.login(
-        agent_id="myorg::reporter",
-        org_id="myorg",
-        cert_path="reporter.crt",
-        key_path="reporter.key",
-    )
+client = CullisClient.from_connector()       # loads ~/.cullis/identity/
+client.login_via_proxy_with_local_key()      # mint a proxy-scoped token
 
-    agents = client.discover(capabilities=["order.write"])
-    target = agents[0]
-
-    session = client.open_session(
-        target.agent_id, target.org_id, ["order.write"],
-    )
-    client.send(
-        session_id=session,
-        from_agent="myorg::reporter",
-        payload={"text": "Place order #42"},
-        to_agent=target.agent_id,
-    )
+resp = client.send_oneshot(
+    recipient_id="acme::supplier-agent",
+    payload={"text": "Quote for 1000 M8 bolts please."},
+    ttl_seconds=300,
+)
+print(resp["msg_id"])
 ```
 
-The SDK does the heavy lifting: x509 mutual TLS to the broker,
-DPoP-bound bearer tokens for replay protection, ECDH key agreement
-for end-to-end encryption to the recipient agent, and (on receive)
+### Server / BYOCA flow
+
+When the agent runs server-side and the cert+key are provisioned by
+your own PKI (Bring-Your-Own-CA), build the client from the identity
+directory directly. The mTLS client cert *is* the credential, so no
+separate login step is needed:
+
+```python
+from cullis_sdk import CullisClient
+
+client = CullisClient.from_identity_dir(
+    "https://mastio.example.com:9443",
+    cert_path="/etc/cullis/agent/cert.pem",
+    key_path="/etc/cullis/agent/key.pem",
+    dpop_key_path="/etc/cullis/agent/dpop.jwk",
+)
+
+resp = client.send_oneshot(
+    recipient_id="acme::supplier-agent",
+    payload={"text": "Quote for 1000 M8 bolts please."},
+    ttl_seconds=300,
+)
+print(resp["msg_id"])
+```
+
+The SDK does the heavy lifting: mTLS to your Mastio with the agent
+cert, DPoP-bound bearer tokens for replay protection, AES-256-GCM +
+RSA-OAEP/ECDH key wrap for end-to-end encryption to the recipient
+agent (the broker never sees the cleartext), and (on receive)
 hash-chain verification of the per-org audit log.
+
+### Migrating from v0.3 sessions
+
+The v0.3 `login()` / `open_session()` / `send()` surface is
+deprecated and will be removed in `cullis-sdk` v0.5 (~2026-08-15).
+Map the legacy API to the canonical one-shot surface:
+
+| v0.3 (deprecated, `DeprecationWarning` at call time) | Canonical (use this) |
+|---|---|
+| `CullisClient(url)` + `client.login(agent_id, org_id, cert, key)` | `CullisClient.from_identity_dir(url, cert_path=, key_path=, dpop_key_path=)` |
+| `client.open_session(target_agent, target_org, caps)` + `client.send(session_id, ...)` | `client.send_oneshot(recipient_id="org::agent", payload=, ttl_seconds=)` (no session needed) |
+| `client.discover(capabilities=[...])` | Same. Discovery still lives on the canonical surface. |
+
+The one-shot surface (ADR-008) is sessionless: every message is its
+own correlation-ID-tagged transaction, intra-org uses signed
+plaintext over mTLS, cross-org uses end-to-end encrypted envelope.
 
 ---
 

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -4,15 +4,32 @@ cullis-agent-sdk — Python SDK for Cullis, the federated agent trust broker.
 Connect your AI agents to the Cullis network with E2E encrypted messaging,
 x509 mutual authentication, and DPoP-bound tokens.
 
-Usage::
+Canonical usage (ADR-008 one-shot, ADR-014 mTLS-cert-as-credential)::
 
     from cullis_sdk import CullisClient
 
-    with CullisClient("https://broker.example.com") as client:
-        client.login("myorg::agent", "myorg", "cert.pem", "key.pem")
-        agents = client.discover(capabilities=["order.write"])
-        session_id = client.open_session(agents[0].agent_id, agents[0].org_id, ["order.write"])
-        client.send(session_id, "myorg::agent", {"text": "Hello"}, agents[0].agent_id)
+    # Connector flow (identity from ~/.cullis/identity/)
+    client = CullisClient.from_connector()
+    client.login_via_proxy_with_local_key()
+
+    # Or server / BYOCA flow (cert + key on disk)
+    # client = CullisClient.from_identity_dir(
+    #     "https://mastio.example.com:9443",
+    #     cert_path="/etc/cullis/agent/cert.pem",
+    #     key_path="/etc/cullis/agent/key.pem",
+    #     dpop_key_path="/etc/cullis/agent/dpop.jwk",
+    # )
+
+    resp = client.send_oneshot(
+        recipient_id="acme::supplier-agent",
+        payload={"text": "Quote for 1000 M8 bolts please."},
+        ttl_seconds=300,
+    )
+    print(resp["msg_id"])
+
+The legacy ``login()`` / ``open_session()`` / ``send()`` surface is
+deprecated and will be removed in v0.5 (~2026-08-15). See the README
+"Migrating from v0.3 sessions" section for the mapping.
 """
 
 from cullis_sdk.client import CullisClient

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1,19 +1,35 @@
 """
 CullisClient — main class for connecting agents to the Cullis trust network.
 
-Handles authentication (x509 + DPoP), session lifecycle, E2E encrypted
-messaging, agent discovery, RFQ, and WebSocket real-time events.
+Handles authentication (mTLS client cert + DPoP), agent discovery,
+one-shot encrypted messaging, RFQ, and WebSocket real-time events.
 
-Usage::
+Canonical usage (ADR-008 one-shot, ADR-014 cert-is-credential)::
 
     from cullis_sdk import CullisClient
 
-    client = CullisClient("https://broker.example.com")
-    client.login("myorg::agent", "myorg", "cert.pem", "key.pem")
+    # Connector flow (identity from ~/.cullis/identity/)
+    client = CullisClient.from_connector()
+    client.login_via_proxy_with_local_key()
 
-    agents = client.discover(capabilities=["order.write"])
-    session_id = client.open_session(agents[0].agent_id, agents[0].org_id, ["order.write"])
-    client.send(session_id, "myorg::agent", {"text": "Hello"}, recipient_agent_id=agents[0].agent_id)
+    # Or server / BYOCA flow (cert + key on disk)
+    # client = CullisClient.from_identity_dir(
+    #     "https://mastio.example.com:9443",
+    #     cert_path="/etc/cullis/agent/cert.pem",
+    #     key_path="/etc/cullis/agent/key.pem",
+    #     dpop_key_path="/etc/cullis/agent/dpop.jwk",
+    # )
+
+    resp = client.send_oneshot(
+        recipient_id="acme::supplier-agent",
+        payload={"text": "Quote for 1000 M8 bolts please."},
+        ttl_seconds=300,
+    )
+
+The legacy ``login()`` / ``open_session()`` / ``send()`` surface
+emits a ``DeprecationWarning`` at call time and will be removed in
+v0.5 (~2026-08-15). See ``cullis_sdk/README.md`` "Migrating from
+v0.3 sessions" for the mapping.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
**Closes F-B-302** (BLOCKER, customer-facing onboarding). Docs-only.

## Summary

The Python SDK quickstart shipped in three locations (`README.md:40-63`, `__init__.py:7-15`, `client.py:7-16`) all called `client.login()`, `client.open_session()`, `client.send()`. Each emits `DeprecationWarning` at call time and is slated for removal in `cullis-sdk` v0.5 (~2026-08-15).

A new integrator running `pip install cullis-sdk` and following the README copy-pastes code that already warns and breaks in ~3 months.

This PR refreshes the three locations to the canonical surface (ADR-008 + ADR-011 + ADR-014):
- `CullisClient.from_connector()` or `CullisClient.from_identity_dir(...)` to build the client.
- `client.send_oneshot(recipient_id=, payload=, ttl_seconds=)` to send.

The deprecated methods themselves stay in place with their existing `DeprecationWarning` emitters until v0.5. This PR only stops *recommending* them.

## Changes

- `cullis_sdk/README.md`: Quick start block split into two flows (Connector + BYOCA), each ending in `send_oneshot(...)`. New "Migrating from v0.3 sessions" table maps the deprecated calls to canonical equivalents.
- `cullis_sdk/__init__.py`: Module docstring matches the new canonical usage.
- `cullis_sdk/client.py`: `CullisClient` class docstring matches.

## ADR cross-refs

- ADR-008 (one-shot canonical, sessions deprecated)
- ADR-011 (unified enrollment, `login()` replaced by `from_identity_dir` / `from_connector`)
- ADR-014 (mTLS client cert IS the credential, no api_key)

## Test plan

- [x] `python -W error::DeprecationWarning -c "import cullis_sdk"` — clean (no `DeprecationWarning` at import).
- [x] `pytest tests/test_sdk_*.py -n auto --dist=loadfile -q` — 171 passed, 1 skipped. The single `DeprecationWarning` emitted by `test_sdk_send_via_proxy.py` is intentional: it gates the deprecation marker on the legacy path until v0.5.
- [x] Docs-only, no code paths touched. Deprecated methods still callable for v0.3 users on the migration path.