### PR TITLE
fix(iam): Court principal CSR refuses non-NIST EC curves (closes F-A-102)

### DIFF
--- a/app/registry/principals_csr.py
+++ b/app/registry/principals_csr.py
@@ -122,6 +122,16 @@ def _verify_csr_signature(csr: x509.CertificateSigningRequest) -> None:
         raise CsrValidationError("CSR signature does not verify")
 
 
+# F-A-102 (audit 2026-05-20, CWE-326). EC public keys in user-principal
+# CSRs must use one of the NIST-approved curves the rest of the broker's
+# verifier paths already accept (see ``app/auth/x509_verifier.py:47``).
+# Before the whitelist the size-only check (``key_size >= 256``) let
+# SECP256K1 (the Bitcoin curve, not FIPS-approved) and BrainpoolP256R1
+# through, even though ``x509_verifier`` would later reject any token
+# minted from such a cert.
+_ALLOWED_EC_CURVES = (ec.SECP256R1, ec.SECP384R1, ec.SECP521R1)
+
+
 def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
     """Refuse weak keys. EC P-256/384/521 ok, RSA >= 2048 ok."""
     pub = csr.public_key()
@@ -131,9 +141,10 @@ def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
                 f"RSA key too small ({pub.key_size} bits); minimum 2048",
             )
     elif isinstance(pub, ec.EllipticCurvePublicKey):
-        if pub.curve.key_size < 256:
+        if not isinstance(pub.curve, _ALLOWED_EC_CURVES):
             raise CsrValidationError(
-                f"EC curve too small ({pub.curve.key_size} bits); minimum 256",
+                f"EC curve {pub.curve.name!r} not allowed; "
+                "use P-256, P-384 or P-521",
             )
     else:
         raise CsrValidationError(

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -124,6 +124,16 @@ def _verify_csr_signature(csr: x509.CertificateSigningRequest) -> None:
         raise CsrValidationError("CSR signature does not verify")
 
 
+# F-A-102 (audit 2026-05-20, CWE-326). EC public keys in user-principal
+# CSRs must use one of the NIST-approved curves the rest of the proxy's
+# verifier paths already accept (mirrors ``app/auth/x509_verifier.py:47``).
+# Before the whitelist the size-only check (``key_size >= 256``) let
+# SECP256K1 (the Bitcoin curve, not FIPS-approved) and BrainpoolP256R1
+# through, even though ``x509_verifier`` would later reject any token
+# minted from such a cert.
+_ALLOWED_EC_CURVES = (ec.SECP256R1, ec.SECP384R1, ec.SECP521R1)
+
+
 def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
     """Refuse weak keys. EC P-256/384/521 ok, RSA >= 2048 ok."""
     pub = csr.public_key()
@@ -133,9 +143,10 @@ def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
                 f"RSA key too small ({pub.key_size} bits); minimum 2048",
             )
     elif isinstance(pub, ec.EllipticCurvePublicKey):
-        if pub.curve.key_size < 256:
+        if not isinstance(pub.curve, _ALLOWED_EC_CURVES):
             raise CsrValidationError(
-                f"EC curve too small ({pub.curve.key_size} bits); minimum 256",
+                f"EC curve {pub.curve.name!r} not allowed; "
+                "use P-256, P-384 or P-521",
             )
     else:
         raise CsrValidationError(

--- a/tests/test_mcp_proxy_principals_csr_curves.py
+++ b/tests/test_mcp_proxy_principals_csr_curves.py
@@ -1,0 +1,73 @@
+"""F-A-102 (audit 2026-05-20, CWE-326) regression for the proxy-side
+CSR public-key validator.
+
+The proxy hosts a sister copy of ``app/registry/principals_csr.py`` at
+``mcp_proxy/registry/principals_csr.py``. Before this finding both
+copies validated EC public keys with a numeric ``key_size >= 256``
+heuristic, which accepted SECP256K1 (Bitcoin) and BrainpoolP256R1 —
+neither of which the downstream verifier in
+``app/auth/x509_verifier.py`` will accept on the resulting token.
+
+The fix mirrors ``_ALLOWED_EC_CURVES = (SECP256R1, SECP384R1, SECP521R1)``
+from the broker x509 verifier into both CSR signers.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from mcp_proxy.registry.principals_csr import (
+    CsrValidationError,
+    _validate_public_key,
+)
+
+
+def _build_csr(curve: ec.EllipticCurve) -> x509.CertificateSigningRequest:
+    priv = ec.generate_private_key(curve)
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "x")]),
+    )
+    builder = builder.add_extension(
+        x509.SubjectAlternativeName(
+            [x509.UniformResourceIdentifier(
+                "spiffe://acme.test/acme/user/mario",
+            )],
+        ),
+        critical=False,
+    )
+    return builder.sign(priv, hashes.SHA256())
+
+
+@pytest.mark.parametrize(
+    "curve_factory",
+    [ec.SECP256K1, ec.BrainpoolP256R1],
+    ids=["secp256k1", "brainpoolp256r1"],
+)
+def test_validate_public_key_rejects_non_nist_curves(curve_factory):
+    csr = _build_csr(curve_factory())
+    with pytest.raises(CsrValidationError, match="not allowed"):
+        _validate_public_key(csr)
+
+
+@pytest.mark.parametrize(
+    "curve_factory",
+    [ec.SECP256R1, ec.SECP384R1, ec.SECP521R1],
+    ids=["p256", "p384", "p521"],
+)
+def test_validate_public_key_accepts_nist_curves(curve_factory):
+    csr = _build_csr(curve_factory())
+    # Must not raise.
+    _validate_public_key(csr)
+
+
+def test_validate_public_key_csr_pem_roundtrip_rejects_secp256k1():
+    """Belt-and-suspenders: load the CSR from PEM (what the HTTP path
+    actually does) and check the validator still rejects."""
+    csr = _build_csr(ec.SECP256K1())
+    pem = csr.public_bytes(serialization.Encoding.PEM)
+    parsed = x509.load_pem_x509_csr(pem)
+    with pytest.raises(CsrValidationError, match="not allowed"):
+        _validate_public_key(parsed)

--- a/tests/test_principals_csr.py
+++ b/tests/test_principals_csr.py
@@ -37,11 +37,19 @@ def _make_csr(
     cn: str = "principal",
     key_type: str = "ec",
     key_size: int = 256,
+    ec_curve: ec.EllipticCurve | None = None,
     extra_uris: list[str] | None = None,
 ) -> tuple[x509.CertificateSigningRequest, str]:
-    """Build a CSR + return PEM. ``spiffe_uri`` None = no SAN extension."""
+    """Build a CSR + return PEM. ``spiffe_uri`` None = no SAN extension.
+
+    When ``ec_curve`` is provided it overrides the ``key_size`` mapping;
+    F-A-102 tests use this to inject specific non-whitelisted curves
+    (SECP256K1, BrainpoolP256R1).
+    """
     if key_type == "ec":
-        if key_size == 256:
+        if ec_curve is not None:
+            curve = ec_curve
+        elif key_size == 256:
             curve = ec.SECP256R1()
         elif key_size == 384:
             curve = ec.SECP384R1()
@@ -172,6 +180,42 @@ async def test_sign_user_csr_weak_rsa_raises():
     )
     with pytest.raises(CsrValidationError, match="too small"):
         await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+# F-A-102 (audit 2026-05-20, CWE-326). The CSR signer must refuse any
+# EC curve that the downstream ``x509_verifier`` does not whitelist.
+# Parametrised over the two non-NIST 256-bit curves ``cryptography``
+# ships out of the box (SECP256K1 — Bitcoin; BrainpoolP256R1 — RFC 5639).
+@pytest.mark.parametrize(
+    "curve_factory",
+    [ec.SECP256K1, ec.BrainpoolP256R1],
+    ids=["secp256k1", "brainpoolp256r1"],
+)
+async def test_sign_user_csr_rejects_non_nist_ec_curves(curve_factory):
+    _, csr_pem = _make_csr(
+        "spiffe://acme.test/acme/user/mario",
+        key_type="ec",
+        ec_curve=curve_factory(),
+    )
+    with pytest.raises(CsrValidationError, match="not allowed"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+async def test_sign_user_csr_accepts_p384():
+    """Positive control: P-384 is on the whitelist and passes the
+    curve gate (signing still fails downstream when the broker CA is
+    not booted in this unit test, but only after the gate)."""
+    from app.registry.principals_csr import _validate_public_key
+
+    csr, _ = _make_csr(
+        "spiffe://acme.test/acme/user/mario",
+        key_type="ec",
+        ec_curve=ec.SECP384R1(),
+    )
+    # The gate alone must not raise. Full sign_user_csr() would need
+    # the KMS bootstrapped, which the rest of this module already
+    # exercises in the happy-path tests.
+    _validate_public_key(csr)
 
 
 async def test_sign_user_csr_malformed_pem_raises():


### PR DESCRIPTION
**Closes F-A-102** (MED, iam). Sister fix on both Court + Mastio.

## Summary

Both `app/registry/principals_csr.py` and `mcp_proxy/registry/principals_csr.py` validated EC public keys with a numeric `key_size >= 256` heuristic. That accepted SECP256K1 (the Bitcoin curve, not FIPS-approved) and BrainpoolP256R1, neither of which the downstream verifier in `app/auth/x509_verifier.py` (`_ALLOWED_EC_CURVES` at line 47) will accept on the resulting token. The CSR signer was strictly weaker than the JWT verifier downstream.

This PR replaces the size-only check with an `isinstance` whitelist mirroring the verifier: SECP256R1, SECP384R1, SECP521R1 only.

## Files

| File | Change |
|---|---|
| `app/registry/principals_csr.py` | `_ALLOWED_EC_CURVES` whitelist + isinstance gate |
| `mcp_proxy/registry/principals_csr.py` | Same fix on Mastio sister |
| `tests/test_principals_csr.py` | Helper `ec_curve=` parameter + 3 new test cases (secp256k1 / brainpoolp256r1 rejection + P-384 positive) |
| `tests/test_mcp_proxy_principals_csr_curves.py` (new) | 6 cases on Mastio sister (2 rejection + 3 acceptance + 1 PEM roundtrip) |

## References

CWE-326 (Inadequate Encryption Strength), RFC 5480, ADR-021.

## Test plan

- [x] `pytest tests/test_principals_csr.py tests/test_court_csr_tofu_pin.py tests/test_mcp_proxy_principals_csr_gate.py tests/test_mcp_proxy_principals_csr_curves.py -n auto --dist=loadfile -q` — 42 passed (9 new cases)
- [x] Sister parity verified: both Court + Mastio reject the same curve set
- [x] No regression on downstream verifier (`x509_verifier._ALLOWED_EC_CURVES` was already strict — this PR closes the asymmetry)