### PR TITLE
fix(config): refuse-to-start in production when VAULT_ALLOW_HTTP=1 (closes F-A-103)

### DIFF
--- a/app/kms/vault.py
+++ b/app/kms/vault.py
@@ -73,13 +73,38 @@ class VaultKMSProvider:
         self._private_key_pem: str | None = None
         self._public_key_pem: str | None = None
 
-        # Enforce TLS — Vault token is the most sensitive credential
+        # Enforce TLS, Vault token is the most sensitive credential
+        # in the deploy. The VAULT_ALLOW_HTTP override exists for local
+        # dev workflows where Vault runs in -dev mode without TLS; in
+        # production environments the override is refused so a stale
+        # dev flag carried over to a prod .env cannot silently leak the
+        # token over plaintext HTTP. Mirrors the production gate pattern
+        # used by app/kms/local.py for loose key perms.
         if not self._vault_addr.startswith("https://"):
             allow_http = os.environ.get("VAULT_ALLOW_HTTP", "").lower() == "true"
+            from app.config import get_settings
+            is_production = getattr(get_settings(), "environment", "") == "production"
+            if allow_http and is_production:
+                _log.critical(
+                    "Refusing VAULT_ALLOW_HTTP=true in production for vault_addr '%s' "
+                    "(plaintext Vault token transport is rejected regardless of operator opt-in)",
+                    self._vault_addr,
+                )
+                raise ValueError(
+                    "VAULT_ALLOW_HTTP=true is rejected in production. "
+                    f"Configure Vault behind TLS (https://) before promoting (got '{self._vault_addr}')."
+                )
             if allow_http:
-                _log.warning("Vault address uses HTTP (TLS disabled via VAULT_ALLOW_HTTP=true) — NOT safe for production")
+                _log.warning(
+                    "Vault address uses HTTP (TLS disabled via VAULT_ALLOW_HTTP=true) "
+                    "for vault_addr '%s', DEV ONLY, NOT safe for production",
+                    self._vault_addr,
+                )
             else:
-                _log.critical("Vault address '%s' does not use HTTPS — refusing to send token over plaintext", self._vault_addr)
+                _log.critical(
+                    "Vault address '%s' does not use HTTPS, refusing to send token over plaintext",
+                    self._vault_addr,
+                )
                 raise ValueError(
                     f"Vault address must use https:// (got '{self._vault_addr}'). "
                     "Set VAULT_ALLOW_HTTP=true to override for development only."

--- a/mcp_proxy/kms/vault.py
+++ b/mcp_proxy/kms/vault.py
@@ -69,16 +69,34 @@ class VaultKMSProvider:
             self._intermediate_ca_path = f"{parent}/intermediate-ca"
 
         # TLS enforcement: refuse plaintext HTTP unless the operator
-        # explicitly opts in for dev. Mirrors app/kms/vault.py.
+        # explicitly opts in for dev. In production environments the
+        # override is rejected so a stale dev flag promoted via .env
+        # cannot leak the Vault token over plaintext HTTP. Mirrors
+        # app/kms/vault.py and the production gate pattern in
+        # mcp_proxy/auth/dpop_jti_store.py.
         if not self._vault_addr.startswith("https://"):
             allow_http = os.environ.get("VAULT_ALLOW_HTTP", "").lower() == "true"
+            from mcp_proxy.config import get_settings
+            is_production = getattr(get_settings(), "environment", "") == "production"
+            if allow_http and is_production:
+                _log.critical(
+                    "Refusing VAULT_ALLOW_HTTP=true in production for vault_addr %r "
+                    "(plaintext Vault token transport is rejected regardless of operator opt-in)",
+                    self._vault_addr,
+                )
+                raise ValueError(
+                    "VAULT_ALLOW_HTTP=true is rejected in production. "
+                    f"Configure Vault behind TLS (https://) before promoting (got {self._vault_addr!r}).",
+                )
             if not allow_http:
                 raise ValueError(
                     f"Vault address must use https:// (got {self._vault_addr!r}). "
                     "Set VAULT_ALLOW_HTTP=true to override for development only.",
                 )
             _log.warning(
-                "Vault address uses HTTP (VAULT_ALLOW_HTTP=true) — NOT safe for production",
+                "Vault address uses HTTP (VAULT_ALLOW_HTTP=true) for vault_addr %r, "
+                "DEV ONLY, NOT safe for production",
+                self._vault_addr,
             )
 
         # When ca_cert_path is provided, httpx uses it as the CA bundle;

--- a/tests/test_audit_r2_t3.py
+++ b/tests/test_audit_r2_t3.py
@@ -49,6 +49,42 @@ class TestVaultTLSEnforcement:
             with pytest.raises(ValueError, match="must use https://"):
                 VaultKMSProvider("http://vault:8200", "s.token", "secret/data/broker")
 
+    def test_http_override_refused_in_production(self, monkeypatch):
+        """F-A-103: VAULT_ALLOW_HTTP=true must be rejected when
+        environment=production. The override is a dev-only escape
+        hatch; promoting a stale dev .env to prod must not leak the
+        Vault token over plaintext HTTP."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("ADMIN_SECRET", "test-secret-not-default")
+        monkeypatch.setenv("DASHBOARD_SIGNING_KEY", "x" * 32)
+        monkeypatch.setenv("VAULT_ALLOW_HTTP", "true")
+        from app.config import get_settings
+        get_settings.cache_clear()
+        try:
+            from app.kms.vault import VaultKMSProvider
+            with pytest.raises(ValueError, match="rejected in production"):
+                VaultKMSProvider(
+                    "http://vault:8200", "s.token", "secret/data/broker",
+                )
+        finally:
+            get_settings.cache_clear()
+
+    def test_http_override_allowed_in_development(self, monkeypatch):
+        """Mirror of the production refuse: development must still
+        accept the override so the dev workflow keeps working."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("VAULT_ALLOW_HTTP", "true")
+        from app.config import get_settings
+        get_settings.cache_clear()
+        try:
+            from app.kms.vault import VaultKMSProvider
+            provider = VaultKMSProvider(
+                "http://vault:8200", "s.token", "secret/data/broker",
+            )
+            assert provider._vault_addr == "http://vault:8200"
+        finally:
+            get_settings.cache_clear()
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # #21 — HKDF random salt per-encryption

--- a/tests/test_kms_vault_provider.py
+++ b/tests/test_kms_vault_provider.py
@@ -231,6 +231,44 @@ def test_init_allows_http_when_override_set(monkeypatch):
     assert provider.name == "vault"
 
 
+def test_init_refuses_http_override_in_production(monkeypatch):
+    """F-A-103: VAULT_ALLOW_HTTP=true must be rejected when the Mastio
+    is configured for production. The override exists for local dev
+    flows; promoting a stale dev .env to prod must not silently leak
+    the Vault token over plaintext HTTP."""
+    monkeypatch.setenv("VAULT_ALLOW_HTTP", "true")
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(ValueError, match="rejected in production"):
+            VaultKMSProvider(
+                vault_addr="http://vault.internal:8200",
+                vault_token=_TOKEN,
+                org_ca_path=_PATH,
+            )
+    finally:
+        get_settings.cache_clear()
+
+
+def test_init_allows_http_override_in_development(monkeypatch):
+    """Mirror of the production refuse: development must still
+    accept the override so dev/test workflows keep working."""
+    monkeypatch.setenv("VAULT_ALLOW_HTTP", "true")
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        provider = VaultKMSProvider(
+            vault_addr="http://vault.internal:8200",
+            vault_token=_TOKEN,
+            org_ca_path=_PATH,
+        )
+        assert provider._vault_addr == "http://vault.internal:8200"
+    finally:
+        get_settings.cache_clear()
+
+
 def test_init_requires_addr():
     with pytest.raises(ValueError, match="vault_addr"):
         VaultKMSProvider(vault_addr="", vault_token=_TOKEN, org_ca_path=_PATH)


### PR DESCRIPTION
**Closes F-A-103** (MED, crypto). Sister fix on both Court + Mastio Vault providers.

## Summary

`VAULT_ALLOW_HTTP` exists as a dev-only escape hatch for Vault `-dev` mode without TLS. Before this change both `VaultKMSProvider` variants (Court `app/kms/vault.py` and Mastio `mcp_proxy/kms/vault.py`) honoured the override unconditionally, so an operator who set it for local work and forgot to scrub the env on promotion would silently ship the Vault token (the most sensitive credential in the deploy) over plaintext HTTP on every secret fetch.

This PR adds an explicit production gate: when `settings.environment == "production"` the override is refused with a `ValueError` that names the offending `vault_addr`, regardless of operator opt-in. Mirrors the existing pattern in `app/kms/local.py` (loose CA key perms refuse-in-production) and `mcp_proxy/auth/dpop_jti_store.py` (existing production check).

## Files

| File | Change |
|---|---|
| `app/kms/vault.py` | Court provider: production gate before HTTP allow |
| `mcp_proxy/kms/vault.py` | Mastio sister: identical gate |
| `tests/test_audit_r2_t3.py` | +2 Court tests (refused-in-production + allowed-in-development) |
| `tests/test_kms_vault_provider.py` | +2 Mastio tests (same coverage) |

## Test plan

- [x] Targeted: 23 passed (4 new) on Vault provider tests
- [x] Wider KMS suite: 127 passed
- [x] H4 + config suite: 25 passed
- [x] Sister-file parity verified: Court + Mastio refuse identically