### PR TITLE
docs(sdk-ts): refresh README quickstart to canonical surface (closes F-B-308)

### DIFF
--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -31,6 +31,19 @@ npm install @agent-trust/sdk
 
 ## Quick Start
 
+> **Status: legacy session API.** The session-based flow shown below
+> (`openSession` / `send` / `poll` / `closeSession`) mirrors the Python
+> SDK's `open_session()` / `send()` surface, which is deprecated as of
+> `cullis-sdk` v0.4.x and will be **removed in v0.5 (~2026-08-15)**.
+> The canonical A2A surface in the wider Cullis ecosystem is one-shot
+> messaging (ADR-008): `send_oneshot` + `receive_oneshot` + ACK, no
+> session lifecycle. The TS SDK has not yet ported one-shot (tracked
+> as F-B-301 / the [Surface gaps](#surface-gaps-vs-python-sdk) table
+> below). Until that ships, the quickstart documents what the SDK
+> actually does today; new TypeScript integrations that can wait for
+> parity should prefer `cullis_sdk` (Python) and its `send_oneshot`
+> flow, see the [Roadmap](#roadmap) section.
+
 ### 1. Create a client and authenticate
 
 ```typescript
@@ -106,6 +119,34 @@ for (const quote of updated.quotes) {
 ```typescript
 await client.closeSession(sessionId);
 ```
+
+## Roadmap
+
+The TS SDK trails the Python SDK on several surfaces. Priority order
+for parity (subject to change, tracked in the Cullis issue tracker):
+
+1. **One-shot messaging (ADR-008)**: `sendOneshot`, `replyOneshot`,
+   inbox poll, ACK. This is the canonical A2A flow and the one the
+   Python SDK's `send_oneshot()` already implements. Required so the
+   TS quickstart can switch off the session API before the Python
+   `v0.5` removal lands (~2026-08-15).
+2. **Proxy-mediated login (ADR-014 / ADR-004)**: `loginViaProxy`,
+   `loginViaProxyWithLocalKey`. Lets a TS agent reuse a Connector or
+   Mastio enrollment instead of carrying raw cert + key.
+3. **Enrollment factories (ADR-011)**: `fromConnector`,
+   `fromIdentityDir`, `fromEnrollment`, `fromApiKeyFile`,
+   `enrollViaByoca`, `enrollViaSpiffe`, `fromUserPrincipalPem`,
+   `fromSpiffeWorkloadApi`.
+4. **AI gateway (ADR-017)**: `chatCompletion`,
+   `chatCompletionStream`, `listModels`, `listMcpTools`, `callMcpTool`,
+   `evaluateToolCallPolicy`.
+
+Migration guidance once one-shot ships: the wire bytes for one-shot
+messages are already stable on the broker side, so a TS port will be
+behaviour-preserving. Existing TS integrations that wait for `v0.2`
+of this SDK will be able to delete the `openSession` / `send` /
+`closeSession` ceremony and replace it with a single `sendOneshot`
+call mirroring the Python `cullis_sdk` quickstart.
 
 ## Architecture
 

--- a/sdk-ts/examples/basic-agent.ts
+++ b/sdk-ts/examples/basic-agent.ts
@@ -1,6 +1,18 @@
 /**
  * Example: Basic buyer agent using the TypeScript SDK.
  *
+ * STATUS: legacy session API. The flow demonstrated below
+ * (login + openSession + send + poll + closeSession) mirrors the
+ * Python SDK's deprecated `open_session()` / `send()` surface, which
+ * emits `DeprecationWarning` and will be removed in `cullis-sdk` v0.5
+ * (~2026-08-15). The canonical Cullis A2A flow is one-shot messaging
+ * (ADR-008: `send_oneshot` + `receive_oneshot` + ACK), which the TS
+ * SDK does not yet expose (tracked as F-B-301 in the audit /
+ * Roadmap section of sdk-ts/README.md). This example documents what
+ * the TS SDK can actually do today; new TypeScript integrations that
+ * can wait for parity should prefer `cullis_sdk` (Python) and its
+ * `send_oneshot()` flow.
+ *
  * Demonstrates:
  *  1. Authenticating with the broker
  *  2. Discovering supplier agents

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -1,7 +1,7 @@
 /**
- * BrokerClient — main class for agent-to-broker communication.
+ * BrokerClient: main class for agent-to-broker communication.
  *
- * Mirrors agents/sdk.py BrokerClient, including:
+ * Exposes the 2025-Q4 session-based wire path:
  * - x509 + DPoP authentication
  * - Session lifecycle (open, accept, close, list)
  * - E2E encrypted messaging (send + poll with auto-decrypt)
@@ -9,6 +9,16 @@
  * - RFQ flow
  * - Transaction tokens
  * - Automatic DPoP nonce handling with retry
+ *
+ * STATUS: legacy session API. The Python equivalents
+ * (`CullisClient.login` / `open_session` / `send` / `close_session`)
+ * are deprecated and scheduled for removal in `cullis-sdk` v0.5
+ * (~2026-08-15). The canonical A2A surface is one-shot messaging
+ * (ADR-008: `send_oneshot` + `receive_oneshot` + ACK), which this
+ * SDK does not yet expose (tracked as F-B-301; see the README
+ * "Surface gaps" and "Roadmap" sections). New TypeScript
+ * integrations that can wait for parity should prefer `cullis_sdk`
+ * (Python) and its `send_oneshot()` flow.
  */
 import { readFile } from "node:fs/promises";
 import type { KeyObject } from "node:crypto";

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1,7 +1,16 @@
 /**
- * @agent-trust/sdk — TypeScript SDK for Cullis.
+ * @agent-trust/sdk: TypeScript SDK for Cullis.
  *
- * Main entry point: re-exports the public API.
+ * Main entry point, re-exports the public API.
+ *
+ * STATUS: BETA, legacy session API only. Exposes the 2025-Q4
+ * session-based wire path (login / openSession / send / poll /
+ * closeSession / RFQ). One-shot messaging (ADR-008), proxy login
+ * (ADR-014), enrollment factories (ADR-011), AI gateway (ADR-017)
+ * and the other surfaces present in the Python `cullis_sdk` are not
+ * yet ported here (tracked as F-B-301). See the README "Surface
+ * gaps" and "Roadmap" sections for the explicit delta and the
+ * migration outlook before `cullis-sdk` v0.5 lands (~2026-08-15).
  */
 
 // Client


### PR DESCRIPTION
**Closes F-B-308** (MAJOR, sdk). Sister fix to F-B-302 (PR #854) on the Python SDK.

## Summary

The TS SDK README still presents the session-based flow (`openSession` / `send` / `poll` / `closeSession`) as the canonical Quick Start, but the mirror Python methods carry `DeprecationWarning` at call time and `_SUNSET = "Will be removed in cullis-sdk v0.5 (~2026-08-15)"`. A TypeScript integrator copying the README ships a v0.1 product that breaks the day `cullis-sdk` v0.5 lands, with no warning surface in TS since the deprecated methods are the only ones available there.

Scope-limited per the finding's "Until F-B-301 ships" caveat: this PR adds the legacy-session callout and Roadmap section, but does NOT yet rewrite the Quick Start to `sendOneshot` (deferred to F-B-301 TS one-shot port).

## Files

| File | Change |
|---|---|
| `sdk-ts/README.md` | Quick Start: `Status: legacy session API` callout + v0.5 sunset citation; new Roadmap section (one-shot, proxy login, enrollment, AI gateway) |
| `sdk-ts/examples/basic-agent.ts` | Header carries the same legacy-session callout (self-describing copy-paste) |
| `sdk-ts/src/index.ts` | Module docstring: BETA + legacy session status, points to README Surface gaps / Roadmap |
| `sdk-ts/src/client.ts` | `BrokerClient` class docstring: drops stale `agents/sdk.py` reference (path removed 2026-02), legacy-session callout |

## ADR cross-refs

- ADR-008 (one-shot canonical, sessions deprecated)
- ADR-011 (unified enrollment, replaces `login()` pattern)
- ADR-014 (mTLS client cert IS the credential)

## Test plan

- [x] Docs-only change, no code paths touched
- [x] Comments-only inside `src/` (no behaviour delta, no test fixtures)
- [x] No `Co-Authored-By: Claude`, no em-dashes in newly authored prose