### PR TITLE
fix(mcp): fail-closed when tool has empty required_capability (closes F-A-304)

### DIFF
--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -162,6 +162,92 @@ async def run(
         )
     )
 
+    # F-A-304 fail-closed gate (audit 2026-05-20).
+    #
+    # Pre-fix, ``if capability_gate_applies and tool_def.required_capability``
+    # silently SKIPPED the gate when a builtin was registered (or
+    # mutated) to carry an empty ``required_capability``. That is a
+    # default-allow on a code path that intends default-deny — the
+    # exact failure mode F-A-304 catalogues.
+    #
+    # Defense in depth: :meth:`ToolRegistry.register` raises at
+    # import time when a builtin lacks a capability, but the executor
+    # MUST NOT trust that invariant — anything routed through
+    # :meth:`ToolRegistry.register_definition` (DB migrations, test
+    # scaffolding, future plugin paths) can land an empty-capability
+    # builtin in the live registry. Reject here so the runtime path
+    # is the load-bearing default-deny.
+    #
+    # MCP resources are deliberately exempted: ADR-007 makes the
+    # binding table the authoritative authz path; empty capability
+    # on a resource is supported by design, but step 2b still gates
+    # execution behind ``has_active_binding``. We emit an explicit
+    # audit subtype just below so SOC can spot the
+    # default-allow-by-capability shape and confirm a binding gate
+    # is enforcing.
+    if (
+        capability_gate_applies
+        and not tool_def.is_mcp_resource
+        and not tool_def.required_capability
+    ):
+        duration_ms = _elapsed_ms(t0)
+        _log.error(
+            "Tool '%s' has no required_capability declared but is a "
+            "builtin (is_mcp_resource=False) — refusing execution. "
+            "Registration-time guard should prevent this; if you see "
+            "this in production, audit how the tool was registered.",
+            tool_name,
+        )
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="tool_execute",
+            tool_name=tool_name,
+            status="denied",
+            detail=(
+                "Tool missing capability declaration "
+                f"(principal_type={principal_type}); fail-closed "
+                "per F-A-304"
+            ),
+            request_id=request_id,
+            duration_ms=duration_ms,
+        )
+        return ToolExecuteResponse(
+            request_id=request_id,
+            tool=tool_name,
+            status="error",
+            error=(
+                f"Forbidden: tool '{tool_name}' has no capability "
+                "declaration"
+            ),
+            execution_time_ms=duration_ms,
+            denied_reason_code=CAPABILITY_DENIED,
+        )
+
+    # F-A-304 recommendation #2: when an MCP resource carries no
+    # ``required_capability``, the binding gate at step 2b is the only
+    # RBAC check. Emit an explicit informational audit row so SOC can
+    # detect misconfigured resources whose authz collapses to binding
+    # alone. The decision is "allow" (the binding gate may still
+    # deny), but the row makes the default-allow-by-capability
+    # explicit instead of silent.
+    if (
+        capability_gate_applies
+        and tool_def.is_mcp_resource
+        and not tool_def.required_capability
+    ):
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="policy.no_capability_required",
+            tool_name=tool_name,
+            status="allow",
+            detail=(
+                f"MCP resource '{tool_def.resource_id}' has no "
+                f"required_capability; authz delegated to binding "
+                f"table (principal_type={principal_type})"
+            ),
+            request_id=request_id,
+        )
+
     if capability_gate_applies and tool_def.required_capability:
         try:
             principal_caps = await _load_principal_capabilities(

--- a/mcp_proxy/tools/registry.py
+++ b/mcp_proxy/tools/registry.py
@@ -71,7 +71,30 @@ class ToolRegistry:
         description: str = "",
         parameters_schema: dict | None = None,
     ) -> Callable:
-        """Decorator to register a tool handler function."""
+        """Decorator to register a builtin tool handler function.
+
+        F-A-304 fail-closed contract (audit 2026-05-20): ``capability``
+        must be a non-empty string. Builtins have no binding row in
+        ``local_agent_resource_bindings``, so an empty capability would
+        collapse the executor's capability gate into a silent allow
+        for every authenticated principal. Refuse at registration so
+        the regression is caught at import time, not in production.
+
+        MCP resources loaded from ``local_mcp_resources`` go through
+        :meth:`register_definition` instead, where empty capability is
+        permitted (the binding table is the authoritative authz path
+        per ADR-007). The executor emits an explicit audit subtype
+        when an MCP resource with empty capability is invoked so SOC
+        can detect misconfigured rows.
+        """
+        if not isinstance(capability, str) or not capability.strip():
+            raise ValueError(
+                f"Tool '{name}' registered without a non-empty "
+                "required_capability. Builtins must declare a "
+                "capability; an empty value would silently bypass "
+                "the capability gate for every authenticated "
+                "principal (F-A-304, ADR-007)."
+            )
 
         def decorator(fn: Callable[[ToolContext], Awaitable[Any]]) -> Callable:
             if name in self._tools:
@@ -127,17 +150,31 @@ class ToolRegistry:
     def has_capability(self, tool_name: str, agent_capabilities: list[str]) -> bool:
         """Check whether the agent has the capability required by the tool.
 
-        Tools with an empty ``required_capability`` (``""``) are treated
-        as having no capability gate — any authenticated agent passes.
-        This matches MCP-resource semantics from ADR-007 where the
-        binding table is the primary authz; capability stays optional
-        metadata for discovery filtering.
+        Semantics (F-A-304 fail-closed contract, audit 2026-05-20):
+
+        * Unknown tool name → ``False``.
+        * Builtin (``is_mcp_resource is False``) with empty
+          ``required_capability`` → ``False``. Registration-time guard
+          should prevent this state from existing in the first place;
+          treating it as fail-closed here is defense-in-depth for any
+          callsite that bypassed the decorator (e.g. direct
+          :meth:`register_definition` from tests or future migrations).
+        * MCP resource with empty ``required_capability`` → ``True``.
+          The binding table is the authoritative authz path per
+          ADR-007; capability stays optional discovery metadata.
+        * Tool with declared capability → membership check.
+
+        Note: the executor (``mcp_proxy/tools/executor.py``) is the
+        runtime enforcement point. This helper exists for
+        discovery-time filtering and is exercised by aggregator code
+        paths; the executor must independently enforce the same
+        contract.
         """
         tool = self._tools.get(tool_name)
         if tool is None:
             return False
         if not tool.required_capability:
-            return True
+            return bool(tool.is_mcp_resource)
         return tool.required_capability in agent_capabilities
 
     # ------------------------------------------------------------------
@@ -190,7 +227,26 @@ class ToolRegistry:
                 if "description" in spec and spec["description"]:
                     existing.description = spec["description"]
                 if "capability" in spec:
-                    existing.required_capability = spec["capability"]
+                    # F-A-304: refuse YAML overrides that blank out the
+                    # capability on a builtin. ``is_mcp_resource`` is False
+                    # for everything loaded via YAML (MCP resources come
+                    # from the DB), so the gate would collapse silently.
+                    new_cap = spec["capability"]
+                    if (
+                        not existing.is_mcp_resource
+                        and (
+                            not isinstance(new_cap, str)
+                            or not new_cap.strip()
+                        )
+                    ):
+                        _log.error(
+                            "Tool '%s' YAML override sets empty "
+                            "required_capability — ignored (F-A-304 "
+                            "fail-closed). Existing capability '%s' kept.",
+                            tool_name, existing.required_capability,
+                        )
+                    else:
+                        existing.required_capability = new_cap
                 if "allowed_domains" in spec:
                     existing.allowed_domains = spec["allowed_domains"]
             else:

--- a/tests/test_mcp_tool_empty_capability_bypass.py
+++ b/tests/test_mcp_tool_empty_capability_bypass.py
@@ -1,0 +1,367 @@
+"""Regression tests for F-A-304 — empty required_capability silent bypass.
+
+Audit ref: ``imp/audits/2026-05-20/findings/track-a/F-A-304.md``.
+
+Pre-fix, a builtin tool registered (or mutated) with an empty
+``required_capability`` would silently bypass the executor's
+capability gate for every authenticated principal type. Recommendation:
+
+1. Builtins MUST declare a non-empty capability at registration time.
+2. The executor MUST fail closed if a builtin somehow reaches it with
+   an empty capability (defense in depth — see ADR-007).
+3. MCP resources with no capability are still allowed (the binding
+   table is authoritative per ADR-007), but the executor emits an
+   explicit informational audit row so SOC can detect the shape.
+
+These tests pin all three contracts.
+"""
+from __future__ import annotations
+
+import os
+
+# Mirror the conftest baseline so this file runs standalone.
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.registry import ToolDefinition, ToolRegistry, tool_registry
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot + restore the singleton registry to keep tests isolated."""
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+def _make_agent(
+    *,
+    agent_id: str = "acme::daniele",
+    org: str = "acme",
+    scope: list[str] | None = None,
+    principal_type: str = "agent",
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}-{principal_type}",
+        scope=scope or [],
+        cnf={"jkt": "fake-jkt"},
+        principal_type=principal_type,
+    )
+
+
+class _FakeSecretProvider:
+    async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
+        return {}
+
+
+def _exec_request(tool_name: str) -> ToolExecuteRequest:
+    return ToolExecuteRequest.model_construct(
+        tool=tool_name,
+        parameters={},
+        request_id="rq-test",
+    )
+
+
+# ── Registration-time guard ──────────────────────────────────────────
+
+
+def test_register_decorator_refuses_empty_capability() -> None:
+    """A builtin registered via the ``@register`` decorator without a
+    capability must fail at import time. ValueError surfaces the
+    misuse where it is cheapest to find — module import — not at
+    runtime under a real principal."""
+    reg = ToolRegistry()
+
+    with pytest.raises(ValueError, match="F-A-304"):
+        @reg.register(name="empty_cap_tool", capability="")
+        async def _h(ctx):  # pragma: no cover — never called
+            return {}
+
+
+def test_register_decorator_refuses_whitespace_capability() -> None:
+    """Whitespace-only capability is treated as empty (otherwise
+    ``"   "`` would silently pass the registration check but fail
+    the membership check at runtime, surfacing the bug late)."""
+    reg = ToolRegistry()
+
+    with pytest.raises(ValueError, match="F-A-304"):
+        @reg.register(name="ws_cap_tool", capability="   ")
+        async def _h(ctx):  # pragma: no cover
+            return {}
+
+
+def test_register_decorator_refuses_none_capability() -> None:
+    """A None capability (e.g. a builder forgot the keyword arg) is
+    rejected. The signature types ``capability: str`` but Python
+    doesn't enforce that at runtime; the guard does."""
+    reg = ToolRegistry()
+
+    with pytest.raises(ValueError, match="F-A-304"):
+        @reg.register(name="none_cap_tool", capability=None)  # type: ignore[arg-type]
+        async def _h(ctx):  # pragma: no cover
+            return {}
+
+
+def test_register_definition_path_accepts_empty_capability_for_mcp_resource(
+    clean_registry,
+) -> None:
+    """MCP resources from ``local_mcp_resources`` may carry empty
+    capability — the binding table is the authz path. The lower-level
+    ``register_definition`` accepts the shape; the executor will
+    emit an informational audit and rely on the binding gate."""
+    async def _h(ctx):
+        return {}
+
+    td = ToolDefinition(
+        name="resource_no_cap",
+        description="MCP resource with no capability declared",
+        required_capability="",
+        allowed_domains=[],
+        handler=_h,
+        resource_id="res-1",
+        endpoint_url="https://upstream.invalid/mcp",
+    )
+    # Should NOT raise — recommendation #2 keeps this shape valid.
+    tool_registry.register_definition(td)
+    assert tool_registry.get("resource_no_cap") is td
+
+
+# ── has_capability semantics ─────────────────────────────────────────
+
+
+def test_has_capability_builtin_with_empty_capability_fails_closed(
+    clean_registry,
+) -> None:
+    """``has_capability`` is a discovery-time helper. Pre-fix it
+    returned True for any builtin with empty capability; post-fix
+    it returns False to mirror the executor's runtime decision."""
+    async def _h(ctx):
+        return {}
+
+    tool_registry.register_definition(ToolDefinition(
+        name="builtin_no_cap",
+        description="",
+        required_capability="",
+        allowed_domains=[],
+        handler=_h,
+    ))
+
+    assert tool_registry.has_capability("builtin_no_cap", []) is False
+    assert tool_registry.has_capability("builtin_no_cap", ["any.cap"]) is False
+
+
+def test_has_capability_resource_with_empty_capability_allows(
+    clean_registry,
+) -> None:
+    """MCP resource with empty capability still returns True from
+    ``has_capability`` — discovery time, binding gate enforces."""
+    async def _h(ctx):
+        return {}
+
+    tool_registry.register_definition(ToolDefinition(
+        name="resource_no_cap",
+        description="",
+        required_capability="",
+        allowed_domains=[],
+        handler=_h,
+        resource_id="res-1",
+        endpoint_url="https://x.invalid/mcp",
+    ))
+
+    assert tool_registry.has_capability("resource_no_cap", []) is True
+
+
+# ── Executor runtime fail-closed ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "principal_type", ["agent", "user", "workload"],
+)
+@pytest.mark.asyncio
+async def test_executor_denies_builtin_with_empty_capability(
+    principal_type: str, clean_registry,
+) -> None:
+    """F-A-304 core regression: an empty-capability builtin reaches
+    the executor (e.g. via ``register_definition`` from a test
+    scaffold or future plugin path). The runtime gate MUST refuse,
+    audit "missing capability declaration", and never invoke the
+    handler — regardless of the caller's scope or principal type."""
+    handler = AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name="builtin_no_cap",
+        description="Empty capability builtin — fail-closed test",
+        required_capability="",
+        allowed_domains=[],
+        handler=handler,
+    ))
+    # Even a maximally privileged caller must be denied.
+    agent = _make_agent(
+        scope=["anything", "everything"], principal_type=principal_type,
+    )
+
+    audit_mock = AsyncMock()
+    with patch("mcp_proxy.tools.executor.log_audit", audit_mock):
+        resp = await executor.run(
+            request=_exec_request("builtin_no_cap"),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+    assert resp.status == "error", (resp.status, resp.error)
+    assert resp.denied_reason_code == "capability_denied"
+    assert "no capability" in (resp.error or "").lower()
+    handler.assert_not_awaited()
+
+    # The audit row carries the F-A-304 fingerprint.
+    audited_details = [
+        kwargs.get("detail", "") for _, kwargs in audit_mock.call_args_list
+    ]
+    assert any(
+        "missing capability declaration" in d.lower() for d in audited_details
+    ), audited_details
+
+
+@pytest.mark.asyncio
+async def test_executor_emits_informational_audit_for_resource_empty_capability(
+    clean_registry,
+) -> None:
+    """Recommendation #2: MCP resource with empty capability gets an
+    explicit ``policy.no_capability_required`` audit row before the
+    binding gate runs. SOC sees the default-allow-by-capability
+    shape; the binding gate still enforces."""
+    handler = AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name="resource_no_cap",
+        description="MCP resource with empty capability",
+        required_capability="",
+        allowed_domains=[],
+        handler=handler,
+        resource_id="res-1",
+        endpoint_url="https://upstream.invalid/mcp",
+    ))
+    agent = _make_agent(scope=[], principal_type="agent")
+
+    async def _binding_ok(*_a, **_k):
+        return True
+
+    audit_mock = AsyncMock()
+    with patch(
+        "mcp_proxy.local.bindings.has_active_binding", _binding_ok,
+    ), patch("mcp_proxy.tools.executor.log_audit", audit_mock):
+        resp = await executor.run(
+            request=_exec_request("resource_no_cap"),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+    assert resp.status == "success", (resp.status, resp.error)
+    handler.assert_awaited_once()
+
+    actions = [
+        kwargs.get("action") for _, kwargs in audit_mock.call_args_list
+    ]
+    assert "policy.no_capability_required" in actions, actions
+
+
+@pytest.mark.asyncio
+async def test_executor_resource_empty_capability_still_blocked_by_missing_binding(
+    clean_registry,
+) -> None:
+    """Belt-and-braces: even with the new informational audit, an
+    MCP resource without a binding is still denied (the binding gate
+    is authoritative). Without this test a future refactor could
+    silently downgrade the binding check to a log."""
+    handler = AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name="resource_no_cap",
+        description="MCP resource with empty capability",
+        required_capability="",
+        allowed_domains=[],
+        handler=handler,
+        resource_id="res-1",
+        endpoint_url="https://upstream.invalid/mcp",
+    ))
+    agent = _make_agent(scope=[], principal_type="user")
+
+    async def _binding_missing(*_a, **_k):
+        return False
+
+    with patch(
+        "mcp_proxy.local.bindings.has_active_binding", _binding_missing,
+    ), patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_exec_request("resource_no_cap"),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+    assert resp.status == "error", (resp.status, resp.error)
+    assert resp.denied_reason_code == "missing_binding"
+    handler.assert_not_awaited()
+
+
+# ── YAML override defense ────────────────────────────────────────────
+
+
+def test_yaml_override_ignored_when_capability_empty(
+    clean_registry, tmp_path,
+) -> None:
+    """``load_from_yaml`` merges YAML overrides into already-registered
+    builtins. If the YAML override sets ``capability: ""``, the merge
+    MUST be rejected so the live definition keeps its registration-time
+    capability — otherwise an attacker (or accident) editing the YAML
+    file could disable the gate without touching code."""
+    async def _h(ctx):
+        return {}
+
+    # First: register a builtin with a real capability (decorator path
+    # would refuse empty, so this is the established baseline).
+    @tool_registry.register(
+        name="yaml_target",
+        capability="real.cap",
+        description="baseline",
+    )
+    async def _real_handler(ctx):
+        return {}
+
+    yaml_file = tmp_path / "tools.yaml"
+    yaml_file.write_text(
+        "tools:\n"
+        "  yaml_target:\n"
+        "    module: tests.test_mcp_tool_empty_capability_bypass\n"
+        "    capability: \"\"\n"
+    )
+    # Load the YAML — the loader should refuse the empty override.
+    tool_registry.load_from_yaml(str(yaml_file))
+
+    td = tool_registry.get("yaml_target")
+    assert td is not None
+    assert td.required_capability == "real.cap", (
+        f"YAML empty-capability override should be ignored; "
+        f"got {td.required_capability!r}"
+    )


### PR DESCRIPTION
**Closes F-A-304** (MED, mcp-egress, iam). Three layers of fail-closed for the ADR-007 capability gate.

## Summary

Builtins registered (or mutated via YAML) with an empty `required_capability` silently bypassed the executor capability gate, defaulting to allow for every authenticated principal type. PR #730 closed the typed-principal short-circuit but made `tool_def.required_capability` the load-bearing default-deny invariant **without enforcing the non-empty contract at registration time**.

This PR enforces the contract at three layers:

1. **Registration-time** (`ToolRegistry.register`): the decorator raises `ValueError` when capability is empty/whitespace/None. Builtins must declare a capability at import time, not at runtime under a real principal.
2. **YAML override-time** (`ToolRegistry.load_from_yaml`): refuses YAML overrides that blank out a builtin's capability. A YAML-only attacker / accident cannot disable the gate without touching code.
3. **Runtime defense-in-depth** (`executor.run`): rejects builtins with empty `required_capability` that reach the executor anyway (in case a future plugin path bypasses the decorator via `register_definition`). Audit row carries `"Tool missing capability declaration ... fail-closed per F-A-304"` so SOC can detect the misuse.

MCP resources (`is_mcp_resource=True`) are deliberately exempted: ADR-007 makes the binding table the authoritative authz path, and step 2b (`has_active_binding`) still enforces. The executor now emits an explicit `policy.no_capability_required` audit row when an MCP resource with empty capability is invoked, so SOC sees the default-allow shape and can confirm a binding is actually enforcing (recommendation #2 in the finding).

## Files

| File | Change |
|---|---|
| `mcp_proxy/tools/registry.py` | `register()` decorator raises on empty cap; `load_from_yaml()` refuses YAML blank-out; `has_capability()` semantics updated |
| `mcp_proxy/tools/executor.py` | Runtime fail-closed branch + informational `policy.no_capability_required` audit row for MCP resources |
| `tests/test_mcp_tool_empty_capability_bypass.py` (new) | 12 cases covering registration guard, YAML override defense, executor runtime fail-closed, MCP resource exemption, binding gate still authoritative |

## References

- ADR-007 (capability gate)
- PR #730 (typed-principal bypass hotfix, related pattern)
- Memory `feedback_mcp_builtin_capability_gate_typed_principals`

## Test plan

- [x] `pytest tests/test_mcp_tool_empty_capability_bypass.py -n auto --dist=loadfile -q` — 12/12 PASS
- [x] Related suites (executor / capability / aggregator / dashboard / PDP / `cullis_send_to_agent` / resource_registry / crit2): 132/132 PASS
- [x] Full unit suite: 4201 passed, 2 pre-existing unrelated failures (`test_dashboard_approvals_nav` badge plugin, `test_connector_atomic_write` parallel-state flake — both reproduce on stashed worktree without this PR's changes)