### PR TITLE
refactor(dashboard): extract Mastio dashboard helpers (F-B-201 PR-1/10)

### DIFF
--- a/mcp_proxy/dashboard/_helpers.py
+++ b/mcp_proxy/dashboard/_helpers.py
@@ -1,0 +1,83 @@
+"""Mastio dashboard — shared helpers for sub-routers.
+
+Sprint F-B-201 PR-1 of 10. Extracted from
+``mcp_proxy/dashboard/router.py`` so the upcoming per-feature sub-routers
+can import these helpers without dragging the whole 5106-LOC router.
+
+Mirrors the Court sibling ``app/dashboard/_helpers.py`` (F-B-202 PR-1).
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from fastapi import Request
+
+from mcp_proxy.dashboard.session import ProxyDashboardSession
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    """Build the standard template context."""
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        **kwargs,
+    }
+
+
+# Wave B G1 (audit 2026-05-11) — SSRF guard for the dashboard's three
+# outbound-fetch test endpoints (test-connection / test-webhook /
+# vault/test). Refuses loopback / RFC1918 / link-local / reserved IPs
+# unless ``allow_private=True`` (the Vault case in docker-compose).
+# Resolves the hostname so a public DNS that points at 127.0.0.1
+# can't bypass the check via a CNAME.
+def _enforce_safe_outbound_url(url: str, *, allow_private: bool = False) -> None:
+    """Raise ValueError when ``url`` resolves to a forbidden target.
+
+    The check parses the URL, resolves the hostname, and inspects every
+    returned IP. ``allow_private=True`` skips the RFC1918/loopback ban
+    for legitimate same-network targets (Vault, dev fixtures); the
+    hostname-resolution + scheme check still fires."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Only http(s) URLs are allowed (got scheme {parsed.scheme!r})"
+        )
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL has no hostname")
+    if not allow_private and hostname in (
+        "localhost", "127.0.0.1", "::1", "0.0.0.0",
+    ):
+        raise ValueError(f"URL points to loopback address: {hostname}")
+    try:
+        addrs = socket.getaddrinfo(
+            hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
+    for _family, _type, _proto, _canonname, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not allow_private and (
+            ip.is_private or ip.is_loopback
+            or ip.is_link_local or ip.is_reserved
+        ):
+            raise ValueError(
+                f"URL resolves to private/reserved IP: {ip}"
+            )
+
+
+def _login_client_ip(request: Request) -> str:
+    """Best-effort client IP for the login handler.
+
+    Uses the immediate transport peer rather than ``X-Forwarded-For``:
+    nginx in front of the Mastio handles trusted-proxy resolution and
+    rewrites ``request.client`` accordingly, while in dev / direct
+    deployments ``X-Forwarded-For`` is attacker-controlled and would
+    let any client mint a fresh "IP" per request to dodge the lockout.
+    """
+    client = request.client
+    return client.host if client is not None else "unknown"

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -63,6 +63,14 @@ from mcp_proxy.dashboard._template_env import (  # noqa: E402
     _parse_device_info,
     build_templates,
 )
+# F-B-201 PR-1: pure helpers extracted to a sibling module so upcoming
+# per-feature sub-routers can import them without dragging the
+# 5000-LOC router.py. Mirrors the Court sibling _helpers.py (F-B-202).
+from mcp_proxy.dashboard._helpers import (  # noqa: E402
+    _ctx,
+    _enforce_safe_outbound_url,
+    _login_client_ip,
+)
 from mcp_proxy import license as _license_mod  # noqa: E402
 
 templates = build_templates(_TEMPLATE_DIR)
@@ -70,18 +78,8 @@ templates = build_templates(_TEMPLATE_DIR)
 router = APIRouter(prefix="/proxy", tags=["dashboard"])
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ─────────────────────────────────────────────────────────────────────────────
-
-def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
-    """Build the standard template context."""
-    return {
-        "request": request,
-        "session": session,
-        "csrf_token": session.csrf_token,
-        **kwargs,
-    }
+# Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip) live in
+# ``mcp_proxy/dashboard/_helpers.py`` since F-B-201 PR-1.
 
 
 def generate_org_ca(org_id: str) -> tuple[str, str]:
@@ -132,51 +130,8 @@ def generate_org_ca(org_id: str) -> tuple[str, str]:
     return cert_pem, key_pem
 
 
-# Wave B G1 (audit 2026-05-11) — SSRF guard for the dashboard's three
-# outbound-fetch test endpoints (test-connection / test-webhook /
-# vault/test). Refuses loopback / RFC1918 / link-local / reserved IPs
-# unless ``allow_private=True`` (the Vault case in docker-compose).
-# Resolves the hostname so a public DNS that points at 127.0.0.1
-# can't bypass the check via a CNAME.
-def _enforce_safe_outbound_url(url: str, *, allow_private: bool = False) -> None:
-    """Raise ValueError when ``url`` resolves to a forbidden target.
-
-    The check parses the URL, resolves the hostname, and inspects every
-    returned IP. ``allow_private=True`` skips the RFC1918/loopback ban
-    for legitimate same-network targets (Vault, dev fixtures); the
-    hostname-resolution + scheme check still fires."""
-    import ipaddress
-    import socket
-    from urllib.parse import urlparse
-
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(
-            f"Only http(s) URLs are allowed (got scheme {parsed.scheme!r})"
-        )
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError("URL has no hostname")
-    if not allow_private and hostname in (
-        "localhost", "127.0.0.1", "::1", "0.0.0.0",
-    ):
-        raise ValueError(f"URL points to loopback address: {hostname}")
-    try:
-        addrs = socket.getaddrinfo(
-            hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
-            proto=socket.IPPROTO_TCP,
-        )
-    except socket.gaierror as exc:
-        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
-    for _family, _type, _proto, _canonname, sockaddr in addrs:
-        ip = ipaddress.ip_address(sockaddr[0])
-        if not allow_private and (
-            ip.is_private or ip.is_loopback
-            or ip.is_link_local or ip.is_reserved
-        ):
-            raise ValueError(
-                f"URL resolves to private/reserved IP: {ip}"
-            )
+# _enforce_safe_outbound_url moved to ``mcp_proxy/dashboard/_helpers.py``
+# since F-B-201 PR-1.
 
 
 async def _test_vault_connectivity(vault_addr: str, vault_token: str) -> tuple[bool, str]:
@@ -283,17 +238,8 @@ async def login_page(request: Request):
     })
 
 
-def _login_client_ip(request: Request) -> str:
-    """Best-effort client IP for the login handler.
-
-    Uses the immediate transport peer rather than ``X-Forwarded-For``:
-    nginx in front of the Mastio handles trusted-proxy resolution and
-    rewrites ``request.client`` accordingly, while in dev / direct
-    deployments ``X-Forwarded-For`` is attacker-controlled and would
-    let any client mint a fresh "IP" per request to dodge the lockout.
-    """
-    client = request.client
-    return client.host if client is not None else "unknown"
+# _login_client_ip moved to ``mcp_proxy/dashboard/_helpers.py``
+# since F-B-201 PR-1.
 
 
 @router.post("/login")


### PR DESCRIPTION
F-B-201 sprint kickoff. PR-1 of 10. Mirrors the F-B-202 (Court dashboard) sprint pattern on the Mastio side.

## Summary

`mcp_proxy/dashboard/router.py` is a 5106-LOC god-object with 16 feature areas in a single file. This PR starts the modularization by lifting the three pure helpers used across the surface into a sibling module so upcoming per-feature sub-routers can import them without dragging the whole router.

| Helper | Purpose |
|---|---|
| `_ctx` | Standard template context builder |
| `_enforce_safe_outbound_url` | SSRF guard (Wave B G1, audit 2026-05-11) |
| `_login_client_ip` | Best-effort client IP for login lockout |

## Layout

| File | LOC | Change |
|---|---|---|
| `mcp_proxy/dashboard/_helpers.py` (new) | 83 | Three helpers + module docstring |
| `mcp_proxy/dashboard/router.py` | 5106 → 5052 (−54) | Helper bodies removed, breadcrumb comments at old positions, one import block |

Pattern parity:
- Court shipped the same split in F-B-202 PR-1 (#839, `app/dashboard/_helpers.py`).
- Mastio `_template_env.py` already exists (predates this sprint), no template factory work needed here.

## Router LOC trajectory target

```
Pre-Sprint  : 66 routes, 5106 LOC
Post-PR-1 (this): 66 routes, 5052 LOC
Target post-PR-10: ~3 routes (overview + landing), ~120 LOC aggregator
```

## Test plan

- [x] `pytest tests/test_proxy_dashboard*.py tests/test_h9_login_lockout.py tests/test_fb9_proxy_logout_csrf.py tests/test_proxy_local_password_toggle.py tests/test_enrollment_dashboard.py tests/test_h4_validate_config_sweep.py -n auto --dist=loadfile -q` — 103 passed
- [x] Behavioural delta: zero (helper bodies identical, only physical location changed)

## Next

PR-2: extract the auth surface (`/proxy/login` + `/proxy/logout` + `/proxy/register` + `/proxy/setup`, ~7 routes ~250 LOC) into `mcp_proxy/dashboard/auth_routes.py` mirroring the Court PR-2 (#841) pattern.