### PR TITLE
fix(sdk-ts): bump version + clarify verifyTls option (closes F-B-304, F-B-307)

### DIFF
--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to `@agent-trust/sdk` (the Cullis TypeScript SDK)
+are documented here. The SDK follows [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html) once a stable `1.0.0`
+is cut; pre-1.0 releases may break the public API between minor
+versions and document each break here.
+
+## 0.2.0-beta.0 — 2026-05-20
+
+Audit-driven polish pass. Closes F-B-304 (version skew vs Python SDK)
+and F-B-307 (`verifyTls` API was a lie).
+
+### Changed
+
+- **`verifyTls` removed from `BrokerClientOptions`.** The option used
+  to be accepted at type level and either silently ignored (`true`)
+  or rejected at construction time (`false`). Node's native fetch
+  cannot disable TLS verification per-call, and the process-wide
+  escape hatch `NODE_TLS_REJECT_UNAUTHORIZED=0` is unsafe. The new
+  surface fails clearly: no option, no hidden behaviour. For brokers
+  with a private or self-signed CA, point Node at the CA PEM via
+  `NODE_EXTRA_CA_CERTS=/path/to/ca.pem` (see README "Self-signed /
+  private CA"). [F-B-307]
+- Package version bumped from `0.1.0` to `0.2.0-beta.0` to (a) flag
+  the parity gap with `cullis_sdk` 0.1.3 surfaced in
+  [F-B-301](../imp/audits/2026-05-20/findings/track-b/F-B-301.md) and
+  (b) match the wider Cullis 0.5 wire surface this SDK targets.
+  [F-B-304]
+
+### Migration
+
+If you were constructing the client with `verifyTls: true`, just drop
+the option. If you were passing `verifyTls: false` (which threw at
+runtime anyway), switch to `NODE_EXTRA_CA_CERTS` and remove the
+option:
+
+```diff
+- const client = new BrokerClient({ baseUrl, verifyTls: false });
++ // export NODE_EXTRA_CA_CERTS=/path/to/cullis-ca.pem
++ const client = new BrokerClient({ baseUrl });
+```
+
+## 0.1.0 — 2025-12 (unreleased to npm)
+
+Initial 2025-Q4 session-based wire surface:
+
+- x509 + DPoP (RFC 9449) login.
+- Session lifecycle (open, accept, send, poll, close, list).
+- E2E encryption (AES-256-GCM + RSA-OAEP-SHA256) with double signature
+  (RSA-PSS-SHA256 inner + outer).
+- Agent discovery (capability-filtered).
+- RFQ flow (request, list responses, accept).
+- Transaction tokens.
+- Automatic DPoP nonce handling with single retry.
+
+Not on npm; lived only in the source tree pending the parity work
+tracked in F-B-301.

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -51,7 +51,6 @@ import { BrokerClient } from "@agent-trust/sdk";
 
 const client = new BrokerClient({
   baseUrl: "https://broker.example.com",
-  verifyTls: true,
 });
 
 await client.login(
@@ -61,6 +60,10 @@ await client.login(
   "./certs/buyer.key",    // private key path
 );
 ```
+
+TLS verification is always on. If your broker presents a private or
+self-signed CA, see [Self-signed / private CA](#self-signed--private-ca)
+below.
 
 ### 2. Discover agents
 
@@ -119,6 +122,28 @@ for (const quote of updated.quotes) {
 ```typescript
 await client.closeSession(sessionId);
 ```
+
+## Self-signed / private CA
+
+This SDK does not expose a `verifyTls` option. Node's native `fetch`
+has no per-call TLS-verify toggle, and the process-wide escape hatch
+`NODE_TLS_REJECT_UNAUTHORIZED=0` disables verification for every
+outbound HTTPS call in the process — unsafe even for dev.
+
+For a broker fronted by a private or self-signed CA (the common
+dogfood case against a local Mastio or sandbox), add the CA PEM to
+Node's trust store via `NODE_EXTRA_CA_CERTS`:
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/cullis-ca.pem
+node my-agent.js
+```
+
+This is scoped to the current Node process. TLS verification stays
+enabled for the broker and for every other HTTPS call your code
+makes. The Python SDK exposes `verify_tls=False` directly because
+`httpx` supports per-client SSL contexts; the TS SDK cannot mirror
+that without taking on a hard `undici` dependency.
 
 ## Roadmap
 

--- a/sdk-ts/examples/basic-agent.ts
+++ b/sdk-ts/examples/basic-agent.ts
@@ -37,10 +37,14 @@ async function main(): Promise<void> {
   const certPath = process.env.CERT_PATH ?? "./certs/buyer.crt";
   const keyPath = process.env.KEY_PATH ?? "./certs/buyer.key";
 
-  // 1. Create client and authenticate
+  // 1. Create client and authenticate.
+  //
+  // TLS verification is always ON. For a broker with a private or
+  // self-signed CA, export NODE_EXTRA_CA_CERTS=/path/to/ca.pem before
+  // running this script — that adds the CA to Node's trust store for
+  // the current process without weakening verification globally.
   const client = new BrokerClient({
     baseUrl: brokerUrl,
-    verifyTls: process.env.VERIFY_TLS !== "false",
   });
 
   console.log(`[${agentId}] Logging in to ${brokerUrl}...`);

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-trust/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-trust/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "jose": "^5.0.0"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-trust/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0-beta.0",
   "description": "TypeScript SDK for Cullis",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -66,7 +66,6 @@ async function httpRequest(
   headers: Record<string, string>,
   options?: RequestOptions,
   timeoutMs = 10_000,
-  verifyTls = true,
 ): Promise<HttpResponse> {
   let fullUrl = url;
   if (options?.params) {
@@ -88,17 +87,13 @@ async function httpRequest(
   // Node 18+ supports AbortSignal.timeout
   fetchOptions.signal = AbortSignal.timeout(timeoutMs);
 
-  // NB: this SDK does NOT implement a scoped TLS-verify opt-out. The
-  // historical workaround (NODE_TLS_REJECT_UNAUTHORIZED=0) disables TLS
-  // verification for the ENTIRE Node process, which is unsafe. If you
-  // need to talk to a broker with a private/self-signed CA, add the CA
-  // to Node's trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem —
-  // this is scoped to the process but keeps verification ON for every
-  // other connection. The `verifyTls` option is retained so callers can
-  // see the default and for future scoped-dispatcher support; setting
-  // it to `false` currently raises at BrokerClient construction time.
-  void verifyTls;
-
+  // TLS verification is always ON. Node's native fetch does not expose
+  // a per-call verify toggle, so this SDK does not offer one. For a
+  // broker with a private or self-signed CA, add the CA PEM to Node's
+  // trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem — scoped to
+  // the current process, leaves verification enabled for every other
+  // connection. Do NOT use NODE_TLS_REJECT_UNAUTHORIZED=0; it disables
+  // verification process-wide and exposes every outbound HTTPS call.
   const response = await fetch(fullUrl, fetchOptions);
   const text = await response.text();
 
@@ -116,7 +111,6 @@ const PUBKEY_CACHE_TTL_MS = 300_000; // 5 minutes
 
 export class BrokerClient {
   private readonly baseUrl: string;
-  private readonly verifyTls: boolean;
   private readonly timeoutMs: number;
 
   private token: string | null = null;
@@ -135,24 +129,14 @@ export class BrokerClient {
 
   constructor(options: BrokerClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
-    this.verifyTls = options.verifyTls ?? true;
     this.timeoutMs = options.timeoutMs ?? 10_000;
 
-    // This SDK does not implement a scoped TLS-verify opt-out (see
-    // note in httpRequest). Refuse rather than silently trust the
-    // network: the previous behavior accepted `verifyTls=false` and
-    // did nothing, which hid the problem from callers.
-    if (!this.verifyTls) {
-      throw new Error(
-        "verifyTls=false is not supported. Node's native fetch cannot " +
-        "disable TLS verification per-call, and the process-wide escape " +
-        "hatch NODE_TLS_REJECT_UNAUTHORIZED=0 is unsafe. For a broker " +
-        "with a private or self-signed CA, add the CA PEM to Node's " +
-        "trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem — this is " +
-        "scoped to this process and keeps verification enabled for every " +
-        "other connection.",
-      );
-    }
+    // TLS verification is mandatory. The SDK no longer exposes a
+    // `verifyTls` option (it used to throw on `false`, which was just
+    // a misleading API). For brokers with a private or self-signed
+    // CA, point Node at the CA PEM via NODE_EXTRA_CA_CERTS — process
+    // scoped, verification stays ON everywhere else. See the README
+    // "Self-signed / private CA" section.
   }
 
   // ── Authentication ───────────────────────────────────────────
@@ -193,7 +177,6 @@ export class BrokerClient {
       { DPoP: dpopProof },
       { body: { client_assertion: assertion } },
       this.timeoutMs,
-      this.verifyTls,
     );
 
     this.updateNonce(resp.headers);
@@ -207,7 +190,6 @@ export class BrokerClient {
         { DPoP: dpopProof },
         { body: { client_assertion: assertion } },
         this.timeoutMs,
-        this.verifyTls,
       );
       this.updateNonce(resp.headers);
     }
@@ -541,7 +523,6 @@ export class BrokerClient {
       headers,
       options,
       this.timeoutMs,
-      this.verifyTls,
     );
     this.updateNonce(resp.headers);
 
@@ -554,7 +535,6 @@ export class BrokerClient {
         retryHeaders,
         options,
         this.timeoutMs,
-        this.verifyTls,
       );
       this.updateNonce(resp.headers);
     }

--- a/sdk-ts/src/types.ts
+++ b/sdk-ts/src/types.ts
@@ -165,8 +165,15 @@ export interface AgentListResponse {
 export interface BrokerClientOptions {
   /** Base URL of the broker (e.g. "https://broker.example.com") */
   baseUrl: string;
-  /** Whether to verify TLS certificates (default: true) */
-  verifyTls?: boolean;
   /** HTTP request timeout in milliseconds (default: 10000) */
   timeoutMs?: number;
+  // NB: there is intentionally no `verifyTls` option. Node's native
+  // fetch does not expose a per-call TLS-verify toggle, and the
+  // process-wide escape hatch (NODE_TLS_REJECT_UNAUTHORIZED=0) is
+  // unsafe. For a broker with a private or self-signed CA, add the CA
+  // PEM to Node's trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem
+  // — scoped to this process, verification stays ON for every other
+  // connection. The Python SDK exposes `verify_tls=False` because
+  // httpx supports per-client SSL contexts; the TS SDK cannot mirror
+  // that surface without taking on a hard `undici` dependency.
 }

--- a/sdk-ts/tests/decrypt_payload.test.mjs
+++ b/sdk-ts/tests/decrypt_payload.test.mjs
@@ -108,10 +108,8 @@ function buildEncryptedInbox({
  * testing: signing key is set so decryption proceeds, and the pubkey
  * cache is pre-seeded with the sender's cert so no HTTP fetch happens.
  *
- * We bypass the constructor's TLS guard via the supported path
- * (verifyTls defaults to true) and reach into private state through
- * the ``any`` escape hatch — this is a unit-test helper, not a real
- * consumer pattern.
+ * Reaches into private state through the ``any`` escape hatch; this
+ * is a unit-test helper, not a real consumer pattern.
  */
 function makeClientWithCachedSenderCert(recipientKeyPem, senderAgentId, senderCertPem) {
   const client = new BrokerClient({ baseUrl: "https://broker.test" });


### PR DESCRIPTION
**Closes F-B-304 + F-B-307** (MAJOR, sdk). Combined sister fixes on `sdk-ts/`.

## Summary

Two MAJOR findings on the TypeScript SDK, both scope-disjoint within `sdk-ts/` so bundled in one PR.

### F-B-304 — Version frozen at 0.1.0

`sdk-ts/package.json` was at `0.1.0` while the wire protocol on Python (`cullis_sdk/__init__.py`) is at `0.1.3` and the broader stack ships v0.5 features. Bumped to `0.2.0-beta.0` (BETA framing justifies the `-beta.0` over flat 0.1.3 parity — flags the F-B-301 surface gap). Fresh `sdk-ts/CHANGELOG.md` documents the bump and reserves SemVer post-1.0.

### F-B-307 — `verifyTls` option misleading

The `verifyTls` option in `BrokerClientOptions` threw on `false` instead of actually skipping TLS verify. Audit recommended option 1 (fail clear): removed the option entirely. Dropped constructor throw, dropped `httpRequest` parameter, dropped field, updated all 4 call sites. Documented `NODE_EXTRA_CA_CERTS` as the supported self-signed-CA escape hatch in README + example.

Option 2 (`undici` dispatcher) rejected: would require adding a runtime dependency; SDK is currently dep-light (only `jose`).

## Files

8 files touched: `package.json`, `package-lock.json`, `CHANGELOG.md` (new), `src/types.ts`, `src/client.ts`, `README.md`, `examples/basic-agent.ts`, `tests/decrypt_payload.test.mjs` (stale comment).

## Test plan

- [x] `npm run build` — clean (zero TS errors)
- [x] `npm test` — 10/10 passing (canonical_json 5/5 + decrypt_payload 5/5)
- [x] Sister-fix scope: F-B-304 + F-B-307 disjoint within `sdk-ts/`, no cross-file concerns