### PR TITLE
fix(audit): cap caller-controlled details payload size (closes F-A-410)

### DIFF
--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -36,6 +36,47 @@ _log = logging.getLogger("app.db.audit")
 # persistent fault; production rarely exceeds 1 retry.
 _MAX_CHAIN_RETRIES = 5
 
+# F-A-410 (audit 2026-05-20) — hard cap on the JSON-serialised
+# ``details`` payload that callers may attach to an audit row. The
+# helpers were designed for operator-curated strings (reason, source,
+# count) but several call sites now feed user-controlled content
+# (exception messages, tool inputs, JWT bodies). Without a cap an
+# authenticated attacker can trigger:
+#
+#   - storage DoS (10 MB rows on an append-only table that cannot be
+#     pruned via SQL),
+#   - hash-chain amplification (each row's ``details`` flows into
+#     ``compute_entry_hash_v2`` and again into every ``verify_chain``
+#     walk — a single fat row drags ``/dashboard/audit/verify`` CPU
+#     up by GB worth of SHA-256 input),
+#   - federation amplification (the Mastio audit publisher batches
+#     200 rows per POST to the Court receiver, so 200 × 10 MB = 2 GB).
+#
+# Reject (rather than truncate) preserves forensic completeness: a
+# silent truncation destroys evidence at the worst possible moment.
+# The ``audit_fail_deny`` policy (see ``audit_chain_background_fail_*``
+# settings) turns the resulting ``RuntimeError`` into a 5xx so the
+# caller cannot succeed without a matching audit row. CWE-770 /
+# CWE-400. Sister-files: ``mcp_proxy/db.py``, ``mcp_proxy/local/audit.py``.
+AUDIT_DETAILS_MAX_BYTES = 16 * 1024
+
+
+def _enforce_details_size(details_json: str | None, *, where: str) -> None:
+    """Raise ``RuntimeError`` if ``details_json`` exceeds the boundary cap.
+
+    No part of ``details_json`` is included in the error message — the
+    caller may have packed user-controlled content into it, and the
+    error path can land on stderr / structured logs.
+    """
+    if details_json is None:
+        return
+    size = len(details_json.encode("utf-8"))
+    if size > AUDIT_DETAILS_MAX_BYTES:
+        raise RuntimeError(
+            f"audit details too large for {where}: "
+            f"{size} bytes (max {AUDIT_DETAILS_MAX_BYTES})"
+        )
+
 # Sentinel org used for audit events that have no natural tenant
 # (system-level events, bootstrap, etc.). Isolates their chain from
 # real tenants so an export for a real org never mixes in system rows.
@@ -395,6 +436,8 @@ async def log_event(
     and retry with the next seq. Bounded by ``_MAX_CHAIN_RETRIES``.
     """
     details_json = json.dumps(details) if details else None
+    # F-A-410 — enforce the cap at the boundary, before any chain work.
+    _enforce_details_size(details_json, where="log_event")
     chain_org = org_id or SYSTEM_ORG
     lock = await _get_org_lock(chain_org)
 
@@ -472,6 +515,10 @@ async def log_event_cross_org(
         raise ValueError("cross-org append requires distinct org ids")
 
     details_json = json.dumps(details) if details else None
+    # F-A-410 — enforce the cap at the boundary. Cross-org writes
+    # produce TWO rows (one per chain) so an oversized payload doubles
+    # the storage and hash-chain amplification surface.
+    _enforce_details_size(details_json, where="log_event_cross_org")
 
     # Deterministic lock order ⇒ no deadlocks when two coroutines race
     # on the same pair in opposite directions.

--- a/app/federation/audit_replicate.py
+++ b/app/federation/audit_replicate.py
@@ -68,7 +68,15 @@ class ReplicaEntry(BaseModel):
     event_type: str = Field(..., max_length=128)
     agent_id: str | None = Field(None, max_length=256)
     session_id: str | None = Field(None, max_length=128)
-    details: str | None = None
+    # F-A-410 (audit 2026-05-20) — defence-in-depth cap mirroring
+    # ``app/db/audit.py::AUDIT_DETAILS_MAX_BYTES``. Pydantic measures
+    # ``max_length`` in characters; for the worst-case multi-byte case
+    # this is still bounded by the per-row 16 KiB byte cap once the
+    # Mastio publisher passes the local boundary, so accepting up to
+    # 16 384 characters here stays consistent with that policy. Keeps
+    # a compromised or buggy Mastio from sneaking unbounded payloads
+    # past the publisher-side guard.
+    details: str | None = Field(None, max_length=16 * 1024)
     result: str = Field(..., max_length=32)
     principal_type: str | None = Field(None, max_length=32)
     hash_format: str | None = Field(None, max_length=8)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -357,6 +357,35 @@ _audit_chain_lock = _asyncio.Lock()
 _AUDIT_CHAIN_GENESIS = "genesis"
 _AUDIT_CHAIN_MAX_RETRIES = 5
 
+# F-A-410 (audit 2026-05-20) — hard cap on the ``detail`` payload that
+# callers may attach to an audit row. Sister of
+# ``app/db/audit.py::AUDIT_DETAILS_MAX_BYTES`` and
+# ``mcp_proxy/local/audit.py::AUDIT_DETAILS_MAX_BYTES``. Keep the three
+# in sync so cross-component audit semantics stay identical. The
+# canonical-form ``detail`` field flows into the per-row hash AND each
+# verify-chain walk, so an uncapped payload becomes a CPU + storage DoS
+# amplifier on an append-only table the operator cannot prune. CWE-770.
+AUDIT_DETAILS_MAX_BYTES = 16 * 1024
+
+
+def _enforce_audit_detail_size(detail: str | None, *, where: str) -> None:
+    """Raise ``RuntimeError`` if ``detail`` exceeds the boundary cap.
+
+    No part of ``detail`` is included in the error message — callers may
+    have packed user-controlled content (exception messages, tool
+    inputs) into it, and the error path lands on stderr / structured
+    logs. The audit ``fail_deny`` policy turns the ``RuntimeError`` into
+    a 5xx so the caller cannot succeed without a matching audit row.
+    """
+    if detail is None:
+        return
+    size = len(detail.encode("utf-8"))
+    if size > AUDIT_DETAILS_MAX_BYTES:
+        raise RuntimeError(
+            f"audit details too large for {where}: "
+            f"{size} bytes (max {AUDIT_DETAILS_MAX_BYTES})"
+        )
+
 
 def compute_audit_row_hash(
     *,
@@ -461,6 +490,12 @@ async def log_audit(
         detail = json.dumps(
             dict(details), separators=(",", ":"), sort_keys=True, default=str,
         )
+
+    # F-A-410 — enforce the cap at the boundary before any chain work.
+    # Apply once after the dict-to-JSON serialisation above so both the
+    # ``detail`` string path and the ``details`` dict path go through
+    # the same gate.
+    _enforce_audit_detail_size(detail, where="log_audit")
 
     # P1.2 — fall back to the per-request contextvar stamped by the
     # DPoP auth deps so DPoP-bound paths populate the column without

--- a/mcp_proxy/local/audit.py
+++ b/mcp_proxy/local/audit.py
@@ -49,6 +49,25 @@ _locks_guard = asyncio.Lock()
 # multi-worker deployments depend on the DB-level UNIQUE to serialise.
 _MAX_CHAIN_RETRIES = 5
 
+# F-A-410 (audit 2026-05-20) — hard cap on the JSON-serialised
+# ``details`` payload. Sister of ``app/db/audit.py::AUDIT_DETAILS_MAX_BYTES``
+# — keep the constants in sync so cross-component audit semantics
+# stay identical. See that file for the threat-model commentary
+# (storage DoS, hash-chain amplification, federation amplification).
+AUDIT_DETAILS_MAX_BYTES = 16 * 1024
+
+
+def _enforce_details_size(details_json: str | None, *, where: str) -> None:
+    """Raise ``RuntimeError`` if ``details_json`` exceeds the boundary cap."""
+    if details_json is None:
+        return
+    size = len(details_json.encode("utf-8"))
+    if size > AUDIT_DETAILS_MAX_BYTES:
+        raise RuntimeError(
+            f"audit details too large for {where}: "
+            f"{size} bytes (max {AUDIT_DETAILS_MAX_BYTES})"
+        )
+
 
 async def _get_org_lock(org_id: str) -> asyncio.Lock:
     if org_id in _org_locks:
@@ -89,6 +108,8 @@ async def append_local_audit(
     """
     chain_org = org_id or SYSTEM_ORG
     details_json = json.dumps(details, separators=(",", ":"), sort_keys=True) if details else None
+    # F-A-410 — enforce the cap at the boundary before any chain work.
+    _enforce_details_size(details_json, where="append_local_audit")
     lock = await _get_org_lock(chain_org)
 
     async with lock:

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -426,3 +426,84 @@ async def test_adr020_cross_org_propagates_principal_type(audit_db):
     )
     assert row_a.principal_type == "user"
     assert row_b.principal_type == "user"
+
+
+# ── F-A-410 — caller-controlled details payload cap ───────────────
+
+async def test_fa410_details_under_cap_accepted(audit_db):
+    """Payloads below the 16 KiB cap append normally."""
+    from app.db.audit import AUDIT_DETAILS_MAX_BYTES
+
+    # 8 KiB is well under the 16 KiB hard cap.
+    payload = {"blob": "x" * (8 * 1024)}
+    entry = await log_event(
+        audit_db, "test.under_cap", "ok",
+        org_id="acme", details=payload,
+    )
+    assert entry.entry_hash is not None
+    assert entry.details is not None
+    assert len(entry.details.encode("utf-8")) < AUDIT_DETAILS_MAX_BYTES
+
+
+async def test_fa410_details_above_cap_rejected(audit_db):
+    """Oversized details are rejected with a clear RuntimeError.
+
+    Reject (not truncate) — silent truncation destroys forensic data
+    and lets an attacker amplify the audit chain via 10 MB rows that
+    every ``verify_chain`` walk has to re-hash.
+    """
+    from sqlalchemy import select, func
+
+    from app.db.audit import AUDIT_DETAILS_MAX_BYTES
+
+    # 32 KiB payload, well above the 16 KiB cap.
+    oversized = {"blob": "x" * (32 * 1024)}
+    rows_before = await audit_db.scalar(
+        select(func.count()).select_from(AuditLog).where(
+            AuditLog.org_id == "acme",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="audit details too large"):
+        await log_event(
+            audit_db, "test.over_cap", "ok",
+            org_id="acme", details=oversized,
+        )
+
+    # No row was written on rejection — the call must fail BEFORE the
+    # chain append. This is the property ``audit_fail_deny`` relies on
+    # to turn the RuntimeError into a 5xx with no orphan audit row.
+    rows_after = await audit_db.scalar(
+        select(func.count()).select_from(AuditLog).where(
+            AuditLog.org_id == "acme",
+        )
+    )
+    assert rows_after == rows_before
+    # Cap constant is exported for sister-file alignment.
+    assert AUDIT_DETAILS_MAX_BYTES == 16 * 1024
+
+
+async def test_fa410_cross_org_oversized_details_rejected(audit_db):
+    """Cross-org dual-write enforces the same cap before either append."""
+    from sqlalchemy import select, func
+
+    from app.db.audit import log_event_cross_org
+
+    oversized = {"blob": "x" * (32 * 1024)}
+    rows_before = await audit_db.scalar(
+        select(func.count()).select_from(AuditLog)
+    )
+
+    with pytest.raises(RuntimeError, match="audit details too large"):
+        await log_event_cross_org(
+            audit_db, "test.cross_over_cap", "ok",
+            org_a="acme", org_b="bravo",
+            details=oversized,
+        )
+
+    # Neither side appended — the gate sits BEFORE the locks so a
+    # rejection cannot leave one chain with a partial row.
+    rows_after = await audit_db.scalar(
+        select(func.count()).select_from(AuditLog)
+    )
+    assert rows_after == rows_before

--- a/tests/test_h4_audit_chain.py
+++ b/tests/test_h4_audit_chain.py
@@ -318,3 +318,53 @@ async def test_log_audit_details_chain_still_verifies(proxy_app):
 
     ok, broken, reason = await verify_audit_chain()
     assert ok is True, f"chain broken at {broken}: {reason}"
+
+
+# ── F-A-410 — caller-controlled detail payload cap ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_fa410_log_audit_oversized_detail_rejected(proxy_app):
+    """``log_audit`` rejects ``detail`` > 16 KiB with a RuntimeError.
+
+    Sister of ``app/db/audit.py::log_event`` and
+    ``mcp_proxy/local/audit.py::append_local_audit``. Same cap, same
+    reject semantics. CWE-770 — caller-controlled exception messages
+    and tool inputs flow through here; without a cap an authenticated
+    attacker can fill the append-only ``audit_log`` table.
+    """
+    _, _ = proxy_app
+    from sqlalchemy import text
+
+    from mcp_proxy.db import AUDIT_DETAILS_MAX_BYTES, get_db, log_audit
+
+    oversized_string = "x" * (32 * 1024)
+
+    async with get_db() as conn:
+        before = (await conn.execute(
+            text("SELECT COUNT(*) FROM audit_log"),
+        )).scalar_one()
+
+    with pytest.raises(RuntimeError, match="audit details too large"):
+        await log_audit(
+            agent_id="alice",
+            action="t.invoke",
+            status="ok",
+            detail=oversized_string,
+        )
+
+    # Same rejection for the dict-shaped ``details`` path.
+    with pytest.raises(RuntimeError, match="audit details too large"):
+        await log_audit(
+            agent_id="alice",
+            action="t.invoke",
+            status="ok",
+            details={"blob": "y" * (32 * 1024)},
+        )
+
+    async with get_db() as conn:
+        after = (await conn.execute(
+            text("SELECT COUNT(*) FROM audit_log"),
+        )).scalar_one()
+    assert after == before, "rejected log_audit must not write a row"
+    assert AUDIT_DETAILS_MAX_BYTES == 16 * 1024

--- a/tests/test_proxy_local_audit_chain.py
+++ b/tests/test_proxy_local_audit_chain.py
@@ -118,3 +118,50 @@ async def test_concurrent_appends_keep_chain_monotonic(fresh_db):
     assert seqs == list(range(1, 21))
     ok, reason = await verify_local_chain("acme")
     assert ok is True, reason
+
+
+# ── F-A-410 — caller-controlled details payload cap ───────────────
+
+@pytest.mark.asyncio
+async def test_fa410_local_audit_oversized_details_rejected(fresh_db):
+    """``append_local_audit`` rejects details > 16 KiB.
+
+    Sister of ``app/db/audit.py::log_event`` — same cap, same reject
+    semantics, no orphan row on rejection.
+    """
+    from mcp_proxy.local.audit import AUDIT_DETAILS_MAX_BYTES
+
+    # 32 KiB blob — well above the 16 KiB cap.
+    oversized = {"blob": "x" * (32 * 1024)}
+
+    # Seed one valid row so we can prove no extra row landed.
+    seed = await append_local_audit(event_type="seed", org_id="acme")
+
+    with pytest.raises(RuntimeError, match="audit details too large"):
+        await append_local_audit(
+            event_type="over_cap",
+            org_id="acme",
+            details=oversized,
+        )
+
+    async with get_db() as conn:
+        cnt = (await conn.execute(
+            text("SELECT COUNT(*) FROM local_audit WHERE org_id = :o"),
+            {"o": "acme"},
+        )).scalar_one()
+    assert cnt == 1, "rejected call must not write a row"
+    assert seed["chain_seq"] == 1
+    assert AUDIT_DETAILS_MAX_BYTES == 16 * 1024
+
+
+@pytest.mark.asyncio
+async def test_fa410_local_audit_under_cap_accepted(fresh_db):
+    """8 KiB details payload appends normally (well under the cap)."""
+    payload = {"blob": "x" * (8 * 1024)}
+    entry = await append_local_audit(
+        event_type="under_cap",
+        org_id="acme",
+        details=payload,
+    )
+    assert entry["chain_seq"] == 1
+    assert entry["entry_hash"] is not None


### PR DESCRIPTION
**Closes F-A-410** (MED, audit). Sister fix on Court + Mastio audit helpers + federation replica Pydantic.

## Summary

Hard-cap the JSON-serialised `details` payload at the audit boundary in all three append helpers:
- `app/db/audit.py::log_event` + `log_event_cross_org` (Court primary chain + cross-org replication)
- `mcp_proxy/local/audit.py::append_local_audit` (Mastio local chain)
- `mcp_proxy/db.py::log_audit` (Mastio primary chain)

Default `AUDIT_DETAILS_MAX_BYTES = 16 KiB` per row, exported on each module so sister-files stay in sync. Oversized payloads raise `RuntimeError("audit details too large ...")` BEFORE any chain work, so `audit_fail_deny=True` surfaces a 5xx with no orphan row landing on the append-only table.

Defence-in-depth: `app/federation/audit_replicate.py::ReplicaEntry.details` gets a Pydantic `Field(max_length=16*1024)` so cross-org replication refuses oversized rows on the wire too.

## Threat (CWE-770 / CWE-400)

The helpers were designed for operator-curated strings (reason, source, count) but several call sites now feed user-controlled content into `details` (exception messages with SQLAlchemy bound params, tool inputs on error, JWT claim bodies on login failure). Without a cap an authenticated attacker can trigger:

- **Storage DoS** — 10 MB rows on an append-only table that cannot be pruned via SQL (Court chain has a BEFORE-UPDATE/DELETE trigger, Mastio has fewer controls)
- **Hash-chain amplification** — each row's `details` flows into `compute_entry_hash_v2` and again into every `verify_chain` walk. One fat row drags `/dashboard/audit/verify` CPU up by GB of SHA-256 input on a dispatchable endpoint.

## Files (7)

- `app/db/audit.py` — `AUDIT_DETAILS_MAX_BYTES` + `_enforce_details_size()`, applied in `log_event` + `log_event_cross_org`
- `mcp_proxy/local/audit.py` — sister constant + helper, applied in `append_local_audit`
- `mcp_proxy/db.py` — sister constant + `_enforce_audit_detail_size()`, applied in `log_audit` post dict/string normalization
- `app/federation/audit_replicate.py` — `Field(max_length=16*1024)` on `ReplicaEntry.details`
- 3 test files extended (6 new tests)

## Test plan

- [x] 6 new tests: under-cap accepted + above-cap rejected on all 4 helpers + cross-org replica refused at Pydantic
- [x] All 43 targeted tests pass
- [x] Broader audit suite: 365 pass / 1 unrelated xdist flake (`test_apply_happy_path`, passes serially)
- [x] Federation replication suite: 23/23 green