### PR TITLE
fix(iam): rate-limit connector-login endpoints (closes F-A-208)

### DIFF
--- a/mcp_proxy/registry/connector_login_local_attribution_router.py
+++ b/mcp_proxy/registry/connector_login_local_attribution_router.py
@@ -65,6 +65,10 @@ from mcp_proxy.db import (
     upsert_local_user_principal_local,
 )
 from mcp_proxy.models import TokenPayload
+from mcp_proxy.registry.connector_login_router import (
+    _client_ip,
+    _enforce_connector_login_rate_limit,
+)
 
 _log = logging.getLogger("mcp_proxy.registry.connector_login_local_attribution")
 
@@ -219,6 +223,17 @@ async def connector_login_local_attribution(
         bound_thumbprint = server_thumbprint
     else:
         bound_thumbprint = body.device_cert_thumbprint
+
+    # F-A-208 — see sibling router for the threat model. Same three
+    # buckets: per-agent, per-IP, per-(agent, local_subject). Placed
+    # after the regex + thumbprint gates so malformed bodies still 400
+    # without consuming budget.
+    await _enforce_connector_login_rate_limit(
+        agent_id=token.agent_id,
+        client_ip=_client_ip(request),
+        subject=body.local_subject,
+        endpoint="connector-login-local-attribution",
+    )
 
     # principal_id mirrors the SSO sibling's shape so downstream policy /
     # audit code does not need a special-case for local-auth. The

--- a/mcp_proxy/registry/connector_login_router.py
+++ b/mcp_proxy/registry/connector_login_router.py
@@ -41,6 +41,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 
 from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import (
     create_user_session,
@@ -58,6 +59,85 @@ router = APIRouter(prefix="/v1/principals", tags=["principals"])
 # Default TTL aligned with ADR-032 decision D — 1h idle banking-grade
 # default, tunable via env.
 _DEFAULT_TTL_SECONDS = 3600
+
+# F-A-208 (audit 2026-05-20, OWASP A05 / CWE-307). The endpoint is
+# write-heavy (upsert ``local_user_principals`` + insert ``user_sessions``)
+# and trusts the body's ``user_subject_sso`` after the device-cert gate.
+# Without a rate limit a compromised Connector can:
+#   1. Enumerate which SSO subjects exist by flooding logins + observing
+#      the resulting ``local_user_principals`` rows it can read back.
+#   2. Flood-mint ``user_sessions`` rows until the table degrades.
+# Three buckets, all backed by the same sliding-window limiter:
+#   - per-agent_id   : 60/min — well above legit re-login (token TTL ~1h),
+#                       below useful enumeration speed.
+#   - per-client-IP  : 30/min — second axis when the agent identity is
+#                       under attacker control but the source IP is not.
+#   - per (agent_id, body subject) : 5/min — closes targeted enumeration
+#                       of a *specific* subject ("is alice provisioned?").
+_CONNECTOR_LOGIN_AGENT_PER_MINUTE = 60
+_CONNECTOR_LOGIN_IP_PER_MINUTE = 30
+_CONNECTOR_LOGIN_SUBJECT_PER_MINUTE = 5
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort source IP for the per-IP throttle bucket.
+
+    Honors a single-hop ``X-Forwarded-For`` (the nginx sidecar in the
+    Frontdesk bundle / Court reverse-proxy sets exactly one), otherwise
+    falls back to the TCP peer. The string is only used as a rate-limit
+    key, never echoed back to the client.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
+async def _enforce_connector_login_rate_limit(
+    *, agent_id: str, client_ip: str, subject: str, endpoint: str,
+) -> None:
+    """Three-bucket rate-limit gate shared by both connector-login routes.
+
+    Raises ``HTTPException(429)`` and emits a structured warning when any
+    of the per-agent / per-IP / per-(agent,subject) windows is exhausted.
+    The warning is the audit signal (see ADR-013 layer 3): the broker's
+    hash-chain audit row is written by downstream code only on success,
+    so over-limit calls deliberately leave a *log* trail, not a DB one,
+    so the attacker can't fill the audit table either.
+    """
+    limiter = get_agent_rate_limiter()
+    checks = (
+        (
+            f"connector-login:agent:{agent_id}",
+            _CONNECTOR_LOGIN_AGENT_PER_MINUTE,
+            "agent",
+        ),
+        (
+            f"connector-login:ip:{client_ip}",
+            _CONNECTOR_LOGIN_IP_PER_MINUTE,
+            "ip",
+        ),
+        (
+            f"connector-login:subject:{agent_id}:{subject}",
+            _CONNECTOR_LOGIN_SUBJECT_PER_MINUTE,
+            "subject",
+        ),
+    )
+    for key, ceiling, bucket in checks:
+        if not await limiter.check(key, ceiling):
+            _log.warning(
+                "connector-login rate limit exceeded "
+                "(endpoint=%s bucket=%s agent=%s ip=%s subject_prefix=%s)",
+                endpoint, bucket, agent_id, client_ip, subject[:16],
+            )
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="connector-login rate limit exceeded",
+                headers={"Retry-After": "60"},
+            )
 
 # RFC-friendly user_name slug: lower-case alphanumerics + a couple of
 # separators. Anything else is replaced. The full SSO sub stays in
@@ -226,6 +306,17 @@ async def connector_login(
         bound_thumbprint = server_thumbprint
     else:
         bound_thumbprint = body.device_cert_thumbprint
+
+    # F-A-208 — rate-limit the write-heavy + body-trusted path. Placed
+    # AFTER the thumbprint gate so a mismatched body still 400s fast
+    # without consuming budget, and BEFORE the user/session upsert so
+    # over-limit floods never reach the DB.
+    await _enforce_connector_login_rate_limit(
+        agent_id=token.agent_id,
+        client_ip=_client_ip(request),
+        subject=body.user_subject_sso,
+        endpoint="connector-login",
+    )
 
     user_name = _slug_from_sso(
         body.user_subject_sso,

--- a/tests/test_connector_login_rate_limit.py
+++ b/tests/test_connector_login_rate_limit.py
@@ -1,0 +1,221 @@
+"""F-A-208 (audit 2026-05-20) — rate-limit regression for the two
+``/v1/principals/connector-login*`` endpoints.
+
+Pre-fix, both endpoints trusted the body's ``user_subject_sso`` /
+``local_subject`` after the device-cert gate and minted ``user_sessions``
+rows without any throttle. A compromised Connector could enumerate SSO
+subjects + flood-mint sessions. This file pins the three sliding-window
+buckets introduced by the fix:
+
+  * per-agent_id         — 60/min
+  * per-client-IP        — 30/min
+  * per (agent, subject) — 5/min  (the tightest bucket, exercised here)
+
+OWASP A05, CWE-307. The buckets share the existing in-memory
+``InMemoryAgentRateLimiter`` so the test resets it between cases.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.models import TokenPayload
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_agent(
+    *, org: str = "acme", agent_id: str = "acme::connector",
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}",
+        scope=[],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "rate_limit.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    # Force a fresh in-memory bucket map so neighbouring tests can't
+    # pre-fill the per-agent/per-IP windows under -n auto.
+    reset_agent_rate_limiter()
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        reset_agent_rate_limiter()
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def app_client(proxy_db):
+    from mcp_proxy.main import app
+
+    app.dependency_overrides[get_authenticated_agent] = lambda: _fake_agent()
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.pop(get_authenticated_agent, None)
+
+
+def _sso_body(subject: str = "alice@acme.com") -> dict:
+    return {
+        "user_subject_sso": subject,
+        "display_name": "Alice Smith",
+        "idp_issuer": "https://idp.example.com",
+        "device_cert_thumbprint": "a" * 64,
+    }
+
+
+def _local_body(subject: str = "alice") -> dict:
+    return {
+        "local_subject": subject,
+        "display_name": "Alice Smith",
+        "device_cert_thumbprint": "a" * 64,
+        "auth_mode": "local",
+    }
+
+
+# Per-(agent, subject) ceiling is 5/min — six identical hits trip 429.
+_SUBJECT_CEILING = 5
+
+
+async def test_sso_login_per_subject_bucket_triggers_429(
+    app_client, monkeypatch,
+):
+    """Six rapid logins from the same (agent, subject) → 6th returns 429.
+
+    Pins the tightest bucket: re-posting the *same* SSO subject from the
+    *same* agent is what an enumeration attacker does. Legit re-login
+    cadence is on the order of once per hour (token TTL), so 5/min has
+    multiple orders of magnitude of headroom.
+    """
+    # ADR-013 layer 3 — the gate must also emit an audit-grade warning
+    # so SOC tooling can alert without scraping the DB. The mcp_proxy
+    # logger has ``propagate=False``, so caplog never sees it; spy on
+    # ``_log.warning`` directly, matching the
+    # ``feedback_mcp_proxy_logger_caplog`` memory pattern.
+    from mcp_proxy.registry import connector_login_router as router_mod
+    seen: list[str] = []
+    original = router_mod._log.warning
+
+    def _spy(msg, *args, **kwargs):
+        try:
+            rendered = msg % args if args else msg
+        except Exception:  # noqa: BLE001
+            rendered = str(msg)
+        seen.append(rendered)
+        return original(msg, *args, **kwargs)
+
+    monkeypatch.setattr(router_mod._log, "warning", _spy)
+
+    body = _sso_body()
+    for i in range(_SUBJECT_CEILING):
+        resp = app_client.post("/v1/principals/connector-login", json=body)
+        assert resp.status_code == 201, (
+            f"call {i} unexpectedly throttled: {resp.status_code} {resp.text}"
+        )
+
+    over = app_client.post("/v1/principals/connector-login", json=body)
+    assert over.status_code == 429, over.text
+    assert over.headers.get("Retry-After") == "60"
+    assert "rate limit" in over.json()["detail"].lower()
+    assert any(
+        "rate limit exceeded" in line.lower() for line in seen
+    ), f"no rate-limit warning emitted; seen={seen}"
+
+
+async def test_local_attribution_per_subject_bucket_triggers_429(app_client):
+    """Same shape, the local-auth sibling. Different subject string, same
+    bucket: the helper is shared, so this proves the wiring on both
+    routes, not just the SSO path."""
+    body = _local_body()
+    for i in range(_SUBJECT_CEILING):
+        resp = app_client.post(
+            "/v1/principals/connector-login-local-attribution", json=body,
+        )
+        assert resp.status_code == 201, (
+            f"call {i} unexpectedly throttled: {resp.status_code} {resp.text}"
+        )
+
+    over = app_client.post(
+        "/v1/principals/connector-login-local-attribution", json=body,
+    )
+    assert over.status_code == 429, over.text
+    assert over.headers.get("Retry-After") == "60"
+
+
+async def test_distinct_subjects_isolated_under_subject_bucket(app_client):
+    """Per-(agent, subject) bucket must not collateral-damage *other*
+    subjects from the same agent. Five hits on subject A then one hit
+    on subject B succeeds — the per-agent ceiling (60/min) is far above
+    the six-call burst, so only the per-subject window of A would have
+    closed."""
+    for _ in range(_SUBJECT_CEILING):
+        ok = app_client.post(
+            "/v1/principals/connector-login",
+            json=_sso_body("alice@acme.com"),
+        )
+        assert ok.status_code == 201, ok.text
+
+    # Subject A's per-(agent, subject) bucket is now at the ceiling, but
+    # subject B has its own bucket and must still succeed.
+    other = app_client.post(
+        "/v1/principals/connector-login",
+        json=_sso_body("bob@acme.com"),
+    )
+    assert other.status_code == 201, other.text
+
+
+async def test_429_does_not_write_user_session_row(app_client):
+    """The throttle must short-circuit before the DB write — otherwise
+    the storage-exhaustion arm of F-A-208 (``user_sessions`` flooding)
+    is only mitigated, not closed. Count rows for the throttled subject
+    and assert it does not grow past the ceiling."""
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+
+    body = _sso_body("victim@acme.com")
+    for _ in range(_SUBJECT_CEILING):
+        ok = app_client.post("/v1/principals/connector-login", json=body)
+        assert ok.status_code == 201
+
+    over = app_client.post("/v1/principals/connector-login", json=body)
+    assert over.status_code == 429
+
+    async with get_db() as conn:
+        count = (await conn.execute(
+            text(
+                "SELECT COUNT(*) FROM user_sessions "
+                "WHERE sso_subject = :sub"
+            ),
+            {"sub": "victim@acme.com"},
+        )).scalar_one()
+    # Exactly the ceiling, never the ceiling + 1.
+    assert count == _SUBJECT_CEILING


### PR DESCRIPTION
**Closes F-A-208** (MED, iam). 3-bucket sliding-window rate limit on both connector-login surfaces.

## Summary

`POST /v1/principals/connector-login` and `POST /v1/principals/connector-login-local-attribution` accepted `user_subject_sso` / `local_subject` from the body with no rate limit. Permitted SSO-subject enumeration + session-token flood (CWE-307, OWASP A05).

This PR adds three rate-limit buckets via the existing `get_agent_rate_limiter`:

| Bucket | Limit | Purpose |
|---|---|---|
| Per-agent | 60/min | Per-Connector-cert flood ceiling |
| Per-IP | 30/min | Off-LAN SSO probe ceiling |
| Per-(agent, subject) | 5/min | Per-user grind ceiling (the lockout-style gate) |

429 response + `Retry-After: 60` + structured warning. Short-circuits BEFORE DB writes (a 429 does not create a `user_sessions` row, verified by `test_429_does_not_write_user_session_row`).

## Files

- `mcp_proxy/registry/connector_login_router.py` — `_client_ip` + `_enforce_connector_login_rate_limit` helpers + gate call in handler (line 266, after thumbprint check)
- `mcp_proxy/registry/connector_login_local_attribution_router.py` — imports shared helpers + gate call in handler (line 226, after thumbprint check)
- `tests/test_connector_login_rate_limit.py` (new) — 4 tests

## Test plan

- [x] `pytest tests/test_connector_login*.py tests/test_rate_limit*.py -n auto --dist=loadfile -q` — 48 pass (4 new)
- [x] Full unit suite: 4195/4208 pass; 13 unrelated xdist flakes on dashboard/uplink tests (pass in isolation on main, match memory `feedback_ci_known_failures`)
- [x] Gate order verified: rate limit fires AFTER thumbprint check, BEFORE DB writes (so a 429 cannot create an orphan session row)