### PR TITLE
refactor(dashboard): extract Mastio auth sub-router (F-B-201 PR-2/10)

### DIFF
--- a/mcp_proxy/dashboard/_helpers.py
+++ b/mcp_proxy/dashboard/_helpers.py
@@ -81,3 +81,23 @@ def _login_client_ip(request: Request) -> str:
     """
     client = request.client
     return client.host if client is not None else "unknown"
+
+
+async def _post_login_redirect() -> str:
+    """Where to send a freshly-authenticated admin.
+
+    - No broker uplink yet     -> /proxy/setup (wizard)
+    - Fully configured         -> /proxy/overview (landing)
+    """
+    from mcp_proxy.db import get_config
+    org_id = await get_config("org_id")
+    return "/proxy/overview" if org_id else "/proxy/setup"
+
+
+async def _load_display_name() -> str:
+    """Safe helper: org display name for the login page header."""
+    from mcp_proxy.db import get_config
+    try:
+        return (await get_config("display_name")) or ""
+    except Exception:
+        return ""

--- a/mcp_proxy/dashboard/auth_routes.py
+++ b/mcp_proxy/dashboard/auth_routes.py
@@ -1,0 +1,268 @@
+"""Mastio dashboard — Auth sub-router.
+
+Sprint F-B-201 PR-2 of 10. Extracts the login / logout / register
+surface from ``mcp_proxy/dashboard/router.py`` (sections "Auth" and
+"Register").
+
+Mounted via ``router.include_router(auth_routes.router)``.
+
+Routes (5):
+
+  GET  /proxy/login        login form (or redirect to register if no pwd set)
+  POST /proxy/login        verify password + lockout/rate-limit gate + audit
+  POST /proxy/logout       clear session (CSRF-gated when cookie present)
+  GET  /proxy/register     one-shot admin password form
+  POST /proxy/register     create admin password + redirect to login
+
+Mirrors the Court sibling ``app/dashboard/auth_routes.py`` (F-B-202 PR-2).
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard._helpers import (
+    _load_display_name,
+    _login_client_ip,
+    _post_login_redirect,
+)
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import (
+    MIN_PASSWORD_LENGTH,
+    clear_session,
+    get_session,
+    is_admin_password_set,
+    set_admin_password,
+    set_session,
+    verify_admin_password,
+    verify_csrf,
+)
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+import pathlib
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-auth"])
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    # Pristine proxy: send the user to set an admin password first.
+    if not await is_admin_password_set():
+        return RedirectResponse(url="/proxy/register", status_code=303)
+
+    # Already authenticated? Skip the form.
+    session = get_session(request)
+    if session.logged_in:
+        return RedirectResponse(url=await _post_login_redirect(), status_code=303)
+
+    from mcp_proxy.dashboard.oidc import is_oidc_configured
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    oidc_enabled = await is_oidc_configured()
+    password_enabled = await is_local_password_login_enabled()
+    display_name = await _load_display_name()
+
+    return templates.TemplateResponse("login.html", {
+        "request": request,
+        "error": None,
+        "oidc_enabled": oidc_enabled,
+        "password_enabled": password_enabled,
+        "display_name": display_name,
+    })
+
+
+@router.post("/login")
+async def login_submit(request: Request):
+    # State guard: if no password is set, you can't sign in — go register first.
+    if not await is_admin_password_set():
+        return RedirectResponse(url="/proxy/register", status_code=303)
+
+    # SSO-only hardening toggle: refuse before touching bcrypt so a
+    # timing side-channel can't probe the stored secret. The env
+    # break-glass (``MCP_PROXY_FORCE_LOCAL_PASSWORD=1``) is honoured
+    # inside ``is_local_password_login_enabled`` itself.
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    if not await is_local_password_login_enabled():
+        from mcp_proxy.db import log_audit
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="denied",
+            detail="password sign-in disabled",
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "Password sign-in is disabled. Use the SSO button instead.",
+            "password_enabled": False,
+        }, status_code=403)
+
+    # H9 audit fix — per-IP lockout + rate-limit before bcrypt.
+    from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
+    from mcp_proxy.dashboard.login_lockout import (
+        LOGIN_RATE_PER_MINUTE,
+        get_login_lockout_store,
+    )
+    from mcp_proxy.db import log_audit
+
+    client_ip = _login_client_ip(request)
+    lockout_store = get_login_lockout_store()
+
+    locked_until = await lockout_store.is_locked(client_ip)
+    if locked_until is not None:
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="denied",
+            detail=f"ip-locked-until {int(locked_until)} ip={client_ip}",
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": (
+                "Too many failed attempts from this address. Try again later "
+                "or reset the admin password from the local CLI."
+            ),
+        }, status_code=429)
+
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}:dashboard.login", LOGIN_RATE_PER_MINUTE,
+    ):
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="denied",
+            detail=f"rate-limited ip={client_ip}",
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "Too many login attempts. Slow down and try again in a minute.",
+        }, status_code=429)
+
+    form = await request.form()
+    password = str(form.get("password", ""))
+
+    if not password:
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "Password is required.",
+        }, status_code=400)
+
+    if not await verify_admin_password(password):
+        # Audit the failure but keep the message vague (don't leak whether the
+        # account exists, the username is wrong, etc.).
+        fail_count, locked_until = await lockout_store.record_failure(client_ip)
+        detail = f"invalid password ip={client_ip} consecutive_fails={fail_count}"
+        if locked_until is not None:
+            detail += f" locked-until={int(locked_until)}"
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="error",
+            detail=detail,
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "Invalid password.",
+        }, status_code=401)
+
+    await lockout_store.record_success(client_ip)
+    await log_audit(
+        agent_id="admin",
+        action="auth.login",
+        status="success",
+        detail=f"ip={client_ip}",
+    )
+
+    response = RedirectResponse(url=await _post_login_redirect(), status_code=303)
+    set_session(response, role="admin")
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request):
+    session = get_session(request)
+    # Audit F-B-9: raise on CSRF failure instead of calling
+    # ``verify_csrf`` purely for side effects. Previously a cross-site
+    # POST without the form token logged the victim out anyway — a
+    # force-logout via any attacker-controlled page the victim loaded
+    # while holding a valid Mastio admin session. Enforce on any
+    # non-empty ``csrf_token`` (valid cookie) and keep the bare
+    # no-cookie path idempotent with a friendly 303.
+    if session.csrf_token and not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+    response = RedirectResponse(url="/proxy/login", status_code=303)
+    clear_session(response)
+    return response
+
+
+@router.get("/register", response_class=HTMLResponse)
+async def register_page(request: Request):
+    # Already registered? Send them to login.
+    if await is_admin_password_set():
+        return RedirectResponse(url="/proxy/login", status_code=303)
+
+    return templates.TemplateResponse("register.html", {
+        "request": request,
+        "error": None,
+        "min_length": MIN_PASSWORD_LENGTH,
+    })
+
+
+@router.post("/register")
+async def register_submit(request: Request):
+    # Cannot re-register: someone already set the password.
+    if await is_admin_password_set():
+        return RedirectResponse(url="/proxy/login", status_code=303)
+
+    form = await request.form()
+    password = str(form.get("password", ""))
+    confirm = str(form.get("confirm_password", ""))
+
+    if not password or not confirm:
+        return templates.TemplateResponse("register.html", {
+            "request": request,
+            "error": "Both fields are required.",
+            "min_length": MIN_PASSWORD_LENGTH,
+        }, status_code=400)
+
+    if len(password) < MIN_PASSWORD_LENGTH:
+        return templates.TemplateResponse("register.html", {
+            "request": request,
+            "error": f"Password must be at least {MIN_PASSWORD_LENGTH} characters long.",
+            "min_length": MIN_PASSWORD_LENGTH,
+        }, status_code=400)
+
+    if password != confirm:
+        return templates.TemplateResponse("register.html", {
+            "request": request,
+            "error": "The two passwords do not match.",
+            "min_length": MIN_PASSWORD_LENGTH,
+        }, status_code=400)
+
+    try:
+        await set_admin_password(password)
+    except ValueError as exc:
+        return templates.TemplateResponse("register.html", {
+            "request": request,
+            "error": str(exc),
+            "min_length": MIN_PASSWORD_LENGTH,
+        }, status_code=400)
+
+    from mcp_proxy.db import log_audit
+    await log_audit(
+        agent_id="admin",
+        action="auth.register",
+        status="success",
+        details={
+            "event": "admin_password_registered",
+            "client_ip": _login_client_ip(request),
+            "user_agent": (request.headers.get("user-agent") or "")[:200],
+        },
+    )
+
+    # Force a clean sign-in for the very first session.
+    return RedirectResponse(url="/proxy/login", status_code=303)

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -69,7 +69,9 @@ from mcp_proxy.dashboard._template_env import (  # noqa: E402
 from mcp_proxy.dashboard._helpers import (  # noqa: E402
     _ctx,
     _enforce_safe_outbound_url,
+    _load_display_name,
     _login_client_ip,
+    _post_login_redirect,
 )
 from mcp_proxy import license as _license_mod  # noqa: E402
 
@@ -77,9 +79,17 @@ templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/proxy", tags=["dashboard"])
 
+# F-B-201 PR-2: include the auth sub-router (login / logout / register).
+# Routes inside auth_routes.py declare paths relative to /proxy so the
+# outer router's prefix is inherited via include_router. Mirrors the
+# Court PR-2 pattern (#841).
+from mcp_proxy.dashboard import auth_routes as _auth_routes  # noqa: E402
+router.include_router(_auth_routes.router)
 
-# Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip) live in
-# ``mcp_proxy/dashboard/_helpers.py`` since F-B-201 PR-1.
+
+# Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip,
+# _post_login_redirect, _load_display_name) live in
+# ``mcp_proxy/dashboard/_helpers.py`` since F-B-201 PR-1 / PR-2.
 
 
 def generate_org_ca(org_id: str) -> tuple[str, str]:
@@ -188,15 +198,8 @@ async def _store_ca_key_in_vault(vault_addr: str, vault_token: str, org_id: str,
 # Every other state-changing endpoint enforces CSRF via verify_csrf().
 
 
-async def _post_login_redirect() -> str:
-    """Where to send a freshly-authenticated admin.
-
-    - No broker uplink yet     -> /proxy/setup (wizard)
-    - Fully configured         -> /proxy/overview (landing)
-    """
-    from mcp_proxy.db import get_config
-    org_id = await get_config("org_id")
-    return "/proxy/overview" if org_id else "/proxy/setup"
+# _post_login_redirect moved to ``mcp_proxy/dashboard/_helpers.py``
+# since F-B-201 PR-2.
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -212,230 +215,8 @@ async def proxy_root(request: Request):
     return RedirectResponse(url=await _post_login_redirect(), status_code=303)
 
 
-@router.get("/login", response_class=HTMLResponse)
-async def login_page(request: Request):
-    # Pristine proxy: send the user to set an admin password first.
-    if not await is_admin_password_set():
-        return RedirectResponse(url="/proxy/register", status_code=303)
-
-    # Already authenticated? Skip the form.
-    session = get_session(request)
-    if session.logged_in:
-        return RedirectResponse(url=await _post_login_redirect(), status_code=303)
-
-    from mcp_proxy.dashboard.oidc import is_oidc_configured
-    from mcp_proxy.dashboard.session import is_local_password_login_enabled
-    oidc_enabled = await is_oidc_configured()
-    password_enabled = await is_local_password_login_enabled()
-    display_name = await _load_display_name()
-
-    return templates.TemplateResponse("login.html", {
-        "request": request,
-        "error": None,
-        "oidc_enabled": oidc_enabled,
-        "password_enabled": password_enabled,
-        "display_name": display_name,
-    })
-
-
-# _login_client_ip moved to ``mcp_proxy/dashboard/_helpers.py``
-# since F-B-201 PR-1.
-
-
-@router.post("/login")
-async def login_submit(request: Request):
-    # State guard: if no password is set, you can't sign in — go register first.
-    if not await is_admin_password_set():
-        return RedirectResponse(url="/proxy/register", status_code=303)
-
-    # SSO-only hardening toggle: refuse before touching bcrypt so a
-    # timing side-channel can't probe the stored secret. The env
-    # break-glass (``MCP_PROXY_FORCE_LOCAL_PASSWORD=1``) is honoured
-    # inside ``is_local_password_login_enabled`` itself.
-    from mcp_proxy.dashboard.session import is_local_password_login_enabled
-    if not await is_local_password_login_enabled():
-        from mcp_proxy.db import log_audit
-        await log_audit(
-            agent_id="admin",
-            action="auth.login",
-            status="denied",
-            detail="password sign-in disabled",
-        )
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": "Password sign-in is disabled. Use the SSO button instead.",
-            "password_enabled": False,
-        }, status_code=403)
-
-    # H9 audit fix — per-IP lockout + rate-limit before bcrypt.
-    from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
-    from mcp_proxy.dashboard.login_lockout import (
-        LOGIN_RATE_PER_MINUTE,
-        get_login_lockout_store,
-    )
-    from mcp_proxy.db import log_audit
-
-    client_ip = _login_client_ip(request)
-    lockout_store = get_login_lockout_store()
-
-    locked_until = await lockout_store.is_locked(client_ip)
-    if locked_until is not None:
-        await log_audit(
-            agent_id="admin",
-            action="auth.login",
-            status="denied",
-            detail=f"ip-locked-until {int(locked_until)} ip={client_ip}",
-        )
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": (
-                "Too many failed attempts from this address. Try again later "
-                "or reset the admin password from the local CLI."
-            ),
-        }, status_code=429)
-
-    if not await get_agent_rate_limiter().check(
-        f"ip:{client_ip}:dashboard.login", LOGIN_RATE_PER_MINUTE,
-    ):
-        await log_audit(
-            agent_id="admin",
-            action="auth.login",
-            status="denied",
-            detail=f"rate-limited ip={client_ip}",
-        )
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": "Too many login attempts. Slow down and try again in a minute.",
-        }, status_code=429)
-
-    form = await request.form()
-    password = str(form.get("password", ""))
-
-    if not password:
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": "Password is required.",
-        }, status_code=400)
-
-    if not await verify_admin_password(password):
-        # Audit the failure but keep the message vague (don't leak whether the
-        # account exists, the username is wrong, etc.).
-        fail_count, locked_until = await lockout_store.record_failure(client_ip)
-        detail = f"invalid password ip={client_ip} consecutive_fails={fail_count}"
-        if locked_until is not None:
-            detail += f" locked-until={int(locked_until)}"
-        await log_audit(
-            agent_id="admin",
-            action="auth.login",
-            status="error",
-            detail=detail,
-        )
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": "Invalid password.",
-        }, status_code=401)
-
-    await lockout_store.record_success(client_ip)
-    await log_audit(
-        agent_id="admin",
-        action="auth.login",
-        status="success",
-        detail=f"ip={client_ip}",
-    )
-
-    response = RedirectResponse(url=await _post_login_redirect(), status_code=303)
-    set_session(response, role="admin")
-    return response
-
-
-@router.post("/logout")
-async def logout(request: Request):
-    session = get_session(request)
-    # Audit F-B-9: raise on CSRF failure instead of calling
-    # ``verify_csrf`` purely for side effects. Previously a cross-site
-    # POST without the form token logged the victim out anyway — a
-    # force-logout via any attacker-controlled page the victim loaded
-    # while holding a valid Mastio admin session. Enforce on any
-    # non-empty ``csrf_token`` (valid cookie) and keep the bare
-    # no-cookie path idempotent with a friendly 303.
-    if session.csrf_token and not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-    response = RedirectResponse(url="/proxy/login", status_code=303)
-    clear_session(response)
-    return response
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Register — one-shot admin password creation
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/register", response_class=HTMLResponse)
-async def register_page(request: Request):
-    # Already registered? Send them to login.
-    if await is_admin_password_set():
-        return RedirectResponse(url="/proxy/login", status_code=303)
-
-    return templates.TemplateResponse("register.html", {
-        "request": request,
-        "error": None,
-        "min_length": MIN_PASSWORD_LENGTH,
-    })
-
-
-@router.post("/register")
-async def register_submit(request: Request):
-    # Cannot re-register: someone already set the password.
-    if await is_admin_password_set():
-        return RedirectResponse(url="/proxy/login", status_code=303)
-
-    form = await request.form()
-    password = str(form.get("password", ""))
-    confirm = str(form.get("confirm_password", ""))
-
-    if not password or not confirm:
-        return templates.TemplateResponse("register.html", {
-            "request": request,
-            "error": "Both fields are required.",
-            "min_length": MIN_PASSWORD_LENGTH,
-        }, status_code=400)
-
-    if len(password) < MIN_PASSWORD_LENGTH:
-        return templates.TemplateResponse("register.html", {
-            "request": request,
-            "error": f"Password must be at least {MIN_PASSWORD_LENGTH} characters long.",
-            "min_length": MIN_PASSWORD_LENGTH,
-        }, status_code=400)
-
-    if password != confirm:
-        return templates.TemplateResponse("register.html", {
-            "request": request,
-            "error": "The two passwords do not match.",
-            "min_length": MIN_PASSWORD_LENGTH,
-        }, status_code=400)
-
-    try:
-        await set_admin_password(password)
-    except ValueError as exc:
-        return templates.TemplateResponse("register.html", {
-            "request": request,
-            "error": str(exc),
-            "min_length": MIN_PASSWORD_LENGTH,
-        }, status_code=400)
-
-    from mcp_proxy.db import log_audit
-    await log_audit(
-        agent_id="admin",
-        action="auth.register",
-        status="success",
-        details={
-            "event": "admin_password_registered",
-            "client_ip": _login_client_ip(request),
-            "user_agent": (request.headers.get("user-agent") or "")[:200],
-        },
-    )
-
-    # Force a clean sign-in for the very first session.
-    return RedirectResponse(url="/proxy/login", status_code=303)
+# Login / logout / register routes moved to
+# ``mcp_proxy/dashboard/auth_routes.py`` since F-B-201 PR-2.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -5034,13 +4815,8 @@ async def oidc_callback(request: Request):
     return response
 
 
-async def _load_display_name() -> str:
-    """Safe helper: org display name for the login page header."""
-    from mcp_proxy.db import get_config
-    try:
-        return (await get_config("display_name")) or ""
-    except Exception:
-        return ""
+# _load_display_name moved to ``mcp_proxy/dashboard/_helpers.py``
+# since F-B-201 PR-2.
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
F-B-201 sprint PR-2 of 10. Mirrors Court PR-2 (#841) pattern on the Mastio dashboard.

## Summary

Extracts 5 password-auth routes from `mcp_proxy/dashboard/router.py` into a dedicated sub-router. Pure cut+paste, behaviour-equivalent. Two pure helpers (`_post_login_redirect`, `_load_display_name`) move to `_helpers.py` because both sides (`auth_routes` + remaining inline OIDC handler in `router.py`) need them.

## Layout

| File | LOC | Routes |
|---|---|---|
| `mcp_proxy/dashboard/auth_routes.py` (new) | 268 | 5 |
| `mcp_proxy/dashboard/_helpers.py` | +20 | (2 helpers added) |
| `mcp_proxy/dashboard/router.py` | 5052 → 4828 (−224 net) | −5 |

Routes extracted:
- `GET /proxy/login` — form + redirect-to-register if pristine
- `POST /proxy/login` — H9 lockout + rate-limit + bcrypt + audit
- `POST /proxy/logout` — CSRF-gated session clear (F-B-9)
- `GET /proxy/register` — one-shot admin password form
- `POST /proxy/register` — `set_admin_password` + audit + redirect-to-login

## Behavioural invariants preserved

- H9 audit lockout + rate limit gate on `POST /login`
- F-B-9 CSRF gate on `POST /logout`
- F-A-507 insecure-default password gate (pre-existing on `set_admin_password`)

## Scope note

OIDC routes (`/proxy/oidc/start`, `/proxy/oidc/callback`) stay inline in `router.py` for now. Sister-file split with `mcp_proxy/dashboard/oidc.py` is already partial (helpers there, handler still in router.py); a future PR can decide whether to consolidate.

## Router LOC trajectory

```
Pre-Sprint:    66 routes, 5106 LOC
Post-PR-1 #859: 66 routes, 5052 LOC
Post-PR-2 (this): 61 routes, 4828 LOC
Target post-PR-10: ~3 routes, ~120 LOC aggregator
```

## Test plan

- [x] `pytest tests/test_h9_login_lockout.py tests/test_fb9_proxy_logout_csrf.py tests/test_proxy_local_password_toggle.py tests/test_proxy_dashboard_oidc.py tests/test_proxy_dashboard_display_name.py -n auto --dist=loadfile -q` — 52 passed

## Next

PR-3: `/proxy/setup` (broker uplink wizard, ~530 LOC, 3 routes across `/setup` GET + POST + `/setup/test-connection`) into `setup_routes.py`.