### PR TITLE
refactor(dashboard): extract Mastio tools + network sub-router (F-B-201 PR-5/10)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -94,6 +94,10 @@ router.include_router(_setup_routes.router)
 from mcp_proxy.dashboard import agents_routes as _agents_routes  # noqa: E402
 router.include_router(_agents_routes.router)
 
+# F-B-201 PR-5: include the tools + network sub-router.
+from mcp_proxy.dashboard import tools_network_routes as _tools_network_routes  # noqa: E402
+router.include_router(_tools_network_routes.router)
+
 
 # Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip,
 # _post_login_redirect, _load_display_name, generate_org_ca,
@@ -325,140 +329,8 @@ async def org_display_name_update(request: Request):
 # consumer was the agents_page handler).
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tools
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/tools", response_class=HTMLResponse)
-async def tools_page(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    from mcp_proxy.tools.registry import tool_registry
-    tools = tool_registry.list_tools()
-
-    return templates.TemplateResponse("tools.html", _ctx(
-        request, session,
-        active="tools",
-        tools=tools,
-    ))
-
-
-@router.get("/network", response_class=HTMLResponse)
-async def network_page(request: Request):
-    """Network directory — discover agents across the trust network via broker."""
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    from mcp_proxy.db import list_agents, get_config
-
-    q = (request.query_params.get("q") or "").strip() or None
-    pattern = (request.query_params.get("pattern") or "").strip() or None
-    org_filter = (request.query_params.get("org_id") or "").strip() or None
-    capabilities_raw = (request.query_params.get("capabilities") or "").strip()
-    capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()] or None
-    # ``include_own_org`` defaults on for the first page load — the list is
-    # a directory, not a filter result, so showing your own org's agents
-    # alongside peers is the expected default. Operators uncheck it when
-    # they want to focus on cross-org visibility.
-    has_query = any(k in request.query_params for k in (
-        "q", "pattern", "org_id", "capabilities", "include_own_org", "querier",
-    ))
-    include_own_org = (
-        request.query_params.get("include_own_org") == "on"
-        if has_query
-        else True
-    )
-    querier = (request.query_params.get("querier") or "").strip() or None
-
-    internal_agents = await list_agents()
-    own_org_id = await get_config("org_id") or ""
-    broker_url = await get_config("broker_url") or ""
-
-    bridge = getattr(request.app.state, "broker_bridge", None)
-
-    # Default querier: first active internal agent.
-    if not querier and internal_agents:
-        querier = next(
-            (a["agent_id"] for a in internal_agents if a.get("is_active", True)),
-            internal_agents[0]["agent_id"],
-        )
-
-    agents: list[dict] = []
-    error: str | None = None
-
-    # Always populate the directory on every page load (no more ``submitted``
-    # gate). Empty filters = full peer list under the selected querier;
-    # typed filters narrow the same list. Errors are surfaced inline so the
-    # missing-prereq path (no bridge / no internal agents) stays discoverable.
-    if bridge is None:
-        error = "Broker bridge not initialized — complete the Setup wizard first."
-    elif not internal_agents:
-        error = "Create an internal agent first — discovery queries go through an agent identity."
-    elif not querier:
-        error = "Select a querier agent."
-    else:
-        try:
-            agents = await bridge.discover_agents(
-                querier,
-                capabilities=capabilities,
-                q=q,
-                org_id=org_filter,
-                pattern=pattern,
-            )
-            if not include_own_org and own_org_id:
-                agents = [a for a in agents if a.get("org_id") != own_org_id]
-        except Exception as exc:
-            _log.warning("Network directory query failed: %s", exc)
-            error = f"Discovery failed: {exc}"
-
-    own_org_count = sum(1 for a in agents if a.get("org_id") == own_org_id) if own_org_id else 0
-    peer_count = len(agents) - own_org_count
-    has_active_filters = bool(q or pattern or org_filter or capabilities)
-
-    return templates.TemplateResponse("network.html", _ctx(
-        request, session,
-        active="network",
-        internal_agents=internal_agents,
-        querier=querier,
-        q=q or "",
-        pattern=pattern or "",
-        org_filter=org_filter or "",
-        capabilities=capabilities_raw,
-        include_own_org=include_own_org,
-        agents=agents,
-        own_org_count=own_org_count,
-        peer_count=peer_count,
-        has_active_filters=has_active_filters,
-        own_org_id=own_org_id,
-        broker_url=broker_url,
-        error=error,
-    ))
-
-
-@router.post("/tools/reload")
-async def tools_reload(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    from mcp_proxy.tools.registry import tool_registry
-    from mcp_proxy.config import get_settings
-
-    settings = get_settings()
-    tool_registry.load_from_yaml(settings.tools_config_path)
-
-    from mcp_proxy.db import log_audit
-    await log_audit(
-        agent_id="admin",
-        action="tools.reload",
-        status="success",
-        detail=f"Loaded {len(tool_registry)} tool(s)",
-    )
+# Tools + Network (/proxy/tools + /proxy/network + /proxy/tools/reload)
+# moved to ``mcp_proxy/dashboard/tools_network_routes.py`` since F-B-201 PR-5.
 
     return RedirectResponse(url="/proxy/tools", status_code=303)
 

--- a/mcp_proxy/dashboard/tools_network_routes.py
+++ b/mcp_proxy/dashboard/tools_network_routes.py
@@ -1,0 +1,166 @@
+"""Mastio dashboard — Tools + Network sub-router.
+
+Sprint F-B-201 PR-5 of 10. Extracts the tool-registry viewer + reload
+plus the cross-network agent discovery directory from
+``mcp_proxy/dashboard/router.py``. Three routes total.
+
+Mounted via ``router.include_router(tools_network_routes.router)``.
+
+Routes (3):
+
+  GET  /proxy/tools          tool registry list (read-only)
+  GET  /proxy/network        cross-org agent discovery directory
+  POST /proxy/tools/reload   reload YAML tool config (CSRF-gated)
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard._helpers import _ctx
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import require_login, verify_csrf
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-tools-network"])
+
+
+@router.get("/tools", response_class=HTMLResponse)
+async def tools_page(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.tools.registry import tool_registry
+    tools = tool_registry.list_tools()
+
+    return templates.TemplateResponse("tools.html", _ctx(
+        request, session,
+        active="tools",
+        tools=tools,
+    ))
+
+
+@router.get("/network", response_class=HTMLResponse)
+async def network_page(request: Request):
+    """Network directory — discover agents across the trust network via broker."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import list_agents, get_config
+
+    q = (request.query_params.get("q") or "").strip() or None
+    pattern = (request.query_params.get("pattern") or "").strip() or None
+    org_filter = (request.query_params.get("org_id") or "").strip() or None
+    capabilities_raw = (request.query_params.get("capabilities") or "").strip()
+    capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()] or None
+    # ``include_own_org`` defaults on for the first page load — the list is
+    # a directory, not a filter result, so showing your own org's agents
+    # alongside peers is the expected default. Operators uncheck it when
+    # they want to focus on cross-org visibility.
+    has_query = any(k in request.query_params for k in (
+        "q", "pattern", "org_id", "capabilities", "include_own_org", "querier",
+    ))
+    include_own_org = (
+        request.query_params.get("include_own_org") == "on"
+        if has_query
+        else True
+    )
+    querier = (request.query_params.get("querier") or "").strip() or None
+
+    internal_agents = await list_agents()
+    own_org_id = await get_config("org_id") or ""
+    broker_url = await get_config("broker_url") or ""
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+
+    # Default querier: first active internal agent.
+    if not querier and internal_agents:
+        querier = next(
+            (a["agent_id"] for a in internal_agents if a.get("is_active", True)),
+            internal_agents[0]["agent_id"],
+        )
+
+    agents: list[dict] = []
+    error: str | None = None
+
+    # Always populate the directory on every page load (no more ``submitted``
+    # gate). Empty filters = full peer list under the selected querier;
+    # typed filters narrow the same list. Errors are surfaced inline so the
+    # missing-prereq path (no bridge / no internal agents) stays discoverable.
+    if bridge is None:
+        error = "Broker bridge not initialized — complete the Setup wizard first."
+    elif not internal_agents:
+        error = "Create an internal agent first — discovery queries go through an agent identity."
+    elif not querier:
+        error = "Select a querier agent."
+    else:
+        try:
+            agents = await bridge.discover_agents(
+                querier,
+                capabilities=capabilities,
+                q=q,
+                org_id=org_filter,
+                pattern=pattern,
+            )
+            if not include_own_org and own_org_id:
+                agents = [a for a in agents if a.get("org_id") != own_org_id]
+        except Exception as exc:
+            _log.warning("Network directory query failed: %s", exc)
+            error = f"Discovery failed: {exc}"
+
+    own_org_count = sum(1 for a in agents if a.get("org_id") == own_org_id) if own_org_id else 0
+    peer_count = len(agents) - own_org_count
+    has_active_filters = bool(q or pattern or org_filter or capabilities)
+
+    return templates.TemplateResponse("network.html", _ctx(
+        request, session,
+        active="network",
+        internal_agents=internal_agents,
+        querier=querier,
+        q=q or "",
+        pattern=pattern or "",
+        org_filter=org_filter or "",
+        capabilities=capabilities_raw,
+        include_own_org=include_own_org,
+        agents=agents,
+        own_org_count=own_org_count,
+        peer_count=peer_count,
+        has_active_filters=has_active_filters,
+        own_org_id=own_org_id,
+        broker_url=broker_url,
+        error=error,
+    ))
+
+
+@router.post("/tools/reload")
+async def tools_reload(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.tools.registry import tool_registry
+    from mcp_proxy.config import get_settings
+
+    settings = get_settings()
+    tool_registry.load_from_yaml(settings.tools_config_path)
+
+    from mcp_proxy.db import log_audit
+    await log_audit(
+        agent_id="admin",
+        action="tools.reload",
+        status="success",
+        detail=f"Loaded {len(tool_registry)} tool(s)",
+    )
+


### PR DESCRIPTION
F-B-201 sprint PR-5 of 10. Combined into one sub-router because tools and network share read-only directory semantics and live in adjacent file sections.

## Summary

Extracts 3 routes from `mcp_proxy/dashboard/router.py`:

| Route | Purpose |
|---|---|
| `GET /proxy/tools` | Tool registry list (read-only) |
| `GET /proxy/network` | Cross-org agent discovery directory |
| `POST /proxy/tools/reload` | Reload YAML tool config (CSRF-gated) |

## Layout

| File | LOC | Change |
|---|---|---|
| `mcp_proxy/dashboard/tools_network_routes.py` (new) | 166 | 3 routes |
| `mcp_proxy/dashboard/router.py` | 3720 → 3592 (−128 net) | −3 routes |

## Behavioural invariants preserved

- `/tools/reload` CSRF check
- `/network` bridge-lookup + filter pipeline (querier default, `include_own_org` default, error surfaces)

## Router LOC trajectory

```
Pre-Sprint:    66 routes, 5106 LOC
Post-PR-1 #859: 66 routes, 5052 LOC  merged
Post-PR-2 #865: 61 routes, 4828 LOC  merged
Post-PR-3 #866: 58 routes, 4117 LOC  merged
Post-PR-4 #868: 51 routes, 3720 LOC  merged
Post-PR-5 (this): 48 routes, 3592 LOC
Target post-PR-10: ~3 routes, ~120 LOC aggregator
```

## Test plan

- [x] `pytest tests/test_proxy_dashboard_oidc.py tests/test_proxy_dashboard_mcp_resources.py tests/test_dashboard.py tests/test_dashboard_principals.py tests/test_h9_login_lockout.py -n auto --dist=loadfile -q` — 100 passed

## Next

PR-6: `/proxy/policies` surface (page + save + test-webhook, 3 routes ~180 LOC) into `policies_routes.py`.