### PR TITLE
refactor(dashboard): extract Mastio policies sub-router (F-B-201 PR-6/10)

### DIFF
--- a/mcp_proxy/dashboard/policies_routes.py
+++ b/mcp_proxy/dashboard/policies_routes.py
@@ -1,0 +1,176 @@
+"""Mastio dashboard — Policies sub-router.
+
+Sprint F-B-201 PR-6 of 10. Extracts the policy editor (rules JSON +
+PDP webhook configuration + webhook connectivity probe) from
+``mcp_proxy/dashboard/router.py``. Three routes total.
+
+Mounted via ``router.include_router(policies_routes.router)``.
+
+Routes (3):
+
+  GET  /proxy/policies               policy editor page
+  POST /proxy/policies/save          persist rules / PDP config (CSRF + approval gate)
+  POST /proxy/policies/test-webhook  HTMX PDP webhook probe (CSRF + SSRF-guarded)
+"""
+from __future__ import annotations
+
+import html as _html
+import json
+import logging
+import pathlib
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.admin.approval_hook import (
+    ACTION_POLICIES_SAVE,
+    maybe_intercept_for_approval,
+)
+from mcp_proxy.dashboard._helpers import _ctx, _enforce_safe_outbound_url
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import require_login, verify_csrf
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-policies"])
+
+
+@router.get("/policies", response_class=HTMLResponse)
+async def policies_page(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import get_config
+
+    rules_json = await get_config("policy_rules") or json.dumps({
+        "allowed_orgs": [],
+        "blocked_agents": [],
+        "capabilities": {},
+    }, indent=2)
+
+    pdp_url = await get_config("pdp_webhook_url") or ""
+    pdp_timeout = await get_config("pdp_timeout") or "5"
+
+    return templates.TemplateResponse("policies.html", _ctx(
+        request, session,
+        active="policies",
+        rules_json=rules_json,
+        pdp_url=pdp_url,
+        pdp_timeout=pdp_timeout,
+    ))
+
+
+@router.post("/policies/save")
+async def policies_save(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_POLICIES_SAVE, payload=payload,
+        request=request,
+    )
+    if intercept is not None:
+        return intercept
+
+    from mcp_proxy.db import set_config, get_config, log_audit
+
+    tab = str(form.get("tab", "rules"))
+
+    if tab == "rules":
+        rules_raw = str(form.get("rules_json", ""))
+        try:
+            parsed = json.loads(rules_raw)
+            rules_json = json.dumps(parsed, indent=2)
+        except json.JSONDecodeError:
+            # Re-render with error
+            pdp_url = await get_config("pdp_webhook_url") or ""
+            pdp_timeout = await get_config("pdp_timeout") or "5"
+            return templates.TemplateResponse("policies.html", _ctx(
+                request, session,
+                active="policies",
+                rules_json=rules_raw,
+                pdp_url=pdp_url,
+                pdp_timeout=pdp_timeout,
+                error="Invalid JSON in policy rules.",
+            ))
+
+        await set_config("policy_rules", rules_json)
+        await log_audit(
+            agent_id="admin",
+            action="policy.update_rules",
+            status="success",
+        )
+
+    elif tab == "pdp":
+        pdp_url = str(form.get("pdp_url", "")).strip()
+        pdp_timeout = str(form.get("pdp_timeout", "5")).strip()
+        await set_config("pdp_webhook_url", pdp_url)
+        await set_config("pdp_timeout", pdp_timeout)
+        await log_audit(
+            agent_id="admin",
+            action="policy.update_pdp",
+            status="success",
+            detail=f"url={pdp_url}, timeout={pdp_timeout}s",
+        )
+
+    return RedirectResponse(url="/proxy/policies", status_code=303)
+
+
+@router.post("/policies/test-webhook")
+async def policies_test_webhook(request: Request):
+    """HTMX endpoint: test PDP webhook connectivity."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
+
+    # Wave B G1 — verify CSRF + SSRF allow-list + escape exception text
+    if not await verify_csrf(request, session):
+        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
+
+    form = await request.form()
+    webhook_url = str(form.get("pdp_url", "")).strip()
+
+    if not webhook_url:
+        return HTMLResponse('<span class="text-red-400">Enter a webhook URL first</span>')
+
+    try:
+        _enforce_safe_outbound_url(webhook_url)
+    except ValueError as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
+        )
+
+    try:
+        import httpx
+        test_payload = {
+            "agent_id": "test::probe",
+            "action": "tool_execute",
+            "tool": "test_tool",
+            "capabilities": ["test"],
+        }
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(webhook_url, json=test_payload)
+            if resp.status_code == 200:
+                return HTMLResponse(
+                    '<span class="text-emerald-400 flex items-center gap-1.5">'
+                    '<span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span>'
+                    'Webhook responded OK</span>'
+                )
+            return HTMLResponse(
+                f'<span class="text-yellow-400">HTTP {resp.status_code}</span>'
+            )
+    except Exception as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">Connection failed: '
+            f'{_html.escape(str(exc))}</span>'
+        )

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -49,7 +49,6 @@ from mcp_proxy.admin.approval_hook import (
     ACTION_LICENSE_IMPORT,
     ACTION_MASTIO_KEY_ROTATE,
     ACTION_PKI_ROTATE_CA,
-    ACTION_POLICIES_SAVE,
     ACTION_USERS_DELETE,
     ACTION_VAULT_MIGRATE_KEYS,
     maybe_intercept_for_approval,
@@ -97,6 +96,10 @@ router.include_router(_agents_routes.router)
 # F-B-201 PR-5: include the tools + network sub-router.
 from mcp_proxy.dashboard import tools_network_routes as _tools_network_routes  # noqa: E402
 router.include_router(_tools_network_routes.router)
+
+# F-B-201 PR-6: include the policies sub-router (rules + PDP + webhook probe).
+from mcp_proxy.dashboard import policies_routes as _policies_routes  # noqa: E402
+router.include_router(_policies_routes.router)
 
 
 # Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip,
@@ -331,150 +334,9 @@ async def org_display_name_update(request: Request):
 
 # Tools + Network (/proxy/tools + /proxy/network + /proxy/tools/reload)
 # moved to ``mcp_proxy/dashboard/tools_network_routes.py`` since F-B-201 PR-5.
-
-    return RedirectResponse(url="/proxy/tools", status_code=303)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Policies
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/policies", response_class=HTMLResponse)
-async def policies_page(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    from mcp_proxy.db import get_config
-
-    rules_json = await get_config("policy_rules") or json.dumps({
-        "allowed_orgs": [],
-        "blocked_agents": [],
-        "capabilities": {},
-    }, indent=2)
-
-    pdp_url = await get_config("pdp_webhook_url") or ""
-    pdp_timeout = await get_config("pdp_timeout") or "5"
-
-    return templates.TemplateResponse("policies.html", _ctx(
-        request, session,
-        active="policies",
-        rules_json=rules_json,
-        pdp_url=pdp_url,
-        pdp_timeout=pdp_timeout,
-    ))
-
-
-@router.post("/policies/save")
-async def policies_save(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    form = await request.form()
-    payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
-    intercept = await maybe_intercept_for_approval(
-        session=session, action_type=ACTION_POLICIES_SAVE, payload=payload,
-        request=request,
-    )
-    if intercept is not None:
-        return intercept
-
-    from mcp_proxy.db import set_config, get_config, log_audit
-
-    tab = str(form.get("tab", "rules"))
-
-    if tab == "rules":
-        rules_raw = str(form.get("rules_json", ""))
-        try:
-            parsed = json.loads(rules_raw)
-            rules_json = json.dumps(parsed, indent=2)
-        except json.JSONDecodeError:
-            # Re-render with error
-            pdp_url = await get_config("pdp_webhook_url") or ""
-            pdp_timeout = await get_config("pdp_timeout") or "5"
-            return templates.TemplateResponse("policies.html", _ctx(
-                request, session,
-                active="policies",
-                rules_json=rules_raw,
-                pdp_url=pdp_url,
-                pdp_timeout=pdp_timeout,
-                error="Invalid JSON in policy rules.",
-            ))
-
-        await set_config("policy_rules", rules_json)
-        await log_audit(
-            agent_id="admin",
-            action="policy.update_rules",
-            status="success",
-        )
-
-    elif tab == "pdp":
-        pdp_url = str(form.get("pdp_url", "")).strip()
-        pdp_timeout = str(form.get("pdp_timeout", "5")).strip()
-        await set_config("pdp_webhook_url", pdp_url)
-        await set_config("pdp_timeout", pdp_timeout)
-        await log_audit(
-            agent_id="admin",
-            action="policy.update_pdp",
-            status="success",
-            detail=f"url={pdp_url}, timeout={pdp_timeout}s",
-        )
-
-    return RedirectResponse(url="/proxy/policies", status_code=303)
-
-
-@router.post("/policies/test-webhook")
-async def policies_test_webhook(request: Request):
-    """HTMX endpoint: test PDP webhook connectivity."""
-    import html as _html
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
-
-    # Wave B G1 — verify CSRF + SSRF allow-list + escape exception text
-    if not await verify_csrf(request, session):
-        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
-
-    form = await request.form()
-    webhook_url = str(form.get("pdp_url", "")).strip()
-
-    if not webhook_url:
-        return HTMLResponse('<span class="text-red-400">Enter a webhook URL first</span>')
-
-    try:
-        _enforce_safe_outbound_url(webhook_url)
-    except ValueError as exc:
-        return HTMLResponse(
-            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
-        )
-
-    try:
-        import httpx
-        test_payload = {
-            "agent_id": "test::probe",
-            "action": "tool_execute",
-            "tool": "test_tool",
-            "capabilities": ["test"],
-        }
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.post(webhook_url, json=test_payload)
-            if resp.status_code == 200:
-                return HTMLResponse(
-                    '<span class="text-emerald-400 flex items-center gap-1.5">'
-                    '<span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span>'
-                    'Webhook responded OK</span>'
-                )
-            return HTMLResponse(
-                f'<span class="text-yellow-400">HTTP {resp.status_code}</span>'
-            )
-    except Exception as exc:
-        return HTMLResponse(
-            f'<span class="text-red-400">Connection failed: '
-            f'{_html.escape(str(exc))}</span>'
-        )
+#
+# Policies (/proxy/policies + /proxy/policies/save + /proxy/policies/test-webhook)
+# moved to ``mcp_proxy/dashboard/policies_routes.py`` since F-B-201 PR-6.
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extracts the 3 `/proxy/policies*` routes (page + save + test-webhook) from the 5106-LOC `mcp_proxy/dashboard/router.py` god-object into a dedicated `policies_routes.py` module.
- Mounted via `router.include_router(policies_routes.router)` — same pattern as PR-2..PR-5.
- Router inline footprint: **3592 -> 3454 LOC** (-138 LOC). 66 routes total (3 policies routes now under the sub-router).
- Drive-by cleanup of a stale `return RedirectResponse` orphaned in PR-5 (unreachable module-level code below a comment marker).
- CSRF gate, approval-hook intercept, SSRF guard on `/policies/test-webhook` and rules-JSON re-render-on-parse-error all preserved verbatim.

F-B-201 progress: **6/10 PR merged** after this lands.

## Routes extracted

| Method | Path | Handler |
|---|---|---|
| GET  | /proxy/policies | policies_page |
| POST | /proxy/policies/save | policies_save |
| POST | /proxy/policies/test-webhook | policies_test_webhook |

## Test plan

- [x] `python -c "from mcp_proxy.dashboard import router"` — clean import
- [x] Verified route registration: 3 policies routes present under expected paths/methods
- [x] `pytest tests/ -n auto -k "dashboard and not approvals_nav"` — 318 passed
- [ ] Manual smoke: editor renders, rules save tab persists, PDP tab persists, webhook probe responds inline