### PR TITLE
refactor(dashboard): extract Mastio vault + oidc sub-routers (F-B-201 PR-9/10)

### DIFF
--- a/mcp_proxy/dashboard/oidc_routes.py
+++ b/mcp_proxy/dashboard/oidc_routes.py
@@ -1,0 +1,166 @@
+"""Mastio dashboard — OIDC sub-router.
+
+Sprint F-B-201 PR-9 of 10. Extracts the OIDC handshake (authorization-code +
+PKCE start + IdP callback) from the ``mcp_proxy/dashboard/router.py``
+god-object. Two routes total.
+
+The OIDC primitives (state machine, token exchange, JWKS verify) live in
+the sibling ``mcp_proxy/dashboard/oidc.py`` module — this file only wires
+those primitives into the dashboard HTTP surface.
+
+Mounted via ``router.include_router(oidc_routes.router)``.
+
+Routes (2):
+
+  GET /proxy/oidc/start     redirect the admin browser to the IdP authn URL
+  GET /proxy/oidc/callback  verify IdP redirect, exchange code, set session
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from fastapi import APIRouter, Request
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard._helpers import _load_display_name, _post_login_redirect
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import set_session
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-oidc"])
+
+
+def _oidc_redirect_uri(request: Request) -> str:
+    """Build the OIDC callback URL.
+
+    Prefers oidc_redirect_uri_base (browser-reachable URL the IdP has
+    registered), then proxy_public_url (legacy single-knob deploys),
+    then the request base URL for dev/test. The first two are distinct
+    because proxy_public_url pins DPoP htu to the internal TLS sidecar
+    (e.g. mastio-nginx:9443), which is not browser-reachable nor
+    registered on the IdP — using it as redirect_uri yields a 400
+    ``Invalid parameter: redirect_uri`` from Keycloak.
+    """
+    from mcp_proxy.config import get_settings as _s
+    settings = _s()
+    base = settings.oidc_redirect_uri_base or settings.proxy_public_url
+    if base:
+        return base.rstrip("/") + "/proxy/oidc/callback"
+    return str(request.base_url).rstrip("/") + "/proxy/oidc/callback"
+
+
+@router.get("/oidc/start")
+async def oidc_start(request: Request):
+    """Initiate the OIDC authorization-code + PKCE flow."""
+    from mcp_proxy.dashboard.oidc import (
+        OidcError,
+        build_authorization_url,
+        create_oidc_state,
+        load_oidc_config,
+    )
+    from mcp_proxy.dashboard.session import set_oidc_state
+
+    cfg = await load_oidc_config()
+    if not cfg["issuer_url"] or not cfg["client_id"]:
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "SSO is not configured on this proxy. Ask an administrator.",
+            "oidc_enabled": False,
+            "display_name": await _load_display_name(),
+        }, status_code=400)
+
+    flow_state = create_oidc_state()
+    redirect_uri = _oidc_redirect_uri(request)
+
+    try:
+        auth_url = await build_authorization_url(
+            cfg["issuer_url"], cfg["client_id"], redirect_uri, flow_state,
+        )
+    except OidcError as exc:
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": f"SSO error: {exc}",
+            "oidc_enabled": True,
+            "display_name": await _load_display_name(),
+        }, status_code=502)
+
+    response = RedirectResponse(url=auth_url, status_code=303)
+    set_oidc_state(response, flow_state.to_dict())
+    return response
+
+
+@router.get("/oidc/callback")
+async def oidc_callback(request: Request):
+    """Handle the IdP redirect: verify state, exchange code, set session."""
+    import hmac as _hmac
+
+    from mcp_proxy.dashboard.oidc import (
+        OidcError,
+        OidcFlowState,
+        exchange_code_for_identity,
+        load_oidc_config,
+    )
+    from mcp_proxy.dashboard.session import clear_oidc_state, get_oidc_state
+    from mcp_proxy.db import log_audit
+
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    err = request.query_params.get("error")
+    err_desc = request.query_params.get("error_description")
+
+    def _login_err(msg: str, status: int = 400):
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": msg,
+            "oidc_enabled": True,
+        }, status_code=status)
+
+    if err:
+        return _login_err(f"SSO provider error: {err_desc or err}")
+    if not code or not state:
+        return _login_err("Missing authorization code or state from SSO provider.")
+
+    flow_data = get_oidc_state(request)
+    if not flow_data:
+        return _login_err("SSO session expired or invalid. Please try again.")
+    if not _hmac.compare_digest(state, flow_data.get("state", "")):
+        return _login_err("SSO state mismatch — possible CSRF attack.", status=403)
+
+    cfg = await load_oidc_config()
+    if not cfg["issuer_url"] or not cfg["client_id"]:
+        return _login_err("SSO is not configured on this proxy.")
+
+    flow_state = OidcFlowState.from_dict(flow_data)
+    redirect_uri = _oidc_redirect_uri(request)
+
+    try:
+        identity = await exchange_code_for_identity(
+            cfg["issuer_url"], cfg["client_id"], cfg["client_secret"] or None,
+            redirect_uri, code, flow_state,
+        )
+    except OidcError as exc:
+        _log.warning("OIDC callback failed: %s", exc)
+        await log_audit(
+            agent_id="admin",
+            action="auth.oidc_login",
+            status="error",
+            detail=str(exc)[:200],
+        )
+        return _login_err(f"SSO authentication failed: {exc}", status=401)
+
+    await log_audit(
+        agent_id="admin",
+        action="auth.oidc_login",
+        status="success",
+        detail=f"sub={identity.sub}, email={identity.email or '?'}, issuer={identity.issuer}",
+    )
+
+    response = RedirectResponse(url=await _post_login_redirect(), status_code=303)
+    clear_oidc_state(response)
+    set_session(response, role="admin")
+    return response

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -30,7 +30,6 @@ from starlette.responses import RedirectResponse
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     get_session,
-    set_session,
     clear_session,
     require_login,
     verify_csrf,
@@ -45,7 +44,6 @@ from mcp_proxy.admin.approval_hook import (
     ACTION_LICENSE_IMPORT,
     ACTION_MASTIO_KEY_ROTATE,
     ACTION_USERS_DELETE,
-    ACTION_VAULT_MIGRATE_KEYS,
     maybe_intercept_for_approval,
 )
 
@@ -63,7 +61,6 @@ from mcp_proxy.dashboard._template_env import (  # noqa: E402
 from mcp_proxy.dashboard._helpers import (  # noqa: E402
     _ctx,
     _enforce_safe_outbound_url,
-    _load_display_name,
     _login_client_ip,
     _post_login_redirect,
 )
@@ -103,6 +100,12 @@ router.include_router(_audit_routes.router)
 # F-B-201 PR-8: include the pki sub-router (CA overview + export + rotate).
 from mcp_proxy.dashboard import pki_routes as _pki_routes  # noqa: E402
 router.include_router(_pki_routes.router)
+
+# F-B-201 PR-9: include the vault + oidc sub-routers.
+from mcp_proxy.dashboard import vault_routes as _vault_routes  # noqa: E402
+router.include_router(_vault_routes.router)
+from mcp_proxy.dashboard import oidc_routes as _oidc_routes  # noqa: E402
+router.include_router(_oidc_routes.router)
 
 
 # Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip,
@@ -804,242 +807,9 @@ async def mastio_key_complete_staged(request: Request):
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Vault Settings
-# ─────────────────────────────────────────────────────────────────────────────
-
-@router.get("/vault", response_class=HTMLResponse)
-async def vault_page(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-
-    from mcp_proxy.db import get_config, get_db
-
-    vault_addr = await get_config("vault_addr") or ""
-    vault_token = await get_config("vault_token") or ""
-
-    # Count local keys (agent_key:* in proxy_config)
-    from sqlalchemy import text
-
-    async with get_db() as db:
-        result = await db.execute(
-            text("SELECT COUNT(*) as cnt FROM proxy_config WHERE key LIKE 'agent_key:%'")
-        )
-        row = result.mappings().first()
-        local_key_count = row["cnt"] if row else 0
-
-    # Test vault status if configured
-    vault_status = None
-    vault_key_count = 0
-    if vault_addr and vault_token:
-        import httpx
-        from mcp_proxy.config import get_settings as _s, vault_tls_verify
-        try:
-            async with httpx.AsyncClient(
-                verify=vault_tls_verify(_s()), timeout=5.0,
-            ) as client:
-                resp = await client.get(
-                    f"{vault_addr.rstrip('/')}/v1/sys/health",
-                    headers={"X-Vault-Token": vault_token},
-                )
-                if resp.status_code == 200:
-                    data = resp.json()
-                    vault_status = {
-                        "connected": not data.get("sealed", True),
-                        "version": data.get("version", "unknown"),
-                        "sealed": data.get("sealed", False),
-                    }
-                else:
-                    vault_status = {"connected": False, "error": f"HTTP {resp.status_code}"}
-        except Exception as exc:
-            vault_status = {"connected": False, "error": str(exc)}
-
-    return templates.TemplateResponse("vault.html", _ctx(
-        request, session,
-        active="vault",
-        vault_addr=vault_addr,
-        vault_token=vault_token,
-        vault_status=vault_status,
-        local_key_count=local_key_count,
-        vault_key_count=vault_key_count,
-    ))
-
-
-@router.post("/vault/save")
-async def vault_save(request: Request):
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    from mcp_proxy.db import set_config, log_audit
-
-    form = await request.form()
-    vault_addr = str(form.get("vault_addr", "")).strip()
-    vault_token = str(form.get("vault_token", "")).strip()
-
-    errors: list[str] = []
-    if not vault_addr:
-        errors.append("Vault address is required.")
-    if not vault_token:
-        errors.append("Vault token is required.")
-
-    if errors:
-        return templates.TemplateResponse("vault.html", _ctx(
-            request, session,
-            active="vault",
-            vault_addr=vault_addr,
-            vault_token="",
-            vault_status=None,
-            local_key_count=0,
-            vault_key_count=0,
-            errors=errors,
-        ))
-
-    # Test connectivity before saving
-    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
-    if not ok:
-        return templates.TemplateResponse("vault.html", _ctx(
-            request, session,
-            active="vault",
-            vault_addr=vault_addr,
-            vault_token="",
-            vault_status={"connected": False, "error": msg},
-            local_key_count=0,
-            vault_key_count=0,
-            errors=[f"Vault connectivity test failed: {msg}"],
-        ))
-
-    await set_config("vault_addr", vault_addr)
-    await set_config("vault_token", vault_token)
-
-    await log_audit(
-        agent_id="admin",
-        action="vault.configure",
-        status="success",
-        detail=f"addr={vault_addr}",
-    )
-
-    return RedirectResponse(url="/proxy/vault", status_code=303)
-
-
-@router.post("/vault/test")
-async def vault_test(request: Request):
-    """HTMX endpoint: test Vault connectivity."""
-    import html as _html
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
-
-    # Wave B G1 — verify CSRF + SSRF allow-list (Vault behind a docker
-    # network is the legitimate case; ``allow_private=True`` honours
-    # the same flag that PDP webhooks use, so docker-compose vault://
-    # addresses keep working).
-    if not await verify_csrf(request, session):
-        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
-
-    form = await request.form()
-    vault_addr = str(form.get("vault_addr", "")).strip()
-    vault_token = str(form.get("vault_token", "")).strip()
-
-    if not vault_addr:
-        return HTMLResponse('<span class="text-red-400">Enter a Vault address first</span>')
-
-    try:
-        _enforce_safe_outbound_url(vault_addr, allow_private=True)
-    except ValueError as exc:
-        return HTMLResponse(
-            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
-        )
-
-    if not vault_token:
-        # Try stored token
-        from mcp_proxy.db import get_config
-        vault_token = await get_config("vault_token") or ""
-
-    if not vault_token:
-        return HTMLResponse('<span class="text-red-400">Vault token required</span>')
-
-    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
-    if ok:
-        return HTMLResponse(
-            '<span class="text-emerald-400 flex items-center gap-1.5">'
-            '<span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span>'
-            'Vault connected and unsealed</span>'
-        )
-    return HTMLResponse(f'<span class="text-red-400">{_html.escape(msg)}</span>')
-
-
-@router.post("/vault/migrate-keys")
-async def vault_migrate_keys(request: Request):
-    """Migrate all agent private keys from DB to Vault."""
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
-    if not await verify_csrf(request, session):
-        raise HTTPException(status_code=403, detail="Invalid CSRF token")
-
-    intercept = await maybe_intercept_for_approval(
-        session=session, action_type=ACTION_VAULT_MIGRATE_KEYS, payload={},
-        request=request,
-    )
-    if intercept is not None:
-        return intercept
-
-    from mcp_proxy.db import get_config, get_db, log_audit
-
-    vault_addr = await get_config("vault_addr")
-    vault_token = await get_config("vault_token")
-    if not vault_addr or not vault_token:
-        raise HTTPException(status_code=400, detail="Vault not configured")
-
-    # Test connectivity first
-    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
-    if not ok:
-        raise HTTPException(status_code=502, detail=f"Vault unreachable: {msg}")
-
-    import httpx
-    from mcp_proxy.config import get_settings as _s, vault_tls_verify
-
-    _vault_verify = vault_tls_verify(_s())
-
-    # Find all agent keys stored in proxy_config (agent_key:* pattern)
-    from sqlalchemy import text
-
-    migrated = 0
-    async with get_db() as db:
-        result = await db.execute(
-            text("SELECT key, value FROM proxy_config WHERE key LIKE 'agent_key:%'")
-        )
-        rows = result.mappings().all()
-
-    for row in rows:
-        agent_id = row["key"].replace("agent_key:", "", 1)
-        key_pem = row["value"]
-        path = f"secret/data/mcp-proxy/agents/{agent_id}"
-        url = f"{vault_addr.rstrip('/')}/v1/{path}"
-        try:
-            async with httpx.AsyncClient(verify=_vault_verify, timeout=5.0) as client:
-                resp = await client.post(
-                    url,
-                    json={"data": {"key_pem": key_pem}},
-                    headers={"X-Vault-Token": vault_token},
-                )
-                resp.raise_for_status()
-            migrated += 1
-        except Exception as exc:
-            _log.warning("Failed to migrate key for %s to Vault: %s", agent_id, exc)
-
-    await log_audit(
-        agent_id="admin",
-        action="vault.migrate_keys",
-        status="success",
-        detail=f"Migrated {migrated}/{len(rows)} agent keys to Vault",
-    )
-
-    return RedirectResponse(url="/proxy/vault", status_code=303)
+# Vault (/proxy/vault + /proxy/vault/save + /proxy/vault/test +
+# /proxy/vault/migrate-keys) moved to
+# ``mcp_proxy/dashboard/vault_routes.py`` since F-B-201 PR-9.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2970,139 +2740,10 @@ async def settings_license_swap(request: Request):
     )
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# OIDC login (Sign-in with SSO)
-# ─────────────────────────────────────────────────────────────────────────────
-
-def _oidc_redirect_uri(request: Request) -> str:
-    """Build the OIDC callback URL.
-
-    Prefers oidc_redirect_uri_base (browser-reachable URL the IdP has
-    registered), then proxy_public_url (legacy single-knob deploys),
-    then the request base URL for dev/test. The first two are distinct
-    because proxy_public_url pins DPoP htu to the internal TLS sidecar
-    (e.g. mastio-nginx:9443), which is not browser-reachable nor
-    registered on the IdP — using it as redirect_uri yields a 400
-    ``Invalid parameter: redirect_uri`` from Keycloak.
-    """
-    from mcp_proxy.config import get_settings as _s
-    settings = _s()
-    base = settings.oidc_redirect_uri_base or settings.proxy_public_url
-    if base:
-        return base.rstrip("/") + "/proxy/oidc/callback"
-    return str(request.base_url).rstrip("/") + "/proxy/oidc/callback"
-
-
-@router.get("/oidc/start")
-async def oidc_start(request: Request):
-    """Initiate the OIDC authorization-code + PKCE flow."""
-    from mcp_proxy.dashboard.oidc import (
-        OidcError,
-        build_authorization_url,
-        create_oidc_state,
-        load_oidc_config,
-    )
-    from mcp_proxy.dashboard.session import set_oidc_state
-
-    cfg = await load_oidc_config()
-    if not cfg["issuer_url"] or not cfg["client_id"]:
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": "SSO is not configured on this proxy. Ask an administrator.",
-            "oidc_enabled": False,
-            "display_name": await _load_display_name(),
-        }, status_code=400)
-
-    flow_state = create_oidc_state()
-    redirect_uri = _oidc_redirect_uri(request)
-
-    try:
-        auth_url = await build_authorization_url(
-            cfg["issuer_url"], cfg["client_id"], redirect_uri, flow_state,
-        )
-    except OidcError as exc:
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": f"SSO error: {exc}",
-            "oidc_enabled": True,
-            "display_name": await _load_display_name(),
-        }, status_code=502)
-
-    response = RedirectResponse(url=auth_url, status_code=303)
-    set_oidc_state(response, flow_state.to_dict())
-    return response
-
-
-@router.get("/oidc/callback")
-async def oidc_callback(request: Request):
-    """Handle the IdP redirect: verify state, exchange code, set session."""
-    import hmac as _hmac
-
-    from mcp_proxy.dashboard.oidc import (
-        OidcError,
-        OidcFlowState,
-        exchange_code_for_identity,
-        load_oidc_config,
-    )
-    from mcp_proxy.dashboard.session import clear_oidc_state, get_oidc_state
-    from mcp_proxy.db import log_audit
-
-    code = request.query_params.get("code")
-    state = request.query_params.get("state")
-    err = request.query_params.get("error")
-    err_desc = request.query_params.get("error_description")
-
-    def _login_err(msg: str, status: int = 400):
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-            "error": msg,
-            "oidc_enabled": True,
-        }, status_code=status)
-
-    if err:
-        return _login_err(f"SSO provider error: {err_desc or err}")
-    if not code or not state:
-        return _login_err("Missing authorization code or state from SSO provider.")
-
-    flow_data = get_oidc_state(request)
-    if not flow_data:
-        return _login_err("SSO session expired or invalid. Please try again.")
-    if not _hmac.compare_digest(state, flow_data.get("state", "")):
-        return _login_err("SSO state mismatch — possible CSRF attack.", status=403)
-
-    cfg = await load_oidc_config()
-    if not cfg["issuer_url"] or not cfg["client_id"]:
-        return _login_err("SSO is not configured on this proxy.")
-
-    flow_state = OidcFlowState.from_dict(flow_data)
-    redirect_uri = _oidc_redirect_uri(request)
-
-    try:
-        identity = await exchange_code_for_identity(
-            cfg["issuer_url"], cfg["client_id"], cfg["client_secret"] or None,
-            redirect_uri, code, flow_state,
-        )
-    except OidcError as exc:
-        _log.warning("OIDC callback failed: %s", exc)
-        await log_audit(
-            agent_id="admin",
-            action="auth.oidc_login",
-            status="error",
-            detail=str(exc)[:200],
-        )
-        return _login_err(f"SSO authentication failed: {exc}", status=401)
-
-    await log_audit(
-        agent_id="admin",
-        action="auth.oidc_login",
-        status="success",
-        detail=f"sub={identity.sub}, email={identity.email or '?'}, issuer={identity.issuer}",
-    )
-
-    response = RedirectResponse(url=await _post_login_redirect(), status_code=303)
-    clear_oidc_state(response)
-    set_session(response, role="admin")
-    return response
+# OIDC handshake (/proxy/oidc/start + /proxy/oidc/callback) moved to
+# ``mcp_proxy/dashboard/oidc_routes.py`` since F-B-201 PR-9.
+# OIDC primitives (state, JWKS, token exchange) still live in the
+# sibling ``mcp_proxy/dashboard/oidc.py`` module.
 
 
 # _load_display_name moved to ``mcp_proxy/dashboard/_helpers.py``

--- a/mcp_proxy/dashboard/vault_routes.py
+++ b/mcp_proxy/dashboard/vault_routes.py
@@ -1,0 +1,276 @@
+"""Mastio dashboard — Vault sub-router.
+
+Sprint F-B-201 PR-9 of 10. Extracts the Vault connection management
+(view + save + connectivity probe + key migration) from the
+``mcp_proxy/dashboard/router.py`` god-object. Four routes total.
+
+Mounted via ``router.include_router(vault_routes.router)``.
+
+Routes (4):
+
+  GET  /proxy/vault               Vault settings page
+  POST /proxy/vault/save          persist vault_addr + vault_token (CSRF)
+  POST /proxy/vault/test          HTMX connectivity probe (CSRF + SSRF guard)
+  POST /proxy/vault/migrate-keys  bulk-migrate agent keys to Vault (CSRF + approval hook)
+"""
+from __future__ import annotations
+
+import html as _html
+import logging
+import pathlib
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.admin.approval_hook import (
+    ACTION_VAULT_MIGRATE_KEYS,
+    maybe_intercept_for_approval,
+)
+from mcp_proxy.dashboard._helpers import (
+    _ctx,
+    _enforce_safe_outbound_url,
+    _test_vault_connectivity,
+)
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import require_login, verify_csrf
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-vault"])
+
+
+@router.get("/vault", response_class=HTMLResponse)
+async def vault_page(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import get_config, get_db
+
+    vault_addr = await get_config("vault_addr") or ""
+    vault_token = await get_config("vault_token") or ""
+
+    # Count local keys (agent_key:* in proxy_config)
+    from sqlalchemy import text
+
+    async with get_db() as db:
+        result = await db.execute(
+            text("SELECT COUNT(*) as cnt FROM proxy_config WHERE key LIKE 'agent_key:%'")
+        )
+        row = result.mappings().first()
+        local_key_count = row["cnt"] if row else 0
+
+    # Test vault status if configured
+    vault_status = None
+    vault_key_count = 0
+    if vault_addr and vault_token:
+        import httpx
+        from mcp_proxy.config import get_settings as _s, vault_tls_verify
+        try:
+            async with httpx.AsyncClient(
+                verify=vault_tls_verify(_s()), timeout=5.0,
+            ) as client:
+                resp = await client.get(
+                    f"{vault_addr.rstrip('/')}/v1/sys/health",
+                    headers={"X-Vault-Token": vault_token},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    vault_status = {
+                        "connected": not data.get("sealed", True),
+                        "version": data.get("version", "unknown"),
+                        "sealed": data.get("sealed", False),
+                    }
+                else:
+                    vault_status = {"connected": False, "error": f"HTTP {resp.status_code}"}
+        except Exception as exc:
+            vault_status = {"connected": False, "error": str(exc)}
+
+    return templates.TemplateResponse("vault.html", _ctx(
+        request, session,
+        active="vault",
+        vault_addr=vault_addr,
+        vault_token=vault_token,
+        vault_status=vault_status,
+        local_key_count=local_key_count,
+        vault_key_count=vault_key_count,
+    ))
+
+
+@router.post("/vault/save")
+async def vault_save(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import set_config, log_audit
+
+    form = await request.form()
+    vault_addr = str(form.get("vault_addr", "")).strip()
+    vault_token = str(form.get("vault_token", "")).strip()
+
+    errors: list[str] = []
+    if not vault_addr:
+        errors.append("Vault address is required.")
+    if not vault_token:
+        errors.append("Vault token is required.")
+
+    if errors:
+        return templates.TemplateResponse("vault.html", _ctx(
+            request, session,
+            active="vault",
+            vault_addr=vault_addr,
+            vault_token="",
+            vault_status=None,
+            local_key_count=0,
+            vault_key_count=0,
+            errors=errors,
+        ))
+
+    # Test connectivity before saving
+    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
+    if not ok:
+        return templates.TemplateResponse("vault.html", _ctx(
+            request, session,
+            active="vault",
+            vault_addr=vault_addr,
+            vault_token="",
+            vault_status={"connected": False, "error": msg},
+            local_key_count=0,
+            vault_key_count=0,
+            errors=[f"Vault connectivity test failed: {msg}"],
+        ))
+
+    await set_config("vault_addr", vault_addr)
+    await set_config("vault_token", vault_token)
+
+    await log_audit(
+        agent_id="admin",
+        action="vault.configure",
+        status="success",
+        detail=f"addr={vault_addr}",
+    )
+
+    return RedirectResponse(url="/proxy/vault", status_code=303)
+
+
+@router.post("/vault/test")
+async def vault_test(request: Request):
+    """HTMX endpoint: test Vault connectivity."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
+
+    # Wave B G1 — verify CSRF + SSRF allow-list (Vault behind a docker
+    # network is the legitimate case; ``allow_private=True`` honours
+    # the same flag that PDP webhooks use, so docker-compose vault://
+    # addresses keep working).
+    if not await verify_csrf(request, session):
+        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
+
+    form = await request.form()
+    vault_addr = str(form.get("vault_addr", "")).strip()
+    vault_token = str(form.get("vault_token", "")).strip()
+
+    if not vault_addr:
+        return HTMLResponse('<span class="text-red-400">Enter a Vault address first</span>')
+
+    try:
+        _enforce_safe_outbound_url(vault_addr, allow_private=True)
+    except ValueError as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
+        )
+
+    if not vault_token:
+        # Try stored token
+        from mcp_proxy.db import get_config
+        vault_token = await get_config("vault_token") or ""
+
+    if not vault_token:
+        return HTMLResponse('<span class="text-red-400">Vault token required</span>')
+
+    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
+    if ok:
+        return HTMLResponse(
+            '<span class="text-emerald-400 flex items-center gap-1.5">'
+            '<span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span>'
+            'Vault connected and unsealed</span>'
+        )
+    return HTMLResponse(f'<span class="text-red-400">{_html.escape(msg)}</span>')
+
+
+@router.post("/vault/migrate-keys")
+async def vault_migrate_keys(request: Request):
+    """Migrate all agent private keys from DB to Vault."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_VAULT_MIGRATE_KEYS, payload={},
+        request=request,
+    )
+    if intercept is not None:
+        return intercept
+
+    from mcp_proxy.db import get_config, get_db, log_audit
+
+    vault_addr = await get_config("vault_addr")
+    vault_token = await get_config("vault_token")
+    if not vault_addr or not vault_token:
+        raise HTTPException(status_code=400, detail="Vault not configured")
+
+    # Test connectivity first
+    ok, msg = await _test_vault_connectivity(vault_addr, vault_token)
+    if not ok:
+        raise HTTPException(status_code=502, detail=f"Vault unreachable: {msg}")
+
+    import httpx
+    from mcp_proxy.config import get_settings as _s, vault_tls_verify
+
+    _vault_verify = vault_tls_verify(_s())
+
+    # Find all agent keys stored in proxy_config (agent_key:* pattern)
+    from sqlalchemy import text
+
+    migrated = 0
+    async with get_db() as db:
+        result = await db.execute(
+            text("SELECT key, value FROM proxy_config WHERE key LIKE 'agent_key:%'")
+        )
+        rows = result.mappings().all()
+
+    for row in rows:
+        agent_id = row["key"].replace("agent_key:", "", 1)
+        key_pem = row["value"]
+        path = f"secret/data/mcp-proxy/agents/{agent_id}"
+        url = f"{vault_addr.rstrip('/')}/v1/{path}"
+        try:
+            async with httpx.AsyncClient(verify=_vault_verify, timeout=5.0) as client:
+                resp = await client.post(
+                    url,
+                    json={"data": {"key_pem": key_pem}},
+                    headers={"X-Vault-Token": vault_token},
+                )
+                resp.raise_for_status()
+            migrated += 1
+        except Exception as exc:
+            _log.warning("Failed to migrate key for %s to Vault: %s", agent_id, exc)
+
+    await log_audit(
+        agent_id="admin",
+        action="vault.migrate_keys",
+        status="success",
+        detail=f"Migrated {migrated}/{len(rows)} agent keys to Vault",
+    )
+
+    return RedirectResponse(url="/proxy/vault", status_code=303)

--- a/tests/test_proxy_dashboard_oidc.py
+++ b/tests/test_proxy_dashboard_oidc.py
@@ -388,7 +388,7 @@ async def test_settings_renders_change_admin_password_section(proxy_app):
 
 def test_oidc_redirect_uri_prefers_dedicated_setting(monkeypatch):
     from mcp_proxy import config as _config
-    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+    from mcp_proxy.dashboard.oidc_routes import _oidc_redirect_uri
 
     s = _config.get_settings()
     monkeypatch.setattr(s, "oidc_redirect_uri_base", "http://localhost:9100")
@@ -400,7 +400,7 @@ def test_oidc_redirect_uri_prefers_dedicated_setting(monkeypatch):
 
 def test_oidc_redirect_uri_falls_back_to_proxy_public_url(monkeypatch):
     from mcp_proxy import config as _config
-    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+    from mcp_proxy.dashboard.oidc_routes import _oidc_redirect_uri
 
     s = _config.get_settings()
     monkeypatch.setattr(s, "oidc_redirect_uri_base", "")
@@ -412,7 +412,7 @@ def test_oidc_redirect_uri_falls_back_to_proxy_public_url(monkeypatch):
 
 def test_oidc_redirect_uri_falls_back_to_request_base_url(monkeypatch):
     from mcp_proxy import config as _config
-    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+    from mcp_proxy.dashboard.oidc_routes import _oidc_redirect_uri
 
     s = _config.get_settings()
     monkeypatch.setattr(s, "oidc_redirect_uri_base", "")


### PR DESCRIPTION
## Summary

- Extracts the four `/proxy/vault*` routes (page + save + test + migrate-keys) plus the two `/proxy/oidc*` routes (start + callback) from the ~3500-LOC `mcp_proxy/dashboard/router.py` god-object into two dedicated sub-router modules, each mounted via `include_router`.
- Same pattern as PR-2..PR-8.
- Router inline footprint: **3592 → 3095 LOC** (-497, includes PR-6 fast-forward). 66 routes total (4 vault + 2 oidc verified registered).

3 vault helpers (`_test_vault_connectivity`, `_store_ca_key_in_vault`, `_enforce_safe_outbound_url`) already lived in `_helpers.py` since PR-1/PR-3, so this PR just imports them. Removed 3 now-orphan top-level imports from `router.py`: `ACTION_VAULT_MIGRATE_KEYS`, `_load_display_name`, `set_session`.

`tests/test_proxy_dashboard_oidc.py` imported `_oidc_redirect_uri` from `router` — updated to import from `oidc_routes` (3 occurrences).

CSRF gate, approval-hook intercept on `/vault/migrate-keys`, SSRF guard on `/vault/test`, and the OIDC handshake state machine all preserved verbatim.

F-B-201 progress: **9/10 PR** after this lands.

## Routes extracted

| Method | Path | Handler |
|---|---|---|
| GET  | /proxy/vault | vault_page |
| POST | /proxy/vault/save | vault_save |
| POST | /proxy/vault/test | vault_test |
| POST | /proxy/vault/migrate-keys | vault_migrate_keys |
| GET  | /proxy/oidc/start | oidc_start |
| GET  | /proxy/oidc/callback | oidc_callback |

## Test plan

- [x] `python -c "from mcp_proxy.dashboard import router"` clean import
- [x] All 6 routes registered via include_router (verified)
- [x] `pytest -k dashboard` → 324 passed, 1 pre-existing fail (`approvals_nav` env-pollution from local enterprise install, unrelated)
- [ ] Manual smoke: vault page renders, save persists, test webhook probe responds, migrate-keys prompts approval, OIDC handshake roundtrips