### PR TITLE
fix(nginx): route /v1/guardian/inspect through mTLS-required group

### DIFF
--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -69,7 +69,13 @@ server {
     # PR-C dropped that path. /v1/auth/token stays anonymous (it
     # validates a client_assertion JWT, not a TLS cert) — see the
     # /v1/* catch-all below.
-    location ~ ^/v1/(egress|agents|audit|llm|chat)(/.*)?$ {
+    # ``guardian`` is the ADR-016 LLM Guardian inspection surface
+    # (``/v1/guardian/inspect``). It uses the same mTLS+DPoP auth as
+    # /v1/egress, so it MUST sit in this mTLS-required group — the
+    # earlier shipped regex missed it and the catch-all below would
+    # strip the client cert, surfacing as ``client_cert_not_verified``
+    # at the Mastio. Sister-file: add new mTLS routes here, not below.
+    location ~ ^/v1/(egress|agents|audit|llm|chat|guardian)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }


### PR DESCRIPTION
## Summary

The Mastio sidecar nginx config has an mTLS-required regex group
(`^/v1/(egress|agents|audit|llm|chat)(/.*)?$`) that gates the
client-cert verification for caller-identity routes. It was missing
`guardian` — so `POST /v1/guardian/inspect` (ADR-016 LLM Guardian
foundation endpoint) fell through to the `^/v1/(.*)$` catch-all,
which does `proxy_set_header X-SSL-Client-Cert ""`. Mastio then saw
no client cert and rejected every call with:

```
HTTP 401 reason=client_cert_not_verified
hint=nginx did not stamp X-SSL-Client-Verify=SUCCESS
```

This made Guardian unreachable from any caller behind the nginx
sidecar in every shipped bundle (`cullis-mastio`, `cullis-frontdesk`).
The endpoint, the SDK `GuardianClient`, and the audit writer were all
correct — only the front-door routing was missing.

Fix: add `guardian` to the existing mTLS-required regex group. One-line
behavioural change.

## Sister-file note

This is the Pattern H4 (sister-file Court↔Mastio) signal from the
2026-05-20 audit. New routes that require mTLS land both at the FastAPI
layer (`get_agent_from_dpop_client_cert` dep) AND in the nginx regex
above. Easy to add the first and forget the second; the catch-all
silently strips the cert and the route appears broken in a way that
looks like a client mis-config. Added a comment block on the location
spelling out "add new mTLS routes here, not below" so the next sister
catches it at review.

## Test plan

- [x] Tested live against the modern dogfood stack (Court + 2 Mastios +
      Frontdesk + 2 BYOCA agents). Out-of-tree probe script invokes
      `CullisClient._guardian_inspect_send` from an enrolled agent.
- [x] Before fix: HTTP 401 `client_cert_not_verified` from Mastio
- [x] After fix: `decision=pass`, JWT ticket present, ticket verifies
      locally with HS256 key, `local_audit` row with
      `event_type=guardian.inspect` written
- [x] No-mTLS caller: still 401 (catch-all behaviour preserved for
      anonymous callers)
- [x] Existing smoke (B1..B6) regression-clean
- [x] `nginx -t` syntax check + `nginx -s reload` clean