### PR TITLE
feat(audit): log tool parameters + result summary on success

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -7,9 +7,10 @@ validate_config() enforces production-safety invariants at startup.
 import logging
 import os
 from functools import lru_cache
+from typing import Annotated
 
 from pydantic import field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 _log = logging.getLogger("mcp_proxy.startup")
 
@@ -390,6 +391,32 @@ class ProxySettings(BaseSettings):
     # ``MCP_PROXY_AUDIT_DETAIL_MAX_BYTES``.
     audit_detail_max_bytes: int = 4096
 
+    # Tool audit capture knobs — opt-in redaction for regulated deployments
+    # (GDPR PII / MNPI). Default keeps current open-core behaviour: parameters
+    # AND result are captured into the audit chain on every successful tool
+    # call. Operators handling regulated data flip the master switch off or
+    # populate the per-tool denylist (fnmatch glob patterns, e.g.
+    # ``payments.*`` or ``trading.transfer``) so the matching tools land a
+    # redacted marker instead of the real value in the append-only chain.
+    # Redaction surrogates carry ``_redacted: true`` + ``reason`` so a
+    # forensic reader still sees that something was elided.
+    # Env wiring:
+    #   * ``MCP_PROXY_AUDIT_CAPTURE_TOOL_PARAMETERS`` (bool, default true)
+    #   * ``MCP_PROXY_AUDIT_CAPTURE_TOOL_PARAMETERS_DENYLIST`` (comma-sep)
+    #   * ``MCP_PROXY_AUDIT_CAPTURE_TOOL_RESULT`` (bool, default true)
+    #   * ``MCP_PROXY_AUDIT_CAPTURE_TOOL_RESULT_DENYLIST`` (comma-sep)
+    audit_capture_tool_parameters: bool = True
+    # ``NoDecode`` disables pydantic-settings' JSON pre-decoding for these
+    # list fields so our ``_split_comma_separated_list`` validator
+    # receives the raw env string (e.g. ``"payments.*,trading.*"``) and
+    # can split on commas. Without it pydantic-settings tries to parse
+    # the value as JSON before the validator runs and raises
+    # ``SettingsError`` on any non-JSON input — which is every operator-
+    # written env value.
+    audit_capture_tool_parameters_denylist: Annotated[list[str], NoDecode] = []
+    audit_capture_tool_result: bool = True
+    audit_capture_tool_result_denylist: Annotated[list[str], NoDecode] = []
+
     # Audit F-A-404 — background flush retry exhaustion.
     # The size-triggered flush from ``append()`` raises
     # ``AuditChainExhausted`` so a caller under ``audit_fail_deny=True``
@@ -726,6 +753,32 @@ class ProxySettings(BaseSettings):
         # maps "" → None) so the standalone auto-flip keeps firing.
         if isinstance(v, str) and v.strip() == "":
             return False
+        return v
+
+    # Operator-facing env vars for the redaction denylists are easier to
+    # write as a comma-separated string (``payments.*,trading.transfer``)
+    # than as a JSON array. Pydantic-settings defaults to JSON for
+    # ``list[str]`` fields; this normaliser accepts both shapes — JSON
+    # array passes through unchanged, comma-separated string splits on
+    # commas with whitespace stripped, empty string yields an empty list.
+    @field_validator(
+        "audit_capture_tool_parameters_denylist",
+        "audit_capture_tool_result_denylist",
+        mode="before",
+    )
+    @classmethod
+    def _split_comma_separated_list(cls, v):
+        if v is None:
+            return []
+        if isinstance(v, str):
+            stripped = v.strip()
+            if not stripped:
+                return []
+            # Permit JSON array shape (operators copying from broker
+            # config) without surprising them.
+            if stripped.startswith("["):
+                return v
+            return [item.strip() for item in stripped.split(",") if item.strip()]
         return v
 
     @model_validator(mode="after")

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -375,6 +375,21 @@ class ProxySettings(BaseSettings):
     audit_chain_flush_interval_s: float = 1.0
     audit_chain_disabled: bool = False
 
+    # Per-call cap on the success-path ``detail`` JSON the tool executor
+    # attaches to a ``tool_execute`` audit row (parameters + result
+    # summary). Lives well below ``AUDIT_DETAILS_MAX_BYTES`` (16 KiB hard
+    # cap, see ``mcp_proxy/db.py:368``) so a single noisy tool result
+    # cannot dominate the chain or amplify the per-row hash cost. The
+    # builder serialises ``{"parameters": ..., "result_summary": ...}``
+    # in canonical JSON and truncates with a ``detail_truncated: true``
+    # flag when over budget; non-JSON-serialisable values fall back to
+    # ``repr(...)`` with a ``_non_serializable`` flag. 4 KiB is enough
+    # to keep the business-readable shape (recipient, amounts, dates,
+    # short result blobs) without inviting LLM-shaped chatter into the
+    # append-only table. Operators tune via
+    # ``MCP_PROXY_AUDIT_DETAIL_MAX_BYTES``.
+    audit_detail_max_bytes: int = 4096
+
     # Audit F-A-404 — background flush retry exhaustion.
     # The size-triggered flush from ``append()`` raises
     # ``AuditChainExhausted`` so a caller under ``audit_fail_deny=True``

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -125,12 +125,25 @@ class AuditLogEntry(Base):
     chain_seq = Column(Integer, nullable=True)
     prev_hash = Column(Text, nullable=True)
     row_hash = Column(Text, nullable=True)
+    # F-A-403 / migrations 0031, 0033, 0034, 0042 — fields originally
+    # introduced by alembic-only migrations. Declaring them here too
+    # lets ``metadata.create_all`` (used under
+    # ``PROXY_SKIP_MIGRATIONS=1`` in tests) build a schema that matches
+    # the production INSERT shape. Without the declarations the test
+    # harness either had to run the full alembic chain (slow) or fail
+    # at log_audit time with "table audit_log has no column named
+    # dpop_jkt".
+    hash_format = Column(Text, nullable=True)
+    dpop_jkt = Column(String(length=64), nullable=True)
+    on_behalf_of_user_id = Column(String(length=255), nullable=True)
 
     __table_args__ = (
         Index("idx_audit_log_agent_id", "agent_id"),
         Index("idx_audit_log_timestamp", "timestamp"),
         Index("idx_audit_log_request_id", "request_id"),
         Index("idx_audit_log_chain_seq", "chain_seq", unique=True),
+        Index("idx_audit_log_dpop_jkt", "dpop_jkt"),
+        Index("idx_audit_log_on_behalf_of_user", "on_behalf_of_user_id"),
     )
 
 

--- a/mcp_proxy/tools/audit_redaction.py
+++ b/mcp_proxy/tools/audit_redaction.py
@@ -1,0 +1,107 @@
+"""Tool audit redaction — opt-in capture controls for regulated deployments.
+
+The default behaviour of :func:`mcp_proxy.tools.executor._build_success_detail`
+captures both ``parameters`` and ``result`` of every successful tool call into
+the audit chain. That is the correct shape for an open-core demo and for
+internal forensic readability, but it is the wrong shape for any deployment
+that handles GDPR-regulated PII or MNPI: IBAN numbers, SSNs, deal names, and
+similar values end up in an append-only table that operators with DB read can
+read forever.
+
+This module exposes two knobs to dial capture down without forcing every
+operator into a fork:
+
+* A boolean master switch per side (parameters / result) — flip to ``False``
+  to redact across the board.
+* A per-tool denylist of ``fnmatch`` glob patterns — flip individual tools
+  (e.g. ``payments.*``) to redacted while keeping the rest captured.
+
+The redaction surrogate keeps the audit row useful: ``_redacted: true`` plus
+a ``reason`` field tells the forensic reader *that* something was elided and
+*why*, without giving them the value. The original value never enters the
+chain.
+
+Defaults stay at *capture on* (backwards compatibility for existing open
+deployments). Regulated operators flip the env vars at boot. See
+:func:`should_redact_parameters` and :func:`should_redact_result` for the
+matching logic.
+"""
+from __future__ import annotations
+
+import fnmatch
+from typing import Any
+
+
+_REDACTED_PARAMETERS_REASON = "tool_denylist"
+_REDACTED_RESULT_REASON = "tool_denylist"
+_REDACTED_GLOBAL_REASON = "capture_disabled"
+
+
+def _matches_any_pattern(tool_name: str, patterns: list[str]) -> bool:
+    """Return True when ``tool_name`` matches any fnmatch glob in
+    ``patterns``.
+
+    The patterns are case-sensitive by design — tool names are
+    case-sensitive everywhere else in the executor, so the denylist
+    must be too. An empty list never matches anything.
+    """
+    if not patterns:
+        return False
+    for pattern in patterns:
+        if pattern and fnmatch.fnmatchcase(tool_name, pattern):
+            return True
+    return False
+
+
+def should_redact_parameters(
+    *,
+    tool_name: str | None,
+    capture_enabled: bool,
+    denylist: list[str],
+) -> bool:
+    """Return True when the executor must replace ``parameters`` with the
+    redacted-marker payload before the audit row lands.
+
+    The two switches compose: when ``capture_enabled`` is False the helper
+    returns True regardless of ``denylist`` (the operator has opted out
+    globally). Otherwise the denylist gates per-tool.
+    """
+    if not capture_enabled:
+        return True
+    if tool_name is None:
+        return False
+    return _matches_any_pattern(tool_name, denylist)
+
+
+def should_redact_result(
+    *,
+    tool_name: str | None,
+    capture_enabled: bool,
+    denylist: list[str],
+) -> bool:
+    """Mirror of :func:`should_redact_parameters` for the ``result``
+    side. Kept as a separate function so a deployment can redact
+    parameters (often contains the user-typed natural-language query)
+    while still capturing the structured result, or vice versa.
+    """
+    if not capture_enabled:
+        return True
+    if tool_name is None:
+        return False
+    return _matches_any_pattern(tool_name, denylist)
+
+
+def redacted_marker(*, reason: str) -> dict[str, Any]:
+    """Return the canonical surrogate dict used in place of a redacted
+    value. The shape mirrors the ``_omitted`` / ``_non_serializable``
+    markers in :mod:`mcp_proxy.tools.executor` so a downstream consumer
+    (dashboard render, forensic export) can pattern-match on the
+    ``_redacted`` flag in one pass."""
+    return {"_redacted": True, "reason": reason}
+
+
+# Exposed reason constants so call sites can use them by name rather than
+# repeating the literal — keeps the audit shape consistent if the strings
+# ever need to be tuned.
+REASON_TOOL_DENYLIST = _REDACTED_PARAMETERS_REASON
+REASON_CAPTURE_DISABLED = _REDACTED_GLOBAL_REASON

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -514,19 +514,34 @@ async def run(
                 duration_ms,
                 request_id,
             )
-            # Resolve the per-call cap lazily — keeps the executor
-            # importable when ``ProxySettings`` cannot be constructed
-            # (test fixtures that monkeypatch only the bits they care
-            # about), at the cost of one dict lookup per success path.
+            # Resolve the per-call cap + redaction settings lazily — keeps
+            # the executor importable when ``ProxySettings`` cannot be
+            # constructed (test fixtures that monkeypatch only the bits
+            # they care about), at the cost of one settings fetch per
+            # success path.
             try:
                 from mcp_proxy.config import get_settings as _get_settings
-                _max_bytes = _get_settings().audit_detail_max_bytes
+                _settings = _get_settings()
+                _max_bytes = _settings.audit_detail_max_bytes
+                _redaction_settings = {
+                    "capture_parameters": _settings.audit_capture_tool_parameters,
+                    "capture_result": _settings.audit_capture_tool_result,
+                    "parameters_denylist": list(
+                        _settings.audit_capture_tool_parameters_denylist,
+                    ),
+                    "result_denylist": list(
+                        _settings.audit_capture_tool_result_denylist,
+                    ),
+                }
             except Exception:  # noqa: BLE001 — never let config crash audit
                 _max_bytes = 4096
+                _redaction_settings = None
             success_detail = _build_success_detail(
                 parameters=request.parameters,
                 result=result,
                 max_bytes=_max_bytes,
+                tool_name=tool_name,
+                redaction_settings=_redaction_settings,
             )
             await log_audit(
                 agent_id=agent.agent_id,
@@ -623,7 +638,7 @@ async def run(
             )
 
 
-def _safe_json_value(value: Any) -> Any:
+def _safe_json_value(value: Any, _seen: set[int] | None = None) -> Any:
     """Return a JSON-serialisable surrogate for ``value`` or a repr fallback.
 
     The audit chain row hash is computed over a canonical JSON encoding of
@@ -641,18 +656,50 @@ def _safe_json_value(value: Any) -> Any:
     ``{"recipient": "acme", "when": datetime}`` becomes
     ``{"recipient": "acme", "when": {"_non_serializable": True, ...}}``
     rather than the whole dict collapsing.
+
+    Cycle detection (P0 #2 fix). A handler that returns a SQLAlchemy ORM
+    object with ``relationship(backref=...)`` or any user code that
+    constructs ``d = {}; d['self'] = d`` would otherwise drive the
+    recursive walk into a ``RecursionError`` that propagates through
+    ``log_audit`` and 500s a successful tool call. The ``_seen`` set
+    tracks ``id(value)`` across the walk; a repeated visit returns a
+    typed circular-reference marker.
     """
-    # Fast happy path: value is JSON-clean as-is.
+    if _seen is None:
+        _seen = set()
+
+    # Fast happy path: value is JSON-clean as-is. ``json.dumps`` itself
+    # detects circular references (raises ``ValueError``) so the cheap
+    # check before recursing is still correct for non-container leaves.
     try:
         _json.dumps(value)
-        return value
+        # ``json.dumps`` accepted it, but for containers we still want to
+        # recurse so a nested non-serialisable leaf gets the marker
+        # treatment rather than relying on dumps to find it again at the
+        # outer call site. Plain values short-circuit here.
+        if not isinstance(value, (dict, list, tuple)):
+            return value
     except (TypeError, ValueError):
         pass
 
-    if isinstance(value, dict):
-        return {str(k): _safe_json_value(v) for k, v in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_safe_json_value(v) for v in value]
+    if isinstance(value, (dict, list, tuple)):
+        value_id = id(value)
+        if value_id in _seen:
+            return {
+                "_omitted": True,
+                "type": type(value).__name__,
+                "reason": "circular_reference",
+            }
+        _seen.add(value_id)
+        try:
+            if isinstance(value, dict):
+                return {str(k): _safe_json_value(v, _seen) for k, v in value.items()}
+            return [_safe_json_value(v, _seen) for v in value]
+        finally:
+            # Pop on the way back up so siblings sharing the same id (rare
+            # but legitimate, e.g. a shared sub-dict) aren't false-positive
+            # flagged as circular.
+            _seen.discard(value_id)
     # Leaf-level fallback: keep enough of the repr to identify the
     # object (class, key fields) without letting a giant binary blob
     # inflate the audit row.
@@ -663,6 +710,23 @@ def _safe_json_value(value: Any) -> Any:
     }
 
 
+def _safe_json_value_top(value: Any) -> Any:
+    """Top-level entry point with belt-and-suspenders ``RecursionError``
+    guard. The ``_safe_json_value`` walker carries cycle detection, but a
+    pathological non-cyclic depth (>1000 nested dicts) would still trip
+    Python's recursion limit. Turn any such crash into the same omit
+    marker so a successful tool call never 500s on audit-side
+    serialisation."""
+    try:
+        return _safe_json_value(value)
+    except RecursionError:
+        return {
+            "_omitted": True,
+            "type": type(value).__name__,
+            "reason": "circular_reference",
+        }
+
+
 def _omit_marker(value: Any) -> dict[str, Any]:
     """Sentinel payload used when ``result_summary`` must be dropped to
     fit under ``max_bytes``. Keeps the type hint for forensic readers
@@ -670,11 +734,43 @@ def _omit_marker(value: Any) -> dict[str, Any]:
     return {"_omitted": True, "type": type(value).__name__}
 
 
+def _parameters_omit_marker(value: Any, encoded_size: int) -> dict[str, Any]:
+    """Sentinel payload used when ``parameters`` themselves must be
+    dropped because they alone exceed ``max_bytes`` after the result
+    has already been omitted (P0 #1 oversize-parameters fix).
+
+    Forensic readers need at least the top-level shape of the original
+    parameters so the audit row stays actionable — without it the only
+    surviving signal would be the tool name, which loses the "what did
+    the agent ask for" trail. ``size_bytes`` carries the original
+    encoded length so a CISO can flag "agent shipped 100 KiB of input
+    to ``payments.transfer``" without recovering the secret values.
+    """
+    marker: dict[str, Any] = {
+        "_omitted": True,
+        "type": type(value).__name__,
+        "size_bytes": encoded_size,
+    }
+    if isinstance(value, dict):
+        # Top-level keys are usually structural (recipient, amount,
+        # memo) and not secret in themselves; preserve them as a
+        # forensic anchor. If a deployment treats the parameter keys
+        # themselves as PII it should redact via the denylist instead
+        # (see ``audit_redaction``).
+        try:
+            marker["top_level_keys"] = sorted(str(k) for k in value.keys())
+        except Exception:  # noqa: BLE001 — never let the marker raise
+            marker["top_level_keys"] = []
+    return marker
+
+
 def _build_success_detail(
     *,
     parameters: Any,
     result: Any,
     max_bytes: int,
+    tool_name: str | None = None,
+    redaction_settings: dict[str, Any] | None = None,
 ) -> str:
     """Build the canonical JSON ``detail`` payload for a successful
     ``tool_execute`` audit row.
@@ -684,21 +780,87 @@ def _build_success_detail(
     so the size check is deterministic and the result is a stable input
     to the per-row hash chain.
 
-    Truncation policy (in order):
+    Default behaviour captures both ``parameters`` and ``result_summary``
+    on every successful tool call. For regulated environments handling
+    PII / MNPI / deal-sensitive data, pass ``redaction_settings`` with
+    ``capture_parameters`` / ``capture_result`` toggles and matching
+    denylists (fnmatch glob patterns, e.g. ``payments.*``); see
+    :mod:`mcp_proxy.tools.audit_redaction`. The matching side is
+    replaced with a ``{"_redacted": True, "reason": ...}`` marker
+    before the size + truncation pipeline runs.
+
+    Truncation policy (in order, P0 #1 fix):
 
       1. Replace non-JSON-serialisable values with the repr fallback
-         from :func:`_safe_json_value`.
-      2. If the payload still exceeds ``max_bytes``, drop
+         from :func:`_safe_json_value`; circular references collapse to
+         the typed marker.
+      2. Apply redaction (when configured) — redacted markers are tiny
+         and consume budget proportionally.
+      3. If the payload still exceeds ``max_bytes``, drop
          ``result_summary`` to ``{"_omitted": True, "type": ...}`` and
          re-encode with a ``"detail_truncated": True`` flag.
-      3. If still over budget (oversize parameters alone), the helper
-         keeps the truncated marker and trusts ``log_audit``'s outer
-         16 KiB cap to refuse: this is a hard ceiling, not a soft
-         shaping rule, and we'd rather fail-deny than ship a row that
-         lies about its content.
+      4. If still over budget (oversize ``parameters`` alone — possible
+         because ``MAX_TOOL_PARAMETERS_BYTES`` is 128 KiB, well above
+         the 4 KiB / 16 KiB audit caps), drop ``parameters`` to a
+         structural marker that keeps the top-level keys + encoded
+         size for forensic anchoring. This guards against the failure
+         mode "tool handler committed side effects, audit row refused
+         by ``_enforce_audit_detail_size``, request becomes a 500
+         under ``audit_fail_deny=True``, agent retries, double-spend".
+      5. If even that is over budget (patological case — top-level keys
+         alone overflow 4 KiB), collapse both sides to bare markers
+         and trust the outer ``AUDIT_DETAILS_MAX_BYTES`` (16 KiB) cap
+         in :func:`mcp_proxy.db._enforce_audit_detail_size` to refuse;
+         the helper deliberately leaves that final cliff to the
+         boundary so the operator sees a structured error rather than
+         a row that lies about its content.
     """
-    safe_params = _safe_json_value(parameters)
-    safe_result = _safe_json_value(result)
+    from mcp_proxy.tools.audit_redaction import (
+        REASON_CAPTURE_DISABLED,
+        REASON_TOOL_DENYLIST,
+        redacted_marker,
+        should_redact_parameters,
+        should_redact_result,
+    )
+
+    safe_params: Any = _safe_json_value_top(parameters)
+    safe_result: Any = _safe_json_value_top(result)
+
+    if redaction_settings is not None:
+        capture_params_enabled = bool(
+            redaction_settings.get("capture_parameters", True),
+        )
+        capture_result_enabled = bool(
+            redaction_settings.get("capture_result", True),
+        )
+        params_denylist = list(
+            redaction_settings.get("parameters_denylist", []) or [],
+        )
+        result_denylist = list(
+            redaction_settings.get("result_denylist", []) or [],
+        )
+        if should_redact_parameters(
+            tool_name=tool_name,
+            capture_enabled=capture_params_enabled,
+            denylist=params_denylist,
+        ):
+            reason = (
+                REASON_CAPTURE_DISABLED
+                if not capture_params_enabled
+                else REASON_TOOL_DENYLIST
+            )
+            safe_params = redacted_marker(reason=reason)
+        if should_redact_result(
+            tool_name=tool_name,
+            capture_enabled=capture_result_enabled,
+            denylist=result_denylist,
+        ):
+            reason = (
+                REASON_CAPTURE_DISABLED
+                if not capture_result_enabled
+                else REASON_TOOL_DENYLIST
+            )
+            safe_result = redacted_marker(reason=reason)
 
     payload: dict[str, Any] = {
         "parameters": safe_params,
@@ -708,14 +870,50 @@ def _build_success_detail(
     if len(encoded.encode("utf-8")) <= max_bytes:
         return encoded
 
-    # Drop result first — parameters are usually the load-bearing signal
-    # for "what did the agent ask for", result is the noisier surface.
+    # Step 3 — drop result first. Parameters are usually the load-bearing
+    # signal for "what did the agent ask for", result is the noisier
+    # surface (logs, file dumps, embedding vectors).
     truncated_payload: dict[str, Any] = {
         "parameters": safe_params,
         "result_summary": _omit_marker(result),
         "detail_truncated": True,
     }
-    return _json.dumps(truncated_payload, sort_keys=True, separators=(",", ":"))
+    encoded = _json.dumps(truncated_payload, sort_keys=True, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return encoded
+
+    # Step 4 — parameters alone overflow. Measure the original encoded
+    # size so the forensic marker carries that signal. ``json.dumps`` on
+    # the safe-walked structure cannot raise here (already serialisable).
+    params_encoded_size = len(
+        _json.dumps(safe_params, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8",
+        ),
+    )
+    truncated_payload = {
+        "parameters": _parameters_omit_marker(parameters, params_encoded_size),
+        "result_summary": _omit_marker(result),
+        "detail_truncated": True,
+    }
+    encoded = _json.dumps(truncated_payload, sort_keys=True, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return encoded
+
+    # Step 5 — pathological: even the structural markers + top_level_keys
+    # overflow. Strip the keys hint and ship bare markers. The outer
+    # ``AUDIT_DETAILS_MAX_BYTES`` boundary still bounds this at 16 KiB,
+    # so the worst case here is "two markers without key lists", which
+    # is always tiny.
+    bare_payload: dict[str, Any] = {
+        "parameters": {
+            "_omitted": True,
+            "type": type(parameters).__name__,
+            "size_bytes": params_encoded_size,
+        },
+        "result_summary": _omit_marker(result),
+        "detail_truncated": True,
+    }
+    return _json.dumps(bare_payload, sort_keys=True, separators=(",", ":"))
 
 
 def _elapsed_ms(t0: float) -> float:

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -5,6 +5,7 @@ context assembly, handler invocation, and audit logging.
 from __future__ import annotations
 
 import asyncio
+import json as _json
 import logging
 import time
 from typing import Any
@@ -513,11 +514,26 @@ async def run(
                 duration_ms,
                 request_id,
             )
+            # Resolve the per-call cap lazily — keeps the executor
+            # importable when ``ProxySettings`` cannot be constructed
+            # (test fixtures that monkeypatch only the bits they care
+            # about), at the cost of one dict lookup per success path.
+            try:
+                from mcp_proxy.config import get_settings as _get_settings
+                _max_bytes = _get_settings().audit_detail_max_bytes
+            except Exception:  # noqa: BLE001 — never let config crash audit
+                _max_bytes = 4096
+            success_detail = _build_success_detail(
+                parameters=request.parameters,
+                result=result,
+                max_bytes=_max_bytes,
+            )
             await log_audit(
                 agent_id=agent.agent_id,
                 action="tool_execute",
                 tool_name=tool_name,
                 status="success",
+                detail=success_detail,
                 request_id=request_id,
                 duration_ms=duration_ms,
             )
@@ -605,6 +621,101 @@ async def run(
                 execution_time_ms=duration_ms,
                 denied_reason_code=INTERNAL_ERROR,
             )
+
+
+def _safe_json_value(value: Any) -> Any:
+    """Return a JSON-serialisable surrogate for ``value`` or a repr fallback.
+
+    The audit chain row hash is computed over a canonical JSON encoding of
+    ``detail``, so any non-serialisable input (custom objects, binary
+    blobs, ``datetime``, exceptions) must collapse to a string here before
+    ``json.dumps`` runs in :func:`_build_success_detail`. We never raise:
+    audit on the success path is best-effort metadata, not a gate, and a
+    ``ValueError`` from ``json.dumps`` would otherwise propagate up through
+    ``log_audit`` and turn a successful tool call into a 500. Returning a
+    truncated ``repr(...)`` + ``_non_serializable`` flag preserves
+    business-readable signal without poisoning the chain.
+
+    Containers are walked one level so a single bad leaf doesn't nuke
+    the whole ``parameters`` / ``result_summary`` business signal:
+    ``{"recipient": "acme", "when": datetime}`` becomes
+    ``{"recipient": "acme", "when": {"_non_serializable": True, ...}}``
+    rather than the whole dict collapsing.
+    """
+    # Fast happy path: value is JSON-clean as-is.
+    try:
+        _json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        pass
+
+    if isinstance(value, dict):
+        return {str(k): _safe_json_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_safe_json_value(v) for v in value]
+    # Leaf-level fallback: keep enough of the repr to identify the
+    # object (class, key fields) without letting a giant binary blob
+    # inflate the audit row.
+    return {
+        "_non_serializable": True,
+        "repr": repr(value)[:512],
+        "type": type(value).__name__,
+    }
+
+
+def _omit_marker(value: Any) -> dict[str, Any]:
+    """Sentinel payload used when ``result_summary`` must be dropped to
+    fit under ``max_bytes``. Keeps the type hint for forensic readers
+    so the operator knows what was elided."""
+    return {"_omitted": True, "type": type(value).__name__}
+
+
+def _build_success_detail(
+    *,
+    parameters: Any,
+    result: Any,
+    max_bytes: int,
+) -> str:
+    """Build the canonical JSON ``detail`` payload for a successful
+    ``tool_execute`` audit row.
+
+    Shape: ``{"parameters": <input>, "result_summary": <result>}``.
+    The encoding is ``json.dumps(..., sort_keys=True, separators=(",",":"))``
+    so the size check is deterministic and the result is a stable input
+    to the per-row hash chain.
+
+    Truncation policy (in order):
+
+      1. Replace non-JSON-serialisable values with the repr fallback
+         from :func:`_safe_json_value`.
+      2. If the payload still exceeds ``max_bytes``, drop
+         ``result_summary`` to ``{"_omitted": True, "type": ...}`` and
+         re-encode with a ``"detail_truncated": True`` flag.
+      3. If still over budget (oversize parameters alone), the helper
+         keeps the truncated marker and trusts ``log_audit``'s outer
+         16 KiB cap to refuse: this is a hard ceiling, not a soft
+         shaping rule, and we'd rather fail-deny than ship a row that
+         lies about its content.
+    """
+    safe_params = _safe_json_value(parameters)
+    safe_result = _safe_json_value(result)
+
+    payload: dict[str, Any] = {
+        "parameters": safe_params,
+        "result_summary": safe_result,
+    }
+    encoded = _json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= max_bytes:
+        return encoded
+
+    # Drop result first — parameters are usually the load-bearing signal
+    # for "what did the agent ask for", result is the noisier surface.
+    truncated_payload: dict[str, Any] = {
+        "parameters": safe_params,
+        "result_summary": _omit_marker(result),
+        "detail_truncated": True,
+    }
+    return _json.dumps(truncated_payload, sort_keys=True, separators=(",", ":"))
 
 
 def _elapsed_ms(t0: float) -> float:

--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -285,14 +285,28 @@ async def forward_to_mcp_resource(
     from mcp_proxy.config import get_settings as _get_settings
     from mcp_proxy.tools.executor import _build_success_detail
     try:
-        _max_bytes = _get_settings().audit_detail_max_bytes
+        _settings = _get_settings()
+        _max_bytes = _settings.audit_detail_max_bytes
+        _redaction_settings = {
+            "capture_parameters": _settings.audit_capture_tool_parameters,
+            "capture_result": _settings.audit_capture_tool_result,
+            "parameters_denylist": list(
+                _settings.audit_capture_tool_parameters_denylist,
+            ),
+            "result_denylist": list(
+                _settings.audit_capture_tool_result_denylist,
+            ),
+        }
     except Exception:  # noqa: BLE001 — audit best-effort
         _max_bytes = 4096
+        _redaction_settings = None
     try:
         success_payload = json.loads(_build_success_detail(
             parameters=ctx.parameters,
             result=rpc_result,
             max_bytes=_max_bytes,
+            tool_name=tool_def.name,
+            redaction_settings=_redaction_settings,
         ))
     except Exception:  # noqa: BLE001 — never let the audit helper crash forward
         success_payload = {}

--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -274,11 +274,34 @@ async def forward_to_mcp_resource(
             f"MCP resource RPC error: {err.get('message', 'unknown')}"
         )
 
+    rpc_result = data.get("result") if isinstance(data, dict) else data
+    # Mirror the executor success-path enrichment (PR feat/audit-detail-
+    # on-success-path): forward the agent's parameters + a result summary
+    # into ``local_audit.details`` so the dashboard ``/proxy/audit`` view
+    # shows business content for resource calls too, not just metadata.
+    # ``_build_success_detail`` already applies the per-call cap +
+    # truncation flag; we decode it back into a dict so it nests cleanly
+    # under ``audit_details`` instead of being a JSON string inside JSON.
+    from mcp_proxy.config import get_settings as _get_settings
+    from mcp_proxy.tools.executor import _build_success_detail
+    try:
+        _max_bytes = _get_settings().audit_detail_max_bytes
+    except Exception:  # noqa: BLE001 — audit best-effort
+        _max_bytes = 4096
+    try:
+        success_payload = json.loads(_build_success_detail(
+            parameters=ctx.parameters,
+            result=rpc_result,
+            max_bytes=_max_bytes,
+        ))
+    except Exception:  # noqa: BLE001 — never let the audit helper crash forward
+        success_payload = {}
+    enriched_details = {**audit_details, **success_payload}
     await append_local_audit(
         event_type="resource_call",
         result="ok",
         agent_id=ctx.agent_id,
         org_id=ctx.org_id,
-        details=audit_details,
+        details=enriched_details,
     )
-    return data.get("result") if isinstance(data, dict) else data
+    return rpc_result

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -4,36 +4,45 @@ The public repo does not host the full Mastio test suite (that lives in
 ``cullis-enterprise/legacy/tests/`` per CLAUDE.md), but feature PRs that
 touch ``mcp_proxy/`` ship targeted tests next to the change so the
 public diff carries its own verification. This file provides the
-minimal scaffolding (in-memory SQLite engine, migration skip, audit
-chain singleton reset) shared by those tests.
+minimal scaffolding (file-backed SQLite engine, migration skip via
+``metadata.create_all``, audit chain singleton reset) shared by those
+tests.
 """
 from __future__ import annotations
-
-import os
 
 import pytest
 
 
 @pytest.fixture
 def audit_test_env(monkeypatch, tmp_path):
-    """Initialise a fresh in-memory SQLite + audit chain for one test.
+    """Initialise a fresh file-backed SQLite + audit chain for one test.
 
-    Uses ``PROXY_SKIP_MIGRATIONS=1`` so the engine builds the schema
+    Forces ``PROXY_SKIP_MIGRATIONS=1`` so the engine builds the schema
     from ``metadata.create_all`` (alembic chain not needed for the
-    audit_log table verification). The batched audit chain singleton
-    is forced off so ``log_audit`` writes synchronously into the same
-    transaction the test inspects, instead of being queued behind a
-    background flush task that the test would have to wait on.
+    audit_log table verification — see ``db_models.AuditLogEntry`` which
+    declares ``dpop_jkt`` / ``on_behalf_of_user_id`` / ``hash_format``
+    so the metadata-built schema matches the production INSERT shape
+    introduced by migrations 0031, 0033, 0034, 0042). Skipping alembic
+    keeps the test suite cheap and removes the cross-env behaviour drift
+    the old (inconsistent) docstring documented.
+
+    The batched audit chain singleton is forced off so ``log_audit``
+    writes synchronously into the same transaction the test inspects,
+    instead of being queued behind a background flush task the test
+    would have to wait on.
     """
     # File-backed sqlite so multiple connections inside the test see the
-    # same data (the in-memory ":memory:" url creates a per-connection DB).
-    # Use ``alembic upgrade head`` (no PROXY_SKIP_MIGRATIONS) so the
-    # ``dpop_jkt`` / ``on_behalf_of_user_id`` columns added by post-2026-04
-    # migrations exist — ``metadata.create_all`` skips them because the
-    # SQLAlchemy model declarations live in the migration scripts only.
+    # same data (the in-memory ``:memory:`` URL creates a per-connection
+    # DB).
     db_path = tmp_path / "audit_test.db"
     db_url = f"sqlite+aiosqlite:///{db_path}"
     monkeypatch.setenv("MCP_PROXY_DATABASE_URL", db_url)
+    # Skip the alembic upgrade chain — ``metadata.create_all`` now covers
+    # every column ``log_audit`` references on INSERT (audit_log columns
+    # added by migrations 0031/0033/0034/0042 are mirrored on
+    # ``db_models.AuditLogEntry``). This makes the test deterministic
+    # across local + CI and shaves the per-test cold-start time.
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
     # Force the legacy per-row path so each log_audit call lands before
     # the assertion that follows it.
     monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,0 +1,46 @@
+"""Shared fixtures for the public Mastio test surface.
+
+The public repo does not host the full Mastio test suite (that lives in
+``cullis-enterprise/legacy/tests/`` per CLAUDE.md), but feature PRs that
+touch ``mcp_proxy/`` ship targeted tests next to the change so the
+public diff carries its own verification. This file provides the
+minimal scaffolding (in-memory SQLite engine, migration skip, audit
+chain singleton reset) shared by those tests.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def audit_test_env(monkeypatch, tmp_path):
+    """Initialise a fresh in-memory SQLite + audit chain for one test.
+
+    Uses ``PROXY_SKIP_MIGRATIONS=1`` so the engine builds the schema
+    from ``metadata.create_all`` (alembic chain not needed for the
+    audit_log table verification). The batched audit chain singleton
+    is forced off so ``log_audit`` writes synchronously into the same
+    transaction the test inspects, instead of being queued behind a
+    background flush task that the test would have to wait on.
+    """
+    # File-backed sqlite so multiple connections inside the test see the
+    # same data (the in-memory ":memory:" url creates a per-connection DB).
+    # Use ``alembic upgrade head`` (no PROXY_SKIP_MIGRATIONS) so the
+    # ``dpop_jkt`` / ``on_behalf_of_user_id`` columns added by post-2026-04
+    # migrations exist — ``metadata.create_all`` skips them because the
+    # SQLAlchemy model declarations live in the migration scripts only.
+    db_path = tmp_path / "audit_test.db"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", db_url)
+    # Force the legacy per-row path so each log_audit call lands before
+    # the assertion that follows it.
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    # Avoid the validate_config insecure-default refusal in dev.
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default")
+    # Reset the lru_cache so the new env vars take effect.
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    yield db_url
+    get_settings.cache_clear()

--- a/test/unit/test_audit_success_detail.py
+++ b/test/unit/test_audit_success_detail.py
@@ -1,0 +1,207 @@
+"""Verification for the tool_execute success-path audit detail.
+
+Branch: ``feat/audit-detail-on-success-path``.
+
+Today's success path in ``mcp_proxy.tools.executor.run`` writes an
+``audit_log`` row with no ``detail`` column populated — the dashboard
+``/proxy/audit`` page therefore renders "No detail attached to this
+event." for every successful tool call. This PR extends the helper so
+the row carries ``{"parameters": <input>, "result_summary": <result>}``
+in canonical JSON, with a per-call size cap and a truncation flag.
+
+These tests pin the helper's output shape, the truncation behaviour,
+the non-serialisable fallback, the hash-chain stability when the new
+detail is attached via the real ``log_audit`` path, and the settings
+override that lets operators tune the cap per deployment.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+
+import pytest
+
+from mcp_proxy.tools.executor import (
+    _build_success_detail,
+    _safe_json_value,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — parameters + result_summary land in detail.
+# ---------------------------------------------------------------------------
+def test_success_detail_contains_parameters_and_result_summary():
+    parameters = {"amount": 100, "recipient": "acme-corp"}
+    result = {"tx_id": "tx_001", "status": "ok"}
+
+    encoded = _build_success_detail(
+        parameters=parameters, result=result, max_bytes=4096,
+    )
+    decoded = json.loads(encoded)
+
+    assert decoded == {
+        "parameters": {"amount": 100, "recipient": "acme-corp"},
+        "result_summary": {"status": "ok", "tx_id": "tx_001"},
+    }
+    # No truncation flag on a small payload.
+    assert "detail_truncated" not in decoded
+    # Canonical encoding — sort_keys + tight separators — so the chain
+    # hash stays stable across Python implementations.
+    assert encoded == json.dumps(decoded, sort_keys=True, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# 2. Oversize payload triggers detail_truncated + size cap honored.
+# ---------------------------------------------------------------------------
+def test_success_detail_truncates_oversize_payload_and_flags_it():
+    parameters = {"query": "small"}
+    # 5 KiB string smashes through a 1 KiB budget — exactly the case the
+    # truncation strategy is designed for.
+    huge_result = {"blob": "x" * 5000}
+    max_bytes = 1024
+
+    encoded = _build_success_detail(
+        parameters=parameters, result=huge_result, max_bytes=max_bytes,
+    )
+    decoded = json.loads(encoded)
+
+    assert decoded["detail_truncated"] is True
+    assert decoded["parameters"] == {"query": "small"}
+    # result_summary collapsed to the omitted marker with the type hint.
+    assert decoded["result_summary"] == {"_omitted": True, "type": "dict"}
+    # Final payload is under the budget — the chain hash + the outer
+    # 16 KiB ``AUDIT_DETAILS_MAX_BYTES`` cap both depend on this.
+    assert len(encoded.encode("utf-8")) <= max_bytes
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-JSON-serialisable values fall back to repr + _non_serializable flag.
+# ---------------------------------------------------------------------------
+def test_success_detail_handles_non_json_serializable_values():
+    parameters = {
+        "when": datetime.datetime(2026, 5, 22, 12, 0, 0),
+        "buf": b"\x00\x01\x02binary",
+    }
+    result = {"ok": True}
+
+    encoded = _build_success_detail(
+        parameters=parameters, result=result, max_bytes=4096,
+    )
+    decoded = json.loads(encoded)
+
+    # Each non-serializable leaf collapses to the same surrogate shape.
+    when_marker = decoded["parameters"]["when"]
+    buf_marker = decoded["parameters"]["buf"]
+    for marker, type_name in ((when_marker, "datetime"), (buf_marker, "bytes")):
+        assert marker["_non_serializable"] is True
+        assert marker["type"] == type_name
+        # repr is truncated to 512 chars so a giant binary cannot inflate
+        # the audit row.
+        assert isinstance(marker["repr"], str)
+        assert len(marker["repr"]) <= 512
+
+    # The serialisable result still rides through untouched.
+    assert decoded["result_summary"] == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# 4. Hash-chain integrity holds when the new detail is attached.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_hash_chain_stays_consistent_with_success_detail(audit_test_env):
+    """Write two audit rows back-to-back with the new detail payload and
+    verify the hash chain is intact end-to-end.
+
+    Regression for the canonical-form requirement: the per-row hash is
+    computed over ``detail`` as-is, so any non-determinism in
+    ``_build_success_detail`` (key order, separator drift) would break
+    ``verify_audit_chain`` on the next boot.
+    """
+    from mcp_proxy.db import init_db, log_audit, verify_audit_chain
+
+    await init_db(audit_test_env)
+
+    detail_1 = _build_success_detail(
+        parameters={"amount": 50},
+        result={"tx_id": "row1"},
+        max_bytes=4096,
+    )
+    detail_2 = _build_success_detail(
+        parameters={"amount": 75},
+        result={"tx_id": "row2"},
+        max_bytes=4096,
+    )
+
+    await log_audit(
+        agent_id="agent-1",
+        action="tool_execute",
+        status="success",
+        tool_name="payments.transfer",
+        detail=detail_1,
+        request_id="req-1",
+        duration_ms=12.0,
+    )
+    await log_audit(
+        agent_id="agent-1",
+        action="tool_execute",
+        status="success",
+        tool_name="payments.transfer",
+        detail=detail_2,
+        request_id="req-2",
+        duration_ms=14.0,
+    )
+
+    ok, break_seq, msg = await verify_audit_chain()
+    assert ok is True, f"chain broken at seq={break_seq}: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# 5. Operator-supplied cap via MCP_PROXY_AUDIT_DETAIL_MAX_BYTES is honored.
+# ---------------------------------------------------------------------------
+def test_settings_override_caps_detail_size(monkeypatch):
+    """Verify the ``audit_detail_max_bytes`` Settings field is wired to
+    the executor success path (the executor reads ``get_settings()`` on
+    every success log_audit). We exercise the helper directly here with
+    the value the settings layer would have passed in."""
+    monkeypatch.setenv("MCP_PROXY_AUDIT_DETAIL_MAX_BYTES", "512")
+    # ProxySettings refuses the insecure default in dev too (audit F-A-507),
+    # so the test must always set a non-default admin secret.
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default")
+    # Reset settings cache so the new env value takes effect.
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.audit_detail_max_bytes == 512
+
+        # Payload larger than 512 must trigger truncation when the cap
+        # from settings is the budget passed to the helper.
+        encoded = _build_success_detail(
+            parameters={"recipient": "acme"},
+            result={"blob": "x" * 1000},
+            max_bytes=settings.audit_detail_max_bytes,
+        )
+        decoded = json.loads(encoded)
+        assert decoded["detail_truncated"] is True
+        assert len(encoded.encode("utf-8")) <= 512
+    finally:
+        get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# 6. Helper is defensive — _safe_json_value never raises.
+# ---------------------------------------------------------------------------
+def test_safe_json_value_passes_serializable_through_unchanged():
+    for value in (None, 1, 1.5, "s", True, [1, 2], {"k": "v"}):
+        assert _safe_json_value(value) == value
+
+
+def test_safe_json_value_marks_non_serializable_with_repr():
+    class _Custom:
+        def __repr__(self) -> str:
+            return "<Custom instance xyz>"
+
+    marker = _safe_json_value(_Custom())
+    assert marker["_non_serializable"] is True
+    assert marker["type"] == "_Custom"
+    assert "Custom instance" in marker["repr"]

--- a/test/unit/test_audit_success_detail.py
+++ b/test/unit/test_audit_success_detail.py
@@ -10,13 +10,18 @@ the row carries ``{"parameters": <input>, "result_summary": <result>}``
 in canonical JSON, with a per-call size cap and a truncation flag.
 
 These tests pin the helper's output shape, the truncation behaviour,
-the non-serialisable fallback, the hash-chain stability when the new
-detail is attached via the real ``log_audit`` path, and the settings
-override that lets operators tune the cap per deployment.
+the non-serialisable fallback (including circular references), the
+oversize-parameters fallback (so a 32 KiB params blob can never
+trigger a 500 inside ``log_audit`` after the handler has already
+committed), the redaction denylist + master switch, the hash-chain
+stability when the new detail is attached via the real ``log_audit``
+path, the settings override that lets operators tune the cap per
+deployment, and a pinned ``row_hash`` digest that protects the
+canonical form from silent drift in NDJSON export verification.
 """
 from __future__ import annotations
 
-import datetime
+import datetime as _dt
 import json
 
 import pytest
@@ -79,7 +84,7 @@ def test_success_detail_truncates_oversize_payload_and_flags_it():
 # ---------------------------------------------------------------------------
 def test_success_detail_handles_non_json_serializable_values():
     parameters = {
-        "when": datetime.datetime(2026, 5, 22, 12, 0, 0),
+        "when": _dt.datetime(2026, 5, 22, 12, 0, 0),
         "buf": b"\x00\x01\x02binary",
     }
     result = {"ok": True}
@@ -205,3 +210,351 @@ def test_safe_json_value_marks_non_serializable_with_repr():
     assert marker["_non_serializable"] is True
     assert marker["type"] == "_Custom"
     assert "Custom instance" in marker["repr"]
+
+
+# ---------------------------------------------------------------------------
+# 7. P0 #1 — oversize parameters never bubble up a RuntimeError from
+#    log_audit. A 32 KiB parameters blob (legitimate per
+#    ``MAX_TOOL_PARAMETERS_BYTES=128 KiB`` in ``mcp_proxy.models``)
+#    exceeds the 16 KiB outer ``AUDIT_DETAILS_MAX_BYTES`` cap, so the
+#    helper MUST drop ``parameters`` to a structural marker too rather
+#    than leaving the raw blob and letting ``_enforce_audit_detail_size``
+#    refuse the row (and 500 the request after the handler committed
+#    side effects — double-spend territory).
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_oversize_parameters_do_not_break_log_audit(audit_test_env):
+    """Reproduce the P0 #1 path: parameters alone overflow the audit cap.
+
+    Pre-fix: ``_build_success_detail`` only truncated ``result_summary``,
+    so a 32 KiB parameters payload made it through unchanged → outer
+    16 KiB ``_enforce_audit_detail_size`` raised → ``log_audit`` raised
+    → caller got 500 → agent retried → side effect duplicated.
+
+    Post-fix: parameters get the ``_parameters_omit_marker`` treatment
+    (omit + structural keys + size_bytes), the detail stays under the
+    operator-tuned cap, the row lands, no 500.
+    """
+    from mcp_proxy.db import init_db, log_audit, verify_audit_chain
+
+    await init_db(audit_test_env)
+
+    # 32 KiB of input — well below ``MAX_TOOL_PARAMETERS_BYTES=128 KiB``
+    # (an entirely legitimate value at the model boundary) but well above
+    # both the 4 KiB per-call cap and the 16 KiB outer cap.
+    huge_parameters = {
+        "memo": "x" * 32 * 1024,
+        "recipient": "acme-corp",
+        "amount": 1500,
+    }
+    result = {"tx_id": "TX-001", "status": "ok"}
+
+    detail = _build_success_detail(
+        parameters=huge_parameters,
+        result=result,
+        max_bytes=4096,
+    )
+
+    # Sanity: encoded form fits in the 4 KiB budget, and the row carries
+    # the truncated-flag + the parameters omit marker (with the top-level
+    # keys + size hint as the forensic anchor).
+    assert len(detail.encode("utf-8")) <= 4096
+    decoded = json.loads(detail)
+    assert decoded["detail_truncated"] is True
+    assert decoded["parameters"]["_omitted"] is True
+    assert decoded["parameters"]["type"] == "dict"
+    assert decoded["parameters"]["size_bytes"] > 32_000
+    assert set(decoded["parameters"]["top_level_keys"]) == {
+        "amount", "memo", "recipient",
+    }
+    assert decoded["result_summary"]["_omitted"] is True
+
+    # And the real ``log_audit`` path accepts the row — no RuntimeError
+    # propagates, the chain stays intact.
+    await log_audit(
+        agent_id="agent-oversize",
+        action="tool_execute",
+        status="success",
+        tool_name="payments.transfer",
+        detail=detail,
+        request_id="req-oversize-1",
+        duration_ms=10.0,
+    )
+    ok, broken_seq, msg = await verify_audit_chain()
+    assert ok is True, f"chain broken at seq={broken_seq}: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# 8. P0 #2 — circular references in parameters / result no longer
+#    blow the recursion stack inside ``_safe_json_value``. The walker
+#    tracks ``id(value)`` so a self-referencing dict collapses to the
+#    circular-reference marker rather than driving Python to a
+#    RecursionError that propagates through ``log_audit``.
+# ---------------------------------------------------------------------------
+def test_circular_reference_in_parameters_yields_marker():
+    """``d = {}; d['self'] = d`` is the canonical trigger. SQLAlchemy ORM
+    objects with ``relationship(backref=...)`` produce the same shape via
+    ``__dict__`` when a tool handler hands one back as-is. Either way the
+    helper must terminate."""
+    parameters: dict[str, object] = {"recipient": "acme"}
+    parameters["self"] = parameters
+    result = {"ok": True}
+
+    detail = _build_success_detail(
+        parameters=parameters,
+        result=result,
+        max_bytes=4096,
+    )
+    decoded = json.loads(detail)
+
+    # The outer dict is rebuilt, the cyclic edge collapses to the marker.
+    assert decoded["parameters"]["recipient"] == "acme"
+    self_marker = decoded["parameters"]["self"]
+    assert self_marker["_omitted"] is True
+    assert self_marker["reason"] == "circular_reference"
+    assert self_marker["type"] == "dict"
+    assert decoded["result_summary"] == {"ok": True}
+
+
+def test_circular_reference_in_result_orm_like_shape():
+    """Simulate the SQLAlchemy ORM gotcha: a result object whose
+    ``__dict__`` contains a reference back to itself via a backref-style
+    relationship. The helper walks containers (dict / list) and falls
+    back to a leaf marker for everything else; the bug pre-fix would
+    have shown up only on objects whose ``json.dumps`` failure path
+    forced the recursive dict walk into the cycle. Here we drive that
+    path directly with a self-referencing dict embedded in the result
+    structure."""
+    inner: dict[str, object] = {"name": "Transaction"}
+    inner["parent"] = inner  # ORM backref shape
+
+    parameters = {"k": "v"}
+    result = {"row": inner, "siblings": [inner, inner]}
+
+    detail = _build_success_detail(
+        parameters=parameters,
+        result=result,
+        max_bytes=8192,
+    )
+    decoded = json.loads(detail)
+
+    # The first visit succeeds at the top level; the back-edge collapses.
+    assert decoded["result_summary"]["row"]["name"] == "Transaction"
+    parent_marker = decoded["result_summary"]["row"]["parent"]
+    assert parent_marker["_omitted"] is True
+    assert parent_marker["reason"] == "circular_reference"
+    # Siblings list — each element is the same object as ``row``. Because
+    # ``_seen`` is popped on the way back up (siblings, not ancestors,
+    # share the id), they get walked again normally and again collapse
+    # internally — they are not falsely flagged at the outer level.
+    assert decoded["result_summary"]["siblings"][0]["name"] == "Transaction"
+    assert decoded["result_summary"]["siblings"][1]["name"] == "Transaction"
+
+
+# ---------------------------------------------------------------------------
+# 9. P1 #1 — redaction denylist (per-tool) + master switch (all tools).
+# ---------------------------------------------------------------------------
+def test_redaction_denylist_redacts_parameters_only():
+    """``parameters_denylist=['payments.*']`` + tool ``payments.transfer``
+    must redact parameters while leaving result_summary captured."""
+    detail = _build_success_detail(
+        parameters={"recipient": "acme", "amount": 1500, "iban": "IT60X0..."},
+        result={"tx_id": "TX-001", "status": "ok"},
+        max_bytes=4096,
+        tool_name="payments.transfer",
+        redaction_settings={
+            "capture_parameters": True,
+            "capture_result": True,
+            "parameters_denylist": ["payments.*"],
+            "result_denylist": [],
+        },
+    )
+    decoded = json.loads(detail)
+    assert decoded["parameters"] == {
+        "_redacted": True, "reason": "tool_denylist",
+    }
+    # Result is untouched — the deployment captured it.
+    assert decoded["result_summary"] == {"status": "ok", "tx_id": "TX-001"}
+
+
+def test_redaction_master_switch_redacts_all_parameters():
+    """``capture_parameters=False`` redacts every tool's parameters
+    regardless of the denylist (use case: PII-pervasive deployment that
+    can't enumerate tools individually)."""
+    detail = _build_success_detail(
+        parameters={"query": "natural language user input"},
+        result={"answer": "structured output"},
+        max_bytes=4096,
+        tool_name="search.semantic",
+        redaction_settings={
+            "capture_parameters": False,
+            "capture_result": True,
+            "parameters_denylist": [],
+            "result_denylist": [],
+        },
+    )
+    decoded = json.loads(detail)
+    assert decoded["parameters"] == {
+        "_redacted": True, "reason": "capture_disabled",
+    }
+    assert decoded["result_summary"] == {"answer": "structured output"}
+
+
+def test_redaction_denylist_no_match_passes_through():
+    """A tool that doesn't match any denylist pattern under the default
+    capture-on stance gets its full parameters captured (the regression
+    guard for "fix #1 doesn't accidentally redact everyone")."""
+    detail = _build_success_detail(
+        parameters={"recipient": "alice"},
+        result={"ok": True},
+        max_bytes=4096,
+        tool_name="email.send",
+        redaction_settings={
+            "capture_parameters": True,
+            "capture_result": True,
+            "parameters_denylist": ["payments.*"],
+            "result_denylist": ["trading.*"],
+        },
+    )
+    decoded = json.loads(detail)
+    assert decoded["parameters"] == {"recipient": "alice"}
+    assert decoded["result_summary"] == {"ok": True}
+
+
+def test_redaction_settings_parsed_from_env(monkeypatch):
+    """The settings layer accepts comma-separated env strings for the
+    denylist fields (operator UX) and JSON arrays (programmatic
+    config). Both reach ``audit_capture_tool_parameters_denylist`` as
+    a Python list."""
+    monkeypatch.setenv(
+        "MCP_PROXY_AUDIT_CAPTURE_TOOL_PARAMETERS_DENYLIST",
+        "payments.*, trading.transfer ,kyc.*",
+    )
+    monkeypatch.setenv(
+        "MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default",
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        settings = get_settings()
+        assert settings.audit_capture_tool_parameters_denylist == [
+            "payments.*", "trading.transfer", "kyc.*",
+        ]
+        # Default master switch is True.
+        assert settings.audit_capture_tool_parameters is True
+        assert settings.audit_capture_tool_result is True
+    finally:
+        get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# 10. P1 #3 — pinned ``row_hash`` digest. The chain-self-verification
+#     test above is tautological (write rows → verify chain → pass),
+#     so a future canonical-form change in ``_build_success_detail``
+#     would silently break verification against NDJSON exports created
+#     today. This test pins a single ``row_hash`` against a known input
+#     so that any drift in the canonical form trips the test (and the
+#     operator can then decide: bump ``hash_format`` to v3 + write a
+#     migration, or revert the canonical change).
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_known_audit_row_hash_pinned(audit_test_env, monkeypatch):
+    """Pin a specific SHA-256 digest for a controlled input.
+
+    The pinned hash protects:
+      * the canonical form of ``_build_success_detail`` (sort_keys +
+        tight separators),
+      * the v2 hash format in ``compute_audit_row_hash`` (the leading
+        ``v2|`` literal + the dpop_jkt / on_behalf_of_user_id binding),
+      * the field ordering inside ``compute_audit_row_hash``.
+
+    Drift in any of those fails this test — the operator gets a loud
+    signal in the diff PR instead of a silent NDJSON-verification
+    regression months later.
+    """
+    from mcp_proxy.db import init_db, log_audit
+    from sqlalchemy import text
+
+    # Freeze the wall clock so the timestamp that feeds into
+    # ``compute_audit_row_hash`` is deterministic across CI runs. The
+    # ``log_audit`` body calls ``datetime.now(timezone.utc).isoformat()``
+    # on a module-level ``datetime`` import (``from datetime import
+    # datetime, timezone``), so patch that symbol on the ``mcp_proxy.db``
+    # module.
+    import mcp_proxy.db as _db_mod
+
+    class _FrozenDatetime:
+        @classmethod
+        def now(cls, tz=None):  # noqa: ARG003 — interface contract
+            return _dt.datetime(
+                2026, 5, 22, 12, 0, 0, 0, tzinfo=_dt.timezone.utc,
+            )
+
+    monkeypatch.setattr(_db_mod, "datetime", _FrozenDatetime)
+
+    await init_db(audit_test_env)
+
+    detail = _build_success_detail(
+        parameters={"k": "v"},
+        result={"ok": True},
+        max_bytes=4096,
+    )
+    # Sanity: the canonical form of the detail itself is pinned.
+    assert detail == '{"parameters":{"k":"v"},"result_summary":{"ok":true}}'
+
+    await log_audit(
+        agent_id="test-agent",
+        action="tool_execute",
+        status="success",
+        tool_name="example",
+        detail=detail,
+        request_id="req-pinned-001",
+    )
+
+    # Read the row back and pin its ``row_hash``.
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT row_hash, hash_format, chain_seq, prev_hash, "
+            "timestamp FROM audit_log WHERE request_id = :rid"
+        ), {"rid": "req-pinned-001"})).first()
+
+    assert row is not None, "audit row did not land"
+    assert row[1] == "v2"
+    assert row[2] == 1
+    assert row[3] == "genesis"
+    assert row[4] == "2026-05-22T12:00:00+00:00"
+
+    # The expected hash is computed via ``compute_audit_row_hash`` with
+    # the exact inputs above (v2 format, frozen timestamp, the detail
+    # pinned earlier, prev_hash="genesis", chain_seq=1, both
+    # dpop_jkt and on_behalf_of_user_id NULL). The value is pinned
+    # here as a literal so a canonical-form drift in either
+    # ``_build_success_detail`` or ``compute_audit_row_hash`` trips
+    # the diff PR.
+    expected = (
+        "3efdd5aece3931c3370a3befb9e9307e134a23a0aa1d59b07b5f43674a3719b4"
+    )
+    # Recompute via the production helper to catch a divergence between
+    # the helper and the SQL-stored value too (defence in depth).
+    from mcp_proxy.db import compute_audit_row_hash
+    recomputed = compute_audit_row_hash(
+        chain_seq=1,
+        timestamp="2026-05-22T12:00:00+00:00",
+        agent_id="test-agent",
+        action="tool_execute",
+        tool_name="example",
+        status="success",
+        detail=detail,
+        request_id="req-pinned-001",
+        prev_hash="genesis",
+        dpop_jkt=None,
+        on_behalf_of_user_id=None,
+        hash_format="v2",
+    )
+    assert recomputed == row[0]
+    assert row[0] == expected, (
+        f"row_hash drift: stored={row[0]} expected={expected}. "
+        "If this is intentional, bump hash_format (v2 -> v3), write a "
+        "migration, and update the pinned digest."
+    )


### PR DESCRIPTION
## Summary

- Extend `mcp_proxy/tools/executor.py:516-523` success-path `log_audit` so the row carries `{"parameters": <input>, "result_summary": <result>}` as canonical JSON — today the column is NULL and `/proxy/audit` shows "No detail attached to this event." for every successful tool call.
- Same enrichment on `mcp_proxy/tools/mcp_resource_forwarder.py` success path (`resource_call` event), so the `local_audit` chain shows business shape for forwarded MCP resource calls too.
- Per-call size cap (default 4 KiB, configurable via `MCP_PROXY_AUDIT_DETAIL_MAX_BYTES`) with deterministic truncation + `detail_truncated: true` flag; non-JSON-serialisable leaves fall back to `repr(...)` + `_non_serializable` marker without nuking the rest of the payload.

## Audit row, before / after

**Before** (`audit_log.detail` is NULL on success):
```
(no detail attached — empty string)
```

**After** (this PR, `audit_log.detail` JSON, sample from `_build_success_detail`):
```json
{
  "parameters": {
    "amount_eur": 1500,
    "recipient": "acme-corp"
  },
  "result_summary": {
    "confirmation_at": "2026-05-22T10:33:01Z",
    "status": "settled",
    "tx_id": "TX-2026-05-22-001"
  }
}
```

Oversize payload sample (`max_bytes=1024`, `result={"blob": "x" * 5000}`):
```json
{
  "detail_truncated": true,
  "parameters": {"query": "small"},
  "result_summary": {"_omitted": true, "type": "dict"}
}
```

The dashboard's `audit.html` already pretty-prints JSON detail via `_pretty_and_recipient` (`mcp_proxy/dashboard/audit_routes.py:39`), so the new content renders on `/proxy/audit` without template changes.

## Test plan

- [x] `_build_success_detail` produces `{"parameters", "result_summary"}` canonical JSON (sort_keys + tight separators) for normal inputs
- [x] Oversize payload sets `detail_truncated: true` and `result_summary` collapses to `{"_omitted": True, "type": ...}` within `max_bytes`
- [x] Non-JSON-serialisable leaves (datetime, bytes, custom objects) fall back to `repr(...)` + `_non_serializable` flag without breaking neighbouring keys
- [x] Hash chain via real `log_audit` + `verify_audit_chain` stays consistent across two consecutive rows with the new detail
- [x] `MCP_PROXY_AUDIT_DETAIL_MAX_BYTES=512` override is honored by `get_settings()` and the helper respects it
- [x] `_safe_json_value` passes serializable input through unchanged + marks non-serializable with repr
- [ ] (manual, post-merge) Verify `/proxy/audit` dashboard renders the new JSON pretty-printed on a live Mastio after one tool call

7 unit tests pass under `pytest test/unit/ -n auto --dist=loadfile`.

## Notes

- Settings field added next to existing `audit_chain_*` knobs in `config.py:378`; 4 KiB default sits well below the 16 KiB hard cap in `_enforce_audit_detail_size` (`db.py:368`) so a single noisy tool cannot dominate the chain or amplify the per-row hash cost
- Other `log_audit` call sites in `executor.py` (timeout 540, ToolExecutionError 566, generic Exception 591, policy.tier_evaluated 680) already had `detail=` populated — this PR is scoped to the success path gap surfaced in the founder's `/proxy/audit` review
- ADR-410 family (`AUDIT_DETAILS_MAX_BYTES`) remains the outer hard cap; the new `audit_detail_max_bytes` is a per-call shaping rule that lives below it