### PR TITLE
feat(audit): chain-integrity verify endpoint + Cullis Audit Envelope + grouped CISO dashboard

### DIFF
--- a/cullis_sdk/audit.py
+++ b/cullis_sdk/audit.py
@@ -1,0 +1,178 @@
+"""Cullis Audit Envelope helpers (ADR-039).
+
+The "Cullis Audit Envelope" is the convention that turns a tool's raw
+RPC return value into a business-readable audit row on the Mastio
+dashboard. Every tool in the Cullis ecosystem is expected to attach a
+``_cullis_audit`` sidecar to its result — three short strings that
+answer "what was the action", "what did it act on", and "what was the
+outcome", in the language a CISO would use to read the log.
+
+Without the envelope, the dashboard still shows the tool name and a
+URL fallback (graceful degradation). With it, the card header reads
+``Pre-trade risk check: BUY €5,000,000 FR0000571085 → approved``
+instead of ``Tool invoked: risk_check``.
+
+Spec
+----
+
+The envelope is a dict with exactly three required string fields::
+
+    {
+        "action":  "Pre-trade risk check",     # what happened (verb-phrase)
+        "subject": "BUY €5,000,000 FR0000571085",  # what was acted upon
+        "outcome": "approved: within mandate (1d VaR €58,150)",  # the result, business terms
+    }
+
+Mastio reads the envelope from anywhere inside the tool result by
+walking the JSON tree, so you can put it at the top level alongside
+``ok``/``error`` or inside a nested ``content`` block — both work.
+
+Usage
+-----
+
+The ``envelope()`` helper attaches the envelope to an existing result
+dict in one call::
+
+    from cullis_sdk.audit import envelope
+
+    @mcp.tool()
+    async def place_order(isin: str, qty: int, price: float):
+        result = await broker.execute(isin, qty, price)
+        return envelope(
+            result,
+            action="Order placement",
+            subject=f"BUY {qty:,} × {isin} @ €{price:,.2f}",
+            outcome=f"filled: order #{result['order_id']}",
+        )
+
+For tools you don't own (third-party MCP servers), the dashboard falls
+back to the tool name + endpoint URL automatically. You can also
+override the display on the Mastio side by attaching an
+``audit_template`` to the tool registry entry — see ADR-039 §4.
+
+Field length budget
+-------------------
+
+The dashboard truncates each field at roughly the lengths below before
+rendering. Stay inside these to keep the card header on one line:
+
+* ``action``  ≤ 40 characters
+* ``subject`` ≤ 80 characters
+* ``outcome`` ≤ 120 characters
+
+Longer values are accepted and stored verbatim in the audit chain;
+only the rendered header is clipped.
+"""
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+T = TypeVar("T", bound=dict)
+
+
+_CULLIS_AUDIT_KEY = "_cullis_audit"
+
+
+def envelope(
+    result: T,
+    *,
+    action: str,
+    subject: str,
+    outcome: str,
+) -> T:
+    """Attach a Cullis Audit Envelope to a tool result.
+
+    Mutates ``result`` in place by adding a ``_cullis_audit`` key and
+    returns the same dict so callers can ``return envelope(...)`` in
+    a single line.
+
+    Raises ``TypeError`` if ``result`` is not a dict-like object — the
+    envelope only attaches to JSON object responses. For tools that
+    return a list or a scalar, wrap the response in a dict before
+    calling.
+
+    Args:
+        result: The tool's native return payload. Mutated in place.
+        action: Verb-phrase describing what the tool did.
+            E.g. "Market data lookup", "KYC screening",
+            "DORA incident logged".
+        subject: The thing acted upon, in human-readable form.
+            E.g. an ISIN, a customer id, an incident id.
+        outcome: The result of the action in business language.
+            E.g. "approved: within mandate", "rejected: off universe".
+
+    Returns:
+        The same ``result`` dict, with ``_cullis_audit`` attached.
+    """
+    if not isinstance(result, dict):
+        raise TypeError(
+            "Cullis Audit Envelope can only attach to a dict result. "
+            f"Got {type(result).__name__}; wrap your value in a dict first."
+        )
+    result[_CULLIS_AUDIT_KEY] = {
+        "action": action,
+        "subject": subject,
+        "outcome": outcome,
+    }
+    return result
+
+
+def make_envelope(
+    *,
+    action: str,
+    subject: str,
+    outcome: str,
+) -> dict[str, str]:
+    """Build a Cullis Audit Envelope as a standalone dict.
+
+    Useful when you want to construct the envelope separately from the
+    result, e.g. to share it across a try/except. The returned dict
+    has the exact shape Mastio expects under ``_cullis_audit``.
+    """
+    return {"action": action, "subject": subject, "outcome": outcome}
+
+
+def extract(payload: Any) -> dict[str, str] | None:
+    """Pull a Cullis Audit Envelope out of an arbitrary JSON-ish payload.
+
+    Mirrors the server-side reader: walks the parsed tree (dicts and
+    lists) up to a small depth and returns the first ``_cullis_audit``
+    object that has all three required fields. Returns ``None`` if
+    nothing was found — callers should treat that as "fall back to the
+    generic display path".
+
+    Mainly useful for tests and for tools that want to forward an
+    upstream envelope through their own response wrapper.
+    """
+    return _walk(payload, depth=0)
+
+
+def _walk(node: Any, depth: int) -> dict[str, str] | None:
+    if depth > 8 or node is None:
+        return None
+    if isinstance(node, dict):
+        env = node.get(_CULLIS_AUDIT_KEY)
+        if (
+            isinstance(env, dict)
+            and isinstance(env.get("action"), str)
+            and isinstance(env.get("subject"), str)
+            and isinstance(env.get("outcome"), str)
+        ):
+            return {
+                "action": env["action"],
+                "subject": env["subject"],
+                "outcome": env["outcome"],
+            }
+        for v in node.values():
+            found = _walk(v, depth + 1)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for v in node:
+            found = _walk(v, depth + 1)
+            if found is not None:
+                return found
+    return None
+
+
+__all__ = ["envelope", "make_envelope", "extract"]

--- a/mcp_proxy/dashboard/audit_routes.py
+++ b/mcp_proxy/dashboard/audit_routes.py
@@ -21,12 +21,12 @@ import logging
 import pathlib
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.responses import RedirectResponse
 
 from mcp_proxy.dashboard._helpers import _ctx
 from mcp_proxy.dashboard._template_env import build_templates
-from mcp_proxy.dashboard.session import require_login
+from mcp_proxy.dashboard.session import require_login, verify_csrf
 
 _log = logging.getLogger("mcp_proxy.dashboard")
 
@@ -34,6 +34,37 @@ _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
 templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(tags=["dashboard-audit"])
+
+
+def _unnest_json_strings(node, _depth: int = 0):
+    """Recursively re-parse JSON-encoded strings found inside a parsed payload.
+
+    MCP ``TextContent`` carries ``{"type": "text", "text": "<json string>"}``,
+    so the audit ``detail`` ends up rendering as ``"text": "{\\"ok\\": ...}"``
+    — readable, but every nested quote shows up as ``\\"``. When we see a
+    string that round-trips through ``json.loads`` into a dict/list, we
+    substitute the parsed value so the inspector shows the underlying
+    object indented inline rather than a single escaped one-liner.
+
+    Depth cap guards against pathological self-referential payloads.
+    """
+    import json as _json
+    if _depth >= 6:
+        return node
+    if isinstance(node, dict):
+        return {k: _unnest_json_strings(v, _depth + 1) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_unnest_json_strings(v, _depth + 1) for v in node]
+    if isinstance(node, str):
+        stripped = node.strip()
+        if stripped.startswith(("{", "[")) and stripped.endswith(("}", "]")) and len(stripped) >= 2:
+            try:
+                inner = _json.loads(stripped)
+            except (ValueError, TypeError):
+                return node
+            if isinstance(inner, (dict, list)):
+                return _unnest_json_strings(inner, _depth + 1)
+    return node
 
 
 def _pretty_and_recipient(raw: str | None) -> tuple[str | None, str | None]:
@@ -52,7 +83,6 @@ def _pretty_and_recipient(raw: str | None) -> tuple[str | None, str | None]:
         parsed = _json.loads(raw)
     except (ValueError, TypeError):
         return raw, None
-    pretty = _json.dumps(parsed, indent=2, sort_keys=True)
     recipient = None
     if isinstance(parsed, dict):
         recipient = (
@@ -61,7 +91,313 @@ def _pretty_and_recipient(raw: str | None) -> tuple[str | None, str | None]:
             or parsed.get("target_agent_id")
             or parsed.get("target")
         )
+    unnested = _unnest_json_strings(parsed)
+    pretty = _json.dumps(unnested, indent=2, sort_keys=True)
     return pretty, recipient
+
+
+def _derive_org_from_agent_id(agent_id: str | None) -> str | None:
+    """Pull the org prefix from a typed agent id like ``orga::agent-name``.
+
+    ``audit_log`` rows don't carry ``org_id`` directly the way the hash-chained
+    ``local_audit`` rows do, but the SPIFFE-shaped ``agent_id`` always carries
+    it as the leading component before ``::``. Surface it so the inspector
+    side panel can show ``Org`` consistently across both audit streams.
+    """
+    if not agent_id or "::" not in agent_id:
+        return None
+    head = agent_id.split("::", 1)[0]
+    return head or None
+
+
+def _extract_mcp_request_id(raw_details: str | None) -> str | None:
+    """Pull ``mcp_request_id`` out of ``local_audit.details`` JSON.
+
+    ``mcp_resource_forwarder.py`` writes the executor-side ``request_id``
+    into ``audit_details["mcp_request_id"]`` so the dashboard can join
+    the traffic-stream ``resource_call`` row with the admin-stream
+    ``tool_execute`` + ``policy.*`` rows that fan out from the same
+    tool call. Returns ``None`` gracefully on legacy rows that pre-date
+    that change.
+    """
+    if not raw_details:
+        return None
+    import json as _json
+    try:
+        parsed = _json.loads(raw_details)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    rid = parsed.get("mcp_request_id")
+    if rid is None:
+        return None
+    return str(rid)
+
+
+# Events that participate in the "one tool call → many audit rows"
+# fan-out. Anything not in this set stays as a singleton group on the
+# dashboard (auth.login, enrollment.*, agent.cert.rotate, etc).
+_TOOL_CALL_EVENTS = frozenset({
+    "tool_execute",
+    "resource_call",
+    "policy.no_capability_required",
+})
+
+# Status precedence — when multiple events share a group_key, the worst
+# outcome wins for the card-level badge. ``denied`` beats ``error``
+# beats ``success`` so a single capability-deny on the policy row
+# colours the whole card red even if the (never-executed) tool_execute
+# ended up with a stale ``success``.
+_STATUS_RANK = {
+    "denied": 3,
+    "error": 2,
+    "allow": 1,
+    "ok": 1,
+    "success": 1,
+}
+
+
+def _worst_status(statuses: list[str]) -> str:
+    """Return the most severe status across a group's rows."""
+    ranked = [(s, _STATUS_RANK.get(s or "", 0)) for s in statuses]
+    ranked.sort(key=lambda kv: kv[1], reverse=True)
+    return ranked[0][0] if ranked else "—"
+
+
+def _humanize_event(event: str | None) -> str:
+    """Map backend event names to short CISO-readable phrases."""
+    if not event:
+        return "Event"
+    return {
+        "tool_execute":                 "Tool execution",
+        "resource_call":                "Egress to MCP resource",
+        "policy.no_capability_required": "Policy check passed",
+        "auth.login":                   "Dashboard login",
+        "auth.token":                   "Token issued",
+        "enroll.approve":               "Agent enrollment approved",
+        "enroll.deny":                  "Agent enrollment denied",
+        "agent.cert.rotate":            "Agent cert rotated",
+        "egress_llm_chat":              "LLM completion (AI gateway)",
+    }.get(event, event.replace("_", " ").replace(".", " · "))
+
+
+# ── Cullis Audit Envelope reader ──────────────────────────────────────
+#
+# The "Cullis Audit Envelope" is the proprietary pattern that turns a
+# tool's raw RPC result into a business-readable audit row. Every tool
+# in the Cullis ecosystem is encouraged to emit a sidecar field —
+# ``_cullis_audit: {action, subject, outcome}`` — alongside its native
+# payload. Mastio reads it and uses it as the card-level header on the
+# audit dashboard.
+#
+# Why a sidecar instead of a per-tool summarizer in Mastio:
+#   - One pattern, scales across domains (trading, KYC, DORA, KYB...).
+#   - Tool developer writes three strings, gets a business-readable
+#     audit row for free.
+#   - Third-party tools that don't adopt the pattern still render with
+#     a generic "Tool invoked: X" fallback (see ``_group_audit_events``).
+#
+# Spec lives in ADR-039 (cullis-audit-envelope).
+
+
+def _extract_audit_envelope(detail_pretty: str | None) -> dict | None:
+    """Pull ``_cullis_audit`` from a tool_execute / resource_call detail.
+
+    The detail string is the already-pretty-printed JSON the dashboard
+    renders (``_pretty_and_recipient`` runs the unnest pass on it), so
+    nested ``content[i].text`` strings have already been turned back
+    into objects. Walks the parsed tree looking for ``_cullis_audit``
+    at any nesting depth — tools may emit it at the top of the result
+    or inside a nested ``content`` entry, both are valid.
+
+    Returns the envelope dict ``{action, subject, outcome}`` or
+    ``None`` if no envelope is present (graceful degradation).
+    """
+    if not detail_pretty:
+        return None
+    import json as _json
+    try:
+        parsed = _json.loads(detail_pretty)
+    except (ValueError, TypeError):
+        return None
+
+    def _walk(node, depth: int = 0):
+        if depth > 8 or node is None:
+            return None
+        if isinstance(node, dict):
+            env = node.get("_cullis_audit")
+            if isinstance(env, dict) and {"action", "subject", "outcome"} <= env.keys():
+                return env
+            for v in node.values():
+                found = _walk(v, depth + 1)
+                if found is not None:
+                    return found
+        elif isinstance(node, list):
+            for v in node:
+                found = _walk(v, depth + 1)
+                if found is not None:
+                    return found
+        return None
+
+    return _walk(parsed)
+
+
+def _ts_seconds(iso: str | None) -> float:
+    """Parse an ISO-8601 timestamp into a float of seconds.
+
+    Used only for the ±N second tiebreaker in the grouper — accuracy
+    to the millisecond is enough, and we tolerate any reasonable
+    formatting variation the audit writers use.
+    """
+    if not iso:
+        return 0.0
+    from datetime import datetime
+    try:
+        # ``fromisoformat`` accepts the ``+00:00`` offset emitted by
+        # ``log_audit`` / ``append_local_audit``.
+        return datetime.fromisoformat(iso).timestamp()
+    except (ValueError, TypeError):
+        return 0.0
+
+
+# MCP JSON-RPC ``id`` is always ``"1"`` per HTTP POST (each tool call
+# is a single envelope), so ``request_id`` does NOT discriminate
+# successive tool calls. The 3 fan-out rows of a single call land
+# within ~50 ms of each other (PDP → executor → forwarder are
+# in-process, sequential). 500 ms is a generous ceiling for the
+# fan-out and an aggressive floor against successive LLM-driven
+# tool calls (which typically wait for the previous result, so are
+# seconds apart).
+_GROUP_TIME_WINDOW_SEC = 0.5
+
+
+def _group_audit_events(entries: list[dict]) -> list[dict]:
+    """Collapse the 3-row fan-out of one tool call into a single card.
+
+    Group key: ``(agent_id, tool_name, request_id)`` PLUS a ±5s
+    timestamp tiebreaker.
+
+    Why the tiebreaker exists: the SDK uses the MCP JSON-RPC sequence
+    (1, 2, 3, ...) for ``request_id``, so two tool calls a few seconds
+    apart on the same agent can collide on ``(agent, tool, "1")``.
+    Without the tiebreaker the dashboard collapses every successive
+    ``get_market_data`` call into one fat card. With it, calls that
+    drift more than 5 seconds apart land in separate cards even if
+    the request_id happens to be re-used.
+
+    Events outside :data:`_TOOL_CALL_EVENTS` stay as singletons. So do
+    tool-call events that happen to have ``request_id`` missing on a
+    legacy row — better one row by itself than a wrong collapse.
+    """
+    # Walk entries in chronological order so the tiebreaker can compare
+    # against the latest timestamp in the candidate bucket. The
+    # ``entries`` argument arrives sorted DESC, so reverse for the
+    # grouping pass and re-sort the card list at the end.
+    asc = sorted(entries, key=lambda x: _ts_seconds(x.get("timestamp")))
+    groups_by_key: dict[str, dict] = {}
+    singletons: list[dict] = []
+
+    for e in asc:
+        event = e.get("event")
+        agent_id = e.get("agent_id")
+        tool_name = e.get("tool_name") or e.get("target")
+        request_id = e.get("request_id")
+
+        if (
+            event in _TOOL_CALL_EVENTS
+            and agent_id
+            and tool_name
+            and request_id
+        ):
+            base_key = f"{agent_id}::{tool_name}::{request_id}"
+            ts = _ts_seconds(e.get("timestamp"))
+            # Find an existing bucket within the time window, else
+            # open a new one with a generation suffix.
+            chosen_key = None
+            gen = 0
+            while True:
+                candidate = f"{base_key}::{gen}"
+                bucket = groups_by_key.get(candidate)
+                if bucket is None:
+                    chosen_key = candidate
+                    break
+                last_ts = bucket["_last_ts"]
+                if abs(ts - last_ts) <= _GROUP_TIME_WINDOW_SEC:
+                    chosen_key = candidate
+                    break
+                gen += 1
+
+            bucket = groups_by_key.setdefault(chosen_key, {
+                "key": chosen_key,
+                "kind": "tool_call",
+                "title": f"Tool invoked: {tool_name}",
+                "subtitle": None,
+                "agent_id": agent_id,
+                "tool_name": tool_name,
+                "org_id": e.get("org_id"),
+                "request_id": request_id,
+                "events": [],
+                "_last_ts": ts,
+            })
+            bucket["events"].append(e)
+            bucket["_last_ts"] = max(bucket["_last_ts"], ts)
+        else:
+            singletons.append({
+                "key": f"singleton::{e.get('timestamp')}::{event}::{agent_id}",
+                "kind": "singleton",
+                "title": _humanize_event(event),
+                "subtitle": e.get("target"),
+                "agent_id": agent_id,
+                "tool_name": e.get("tool_name"),
+                "org_id": e.get("org_id"),
+                "request_id": e.get("request_id"),
+                "events": [e],
+            })
+
+    cards: list[dict] = list(groups_by_key.values()) + singletons
+
+    for card in cards:
+        evs = sorted(card["events"], key=lambda x: x.get("timestamp") or "")
+        card["events"] = evs
+        card["timestamp"] = evs[0].get("timestamp") if evs else None
+        card["timestamp_end"] = evs[-1].get("timestamp") if evs else None
+        card["status"] = _worst_status([ev.get("status") for ev in evs])
+        # Duration comes from the ``tool_execute`` row when present;
+        # ``resource_call`` doesn't carry one and ``policy.*`` is point-in-time.
+        tool_exec = next((ev for ev in evs if ev.get("event") == "tool_execute"), None)
+        card["duration_ms"] = (tool_exec or evs[0]).get("duration_ms") if evs else None
+        card["chain_seqs"] = [ev.get("chain_seq") for ev in evs if ev.get("chain_seq") is not None]
+        # ── Cullis Audit Envelope override ────────────────────────────
+        # If the tool emitted ``_cullis_audit`` (see ADR-039), use it
+        # as the card title/subtitle so the dashboard tells a business
+        # story instead of an RPC name. Search the resource_call detail
+        # first (closest to the tool's native response) and fall back
+        # to tool_execute detail (carries the same payload through
+        # PR #886's result_summary).
+        envelope = None
+        for ev in evs:
+            if ev.get("event") in ("resource_call", "tool_execute"):
+                envelope = _extract_audit_envelope(ev.get("detail_pretty"))
+                if envelope:
+                    break
+        card["envelope"] = envelope
+        if envelope:
+            card["title"] = f"{envelope['action']}: {envelope['subject']}"
+            card["subtitle"] = envelope["outcome"]
+        elif card["kind"] == "tool_call":
+            for ev in evs:
+                if ev.get("event") == "resource_call" and ev.get("endpoint_url"):
+                    card["subtitle"] = ev["endpoint_url"]
+                    break
+            if not card["subtitle"]:
+                card["subtitle"] = "via Mastio gateway"
+        card["events_count"] = len(evs)
+
+    # Most recent card first by *end* timestamp (the last event written
+    # for a group is the one that closes it).
+    cards.sort(key=lambda c: c.get("timestamp_end") or c.get("timestamp") or "", reverse=True)
+    return cards
 
 
 @router.get("/audit", response_class=HTMLResponse)
@@ -76,6 +412,12 @@ async def audit_page(request: Request):
     action_filter = request.query_params.get("action", "")
     status_filter = request.query_params.get("status", "")
     source_filter = request.query_params.get("source", "")  # '', 'admin', 'traffic'
+    # ``view=grouped`` (default) collapses the 3-row fan-out of one
+    # tool call into a single card readable by a CISO. ``view=raw``
+    # keeps the legacy per-row table for maintainer-side debugging.
+    view_mode = request.query_params.get("view", "grouped")
+    if view_mode not in ("grouped", "raw"):
+        view_mode = "grouped"
     page = int(request.query_params.get("page", "1"))
     per_page = 50
 
@@ -142,37 +484,60 @@ async def audit_page(request: Request):
     unified: list[dict] = []
     for r in admin_rows:
         detail_pretty, _ = _pretty_and_recipient(r.get("detail"))
+        agent_id = r.get("agent_id")
         unified.append({
             "source": "admin",
             "timestamp": r.get("timestamp"),
-            "agent_id": r.get("agent_id"),
+            "agent_id": agent_id,
             "event": r.get("action"),
             "status": r.get("status"),
             "target": r.get("tool_name"),
             "tool_name": r.get("tool_name"),
             "duration_ms": r.get("duration_ms"),
             "request_id": r.get("request_id"),
+            "endpoint_url": None,
             "session_id": None,
-            "org_id": None,
-            "chain_seq": None,
-            "entry_hash": None,
+            # ``audit_log`` rows participate in the same hash chain as
+            # ``local_audit`` (ADR-014). Surface ``chain_seq`` + ``row_hash``
+            # in the side panel so admin events show their chain position
+            # alongside traffic events. Org is derived from the typed
+            # agent_id prefix (no native column on ``audit_log``).
+            "org_id": _derive_org_from_agent_id(agent_id),
+            "chain_seq": r.get("chain_seq"),
+            "entry_hash": r.get("row_hash"),
             "peer_org_id": None,
             "detail_pretty": detail_pretty,
         })
     for r in traffic_rows:
-        detail_pretty, recipient = _pretty_and_recipient(r.get("details"))
+        raw_details = r.get("details")
+        detail_pretty, recipient = _pretty_and_recipient(raw_details)
         raw_result = r.get("result")
         status_display = "success" if raw_result == "ok" else raw_result
+        # Pull ``tool`` and ``endpoint_url`` out of the details JSON
+        # so the grouper can match on ``tool_name`` and surface the
+        # MCP origin (mcp-portfolio:9900) in the card subtitle.
+        import json as _json_local
+        tool_name_traffic = None
+        endpoint_url = None
+        if raw_details:
+            try:
+                _det = _json_local.loads(raw_details)
+                if isinstance(_det, dict):
+                    tool_name_traffic = _det.get("tool")
+                    endpoint_url = _det.get("endpoint_url")
+            except (ValueError, TypeError):
+                pass
         unified.append({
             "source": "traffic",
             "timestamp": r.get("timestamp"),
             "agent_id": r.get("agent_id"),
             "event": r.get("event_type"),
             "status": status_display,
-            "target": recipient,
-            "tool_name": None,
+            "target": recipient or tool_name_traffic,
+            "tool_name": tool_name_traffic,
+            "endpoint_url": endpoint_url,
             "duration_ms": None,
-            "request_id": None,
+            "request_id": _extract_mcp_request_id(raw_details),
             "session_id": r.get("session_id"),
             "org_id": r.get("org_id"),
             "chain_seq": r.get("chain_seq"),
@@ -184,12 +549,24 @@ async def audit_page(request: Request):
     # ISO-8601 strings sort correctly as plain strings, no parsing needed.
     unified.sort(key=lambda x: x["timestamp"] or "", reverse=True)
 
-    total = len(unified)
     admin_total = sum(1 for e in unified if e["source"] == "admin")
-    traffic_total = total - admin_total
-    total_pages = max(1, (total + per_page - 1) // per_page)
-    offset = (page - 1) * per_page
-    entries = unified[offset:offset + per_page]
+    traffic_total = len(unified) - admin_total
+
+    # ``view=grouped`` (default) → CISO-mode card view, one card per
+    # tool call. ``view=raw`` → maintainer-mode flat row table.
+    if view_mode == "grouped":
+        cards = _group_audit_events(unified)
+        total = len(cards)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        offset = (page - 1) * per_page
+        page_cards = cards[offset:offset + per_page]
+        entries = []  # raw-view list stays empty in grouped mode
+    else:
+        total = len(unified)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        offset = (page - 1) * per_page
+        entries = unified[offset:offset + per_page]
+        page_cards = []
 
     agents = await list_agents()
     agent_ids = sorted(set(a["agent_id"] for a in agents))
@@ -197,6 +574,8 @@ async def audit_page(request: Request):
     return templates.TemplateResponse("audit.html", _ctx(
         request, session,
         active="audit",
+        view_mode=view_mode,
+        cards=page_cards,
         entries=entries,
         agent_ids=agent_ids,
         actions=actions,
@@ -210,3 +589,199 @@ async def audit_page(request: Request):
         traffic_total=traffic_total,
         total=total,
     ))
+
+
+# ── Chain integrity verification (POST /proxy/audit/verify) ────────
+#
+# Mirrors the logic in ``scripts/cullis-audit-verify.py`` but runs
+# in-process against the live ``local_audit`` table so an operator can
+# click "Verify chain integrity" in the dashboard and get a verdict
+# without having to export NDJSON + run a CLI offline. Both paths
+# remain valid — the CLI is the auditor's "without trusting Cullis"
+# story, this is the operator's "is my chain healthy today" story.
+
+
+def _canonical_for_row(entry: dict, previous_hash: str | None) -> str:
+    """Reconstruct the canonical string used to compute ``entry_hash``.
+
+    Kept byte-compatible with ``scripts/cullis-audit-verify.py::canonical``
+    (and with the writer in ``mcp_proxy/local/audit_chain.py``) so a
+    pass here matches a pass under the offline verifier and vice versa.
+    """
+    fmt = (entry.get("hash_format") or "v1").lower()
+    chain_seq = entry.get("chain_seq")
+    if fmt == "v2":
+        canonical_str = "|".join([
+            "v2",
+            entry["timestamp"] or "",
+            entry["event_type"],
+            entry.get("agent_id") or "",
+            entry.get("session_id") or "",
+            entry.get("org_id") or "",
+            entry["result"],
+            entry.get("details") or "",
+            previous_hash or "genesis",
+            f"seq={chain_seq}",
+            f"peer={entry.get('peer_org_id') or ''}",
+        ])
+    else:
+        base = "|".join([
+            str(entry["id"]),
+            entry["timestamp"] or "",
+            entry["event_type"],
+            entry.get("agent_id") or "",
+            entry.get("session_id") or "",
+            entry.get("org_id") or "",
+            entry["result"],
+            entry.get("details") or "",
+            previous_hash or "genesis",
+        ])
+        if chain_seq is None:
+            canonical_str = base
+        else:
+            canonical_str = (
+                f"{base}|seq={chain_seq}|peer={entry.get('peer_org_id') or ''}"
+            )
+    pt = entry.get("principal_type")
+    if pt and pt != "agent":
+        canonical_str = f"{canonical_str}|pt={pt}"
+    return canonical_str
+
+
+@router.post("/audit/verify")
+async def verify_chain(request: Request) -> JSONResponse:
+    """Run the same chain check as ``cullis-audit-verify.py``, in-process.
+
+    Returns 200 with a JSON verdict regardless of pass/fail — the
+    front-end inspects ``ok`` and renders a green or red banner. Real
+    failures use HTTP 200 + ``ok: false`` rather than HTTP 4xx/5xx so
+    the operator can read the failure detail without their browser
+    showing an error page.
+    """
+    import hashlib
+    from collections import defaultdict
+
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return JSONResponse({"ok": False, "error": "auth_required"}, status_code=401)
+    if not await verify_csrf(request, session):
+        return JSONResponse({"ok": False, "error": "csrf_invalid"}, status_code=403)
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+
+    async with get_db() as db:
+        result = await db.execute(text(
+            "SELECT id, timestamp, agent_id, event_type, details, "
+            "previous_hash, entry_hash, session_id, org_id, result, "
+            "chain_seq, peer_org_id, peer_row_hash, hash_format "
+            "FROM local_audit ORDER BY id ASC"
+        ))
+        entries = [dict(r) for r in result.mappings().all()]
+
+    # Per-org chain check (mirrors verify_chains in the CLI). Legacy
+    # global-chain rows (chain_seq IS NULL) are still validated first
+    # so their tail becomes the seed for the per-org chain.
+    agents_seen: set[str] = set()
+    orgs_seen: set[str] = set()
+    for e in entries:
+        if e.get("agent_id"):
+            agents_seen.add(e["agent_id"])
+        if e.get("org_id"):
+            orgs_seen.add(e["org_id"])
+
+    # Legacy global chain
+    legacy_prev: str | None = None
+    legacy_n = 0
+    for e in entries:
+        if e.get("chain_seq") is not None or e.get("entry_hash") is None:
+            continue
+        expected = _canonical_for_row(e, legacy_prev)
+        computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
+        if computed != e["entry_hash"]:
+            return JSONResponse({
+                "ok": False,
+                "failure": {
+                    "kind": "mismatch",
+                    "scope": "legacy",
+                    "id": e["id"],
+                    "agent_id": e.get("agent_id"),
+                    "event_type": e.get("event_type"),
+                    "timestamp": e.get("timestamp"),
+                    "expected_hash": computed,
+                    "observed_hash": e["entry_hash"],
+                },
+            })
+        if e.get("previous_hash") != legacy_prev:
+            return JSONResponse({
+                "ok": False,
+                "failure": {
+                    "kind": "break",
+                    "scope": "legacy",
+                    "id": e["id"],
+                    "timestamp": e.get("timestamp"),
+                    "declared_prev": e.get("previous_hash"),
+                    "expected_prev": legacy_prev,
+                },
+            })
+        legacy_prev = e["entry_hash"]
+        legacy_n += 1
+
+    last_legacy: dict[str, str] = {}
+    for e in entries:
+        if e.get("chain_seq") is None and e.get("entry_hash") is not None:
+            last_legacy[e.get("org_id") or ""] = e["entry_hash"]
+
+    per_org: dict[str, list[dict]] = defaultdict(list)
+    for e in entries:
+        if e.get("chain_seq") is not None:
+            per_org[e.get("org_id") or ""].append(e)
+
+    per_org_n = 0
+    for org, rows in per_org.items():
+        rows.sort(key=lambda r: r["chain_seq"])
+        expected_prev = last_legacy.get(org)
+        for e in rows:
+            expected = _canonical_for_row(e, expected_prev)
+            computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
+            if computed != e["entry_hash"]:
+                return JSONResponse({
+                    "ok": False,
+                    "failure": {
+                        "kind": "mismatch",
+                        "scope": "per_org",
+                        "org_id": org,
+                        "chain_seq": e["chain_seq"],
+                        "id": e["id"],
+                        "agent_id": e.get("agent_id"),
+                        "event_type": e.get("event_type"),
+                        "timestamp": e.get("timestamp"),
+                        "expected_hash": computed,
+                        "observed_hash": e["entry_hash"],
+                    },
+                })
+            if e.get("previous_hash") != expected_prev:
+                return JSONResponse({
+                    "ok": False,
+                    "failure": {
+                        "kind": "break",
+                        "scope": "per_org",
+                        "org_id": org,
+                        "chain_seq": e["chain_seq"],
+                        "id": e["id"],
+                        "timestamp": e.get("timestamp"),
+                        "declared_prev": e.get("previous_hash"),
+                        "expected_prev": expected_prev,
+                    },
+                })
+            expected_prev = e["entry_hash"]
+            per_org_n += 1
+
+    return JSONResponse({
+        "ok": True,
+        "entries": len(entries),
+        "agents": len(agents_seen),
+        "orgs": len(orgs_seen),
+        "legacy_chain_rows": legacy_n,
+        "per_org_chain_rows": per_org_n,
+    })

--- a/mcp_proxy/dashboard/templates/audit.html
+++ b/mcp_proxy/dashboard/templates/audit.html
@@ -9,14 +9,18 @@
         <div class="min-w-0">
             <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Audit Log</h2>
             <p class="text-xs text-gray-600 mt-0.5">
-                Unified stream — admin events + local runtime chain
+                {% if view_mode == 'grouped' %}
+                Grouped by tool call — every card collapses the policy decision, executor row, and egress for one action
+                {% else %}
+                Raw event stream — one row per audit-log entry
+                {% endif %}
             </p>
         </div>
 
         <!-- Counter chip: Total · Admin · Traffic -->
         <div class="flex items-center gap-0 flex-shrink-0 border border-gray-800/60 rounded-md overflow-hidden bg-surface-900/60 backdrop-blur-sm">
             <div class="px-3 py-1.5 flex items-center gap-2">
-                <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Total</span>
+                <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">{% if view_mode == 'grouped' %}Tool calls{% else %}Events{% endif %}</span>
                 <span class="text-sm font-mono text-white">{{ total }}</span>
             </div>
             <div class="w-px h-5 bg-gray-800/80 self-center"></div>
@@ -31,6 +35,30 @@
             </div>
         </div>
     </div>
+
+    <!-- View toggle (Grouped vs Raw) + Verify chain integrity button -->
+    {% set _filter_qs %}{% if source_filter %}&source={{ source_filter }}{% endif %}{% if agent_filter %}&agent={{ agent_filter }}{% endif %}{% if action_filter %}&action={{ action_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% endset %}
+    <div class="flex items-center justify-between gap-2 mb-4 flex-wrap">
+        <div class="flex items-center gap-2">
+            <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">View</span>
+            <div class="inline-flex border border-gray-800/60 rounded-md overflow-hidden bg-surface-900/60">
+                <a href="/proxy/audit?view=grouped{{ _filter_qs }}" class="px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider transition-colors {% if view_mode == 'grouped' %}bg-accent-400/15 text-accent-400{% else %}text-gray-500 hover:text-gray-300 hover:bg-gray-800/40{% endif %}">Grouped</a>
+                <a href="/proxy/audit?view=raw{{ _filter_qs }}" class="px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider transition-colors {% if view_mode == 'raw' %}bg-accent-400/15 text-accent-400{% else %}text-gray-500 hover:text-gray-300 hover:bg-gray-800/40{% endif %}">Raw</a>
+            </div>
+            <span class="text-[10px] text-gray-700 ml-2 hidden md:inline">
+                {% if view_mode == 'grouped' %}cards collapse 1 tool call = 3 rows; switch to Raw for the per-event table.{% else %}1 row = 1 audit entry; switch to Grouped for the CISO-readable view.{% endif %}
+            </span>
+        </div>
+        <button type="button" id="verify-chain-btn"
+                data-csrf="{{ csrf_token }}"
+                class="inline-flex items-center gap-2 px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider border border-accent-400/40 text-accent-400 bg-accent-400/5 rounded-md hover:bg-accent-400/15 transition-colors disabled:opacity-50 disabled:cursor-wait">
+            <svg id="verify-chain-icon" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+            <span id="verify-chain-label">Verify chain integrity</span>
+        </button>
+    </div>
+
+    <!-- Verify result banner — populated by JS after click -->
+    <div id="verify-chain-banner" class="mb-5" hidden></div>
 
     <!-- Filter bar -->
     <form method="get" action="/proxy/audit" class="flex flex-wrap items-center gap-3 mb-5">
@@ -62,10 +90,114 @@
             Filter
         </button>
         {% if agent_filter or action_filter or status_filter or source_filter %}
-        <a href="/proxy/audit" class="px-3 py-2 text-xs text-gray-600 hover:text-gray-400 transition-colors">Clear</a>
+        <a href="/proxy/audit?view={{ view_mode }}" class="px-3 py-2 text-xs text-gray-600 hover:text-gray-400 transition-colors">Clear</a>
         {% endif %}
+        <input type="hidden" name="view" value="{{ view_mode }}">
     </form>
 
+    {% if view_mode == 'grouped' %}
+    <!-- Grouped card view — one card per tool call -->
+    <div class="space-y-2">
+        {% for card in cards %}
+        {% set _status_class = 'emerald' if card.status in ('success','ok','allow') else ('red' if card.status in ('denied','error') else 'yellow') %}
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
+            <!-- Card header (clickable) -->
+            <button type="button" data-card-toggle="{{ loop.index0 }}"
+                    class="w-full px-5 py-4 flex items-center gap-4 hover:bg-gray-800/30 transition-colors text-left"
+                    aria-expanded="false" aria-controls="card-expand-{{ loop.index0 }}">
+                <span class="w-2 h-2 rounded-full flex-shrink-0 bg-{{ _status_class }}-500"></span>
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2 flex-wrap">
+                        <span class="text-sm text-gray-100 font-medium truncate">{{ card.title }}</span>
+                        {% if card.kind == 'tool_call' %}
+                        <span class="text-[10px] text-gray-600 font-mono">·</span>
+                        <span class="text-[11px] text-gray-500 font-mono">{{ card.events_count }} chained events</span>
+                        {% endif %}
+                    </div>
+                    {% if card.subtitle %}
+                    <div class="text-[11px] text-gray-500 font-mono mt-0.5 truncate">{{ card.subtitle }}</div>
+                    {% endif %}
+                </div>
+                <div class="hidden md:flex flex-col items-end gap-0.5 flex-shrink-0 mr-1">
+                    <div class="text-[11px] text-gray-400 font-mono truncate max-w-[200px]">{{ card.agent_id or '—' }}</div>
+                    <div class="text-[10px] text-gray-600 font-mono">{{ card.timestamp[:19] if card.timestamp else '—' }}</div>
+                </div>
+                {% if card.duration_ms is not none %}
+                <span class="hidden md:inline text-[10px] text-gray-500 font-mono whitespace-nowrap flex-shrink-0">{{ '%.0f' | format(card.duration_ms) }} ms</span>
+                {% endif %}
+                {% if card.status in ('success','ok','allow') %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider flex-shrink-0">OK</span>
+                {% elif card.status == 'denied' %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider flex-shrink-0">Denied</span>
+                {% elif card.status == 'error' %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider flex-shrink-0">Error</span>
+                {% else %}
+                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-500/10 text-yellow-400 uppercase tracking-wider flex-shrink-0">{{ card.status or '—' }}</span>
+                {% endif %}
+                <svg class="card-chevron w-3.5 h-3.5 text-gray-600 transition-transform duration-150 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </button>
+
+            <!-- Expanded chained events -->
+            <div class="card-expand border-t border-gray-800/40" id="card-expand-{{ loop.index0 }}" hidden aria-hidden="true">
+                {% for ev in card.events %}
+                {% set _ev_outer = loop %}
+                <details class="border-b border-gray-800/30 last:border-b-0 group">
+                    <summary class="px-5 py-2.5 flex items-center gap-3 cursor-pointer hover:bg-gray-800/20 select-none">
+                        <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {% if ev.status in ('success','ok','allow') %}bg-emerald-500{% elif ev.status in ('denied','error') %}bg-red-500{% else %}bg-yellow-500{% endif %}"></span>
+                        {% if ev.source == 'admin' %}
+                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium bg-blue-500/10 text-blue-400 uppercase tracking-wider border border-blue-500/20 flex-shrink-0">Admin</span>
+                        {% else %}
+                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-medium bg-accent-400/10 text-accent-400 uppercase tracking-wider border border-accent-400/20 flex-shrink-0">Traffic</span>
+                        {% endif %}
+                        <span class="text-[11px] text-gray-300 font-mono">{{ ev.event or '—' }}</span>
+                        <span class="text-[10px] text-gray-700 font-mono ml-auto flex-shrink-0">{{ ev.timestamp[11:23] if ev.timestamp else '' }}</span>
+                        {% if ev.chain_seq is not none %}
+                        <span class="text-[10px] text-gray-600 font-mono flex-shrink-0">chain #{{ ev.chain_seq }}</span>
+                        {% endif %}
+                        <svg class="w-3 h-3 text-gray-700 transition-transform duration-150 group-open:rotate-90 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    </summary>
+                    <div class="px-5 pb-4 pt-1 bg-surface-950/40 border-t border-gray-800/20 grid grid-cols-1 lg:grid-cols-3 gap-4">
+                        <div class="lg:col-span-2">
+                            {% if ev.detail_pretty %}
+                            <pre class="text-[11px] leading-relaxed font-mono text-gray-300 bg-surface-950 border border-gray-800/60 rounded p-3 max-h-[360px] overflow-y-auto whitespace-pre-wrap break-words">{{ ev.detail_pretty }}</pre>
+                            {% else %}
+                            <p class="text-xs text-gray-600 italic">No detail attached to this event.</p>
+                            {% endif %}
+                        </div>
+                        <div class="text-[11px] font-mono space-y-2">
+                            {% if ev.entry_hash %}
+                            <div>
+                                <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-0.5">Entry Hash</p>
+                                <code class="text-accent-400 break-all block">{{ ev.entry_hash[:32] }}…</code>
+                            </div>
+                            {% endif %}
+                            {% if ev.status %}
+                            <div>
+                                <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-0.5">Status</p>
+                                <span class="{% if ev.status in ('success','ok','allow') %}text-emerald-400{% elif ev.status in ('denied','error') %}text-red-400{% else %}text-yellow-400{% endif %}">{{ ev.status }}</span>
+                            </div>
+                            {% endif %}
+                            {% if ev.duration_ms is not none %}
+                            <div>
+                                <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-0.5">Duration</p>
+                                <span class="text-gray-300">{{ '%.1f' | format(ev.duration_ms) }} ms</span>
+                            </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </details>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+        {% if not cards %}
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-16 text-center">
+            <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+            <p class="text-sm text-gray-600">No audit entries{% if agent_filter or action_filter or status_filter or source_filter %} matching filters{% endif %}</p>
+        </div>
+        {% endif %}
+    </div>
+    {% else %}
     <!-- Audit table -->
     <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
         <table class="w-full">
@@ -133,7 +265,7 @@
                                     {% endif %}
                                 </div>
                                 {% if entry.detail_pretty %}
-                                <pre id="audit-detail-{{ loop.index0 }}" class="text-[11px] leading-relaxed font-mono text-gray-300 bg-surface-950 border border-gray-800/60 rounded p-3 overflow-x-auto whitespace-pre">{{ entry.detail_pretty }}</pre>
+                                <pre id="audit-detail-{{ loop.index0 }}" class="text-[11px] leading-relaxed font-mono text-gray-300 bg-surface-950 border border-gray-800/60 rounded p-3 max-h-[420px] overflow-y-auto whitespace-pre-wrap break-words">{{ entry.detail_pretty }}</pre>
                                 {% else %}
                                 <p class="text-xs text-gray-600 italic">No detail attached to this event.</p>
                                 {% endif %}
@@ -149,10 +281,9 @@
                                     <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Agent</p>
                                     <p class="text-[11px] font-mono text-gray-300 break-all">{{ entry.agent_id or '—' }}</p>
                                 </div>
-                                {% if entry.source == 'admin' %}
-                                {% if entry.request_id %}
+                                {% if entry.source == 'admin' and entry.request_id %}
                                 <div>
-                                    <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Request ID</p>
+                                    <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">MCP Request ID</p>
                                     <div class="flex items-center gap-1.5">
                                         <code class="flex-1 min-w-0 text-[11px] font-mono text-accent-400 truncate">{{ entry.request_id }}</code>
                                         <button type="button" onclick="copyToClipboard('{{ entry.request_id }}')"
@@ -162,6 +293,7 @@
                                     </div>
                                 </div>
                                 {% endif %}
+                                {% if entry.source == 'admin' %}
                                 <div class="grid grid-cols-2 gap-3">
                                     <div>
                                         <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Tool</p>
@@ -172,13 +304,14 @@
                                         <p class="text-[11px] font-mono text-gray-300">{% if entry.duration_ms is not none %}{{ '%.1f' | format(entry.duration_ms) }} ms{% else %}—{% endif %}</p>
                                     </div>
                                 </div>
-                                {% else %}
-                                {% if entry.target %}
+                                {% endif %}
+                                {% if entry.source == 'traffic' and entry.target %}
                                 <div>
                                     <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Recipient</p>
                                     <p class="text-[11px] font-mono text-gray-300 break-all">{{ entry.target }}</p>
                                 </div>
                                 {% endif %}
+                                {% if entry.org_id or entry.chain_seq is not none %}
                                 <div class="grid grid-cols-2 gap-3">
                                     <div>
                                         <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Org</p>
@@ -189,6 +322,7 @@
                                         <p class="text-[11px] font-mono text-gray-300">#{{ entry.chain_seq if entry.chain_seq is not none else '—' }}</p>
                                     </div>
                                 </div>
+                                {% endif %}
                                 {% if entry.session_id %}
                                 <div>
                                     <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Session</p>
@@ -213,7 +347,6 @@
                                     </div>
                                 </div>
                                 {% endif %}
-                                {% endif %}
                                 <div>
                                     <p class="text-[9px] font-heading uppercase tracking-[0.2em] text-gray-600 mb-1">Status</p>
                                     <p class="text-[11px] font-mono {% if entry.status == 'success' %}text-emerald-400{% elif entry.status in ('denied','error') %}text-red-400{% else %}text-yellow-400{% endif %}">{{ entry.status or '—' }}</p>
@@ -234,6 +367,7 @@
             </tbody>
         </table>
     </div>
+    {% endif %}
 
     <!-- Pagination -->
     {% if total_pages > 1 %}
@@ -242,7 +376,7 @@
             Page {{ page }} of {{ total_pages }}
         </p>
         <div class="flex items-center gap-2">
-            {% set _qs %}{% if source_filter %}&source={{ source_filter }}{% endif %}{% if agent_filter %}&agent={{ agent_filter }}{% endif %}{% if action_filter %}&action={{ action_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% endset %}
+            {% set _qs %}&view={{ view_mode }}{% if source_filter %}&source={{ source_filter }}{% endif %}{% if agent_filter %}&agent={{ agent_filter }}{% endif %}{% if action_filter %}&action={{ action_filter }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% endset %}
             {% if page > 1 %}
             <a href="/proxy/audit?page={{ page - 1 }}{{ _qs }}"
                class="px-3 py-1.5 text-xs font-medium border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-gray-300 transition-colors">
@@ -307,6 +441,121 @@
             }
         });
     });
+
+    // Verify chain integrity button — POST /proxy/audit/verify + render banner.
+    var verifyBtn = document.getElementById('verify-chain-btn');
+    var verifyBanner = document.getElementById('verify-chain-banner');
+    var verifyLabel = document.getElementById('verify-chain-label');
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+    function renderVerifyBanner(data) {
+        if (!verifyBanner) return;
+        if (data && data.ok) {
+            verifyBanner.innerHTML =
+                '<div class="border border-emerald-500/40 bg-emerald-500/10 rounded-lg p-4 flex items-start gap-3">' +
+                  '<svg class="w-5 h-5 text-emerald-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>' +
+                  '<div class="flex-1 min-w-0">' +
+                    '<p class="text-sm font-semibold text-emerald-400 uppercase tracking-wider">Chain verified</p>' +
+                    '<p class="text-[12px] text-gray-300 mt-1 font-mono">' +
+                      escapeHtml(data.entries) + ' entries · ' +
+                      escapeHtml(data.agents) + ' agent' + (data.agents === 1 ? '' : 's') + ' · ' +
+                      escapeHtml(data.orgs) + ' org' + (data.orgs === 1 ? '' : 's') + ' · ' +
+                      escapeHtml(data.legacy_chain_rows) + ' legacy · ' +
+                      escapeHtml(data.per_org_chain_rows) + ' per-org chain rows' +
+                    '</p>' +
+                    '<p class="text-[11px] text-gray-500 mt-1.5 leading-relaxed">' +
+                      'Every entry_hash matches the SHA-256 of its canonical row. No previous_hash → next entry_hash break detected. Bundle intact end-to-end.' +
+                    '</p>' +
+                  '</div>' +
+                '</div>';
+        } else if (data && data.failure) {
+            var f = data.failure;
+            var rows = [];
+            rows.push(['scope', f.scope]);
+            if (f.org_id) rows.push(['org', f.org_id]);
+            if (f.chain_seq != null) rows.push(['chain_seq', f.chain_seq]);
+            rows.push(['id', f.id]);
+            if (f.timestamp) rows.push(['timestamp', f.timestamp]);
+            if (f.event_type) rows.push(['event_type', f.event_type]);
+            if (f.agent_id) rows.push(['agent_id', f.agent_id]);
+            if (f.expected_hash) rows.push(['expected hash', f.expected_hash]);
+            if (f.observed_hash) rows.push(['observed hash', f.observed_hash]);
+            if (f.declared_prev) rows.push(['declared prev', f.declared_prev]);
+            if (f.expected_prev) rows.push(['expected prev', f.expected_prev]);
+            var detailHtml = rows.map(function(p){
+                return '<div class="flex gap-3"><span class="text-[10px] text-gray-600 uppercase tracking-wider w-32 flex-shrink-0">' + escapeHtml(p[0]) + '</span><code class="text-[11px] text-red-300 break-all">' + escapeHtml(p[1]) + '</code></div>';
+            }).join('');
+            var kindLabel = f.kind === 'break'
+                ? "The row's previous_hash does not point at the prior row's entry_hash. A row was deleted, reordered, or the linkage was rewritten."
+                : "The row's content does not produce the entry_hash it carries. A field on this row was altered after the chain was written.";
+            verifyBanner.innerHTML =
+                '<div class="border border-red-500/40 bg-red-500/10 rounded-lg p-4 flex items-start gap-3">' +
+                  '<svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12"/></svg>' +
+                  '<div class="flex-1 min-w-0">' +
+                    '<p class="text-sm font-semibold text-red-400 uppercase tracking-wider">Chain tamper detected</p>' +
+                    '<p class="text-[12px] text-gray-300 mt-1 leading-relaxed">' + escapeHtml(kindLabel) + '</p>' +
+                    '<div class="mt-3 space-y-1.5 font-mono">' + detailHtml + '</div>' +
+                  '</div>' +
+                '</div>';
+        } else {
+            verifyBanner.innerHTML =
+                '<div class="border border-yellow-500/40 bg-yellow-500/10 rounded-lg p-3 text-[12px] text-yellow-300">' +
+                  'Unexpected response: ' + escapeHtml(JSON.stringify(data || {})) +
+                '</div>';
+        }
+        verifyBanner.removeAttribute('hidden');
+    }
+    if (verifyBtn) {
+        verifyBtn.addEventListener('click', function () {
+            verifyBtn.disabled = true;
+            verifyLabel.textContent = 'Verifying...';
+            verifyBanner.setAttribute('hidden', '');
+            var body = 'csrf_token=' + encodeURIComponent(verifyBtn.dataset.csrf || '');
+            fetch('/proxy/audit/verify', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body,
+            })
+            .then(function (r) { return r.json().then(function(j){ return { status: r.status, body: j }; }); })
+            .then(function (resp) { renderVerifyBanner(resp.body); })
+            .catch(function (e) {
+                verifyBanner.innerHTML =
+                    '<div class="border border-red-500/40 bg-red-500/10 rounded-lg p-3 text-[12px] text-red-300">' +
+                    'Verify request failed: ' + escapeHtml(e && e.message ? e.message : String(e)) +
+                    '</div>';
+                verifyBanner.removeAttribute('hidden');
+            })
+            .finally(function () {
+                verifyBtn.disabled = false;
+                verifyLabel.textContent = 'Verify chain integrity';
+            });
+        });
+    }
+
+    // Grouped-view: toggle the card-level expand block.
+    document.querySelectorAll('[data-card-toggle]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var idx = btn.dataset.cardToggle;
+            var panel = document.getElementById('card-expand-' + idx);
+            if (!panel) return;
+            var isOpen = btn.getAttribute('aria-expanded') === 'true';
+            btn.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+            if (isOpen) {
+                panel.setAttribute('hidden', '');
+                panel.setAttribute('aria-hidden', 'true');
+            } else {
+                panel.removeAttribute('hidden');
+                panel.setAttribute('aria-hidden', 'false');
+            }
+        });
+    });
 })();
 </script>
+<style>
+    [data-card-toggle][aria-expanded="true"] .card-chevron { transform: rotate(90deg); color: rgb(0 229 199 / 0.8); }
+</style>
 {% endblock %}

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -87,12 +87,12 @@
             <a href="/proxy/tools"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'tools' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>
-                Tools
+                Tool Registry
             </a>
             <a href="/proxy/backends"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'backends' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
-                Backends
+                Tools
             </a>
             <a href="/proxy/pki"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'pki' %}nav-active{% else %}text-gray-500{% endif %}">

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -122,19 +122,19 @@
             </div>
             <div class="topo-arrow">───▶</div>
             <a href="/proxy/backends" class="topo-node hover:border-accent-400/40 transition-colors block">
-                <div class="topo-label">Backends</div>
+                <div class="topo-label">Tools</div>
                 <div class="topo-count">{{ backend_enabled }}</div>
                 <div class="topo-sub">{{ backend_total }} attached</div>
             </a>
         </div>
         <p class="mt-4 text-[11px] text-gray-500 leading-relaxed">
-            Agents enrolled in this org reach backends (MCP servers) through
+            Agents enrolled in this org reach tools (MCP servers) through
             the Mastio reverse-proxy. Each hop is signed with SPIFFE identity;
             access is gated by explicit <a href="/proxy/backends" class="text-accent-400 hover:underline">bindings</a>.
         </p>
     </div>
 
-    <!-- Two-column: Agents | Backends -->
+    <!-- Two-column: Agents | Tools -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
         <!-- AGENTS section -->
@@ -184,11 +184,11 @@
             {% endif %}
         </div>
 
-        <!-- BACKENDS section -->
+        <!-- TOOLS section -->
         <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
             <div class="flex items-center justify-between mb-4">
                 <h3 class="text-sm font-semibold text-white uppercase tracking-[0.18em]"
-                    style="font-family: 'Chakra Petch', sans-serif;">Backends</h3>
+                    style="font-family: 'Chakra Petch', sans-serif;">Tools</h3>
                 <a href="/proxy/backends" class="text-[10px] text-accent-400 hover:text-accent-300 uppercase tracking-wider">Manage &rarr;</a>
             </div>
 
@@ -224,7 +224,7 @@
             </ul>
             {% else %}
             <p class="text-xs text-gray-600">
-                No backends attached.
+                No tools attached.
                 <a href="/proxy/backends" class="text-accent-400 hover:underline">Attach an MCP server</a>
                 so your agents can reach it.
             </p>

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -95,7 +95,22 @@ async def run(
     del db  # kept in signature for backwards compatibility
     t0 = time.monotonic()
     tool_name = request.tool
-    request_id = request.request_id
+    # ``request.request_id`` carries the caller-supplied MCP JSON-RPC
+    # ``id`` field. The Python SDK pins it to ``"1"`` for every POST
+    # (each tools/call is a fresh JSON-RPC envelope), which makes it
+    # useless as a trace key for the dashboard — the dashboard needs
+    # to group the policy decision + tool_execute + resource_call
+    # rows that fan out from a single invocation. We therefore mint
+    # a server-side invocation id at ``run()`` entry and propagate it
+    # as ``request_id`` everywhere: into the audit_log column, into
+    # ``ToolContext.request_id`` (which the MCP resource forwarder
+    # records under ``local_audit.details.mcp_request_id``), and into
+    # the ``ToolExecuteResponse.request_id`` returned to the caller.
+    # The original MCP id is discarded; nothing downstream relies on
+    # the literal ``"1"``. See dashboard ``_group_audit_events`` for
+    # how the join key flows through.
+    import uuid as _uuid_run
+    request_id = f"inv-{_uuid_run.uuid4().hex[:12]}"
 
     # 1. Lookup
     tool_def = tool_registry.get(tool_name)

--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -192,10 +192,17 @@ async def forward_to_mcp_resource(
         },
     }
 
+    # ``mcp_request_id`` carries the server-minted invocation id so the
+    # dashboard ``_group_audit_events`` helper can join this
+    # traffic-stream ``resource_call`` row with the matching
+    # admin-stream ``tool_execute`` + ``policy.*`` rows that fan out
+    # from the same tool invocation. The executor mints it once at
+    # ``run()`` entry and propagates via ``ctx.request_id``.
     audit_details = {
         "resource_id": tool_def.resource_id,
         "endpoint_url": endpoint,
         "tool": tool_def.name,
+        "mcp_request_id": ctx.request_id,
     }
 
     transport = WhitelistedTransport(allowed_domains=tool_def.allowed_domains)

--- a/scripts/cullis-audit-verify.py
+++ b/scripts/cullis-audit-verify.py
@@ -161,13 +161,69 @@ def load_bundle(path: str) -> tuple[list[dict], list[dict]]:
     return entries, anchors
 
 
-def verify_chains(entries: list[dict]) -> tuple[int, int]:
-    """Verify all chains in a single bundle. Returns (legacy_n, per_org_n).
-    Exits with code 2 on any tamper."""
+def _print_tamper_detail(
+    *,
+    kind: str,
+    e: dict,
+    computed: str | None = None,
+    declared_prev: str | None = None,
+    expected_prev: str | None = None,
+) -> None:
+    """Print a CISO-readable explanation of a chain failure.
+
+    Two failure modes:
+      * ``MISMATCH`` — the row's content does not produce the
+        ``entry_hash`` it carries. Someone altered a field after
+        the row was written. Show computed vs declared hash so the
+        auditor can pin the row.
+      * ``BREAK`` — the row's ``previous_hash`` does not point at
+        the prior row's ``entry_hash``. Either a row was deleted, or
+        the linkage was tampered. Show declared vs expected prev.
+    """
+    print("")
+    print("✗ CHAIN TAMPER DETECTED")
+    print("")
+    where = (
+        f"  org={e.get('org_id', '?')}"
+        f" · chain_seq={e.get('chain_seq', '-')}"
+        f" · id={e['id']}"
+    )
+    print(where)
+    print(f"  timestamp={e.get('timestamp', '-')}")
+    print(f"  event_type={e.get('event_type', '-')}")
+    print(f"  agent_id={e.get('agent_id', '-')}")
+    print("")
+    if kind == "MISMATCH":
+        print("  The row's content does not produce the entry_hash it carries.")
+        print("  A field on this row was altered after the chain was written.")
+        print("")
+        print(f"    expected entry_hash (computed from row): {computed}")
+        print(f"    observed entry_hash (recorded on row):   {e['entry_hash']}")
+    else:  # BREAK
+        print("  The row's previous_hash does not point at the prior row's entry_hash.")
+        print("  A row was deleted, reordered, or the linkage was rewritten.")
+        print("")
+        print(f"    declared previous_hash: {declared_prev}")
+        print(f"    expected previous_hash: {expected_prev}")
+    print("")
+    print(f"  Rows after seq={e.get('chain_seq', '?')} cannot be trusted.")
+    print("")
+
+
+def verify_chains(entries: list[dict]) -> tuple[int, int, int]:
+    """Verify all chains in a single bundle.
+
+    Returns (legacy_n, per_org_n, agent_count). Exits 2 on any
+    tamper. The agent count is surfaced so the PASS output can
+    say "X entries · Y agents" without the caller re-scanning.
+    """
     # Legacy
     prev: str | None = None
     legacy_n = 0
+    agents_seen: set[str] = set()
     for e in entries:
+        if e.get("agent_id"):
+            agents_seen.add(e["agent_id"])
         if e.get("chain_seq") is not None:
             continue
         if e.get("entry_hash") is None:
@@ -175,10 +231,14 @@ def verify_chains(entries: list[dict]) -> tuple[int, int]:
         expected = canonical(e, prev)
         computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
         if computed != e["entry_hash"]:
-            print(f"CHAIN MISMATCH legacy id={e['id']}")
+            _print_tamper_detail(kind="MISMATCH", e=e, computed=computed)
             sys.exit(2)
         if e.get("previous_hash") != prev:
-            print(f"CHAIN BREAK legacy id={e['id']}")
+            _print_tamper_detail(
+                kind="BREAK", e=e,
+                declared_prev=e.get("previous_hash"),
+                expected_prev=prev,
+            )
             sys.exit(2)
         prev = e["entry_hash"]
         legacy_n += 1
@@ -202,15 +262,19 @@ def verify_chains(entries: list[dict]) -> tuple[int, int]:
             expected = canonical(e, expected_prev)
             computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
             if computed != e["entry_hash"]:
-                print(f"CHAIN MISMATCH org={org} seq={e['chain_seq']} id={e['id']}")
+                _print_tamper_detail(kind="MISMATCH", e=e, computed=computed)
                 sys.exit(2)
             if e.get("previous_hash") != expected_prev:
-                print(f"CHAIN BREAK org={org} seq={e['chain_seq']} id={e['id']}")
+                _print_tamper_detail(
+                    kind="BREAK", e=e,
+                    declared_prev=e.get("previous_hash"),
+                    expected_prev=expected_prev,
+                )
                 sys.exit(2)
             expected_prev = e["entry_hash"]
             per_org_n += 1
 
-    return (legacy_n, per_org_n)
+    return (legacy_n, per_org_n, len(agents_seen))
 
 
 def verify_anchors(entries: list[dict], anchors: list[dict]) -> int:
@@ -299,24 +363,47 @@ def main() -> int:
 
     bundles: list[tuple[str, list[dict]]] = []
     total_legacy = total_per_org = total_anchors = 0
+    total_entries = 0
+    total_orgs: set[str] = set()
+    total_agents: set[str] = set()
     for path in args.bundle:
         entries, anchors = load_bundle(path)
-        legacy_n, per_org_n = verify_chains(entries)
+        legacy_n, per_org_n, _agent_n = verify_chains(entries)
         anchor_n = verify_anchors(entries, anchors)
         total_legacy += legacy_n
         total_per_org += per_org_n
         total_anchors += anchor_n
+        total_entries += len(entries)
+        for e in entries:
+            if e.get("org_id"):
+                total_orgs.add(e["org_id"])
+            if e.get("agent_id"):
+                total_agents.add(e["agent_id"])
         bundles.append((path, entries))
-        print(f"OK {path}: legacy={legacy_n} per_org={per_org_n} anchors={anchor_n}")
 
     cross_n = cross_reconcile(bundles)
-    if cross_n:
-        print(f"OK cross-reconcile: {cross_n} linked row(s) consistent across bundles")
 
+    # CISO-readable PASS summary. The line breaks below are deliberate
+    # so the auditor's terminal output reads like a verdict, not a CSV.
+    print("")
+    print("✓ CHAIN VERIFIED")
+    print("")
     print(
-        f"VERIFY PASS — legacy={total_legacy} per_org={total_per_org} "
-        f"anchors={total_anchors} cross={cross_n}"
+        f"  {total_entries} entries · "
+        f"{len(total_agents)} agent{'s' if len(total_agents) != 1 else ''} · "
+        f"{len(total_orgs)} org{'s' if len(total_orgs) != 1 else ''} · "
+        f"{total_legacy} legacy · {total_per_org} per-org · "
+        f"{total_anchors} TSA anchor{'s' if total_anchors != 1 else ''}"
     )
+    if cross_n:
+        print(f"  {cross_n} cross-org peer row{'s' if cross_n != 1 else ''} reconciled")
+    print("")
+    print("  Every entry_hash matches the SHA-256 of its canonical row.")
+    print("  No previous_hash → next entry_hash break detected.")
+    print("")
+    print("  Bundle is intact end-to-end. No row was added, altered, or")
+    print("  removed after the original audit chain was written.")
+    print("")
     return 0
 
 


### PR DESCRIPTION
## Summary

Three changes that turn the Mastio audit dashboard into something a CISO can read end-to-end, plus the proprietary pattern (Cullis Audit Envelope) that lets tools surface business-readable rows for free.

- **`feat(audit)` — verify endpoint + grouped card view** (4 files, +874/-28). New POST `/proxy/audit/verify` runs the chain-integrity check in-process and returns JSON pass/fail; new grouped card view collapses the 3-row fan-out of one tool call (PDP decision + executor row + egress) into a single CISO-readable card, keyed by a server-minted invocation id (`inv-<hex12>`) instead of the useless caller-supplied MCP JSON-RPC `id` (always `"1"`).
- **`refactor(dashboard)` — Backends → Tools** (2 files). Sidebar entry renamed to match the term the rest of the product uses; the previous `Tools` entry (runtime tool registry) becomes `Tool Registry` for disambiguation. URL paths unchanged.
- **`feat(sdk,verifier)` — Cullis Audit Envelope helper + CISO-readable verifier** (2 files, +279/-14). New `cullis_sdk.audit` module with `envelope`/`make_envelope`/`extract`. Standalone offline verifier `scripts/cullis-audit-verify.py` keeps its 'verify without trusting Cullis' role but its output is rewritten to be readable by a non-engineer.

## Cullis Audit Envelope pattern

Tools opt in to a business-readable audit row by attaching a sidecar to their result:

```python
from cullis_sdk.audit import envelope

@mcp.tool()
async def place_order(isin: str, qty: int, price: float):
    result = await broker.execute(isin, qty, price)
    return envelope(
        result,
        action="Order placement",
        subject=f"BUY {qty:,} × {isin} @ €{price:,.2f}",
        outcome=f"filled: order #{result['order_id']}",
    )
```

Mastio walks the parsed result for `_cullis_audit` (depth-capped) and uses `{action, subject, outcome}` as the card-level header. Tools that don't opt in fall back to `Tool invoked: <name>` so adoption is incremental and zero-risk for legacy tools.

Spec lives in ADR-035 (still in `imp/adrs/` — publication to `docs/adrs/` is a follow-up).

## Test plan

- [x] `scripts/cullis-audit-verify.py --bundle good.ndjson` — green output with new entries/agents/orgs summary
- [x] `scripts/cullis-audit-verify.py --bundle tampered.ndjson` — red output with expected vs observed hash diff, exit 2
- [x] Dashboard click on `Verify chain integrity` button — banner green with chain stats
- [x] Tamper a `local_audit` row server-side (drop trigger, UPDATE, re-create trigger) — banner red with failure detail
- [x] Grouped view: 1 card = 3 chained events visible on expand
- [x] Mixed-agent run (4 demo agents: portfolio rebalancer, KYC, pitchbook, DORA) — each card shows business action when envelope is present
- [x] Toggle `?view=raw` — legacy per-event table still works
- [x] Sidebar nav: Tool Registry / Tools both clickable, URLs unchanged
- [ ] **`/security-review` pre-merge** (mandatory per repo guidance — pending)

## Risk

- **POST /proxy/audit/verify**: CSRF-gated, admin-session-only, runs in-process against `local_audit` table. Read-only. Worst case: leaks chain mismatch detail to an authenticated dashboard admin — same audience that can already read every row.
- **invocation_id rename**: `request_id` column on `audit_log` now carries `inv-<hex12>` instead of the literal `"1"`. No downstream consumer in this repo relies on the literal. External downstream consumers (SIEM ingestion of `request_id`) would need a heads-up.
- **Envelope reader**: pure read-side; if a tool emits malformed `_cullis_audit`, the reader silently falls back to the default display. No write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)