### PR TITLE
fix(dockerfile): drop COPY of gitignored app/dashboard/templates/

### DIFF
--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR /src
 COPY tailwind.config.js ./
 COPY mcp_proxy/dashboard/static_src/ ./mcp_proxy/dashboard/static_src/
 COPY mcp_proxy/dashboard/templates/ ./mcp_proxy/dashboard/templates/
-COPY app/dashboard/templates/ ./app/dashboard/templates/
 RUN mkdir -p /out \
  && tailwindcss \
       -c ./tailwind.config.js \

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './app/dashboard/templates/**/*.html',
     './mcp_proxy/dashboard/templates/**/*.html',
   ],
   theme: {


### PR DESCRIPTION
## Summary

Portkey cleanup (PR #884) gitignored `app/`, but `mcp_proxy/Dockerfile` still tried to `COPY app/dashboard/templates/` in the tailwind build stage. Fresh clones (incl. CI / customer install) fail with:

```
COPY failed: stat app/dashboard/templates: file does not exist
```

Only the `mcp_proxy/dashboard/templates/` are wired into the runtime; the legacy `app/` templates were never served. The tailwind `content` glob is trimmed accordingly so no class detection is lost.

## Test plan

- [x] Identified by attempting a fresh build for the mastio-v0.5.2 release
- [ ] After merge: re-tag v0.5.2 and build image from clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)