### PR TITLE
docs(readme): bump Mastio install pin to v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Pull the Mastio bundle, deploy it, enroll an agent identity, install the SDK, ru
 
 ```bash
 # 1. Mastio
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.1/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Open https://localhost:9443/proxy/login, accept the self-signed TLS warning,
@@ -124,7 +124,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 
 | Component | Latest | What it is |
 |---|---|---|
-| **Cullis Mastio** | [`mastio-v0.5.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.1) | Org gateway, agent CA, policy enforcement, audit chain, MCP reverse proxy, embedded AI gateway |
+| **Cullis Mastio** | [`mastio-v0.5.2`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.2) | Org gateway, agent CA, policy enforcement, audit chain, MCP reverse proxy, embedded AI gateway |
 | **Cullis SDK** | [`cullis-sdk 0.1.3`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio |
 
 Use Cullis in evaluation, integration, and internal deploys. Talk to us before putting it in front of regulated production traffic.


### PR DESCRIPTION
## Summary

Two README occurrences of `mastio-v0.5.1` bumped to `mastio-v0.5.2` (the curl quickstart line and the components table). The site index.astro carries the same pin but is left for the follow-up site-restyle branch to avoid stash conflict.

## Test plan

- [x] Bundle URL https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.2/cullis-mastio-bundle.tar.gz returns 200
- [x] Tag https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.2 exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)