### PR TITLE
docs(sdk): fix bugs + dev-vs-operator framing in quickstart

### DIFF
--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -8,14 +8,20 @@ updated: "2026-05-22"
 
 # Python SDK quickstart
 
+**Scope of this page**: enrollment + transport-layer authentication. LLM completions and MCP tool calls (`client.chat_completion`, `client.call_mcp_tool`) are documented on their own pages — this one gets you to the point where those calls work.
+
+**Python only.** TypeScript / Go / Java SDKs are not available publicly.
+
 **Who this is for**: a Python developer writing an agent that authenticates to a Cullis Mastio (org gateway) and makes LLM completions + MCP tool calls through it.
 
 The flow is two phases that happen at different times by different people:
 
-1. **Provisioning** (one-time, operator). Mastio mints or accepts a cert+key+DPoP key for the agent. Files end up on disk.
+1. **Provisioning** (one-time, operator). Mastio mints or accepts a cert+key+DPoP key for the agent. Files end up on disk. **If someone in your team already handed you the three files, skip to step 3.**
 2. **Runtime** (every agent start, agent itself). Agent reads those files and authenticates to Mastio via mTLS.
 
-This page shows both phases. The runtime block (step 3) is the same regardless of how you provisioned.
+> **Need a Mastio to talk to?** A single-host Docker bundle gives you `https://localhost:9443` in two commands — see [Install Mastio on Docker](../install/mastio-bundle). The rest of this page uses `https://mastio.acme.corp` as a placeholder; substitute the host you actually reach.
+
+> **Known issue, current release**: `client.chat_completion()` has a DPoP pinning bug that surfaces as a 401 with no auto-retry. Workaround in the reference agents is a direct `httpx.Client(cert=...)` call against `POST /v1/llm/chat` — `agent_kyc_screener/main_stack.py` lines 162–176 in the demo stack shows the pattern. mTLS still applies, only the SDK helper path is broken. Tracked, fix on the roadmap.
 
 ## 1. Install
 
@@ -25,7 +31,13 @@ pip install cullis-sdk
 
 Python 3.10+. No required system dependencies. Linux, macOS, Windows supported.
 
-For SPIRE/SPIFFE workload-API integration (only if you provision via SPIRE — section 2b), install the extra:
+Pin to a released minor in your `pyproject.toml` so a breaking minor bump doesn't surprise a future-you:
+
+```toml
+cullis-sdk = ">=0.1,<0.2"
+```
+
+For SPIRE/SPIFFE workload-API integration (only if you provision via SPIRE — section 2c), install the extra:
 
 ```bash
 pip install 'cullis-sdk[spiffe]'
@@ -37,9 +49,11 @@ The agent's runtime identity is **three files**:
 
 - `cert.pem` — x509 client cert, with SAN like `spiffe://acme.corp/orga/<agent-name>`
 - `agent-key.pem` — private key matching the cert
-- `dpop.jwk` — EC private key bound to the cert for replay protection (DPoP, RFC 9449)
+- `dpop.jwk` — EC P-256 private key bound to the cert thumbprint (DPoP, [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) — a JWT that proves the request comes from the holder of the matching private key, not just a token bearer)
 
-Pick one of the two provisioning paths depending on whether your org already has a PKI.
+**A note on agent IDs.** Cullis identifies agents as `<org-id>::<agent-name>` (e.g. `orga::kyc-screener`). When you call the **raw HTTP admin API** you pass the full `agent_id`. When you call the **SDK** you pass only `agent_name` — the SDK derives the org from the admin token and prepends it. The two paths show both styles below.
+
+Pick one of the three provisioning paths depending on whether your org already has a PKI.
 
 ### a. Mastio mints the cert (no existing PKI)
 
@@ -71,22 +85,29 @@ Mastio pins the cert thumbprint in its DB. From this moment any TLS handshake pr
 Your organisation already runs a CA (HashiCorp Vault, AD CS, EJBCA, AWS Private CA, whatever). The agent has a cert + private key signed by it. You hand both to Mastio once; Mastio verifies the chain and pins the thumbprint.
 
 ```python
-# Operator-side script, run once per agent at provisioning time
+import os
+from pathlib import Path
 from cullis_sdk import CullisClient
+
+# Operator-side script, run once per agent at provisioning time
+with open("/path/to/agent.pem") as f:
+    cert_pem = f.read()
+with open("/path/to/agent-key.pem") as f:
+    private_key_pem = f.read()
 
 CullisClient.enroll_via_byoca(
     "https://mastio.acme.corp",
-    admin_secret="$MASTIO_ADMIN_SECRET",   # ← admin privilege
-    agent_name="kyc-screener",
+    admin_secret=os.environ["MASTIO_ADMIN_SECRET"],   # ← admin privilege
+    agent_name="kyc-screener",                         # org prefix auto-prepended
     display_name="KYC Screener",
-    cert_pem=open("/path/to/agent.pem").read(),
-    private_key_pem=open("/path/to/agent-key.pem").read(),
+    cert_pem=cert_pem,
+    private_key_pem=private_key_pem,
     capabilities=["kyc.read", "kyc.submit"],
-    persist_to="/etc/cullis/agents/kyc/",   # writes cert.pem + key.pem + dpop.jwk
+    persist_to="/etc/cullis/agents/kyc/",              # writes cert.pem + agent-key.pem + dpop.jwk
 )
 ```
 
-Mastio verifies the chain against the Org CA you previously attached (see [BYOCA enrollment](../enroll/byoca)), pins the thumbprint, mints a DPoP key, persists the three files at `persist_to`.
+Mastio verifies the chain against the Org CA you previously attached (see [BYOCA enrollment](../enroll/byoca)), pins the thumbprint, mints a DPoP key, persists the three files at `persist_to` using the same filenames the runtime constructor expects.
 
 → Full chain rules + CA attach flow: [BYOCA enrollment](../enroll/byoca).
 
@@ -95,13 +116,14 @@ Mastio verifies the chain against the Org CA you previously attached (see [BYOCA
 Your agent runs in a SPIRE-attested environment (Kubernetes with SPIRE installed). The SPIRE workload API hands the agent an SVID; the SDK exchanges it for cert+key pinned in Mastio.
 
 ```python
+import os
 from cullis_sdk import CullisClient
 
 CullisClient.enroll_via_spiffe(
     "https://mastio.acme.corp",
-    admin_secret="$MASTIO_ADMIN_SECRET",
-    agent_name="kyc-screener",
-    persist_to="/var/lib/cullis/agents/kyc/",
+    admin_secret=os.environ["MASTIO_ADMIN_SECRET"],
+    agent_name="kyc-screener",                         # org prefix auto-prepended
+    persist_to="/var/lib/cullis/agents/kyc/",          # writes cert.pem + agent-key.pem + dpop.jwk
 )
 ```
 
@@ -124,14 +146,23 @@ client = CullisClient.from_identity_dir(
 client.login_via_proxy_with_local_key()
 ```
 
-What happens under the hood:
+**Where does `ca_chain_path` come from?** It's the Org CA cert that signs Mastio's own TLS cert. Operators export it from the Mastio dashboard (PKI → Export CA Certificate) or fetch it from the bundle's `nginx-certs/org-ca.crt`. Distribute it alongside the three identity files. If you set `verify_tls=False` you don't need it, but that's for local dogfood only.
 
-1. The SDK opens a TLS handshake to Mastio **presenting the agent cert as a client cert** (mTLS, RFC 8705).
+**Two-line mental model**:
+
+- `from_identity_dir(...)` is **pure local**: opens 3 files, builds an httpx client. **No network call.** If this fails, your error is a `FileNotFoundError` or bad PEM format.
+- `login_via_proxy_with_local_key()` is the **first network call**. mTLS handshake + DPoP challenge + token issue. If this fails, your error is a TLS / 401 / connection error pointing at the Mastio.
+
+**Verify it works**: if `login_via_proxy_with_local_key()` returns without raising, you are authenticated. The SDK has cached a short-lived token bound to your cert + DPoP key, and will auto-attach it to every subsequent call. There is no explicit `.ping()` to run — a successful login is the green light.
+
+### What happens under the hood
+
+1. The SDK opens a TLS handshake to Mastio **presenting the agent cert as a client cert** (mTLS, [RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705) — the TLS-layer counterpart to OAuth client authentication).
 2. Mastio compares the cert's SHA-256 thumbprint against the one pinned at provisioning. Mismatch → 401.
-3. The DPoP key signs subsequent egress requests, binding the token to the keypair (RFC 9449). Mastio rejects replays from other clients.
+3. The DPoP key signs subsequent egress requests, binding the token to the keypair. Mastio rejects replays from other clients.
 4. From here on `client` has an authenticated session. No admin secret in scope, no enrollment call at startup.
 
-`from_identity_dir` is the only runtime constructor you need. Production agents that load credentials from Vault, K8s secrets, HSMs, or any other secret store use this same call once the material has been read.
+`from_identity_dir` is the only runtime constructor you need. Production agents that load credentials from Vault, K8s secrets, HSMs, or any other secret store use this same call once the material has been read into the three file paths.
 
 ## What's next
 
@@ -139,5 +170,6 @@ What happens under the hood:
 - [SPIRE enrollment](../enroll/spire) — workload API integration in detail
 - [Configuration](../reference/configuration) — every `CULLIS_*` env var the SDK reads
 - [Enrollment API reference](../reference/enrollment-api) — raw HTTP if you'd rather not use the SDK
+- [Mastio on Docker](../install/mastio-bundle) — stand up a local Mastio at `https://localhost:9443` in two commands
 
-If anything in here breaks against the version on your machine, the SDK exposes `cullis_sdk.__version__` — pin to a released minor in your project's `pyproject.toml` (`cullis-sdk>=0.1,<0.2`) so a future-you doesn't get surprised by a breaking minor bump.
+The SDK exposes `cullis_sdk.__version__` if you need to assert the running version in your own diagnostics.


### PR DESCRIPTION
Acting on a structured external review of \`docs/quickstart/sdk.md\`. The reviewer flagged three bugs that would burn a copy-paste dev, plus several missing callouts at the head of the page that the new dev-vs-operator framing makes obvious.

## Bugs fixed (the part that would actually break a copy-paste)

| # | What | Fix |
|---|---|---|
| 1 | \`admin_secret=\"\$MASTIO_ADMIN_SECRET\"\` inside the Python BYOCA + SPIRE examples passes the literal string \`\"\$MASTIO_ADMIN_SECRET\"\`, not the env var | Replaced with \`os.environ[\"MASTIO_ADMIN_SECRET\"]\` + added \`import os\` |
| 2 | BYOCA comment claimed \`persist_to\` writes \`key.pem\`; the §3 runtime constructor expects \`agent-key.pem\` | Comment now matches the actual filename the SDK writes |
| 3 | Raw-curl path used \`agent_id: \"orga::kyc-screener\"\`, SDK paths used bare \`agent_name=\"kyc-screener\"\` with no explanation of the prefix | Added a \"note on agent IDs\" box explaining \`<org-id>::<agent-name>\` derivation and which surface expects which form |

## Callouts added at the head

- **\"Python only\"** directly under the title (saves the TS / Go visitor a scroll).
- **Scope statement**: this page is enrollment + auth, not \`chat_completion\` / tool calls. The reviewer mistook the scope on first read; explicit framing prevents that.
- **\"If someone handed you the 3 files, skip to step 3\"** — devs who consume an already-enrolled identity shouldn't slog through operator territory.
- **\"Need a Mastio?\"** link to \`install/mastio-bundle\` for the localhost:9443 path.
- **Known-issue banner** for the \`chat_completion\` DPoP pinning bug with a pointer to the \`agent_kyc_screener/main_stack.py\` workaround.

## Conceptual improvements

- \`from_identity_dir\` is **local**, \`login_via_proxy_with_local_key\` is the **first network call** — explicit, with the matching error categories you'd see for each failure mode.
- \"Verify it works\" line: a successful \`login_via_proxy_with_local_key()\` return is the green light, no \`.ping()\` needed.
- \`ca_chain_path\` provenance documented: Mastio dashboard PKI → Export or bundle \`nginx-certs/org-ca.crt\`.
- DPoP (RFC 9449) and mTLS (RFC 8705) each get a one-line intuition inline. A reader who hasn't met the acronyms doesn't have to leave the page.

## Polishing

- BYOCA example uses \`with open()\` instead of \`open().read()\` (file-handle leak, even if cosmetic here).
- \`pyproject.toml\` version pin example moved up under Install where it belongs.
- \`__version__\` mention moved to a footer line.

## Test plan

- [x] File renders 200 on Astro dev server
- [x] All three bug fixes verified against agent_kyc_screener (the \`agent-key.pem\` filename, the env-var pattern)
- [ ] After merge: hard-refresh \`cullis.io/docs/quickstart/sdk\` and confirm the new callouts ship