### PR TITLE
docs(sdk): close 3 minor review points + drop stale chat_completion banner

### DIFF
--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -8,7 +8,7 @@ updated: "2026-05-22"
 
 # Python SDK quickstart
 
-**Scope of this page**: enrollment + transport-layer authentication. LLM completions and MCP tool calls (`client.chat_completion`, `client.call_mcp_tool`) are documented on their own pages — this one gets you to the point where those calls work.
+**Scope of this page**: enrollment + transport-layer authentication. LLM completions and MCP tool calls (`client.chat_completion`, `client.call_mcp_tool`) get you to the point where those calls work; companion pages for the call surfaces are in progress. Until they land, the reference agent in `agent_kyc_screener/main_stack.py` (cullis-enterprise repo) shows the full loop end-to-end.
 
 **Python only.** TypeScript / Go / Java SDKs are not available publicly.
 
@@ -20,8 +20,6 @@ The flow is two phases that happen at different times by different people:
 2. **Runtime** (every agent start, agent itself). Agent reads those files and authenticates to Mastio via mTLS.
 
 > **Need a Mastio to talk to?** A single-host Docker bundle gives you `https://localhost:9443` in two commands — see [Install Mastio on Docker](../install/mastio-bundle). The rest of this page uses `https://mastio.acme.corp` as a placeholder; substitute the host you actually reach.
-
-> **Known issue, current release**: `client.chat_completion()` has a DPoP pinning bug that surfaces as a 401 with no auto-retry. Workaround in the reference agents is a direct `httpx.Client(cert=...)` call against `POST /v1/llm/chat` — `agent_kyc_screener/main_stack.py` lines 162–176 in the demo stack shows the pattern. mTLS still applies, only the SDK helper path is broken. Tracked, fix on the roadmap.
 
 ## 1. Install
 
@@ -52,6 +50,10 @@ The agent's runtime identity is **three files**:
 - `dpop.jwk` — EC P-256 private key bound to the cert thumbprint (DPoP, [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) — a JWT that proves the request comes from the holder of the matching private key, not just a token bearer)
 
 **A note on agent IDs.** Cullis identifies agents as `<org-id>::<agent-name>` (e.g. `orga::kyc-screener`). When you call the **raw HTTP admin API** you pass the full `agent_id`. When you call the **SDK** you pass only `agent_name` — the SDK derives the org from the admin token and prepends it. The two paths show both styles below.
+
+**A note on `capabilities`.** Free-form strings. There is no closed vocabulary. The convention is `<area>.<verb>` (e.g. `kyc.read`, `kyc.submit`, `portfolio.place_order`) but Mastio does not validate the syntax at enrollment. What matters is that the strings here **match exactly** the capabilities required by the MCP tools the agent will call — Mastio's capability gate compares them literally when a tool is dispatched. Each MCP tool declares its required capability in its server manifest; ask the team that operates the MCP server for the list, or list them at runtime with `client.list_mcp_tools()`.
+
+**A note on `X-Admin-Secret`.** It's the Mastio operator secret. First-boot wizard bcrypts it into Vault; the env var (`MCP_PROXY_ADMIN_SECRET`) is consulted only when the hash is empty. Rotation is via dashboard / `proxy.env` rotate + restart. Full details: [Configuration reference](../reference/configuration) (search `MCP_PROXY_ADMIN_SECRET`) and [Runbook § Admin lockout](../operate/runbook#7-admin-lockout) for the recovery flow.
 
 Pick one of the three provisioning paths depending on whether your org already has a PKI.
 


### PR DESCRIPTION
Post-merge follow-up on the SDK quickstart. The reviewer raised three minor points after the 7.5→9 jump, and a banner that should have shipped removed slipped past the squash merge of #893.

## What changes

1. **`capabilities` format** (was \"free-form or closed vocabulary?\"). Added an explicit note: free-form strings, convention `<area>.<verb>`, validated at tool dispatch time by Mastio's capability gate, not at enrollment. Pointer to `client.list_mcp_tools()` and the per-MCP-server manifest as the source of truth for the actual set.

2. **`X-Admin-Secret` bootstrap / rotation**. Linked the existing answer from where the question arises: the Configuration reference (`MCP_PROXY_ADMIN_SECRET` row) for bootstrap, the Runbook §7 Admin lockout for rotation. No new pages, just the missing breadcrumb.

3. **Companion pages for `chat_completion` / MCP tool calls**. Re-phrased the scope blurb to make explicit those pages are \"in progress\" rather than implying they exist. Pointer at `agent_kyc_screener/main_stack.py` as the working end-to-end reference until the dedicated pages land.

## Plus a cleanup

The chat_completion DPoP-pinning known-issue banner had been added in #893 based on a stale session-memory entry. The bug was fixed by PR #724 in May 2026 and the fix shipped in `cullis-sdk 0.1.3`. A follow-up commit on the source branch had removed the banner, but the squash merge of #893 took the earlier tip — so the stale banner went live. This PR completes the cleanup on main.

## Test plan

- [x] File renders, all four edits visible by grep
- [ ] After merge: `curl -sL https://cullis.io/docs/quickstart/sdk/ | grep -oE \"(capabilities|Free-form|X-Admin-Secret|Admin lockout|companion pages)\"` returns the new strings