### PR TITLE
docs(site): fix 5 broken links + drop Connector refs post-pivot

### DIFF
--- a/site/src/content/docs/enroll/byoca.md
+++ b/site/src/content/docs/enroll/byoca.md
@@ -10,7 +10,7 @@ updated: "2026-04-23"
 
 **Who this is for**: a platform engineer provisioning headless agents (CI/CD jobs, backend services, scheduled workflows) where the organization already runs an internal PKI. BYOCA — "bring your own CA" — lets you use the cert material your security team already manages instead of a Connector approval click.
 
-If you're an end-user developer on a laptop, use the [Connector device-code flow](connector-device-code) instead. If your agents already hold a SPIRE SVID, use [SPIRE enrollment](spire).
+If your agents already hold a SPIRE SVID, use [SPIRE enrollment](spire) instead.
 
 ## Prerequisites
 

--- a/site/src/content/docs/enroll/spire.md
+++ b/site/src/content/docs/enroll/spire.md
@@ -8,7 +8,7 @@ updated: "2026-04-23"
 
 # SPIRE enrollment
 
-**Who this is for**: a platform engineer whose organization already runs SPIRE as the workload identity fabric, and who wants Cullis to trust the same SPIFFE identities the rest of the stack does. If you don't run SPIRE, use [Connector](connector-device-code) (laptops) or [BYOCA](byoca) (long-lived agents with an org CA) instead.
+**Who this is for**: a platform engineer whose organization already runs SPIRE as the workload identity fabric, and who wants Cullis to trust the same SPIFFE identities the rest of the stack does. If you don't run SPIRE, use [BYOCA](byoca) instead — it covers both long-lived agents signed by an org CA and ad-hoc developer enrollment.
 
 ## When SPIRE is the right enrollment method
 

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -173,7 +173,7 @@ MCP_PROXY_STANDALONE=false
 
 ## Next
 
-- [Self-host the Mastio](../install/mastio-self-host) — step-by-step for a production `.env`
+- [Mastio bundle](../install/mastio-bundle) — step-by-step `docker compose` deploy with a production `.env`
 - [Mastio on Kubernetes](../install/mastio-kubernetes) — Helm `values.yaml` equivalents
 - [Rotate keys](../operate/rotate-keys) — which variables participate in key rotation
 - [Migration from direct login](migration-from-direct-login) — context for `CULLIS_ALLOW_LEGACY_AUTH_LOGIN`

--- a/site/src/content/docs/reference/enrollment-api.md
+++ b/site/src/content/docs/reference/enrollment-api.md
@@ -122,9 +122,9 @@ Enroll an agent via an X.509-SVID verified against a SPIRE trust bundle.
 
 The pre-ADR-011 path. Still the default for programmatic agents created from scripts or CI. See existing runbooks — behavior unchanged, except the row now carries `enrollment_method='admin'` automatically.
 
-## `POST /v1/enrollment/start` + polling — connector flow
+## `POST /v1/enrollment/start` + polling — device-code flow
 
-The device-code enrollment for Connector Desktop. Unchanged; see [SPIFFE onboarding](spiffe-onboarding.md) and the Connector README. Rows get `enrollment_method='connector'`.
+The device-code enrollment flow. An interactive client (typically running on a developer laptop or workstation) starts a session, the user approves the request from a browser-based dashboard, the client polls for the issued credential. Rows get `enrollment_method='connector'` for historical reasons. See [SPIRE enrollment](../enroll/spire) for the non-interactive equivalent.
 
 ---
 

--- a/site/src/content/docs/reference/migration-from-direct-login.md
+++ b/site/src/content/docs/reference/migration-from-direct-login.md
@@ -166,6 +166,6 @@ During the grace window, yes — the legacy login still works. After `CULLIS_ALL
 
 ## See also
 
-- [Agent enrollment — the three methods](enrollment.md)
-- [Enrollment API reference](enrollment-api-reference.md)
-- [SPIFFE onboarding](spiffe-onboarding.md) for deploying SPIRE alongside Cullis
+- [BYOCA enrollment](../enroll/byoca) — issue agent credentials from an existing org CA
+- [SPIRE enrollment](../enroll/spire) — federate Cullis with a SPIRE workload identity fabric
+- [Enrollment API reference](enrollment-api) — the underlying HTTP surface


### PR DESCRIPTION
## Summary

Visitor-as-HN-reader walk-through (2 days before Show HN) found five broken or leaky links across the docs pages that survived the 2026-05-21 pivot to *Mastio + SDK only*. Fixing them all in one PR.

- `enroll/byoca.md` + `enroll/spire.md`: dropped `[Connector device-code](connector-device-code)` cross-links — Connector source moved to the private enterprise repo and the public docs page never existed, so this was a 404 plus a Connector mention that no longer matches the public surface.
- `reference/enrollment-api.md`: rewrote the `/v1/enrollment/start` section to describe the endpoint generically (the Mastio still ships it: `mcp_proxy/enrollment/router.py:101`). Dropped the "Connector Desktop" / "Connector README" references and the broken `spiffe-onboarding.md` link, redirected to `enroll/spire`.
- `reference/configuration.md`: `../install/mastio-self-host` → `../install/mastio-bundle` (target page does not exist; the bundle is the canonical install path post-pivot).
- `reference/migration-from-direct-login.md`: three broken "See also" links rewritten to the pages that actually exist (`enroll/byoca`, `enroll/spire`, `reference/enrollment-api`).

## Test plan

- [x] Astro build green: 26 pages, no warnings
- [x] Re-grep all relative `[...](...)` targets against `find site/src/content/docs -name '*.md' | xargs basename` — no remaining unresolved targets
- [x] Spot-check that the rewritten copy still reads naturally (no orphan sentences pointing at removed Connector path)

## Why now

HN Show is on 2026-05-25 and the docs pages are the second-most-likely click after the README. A broken `[Connector device-code](connector-device-code)` on the BYOCA enrollment page would advertise both a 404 and a product that the public repo no longer hosts.