### PR TITLE
docs: fix residual Court/Connector/Frontdesk leaks from final walk-through

### DIFF
--- a/deploy_proxy.sh
+++ b/deploy_proxy.sh
@@ -3,26 +3,24 @@
 # Cullis — MCP Proxy deployment (org-level gateway + built-in PDP)
 # ═══════════════════════════════════════════════════════════════════════════════
 #
-# Deploys the MCP Proxy for one organization.
+# Deploys the Cullis Mastio (the org-level MCP proxy) standalone on a
+# private docker network. The Mastio derives its Org CA at first boot
+# and works zero-config.
 #
-# Default = standalone Mastio on its own private docker network. The
-# Mastio derives its Org CA at first boot and works zero-config; allaccio
-# al Court is post-setup via the dashboard. The --shared-broker override
-# is only for bringing up the Mastio alongside a Court already running
-# on the same docker host (CI fixtures, single-host dev).
+# For the customer-facing one-shot deploy script (bundled docker-compose,
+# nginx TLS sidecar, env templates), use packaging/mastio-bundle/deploy.sh.
+# This script is the lower-level dev entrypoint used when working against
+# the source tree directly.
 #
 # Modes (combinable):
 #   (default)         standalone Mastio, private docker network
-#   --shared-broker   join the broker's docker network (Court must be up)
 #   --prod            fail-fast on insecure defaults + prod overlay
 #   --down            stop + remove containers
 #   --rebuild         rebuild images and restart
 #
 # Examples:
 #   ./deploy_proxy.sh                       # standalone (default)
-#   ./deploy_proxy.sh --shared-broker       # join Court on same host
 #   ./deploy_proxy.sh --prod                # standalone, prod safety
-#   ./deploy_proxy.sh --prod --shared-broker
 #   ./deploy_proxy.sh --down
 #
 set -euo pipefail
@@ -30,10 +28,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Distinct compose project name isolates the proxy stack from the broker
-# (deploy_broker.sh → cullis-broker). Otherwise fresh clones named `cullis`
-# would share docker volumes across stacks and a fresh user would hit
-# opaque volume/password collisions (shake-out P0-03).
+# Distinct compose project name isolates the proxy stack so fresh
+# clones named `cullis` do not share docker volumes across stacks
+# and a fresh user does not hit opaque volume/password collisions.
 export COMPOSE_PROJECT_NAME="cullis-proxy"
 
 GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
@@ -62,15 +59,11 @@ print_help() {
     cat <<EOF
 Usage: $0 [OPTIONS]
 
-Deploys the MCP Proxy for one organization. Default = standalone Mastio
-(zero broker dependency). Combine with --down / --rebuild for lifecycle
-management, --shared-broker only when a Court is up on the same host.
+Deploys the Cullis Mastio (org-level MCP proxy). Default = standalone
+Mastio on a private docker network.
 
 Options:
   (no flags)                  Standalone Mastio, private docker network
-                              (default — no broker required at boot)
-  --shared-broker             Join the broker's docker network. Requires
-                              the Court compose project to be up.
   --prod                      Production: fail-fast on insecure defaults,
                               requires proxy.env pre-provisioned.
   --down                      Stop and remove containers.
@@ -79,40 +72,26 @@ Options:
 
 Examples:
   ./deploy_proxy.sh                              # standalone (default)
-  ./deploy_proxy.sh --shared-broker              # join Court on same host
   ./deploy_proxy.sh --prod                       # standalone, prod safety
-  ./deploy_proxy.sh --prod --shared-broker       # federated prod
   ./deploy_proxy.sh --down                       # stop + remove containers
-
-Legacy --standalone (no-op) is accepted with a deprecation warning so
-older runbooks keep running.
 EOF
 }
 
 ACTION="up"
 MODE="development"
-SHARED_BROKER=0
 for arg in "$@"; do
     case "$arg" in
         --down)          ACTION="down" ;;
         --rebuild)       ACTION="rebuild" ;;
         --prod)          MODE="production" ;;
-        --shared-broker) SHARED_BROKER=1 ;;
-        --standalone)
-            warn "--standalone is the new default — flag is a no-op. Drop it from your scripts."
-            ;;
         --help|-h)       print_help; exit 0 ;;
         *) die "Unknown argument: $arg (use --help)" ;;
     esac
 done
 
 # ── Compose file stacking ───────────────────────────────────────────────────
-# Default = standalone (private proxy_net + MCP_PROXY_STANDALONE=true
-# in the base compose). The shared-broker override layers on broker_net
-# + MCP_PROXY_STANDALONE=false.
-# Base compose is already in $COMPOSE; here we add only the overlays.
+# Base compose is already in $COMPOSE; here we add only the prod overlay.
 COMPOSE_FILES=""
-[[ $SHARED_BROKER -eq 1 ]]   && COMPOSE_FILES="$COMPOSE_FILES -f deploy/compose/docker-compose.proxy.shared-broker.yml"
 [[ "$MODE" == "production" ]] && COMPOSE_FILES="$COMPOSE_FILES -f deploy/compose/docker-compose.proxy.prod.yml"
 
 # ── Down early-exit ─────────────────────────────────────────────────────────
@@ -178,21 +157,12 @@ if [[ "$MODE" == "production" ]]; then
 fi
 
 # ── Build + Start ───────────────────────────────────────────────────────────
-step "Deploying Cullis MCP Proxy (${MODE}, $([ $SHARED_BROKER -eq 1 ] && echo shared-broker || echo standalone))"
+step "Deploying Cullis MCP Proxy (${MODE}, standalone)"
 
 if [[ "$ACTION" == "rebuild" ]]; then
     echo -e "  ${GRAY}$COMPOSE $COMPOSE_FILES --env-file deploy/proxy/proxy.env build --no-cache${RESET}"
     $COMPOSE $COMPOSE_FILES --env-file deploy/proxy/proxy.env build --no-cache
     ok "Images rebuilt"
-fi
-
-# --shared-broker assumes the broker compose project is up so its docker
-# network is reachable. Bail with a useful error if it isn't, instead of
-# letting compose emit "network cullis-broker_default not found".
-if [[ $SHARED_BROKER -eq 1 ]]; then
-    if ! docker network inspect cullis-broker_default >/dev/null 2>&1; then
-        die "--shared-broker requires the broker compose to be up. Either run ./deploy_broker.sh --dev first, or drop --shared-broker for the standalone default."
-    fi
 fi
 
 echo -e "  ${GRAY}$COMPOSE $COMPOSE_FILES --env-file deploy/proxy/proxy.env up --build -d${RESET}"

--- a/site/src/content/docs/enroll/byoca.md
+++ b/site/src/content/docs/enroll/byoca.md
@@ -8,7 +8,7 @@ updated: "2026-04-23"
 
 # BYOCA enrollment
 
-**Who this is for**: a platform engineer provisioning headless agents (CI/CD jobs, backend services, scheduled workflows) where the organization already runs an internal PKI. BYOCA — "bring your own CA" — lets you use the cert material your security team already manages instead of a Connector approval click.
+**Who this is for**: a platform engineer provisioning headless agents (CI/CD jobs, backend services, scheduled workflows) where the organization already runs an internal PKI. BYOCA — "bring your own CA" — lets you use the cert material your security team already manages.
 
 If your agents already hold a SPIRE SVID, use [SPIRE enrollment](spire) instead.
 

--- a/site/src/content/docs/install/mastio-bundle.md
+++ b/site/src/content/docs/install/mastio-bundle.md
@@ -81,7 +81,7 @@ If `/readyz` returns `503`, jump to [Troubleshoot](#troubleshoot).
 
 ## Enable chat (Anthropic API key)
 
-The Mastio includes an embedded AI gateway that powers the chat completion endpoint used by Cullis Chat and Frontdesk. Without a provider key, chat returns HTTP `503 provider_key_missing` — registry / MCP / audit keep working regardless.
+The Mastio includes an embedded AI gateway that powers the `/v1/llm/chat` endpoint your agents call via the SDK. Without a provider key, chat returns HTTP `503 provider_key_missing` — registry / MCP / audit keep working regardless.
 
 Open `proxy.env` and set:
 


### PR DESCRIPTION
## Summary

Post-cleanup re-clone walk-through (sabato sera pre-HN) caught three more places where the 2026-05-21 pivot left visible-to-HN-visitor references:

### `deploy_proxy.sh` (root, tracked)

Header comment described the Mastio as \"allaccio al Court is post-setup via the dashboard\" and the help text offered a `--shared-broker` mode that joins a Court network.

The `docker-compose.proxy.shared-broker.yml` file the flag tried to layer is **not in the repo**, so `--shared-broker` was already broken at runtime (`compose: file not found`). Cleaner to remove the dead mode end-to-end than to leave a half-removed flag in the public surface.

Changes: parse, help, compose stacking, pre-flight network check, status banner — all the `--shared-broker` paths are gone. Script is now Mastio-standalone only.

### `site/src/content/docs/install/mastio-bundle.md`

> embedded AI gateway that powers the chat completion endpoint used by **Cullis Chat and Frontdesk**

rewritten to

> embedded AI gateway that powers the `/v1/llm/chat` endpoint your agents call via the SDK

Cullis Chat / Frontdesk are enterprise post-pivot; the public surface is the SDK.

### `site/src/content/docs/enroll/byoca.md`

> BYOCA — \"bring your own CA\" — lets you use the cert material your security team already manages **instead of a Connector approval click**

The Connector comparison no longer belongs on the public docs. The sentence stands on its own without it.

## Test plan

- [x] Astro build green: 24 pages, no warnings
- [x] `bash -n deploy_proxy.sh` passes (syntax OK)
- [x] `grep -n shared-broker deploy_proxy.sh` returns empty

## Follow-ups (deliberately not in this PR)

`grep -rn -E '\\b(Court|Connector|Frontdesk)\\b'` against the tracked tree still returns code-internal occurrences not visible to a docs reader:

- `mcp_proxy/enrollment/__init__.py` + `service.py`: 8 docstrings on the device-code flow that name \"the Connector\" (it is the only client that drives that flow today)
- `mcp_proxy/db_models.py`: 5 internal comments and 1 Frontdesk comment
- `mcp_proxy/alembic/versions/0035_mdm_device_state.py`: 2 mentions in the migration's own historical commentary
- `mcp_proxy/main.py`: 6 inline code comments on the federation flow
- `deploy/compose/docker-compose.proxy.yml:102`: one nginx-sidecar comment naming \"Connector → Mastio\"
- `scripts/cullis-audit-verify.py:53`: one comment \"CRIT-3 Court\"

These are code internals (docstrings, migration history, inline comments). Tidying them is reasonable but should happen during a codebase pass, not as a docs sweep.

## Why now

Final walk-through pre-HN (lunedì 2026-05-25). A reader who clones the repo and opens `deploy_proxy.sh --help` would see \"join Court on same host\" and `--shared-broker` — both pointing at infrastructure the public repo no longer hosts. Same for the two docs strings.