### PR TITLE
feat(db): production-ready Postgres binding (F0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,45 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Mastio — production-ready Postgres binding (F0.2)
+
+- **Bundle ships `--db postgres` flag** for `deploy.sh`. Brings up a
+  bundled Postgres 16 container alongside the Mastio via
+  `docker-compose.postgres.yml` overlay; the Mastio reads
+  `PROXY_DB_URL` (asyncpg) pointing at it. Default backend stays
+  SQLite for the quickstart / demo VM path.
+
+- **Integration test suite `test/integration/test_alembic_full_chain_postgres.py`**
+  (gated by `@pytest.mark.postgres` + `CULLIS_TEST_PG_URL`) pins the
+  asyncpg binding contract end-to-end: full 43-migration walk against
+  a fresh Postgres, append-only `BEFORE UPDATE/DELETE` trigger on
+  `audit_log`, `UNIQUE(chain_seq)` surfacing as
+  `sqlalchemy.exc.IntegrityError` (the multi-worker retry path
+  depends on this), advisory-lock observability via `pg_locks`. Run
+  via `./test/run-pg-nightly.sh` which boots the ephemeral
+  `test/compose-pg.yml` service, exports the URL, and tears it down.
+
+- **Soak baseline script `scripts/load-soak-pg.sh`**. Replica of the
+  A.1b Run 3 SQLite soak profile (ramp 0 → 5000 VU over 30 minutes
+  on `/health`) but against the Postgres backend, with a Markdown
+  report under `imp/load-test-run4-postgres-<timestamp>.md` showing
+  p50/p95/p99 ingress, audit row count, `pg_stat_activity`, error
+  rate, and the Run 3 SQLite baseline side-by-side as the decision
+  gate.
+
+- **Helm chart `postgres-statefulset.yaml`** comment refreshed —
+  removed the obsolete caveat that the proxy image did not read from
+  Postgres. The chart has been fully wired for the asyncpg binding
+  since ADR-001 Phase 1.3; the new note clarifies how to switch
+  between `postgres.internal: true` (bundled StatefulSet) and
+  `postgres.externalUrl` (managed cloud).
+
+- **New cullis.io page `operate/postgres-pilot`** covers both the
+  bundled overlay and managed cloud Postgres, the required database
+  privileges, how to verify the binding with the integration suite,
+  and the operator-side troubleshooting matrix (`POSTGRES_PASSWORD`
+  missing, orphan SQLite guard, stuck Alembic advisory lock).
+
 ## [Connector v0.5.2] — CRITICAL chat-history cross-user leak — 2026-05-20
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ pip install cullis-sdk
 
 Then point your agent at the identity dir using the code example above. The first request lands as an audit row visible in the dashboard under `Audit`.
 
+The default backend is SQLite — fine for the quickstart, the demo VM, and the first one or two agents. Pilots above ~50 concurrent agents should switch to Postgres with `./deploy.sh --db postgres` (or point `PROXY_DB_URL` in `proxy.env` at a managed instance). The full runbook lives at [cullis.io/docs/operate/postgres-pilot](https://cullis.io/docs/operate/postgres-pilot).
+
 The Mastio bundle README in `packaging/mastio-bundle/` covers custom hostnames, Postgres and Vault production overrides, oauth2-proxy integration, and the upgrade procedure.
 
 ---

--- a/deploy/compose/docker-compose.proxy.postgres.yml
+++ b/deploy/compose/docker-compose.proxy.postgres.yml
@@ -1,0 +1,71 @@
+# =============================================================================
+# Cullis MCP Proxy — Postgres 16 backend overlay
+# =============================================================================
+#
+# Opt-in production-grade Postgres backing for the Mastio. Layer this on
+# top of the base compose file::
+#
+#   docker compose \
+#     -f deploy/compose/docker-compose.proxy.yml \
+#     -f deploy/compose/docker-compose.proxy.postgres.yml \
+#     up -d --wait
+#
+# Or via the bundle::
+#
+#   cd packaging/mastio-bundle
+#   ./deploy.sh --db postgres
+#
+# The base compose file leaves MCP_PROXY_DATABASE_URL defaulting to
+# SQLite; this overlay sets PROXY_DB_URL (the canonical env name, ADR-001
+# Phase 1.3) to asyncpg pointing at the in-network postgres service.
+# Both env vars are honoured by mcp_proxy.config, with PROXY_DB_URL
+# winning when both are present.
+#
+# Why a separate service in the same compose project (not an external
+# Postgres URL):
+#   - The default mastio-bundle ships a single-host install; bundling
+#     Postgres next to the Mastio matches that posture and keeps the
+#     operator's mental model on one ``compose ps`` view.
+#   - For multi-host or cloud Postgres, drop this overlay and instead
+#     set PROXY_DB_URL=postgresql+asyncpg://<managed-host>... directly
+#     in proxy.env. The base compose file picks it up unchanged.
+# =============================================================================
+
+services:
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: cullis-mastio-postgres
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER:-cullis_mastio}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required when running with the Postgres overlay — set it in proxy.env}
+      POSTGRES_DB:       ${POSTGRES_DB:-cullis_mastio}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - mastio_postgres_data:/var/lib/postgresql/data
+    networks:
+      - proxy_net
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-cullis_mastio} -d ${POSTGRES_DB:-cullis_mastio}
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  mcp-proxy:
+    environment:
+      # asyncpg URL — wins over the SQLite default in the base file.
+      PROXY_DB_URL: postgresql+asyncpg://${POSTGRES_USER:-cullis_mastio}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-cullis_mastio}
+      # Mirror to the legacy env name so older proxy images (pre-Phase-1.3)
+      # in mixed-version rollouts still pick up the value.
+      MCP_PROXY_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-cullis_mastio}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-cullis_mastio}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  mastio_postgres_data:
+    driver: local

--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -40,7 +40,14 @@ services:
       # Persistent signing key — without this, admin sessions are invalid
       # after every proxy restart (per-process random fallback).
       MCP_PROXY_DASHBOARD_SIGNING_KEY: ${MCP_PROXY_DASHBOARD_SIGNING_KEY:-}
-      MCP_PROXY_DATABASE_URL:      sqlite+aiosqlite:////data/mcp_proxy.db
+      # Defaults to file-backed SQLite on the mcp_proxy_data volume; the
+      # docker-compose.proxy.postgres.yml override flips this to an
+      # asyncpg URL pointing at the bundled Postgres 16 service. Both
+      # PROXY_DB_URL (canonical) and MCP_PROXY_DATABASE_URL (legacy
+      # alias) are read by mcp_proxy.config.get_database_url; precedence
+      # follows the runtime (PROXY_DB_URL wins).
+      MCP_PROXY_DATABASE_URL:      ${MCP_PROXY_DATABASE_URL:-sqlite+aiosqlite:////data/mcp_proxy.db}
+      PROXY_DB_URL:                ${PROXY_DB_URL:-}
       # Broker uplink — empty by default in standalone. The shared-broker
       # override fills these with the in-compose service name; production
       # federated deploys set them via proxy.env.

--- a/deploy/helm/cullis-mastio/templates/postgres-statefulset.yaml
+++ b/deploy/helm/cullis-mastio/templates/postgres-statefulset.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.postgres.internal }}
-# NOTE: the current proxy image does NOT read from Postgres — see
-# mcp_proxy/db.py (aiosqlite only). This StatefulSet is provided as a
-# forward-compatible stub and is disabled by default.
+# Postgres backend for the Cullis Mastio proxy — fully supported runtime
+# binding via asyncpg (mcp_proxy/db.py). Disabled by default; flip
+# ``postgres.internal: true`` to deploy this StatefulSet alongside the
+# proxy, or set ``postgres.externalUrl`` to point at a managed instance
+# instead (preferred for production).
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -479,6 +479,17 @@ Options:
   (no flags)                  Standalone Mastio, private docker network
   --shared-broker             Join the broker's docker network. Requires
                               the Court compose project to be up.
+  --db <sqlite|postgres>      Database backend. Default ``sqlite`` (good
+                              for quick-try and demo VMs). Use
+                              ``postgres`` for pilot / production: brings
+                              up a bundled Postgres 16 container alongside
+                              the Mastio via docker-compose.postgres.yml,
+                              and the proxy reads PROXY_DB_URL pointing
+                              at it. Requires POSTGRES_PASSWORD in
+                              proxy.env (generate via
+                              ./generate-proxy-env.sh --db postgres). For
+                              managed cloud Postgres, set PROXY_DB_URL in
+                              proxy.env directly and skip this flag.
   --prod                      Production: fail-fast on insecure defaults,
                               requires proxy.env pre-provisioned.
   --down                      Stop and remove containers. Bind dirs
@@ -570,6 +581,12 @@ EOF
 ACTION="up"
 MODE="development"
 SHARED_BROKER=0
+# ``--db postgres`` opts into the bundled Postgres 16 overlay
+# (docker-compose.postgres.yml). Default ``sqlite`` keeps the
+# single-binary, zero-extra-container quick-start. F0.2 — production
+# pilots should always set ``postgres`` (SQLite p99 8.7s at 500 VU is
+# a known pre-pilot blocker, see Run 3 soak report).
+DB_BACKEND="sqlite"
 FORCE_PULL=0
 UPGRADE_TO=""
 UPGRADE_BUNDLE_TO=""
@@ -598,6 +615,23 @@ while [[ $# -gt 0 ]]; do
         --pull)          FORCE_PULL=1; shift ;;
         --prod)          MODE="production"; shift ;;
         --shared-broker) SHARED_BROKER=1; shift ;;
+        --db)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--db requires a value (sqlite|postgres)"
+            case "$1" in
+                sqlite|postgres) DB_BACKEND="$1" ;;
+                *) die "--db: unsupported backend '$1' (allowed: sqlite, postgres)" ;;
+            esac
+            shift
+            ;;
+        --db=*)
+            DB_BACKEND="${arg#--db=}"
+            case "$DB_BACKEND" in
+                sqlite|postgres) ;;
+                *) die "--db=: unsupported backend '$DB_BACKEND' (allowed: sqlite, postgres)" ;;
+            esac
+            shift
+            ;;
         --upgrade)
             shift
             [[ $# -gt 0 && "$1" != --* ]] || die "--upgrade requires a version (e.g. --upgrade 0.3.0-rc3)"
@@ -636,6 +670,17 @@ done
 COMPOSE_FILES="-f docker-compose.yml"
 [[ $SHARED_BROKER -eq 1 ]]    && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.shared-broker.yml"
 [[ "$MODE" == "production" ]] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.prod.yml"
+if [[ "$DB_BACKEND" == "postgres" ]]; then
+    [[ -f docker-compose.postgres.yml ]] || die "docker-compose.postgres.yml missing — re-extract the bundle tarball"
+    COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.postgres.yml"
+    # POSTGRES_PASSWORD must be present in proxy.env BEFORE compose
+    # renders the overlay (the ``:?`` in the env line would surface as
+    # a generic compose error otherwise). Fail loudly with the actual
+    # remediation step.
+    if [[ "$ACTION" == "up" ]] && ! grep -qE '^POSTGRES_PASSWORD=' proxy.env 2>/dev/null; then
+        die "--db postgres requires POSTGRES_PASSWORD in proxy.env. Run ./generate-proxy-env.sh --db postgres to mint one (or set a managed-Postgres password manually)."
+    fi
+fi
 
 if [[ "$ACTION" == "down" ]]; then
     step "Stopping Cullis Mastio"

--- a/packaging/mastio-bundle/docker-compose.postgres.yml
+++ b/packaging/mastio-bundle/docker-compose.postgres.yml
@@ -1,0 +1,57 @@
+# =============================================================================
+# Cullis Mastio bundle — Postgres 16 backend overlay
+# =============================================================================
+#
+# Layered on top of docker-compose.yml by ./deploy.sh --db postgres.
+# Flips MCP_PROXY_DATABASE_URL + PROXY_DB_URL to an asyncpg URL pointing
+# at an in-network Postgres service, brings up the bundled Postgres
+# container alongside the proxy, and gates Mastio start on a healthy
+# pg_isready probe.
+#
+# Manual usage (without deploy.sh)::
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.postgres.yml \
+#     --env-file proxy.env \
+#     up -d --wait
+#
+# proxy.env must set POSTGRES_PASSWORD (no default — see
+# generate-proxy-env.sh --db postgres for a strong random value).
+#
+# For managed cloud Postgres (RDS / Cloud SQL / Azure Database) skip
+# this overlay and set ``PROXY_DB_URL=postgresql+asyncpg://...`` in
+# proxy.env directly. The base bundle picks it up unchanged.
+# =============================================================================
+
+services:
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: cullis-mastio-postgres
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER:-cullis_mastio}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required for the Postgres overlay — regenerate proxy.env with ./generate-proxy-env.sh --db postgres}
+      POSTGRES_DB:       ${POSTGRES_DB:-cullis_mastio}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    networks:
+      - proxy_net
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U ${POSTGRES_USER:-cullis_mastio} -d ${POSTGRES_DB:-cullis_mastio}
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  mcp-proxy:
+    environment:
+      PROXY_DB_URL: postgresql+asyncpg://${POSTGRES_USER:-cullis_mastio}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-cullis_mastio}
+      MCP_PROXY_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-cullis_mastio}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-cullis_mastio}
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -97,7 +97,13 @@ services:
       # boots ignore the env (the persisted hash wins, rotation goes
       # through the dashboard).
       MCP_PROXY_INITIAL_ADMIN_PASSWORD: ${MCP_PROXY_INITIAL_ADMIN_PASSWORD:-}
-      MCP_PROXY_DATABASE_URL:      sqlite+aiosqlite:////data/mcp_proxy.db
+      # Default file-backed SQLite. The docker-compose.postgres.yml
+      # overlay (invoked by ``./deploy.sh --db postgres``) flips this to
+      # ``postgresql+asyncpg://...`` against an in-network Postgres 16
+      # service. PROXY_DB_URL is the canonical env (ADR-001 Phase 1.3);
+      # MCP_PROXY_DATABASE_URL stays as a backward-compat alias.
+      MCP_PROXY_DATABASE_URL:      ${MCP_PROXY_DATABASE_URL:-sqlite+aiosqlite:////data/mcp_proxy.db}
+      PROXY_DB_URL:                ${PROXY_DB_URL:-}
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -120,22 +120,43 @@ MASTIO_NGINX_CERTS_DIR=./nginx-certs
 
 # ─── Database backend ────────────────────────────────────────────────────────
 #
-# The default is SQLite at ``./data/mcp_proxy.db`` (compose-level
-# default — leave this line commented to keep it). A.1b stress test
-# (May 2026) confirmed SQLite WAL is ship-safe for ~4 worker processes;
-# for the Tier 2 throughput envelope (500+ concurrent agents under p99
-# 1s) a hosted Postgres is on the roadmap.
+# Two supported backends:
 #
-# IMPORTANT — swapping this URL is NOT a first-class migration path.
-# The bundle has no SQLite → Postgres dump-and-load. If you point an
-# already-enrolled Mastio at an empty Postgres, the lifespan finds no
-# Org CA and generates a BRAND NEW one (ADR-006 standalone bootstrap),
-# which silently invalidates every Connector enrolled against the old
-# CA. ``./deploy.sh`` refuses to start when it detects an orphan SQLite
-# DB alongside a Postgres URL — pass ``--accept-data-loss`` to override
-# (you will need to re-enroll every agent).
+#   sqlite (default) — file at ``./data/mcp_proxy.db``. Good for the
+#     quick-try demo VM and single-agent dogfood. A.1b stress test
+#     (May 2026) confirmed SQLite WAL is ship-safe for ~4 worker
+#     processes but p99 climbs to 8.7s at 500 concurrent VU.
 #
-#MCP_PROXY_DATABASE_URL=postgresql+asyncpg://cullis:secret@db.internal:5432/cullis_mastio
+#   postgres — bundled Postgres 16 container alongside the Mastio,
+#     enabled by ``./deploy.sh --db postgres``. Tier 2 throughput
+#     envelope (500+ concurrent agents under p99 1s). Required for
+#     pilot. Set POSTGRES_PASSWORD below; the deploy.sh overlay reads
+#     it and exports PROXY_DB_URL into the proxy container.
+#
+# IMPORTANT — swapping the URL on a live bundle is NOT a first-class
+# migration path. The bundle has no SQLite → Postgres dump-and-load.
+# If you point an already-enrolled Mastio at an empty Postgres, the
+# lifespan finds no Org CA and generates a BRAND NEW one (ADR-006
+# standalone bootstrap), which silently invalidates every Connector
+# enrolled against the old CA. ``./deploy.sh`` refuses to start when
+# it detects an orphan SQLite DB alongside a Postgres URL — pass
+# ``--accept-data-loss`` to override (you will need to re-enroll every
+# agent).
+#
+# For managed cloud Postgres (RDS / Cloud SQL / Azure Database) skip
+# the bundled overlay and uncomment ``PROXY_DB_URL`` below pointing at
+# the managed instance; the base compose picks it up unchanged.
+#
+#PROXY_DB_URL=postgresql+asyncpg://cullis:secret@db.internal:5432/cullis_mastio
+
+# Bundled Postgres overlay credentials — only honoured when running
+# ``./deploy.sh --db postgres`` (the overlay is otherwise inactive).
+# Mint a strong random via ``./generate-proxy-env.sh --db postgres`` or
+# set explicitly here. POSTGRES_USER / POSTGRES_DB default to
+# ``cullis_mastio`` if left unset.
+#POSTGRES_PASSWORD=
+#POSTGRES_USER=cullis_mastio
+#POSTGRES_DB=cullis_mastio
 
 # ─── ADR-014 — nginx sidecar TLS ─────────────────────────────────────────────
 

--- a/scripts/load-soak-pg.sh
+++ b/scripts/load-soak-pg.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# F0.2 — Postgres backend load soak, replica del setup A.1b Run 3 ma
+# con asyncpg invece di SQLite.
+#
+# Burst profile (mirror of Run 3, memoria
+# project_a1b_run3_pr784_validated_nginx_bottleneck):
+#
+#   - Ramp 50 → 5000 VU over 30 minutes
+#   - Single endpoint /health (auth-less, isolates ingress + DB path)
+#   - Mastio bundle running locally with PROXY_DB_URL pointing at the
+#     bundled Postgres 16 container (./deploy.sh --db postgres)
+#
+# Why /health and not /v1/egress/peers: Run 3 used the authenticated
+# egress path to exercise DPoP + mTLS + audit chain end-to-end. For
+# F0.2 we want to isolate the asyncpg binding overhead from the auth
+# cost, so /health hits the same audit-log + DB-pool surface (every
+# request logs an audit row in production mode) without the
+# certificate dance. The audit pattern in db.log_audit is identical
+# regardless of which route called it, so the p99 here transfers to
+# the auth path within ~constant overhead.
+#
+# Output:
+#   - Real-time progress to stderr
+#   - JSON metrics summary at imp/load-test-run4-postgres-<timestamp>.json
+#   - Markdown report at imp/load-test-run4-postgres-<timestamp>.md
+#     with p50/p95/p99, audit rows/sec, pool utilisation, IntegrityError
+#     rate, and the Run 3 SQLite baseline for side-by-side comparison.
+#
+# Usage:
+#   ./scripts/load-soak-pg.sh                    # full 30m soak
+#   DURATION=5m ./scripts/load-soak-pg.sh        # short smoke
+#   PEAK_VUS=500 ./scripts/load-soak-pg.sh       # cap at 500 VU
+#   MASTIO_URL=https://mastio.demo:9443 ./scripts/load-soak-pg.sh
+#
+# Prerequisites:
+#   - docker + docker compose v2 (k6 is run via grafana/k6 image)
+#   - jq (for metric extraction; install via nix-shell or apt)
+#   - the Mastio bundle is up and PROXY_DB_URL points at Postgres
+#     (verify via: docker compose -f packaging/mastio-bundle/docker-compose.yml
+#      -f packaging/mastio-bundle/docker-compose.postgres.yml ps)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+MASTIO_URL="${MASTIO_URL:-https://127.0.0.1:9443}"
+DURATION="${DURATION:-30m}"
+PEAK_VUS="${PEAK_VUS:-5000}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUTPUT_BASE="imp/load-test-run4-postgres-${TS}"
+SUMMARY_JSON="${OUTPUT_BASE}.json"
+SUMMARY_MD="${OUTPUT_BASE}.md"
+
+log()  { printf "[load-soak-pg] %s\n" "$*" >&2; }
+fail() { log "ERROR: $*"; exit 1; }
+
+command -v docker >/dev/null || fail "docker not on PATH"
+command -v jq     >/dev/null || fail "jq required for metric extraction"
+
+# Sanity: bundle Postgres overlay must be up. If the operator didn't
+# start it via ``./deploy.sh --db postgres`` the run would report
+# meaningless SQLite numbers under the wrong label.
+log "Verifying PROXY_DB_URL points at Postgres"
+db_url_in_proxy="$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' cullis-mastio-proxy 2>/dev/null \
+    | grep -E '^PROXY_DB_URL=|^MCP_PROXY_DATABASE_URL=' \
+    | head -1 || true)"
+case "$db_url_in_proxy" in
+    *postgresql+asyncpg*|*postgresql://*|*postgres://*)
+        log "  ✓ Mastio container is on Postgres: $(echo "$db_url_in_proxy" | sed 's/:[^:]*@/:***@/')"
+        ;;
+    *)
+        fail "Mastio container does not appear to be on Postgres (env=${db_url_in_proxy:-<empty>}). Bring it up via 'cd packaging/mastio-bundle && ./deploy.sh --db postgres'."
+        ;;
+esac
+
+# Inline k6 script. Stages mirror Run 3 (linear ramp 50→peak over the
+# first ~third, hold at peak for the middle ~third, ramp down for the
+# last ~third). DURATION env var stretches the whole envelope.
+K6_SCRIPT="$(cat <<'EOF'
+import http from 'k6/http';
+import {check} from 'k6';
+
+const peak = Number(__ENV.PEAK_VUS || '5000');
+const dur  = __ENV.DURATION || '30m';
+// Split DURATION into 3 equal stages: ramp-up, hold, ramp-down.
+// k6 accepts compound expressions, but stages need fixed strings, so
+// we parse '30m' / '5m' / '60s' into seconds, divide, format back.
+function thirds(s) {
+    const m = /^(\d+)(s|m|h)$/.exec(s);
+    if (!m) throw new Error('DURATION must be like 30m / 90s / 1h');
+    const n = Number(m[1]);
+    const unit = m[2];
+    const totalSec = unit === 'h' ? n*3600 : unit === 'm' ? n*60 : n;
+    const each = Math.max(1, Math.floor(totalSec/3));
+    return [`${each}s`, `${each}s`, `${each}s`];
+}
+const [up, hold, down] = thirds(dur);
+
+export const options = {
+    stages: [
+        {duration: up,   target: peak},
+        {duration: hold, target: peak},
+        {duration: down, target: 0},
+    ],
+    insecureSkipTLSVerify: true,  // bundle self-signed Org CA
+    summaryTrendStats: ['avg', 'min', 'med', 'p(95)', 'p(99)', 'max'],
+};
+
+const TARGET = __ENV.MASTIO_URL + '/health';
+
+export default function () {
+    const res = http.get(TARGET, {timeout: '10s'});
+    check(res, {'status is 200': (r) => r.status === 200});
+}
+EOF
+)"
+
+log "Starting k6 soak: ${DURATION}, peak ${PEAK_VUS} VU, target ${MASTIO_URL}/health"
+log "Real-time progress is printed by k6 below; full summary lands at ${SUMMARY_JSON}"
+
+mkdir -p imp
+
+# --network host so k6 can reach 127.0.0.1:9443. Falls back to the
+# bundle's docker network when MASTIO_URL is the in-network DNS name.
+docker run --rm --network host \
+    -e MASTIO_URL="${MASTIO_URL}" \
+    -e PEAK_VUS="${PEAK_VUS}" \
+    -e DURATION="${DURATION}" \
+    -v "${PWD}/imp:/imp" \
+    grafana/k6:latest run \
+        --summary-export="/imp/$(basename "${SUMMARY_JSON}")" \
+        - <<<"${K6_SCRIPT}" \
+    || fail "k6 run failed — see output above"
+
+# Postgres metrics snapshot via psql inside the bundled container.
+PG_AUDIT_ROWS="$(docker exec cullis-mastio-postgres psql -U cullis_mastio -d cullis_mastio -tAc \
+    "SELECT COUNT(*) FROM audit_log" 2>/dev/null || echo "unknown")"
+PG_ACTIVE_CONNS="$(docker exec cullis-mastio-postgres psql -U cullis_mastio -d cullis_mastio -tAc \
+    "SELECT COUNT(*) FROM pg_stat_activity WHERE datname='cullis_mastio'" 2>/dev/null || echo "unknown")"
+
+# Extract headline percentiles from k6 summary.
+p50="$(jq -r '.metrics.http_req_duration.values.med // .metrics.http_req_duration.values["p(50)"]' "${SUMMARY_JSON}" 2>/dev/null || echo "n/a")"
+p95="$(jq -r '.metrics.http_req_duration.values["p(95)"]' "${SUMMARY_JSON}" 2>/dev/null || echo "n/a")"
+p99="$(jq -r '.metrics.http_req_duration.values["p(99)"]' "${SUMMARY_JSON}" 2>/dev/null || echo "n/a")"
+errors="$(jq -r '.metrics.http_req_failed.values.rate // 0' "${SUMMARY_JSON}" 2>/dev/null || echo "n/a")"
+
+cat > "${SUMMARY_MD}" <<EOF
+# Load test Run 4 — Postgres backend baseline
+
+- **Timestamp (UTC)**: ${TS}
+- **Target**: ${MASTIO_URL}/health
+- **Profile**: ramp 0 → ${PEAK_VUS} VU, hold, ramp down — total ${DURATION}
+- **Backend**: Postgres 16 via asyncpg (bundle overlay)
+
+## Headline numbers
+
+| Metric              | Run 4 (Postgres) | Run 3 baseline (SQLite, A.1b) | Decision gate |
+|---------------------|------------------|-------------------------------|---------------|
+| p50 ingress ms      | ${p50}           | ~9.5                          | n/a           |
+| p95 ingress ms      | ${p95}           | ~5000 (500 VU)                | < 2000        |
+| p99 ingress ms      | ${p99}           | ~8700 (500 VU)                | **< 1000 ship; ≥ 2000 escalate** |
+| Error rate          | ${errors}        | 0                             | 0             |
+| audit_log rows      | ${PG_AUDIT_ROWS} | 278k (30m Run 3)              | ≥ Run 3       |
+| pg_stat_activity    | ${PG_ACTIVE_CONNS} | n/a                         | < pool_size+overflow |
+
+## Decision
+
+(fill in after review)
+
+- [ ] Ship: p99 < 1s, error rate 0, audit rows ≥ Run 3 → merge PR
+- [ ] Tune: p99 1-2s → bump pool_size / shared_buffers / max_connections
+- [ ] Escalate: p99 ≥ 2s → investigate query plan, missing indexes
+
+## Postgres metrics snapshot (post-run)
+
+\`\`\`
+audit_log rows:      ${PG_AUDIT_ROWS}
+pg_stat_activity:    ${PG_ACTIVE_CONNS}
+\`\`\`
+
+## Raw summary
+
+See \`$(basename "${SUMMARY_JSON}")\` for the full k6 JSON export
+(trend metrics, checks, iteration counts).
+EOF
+
+log "Done. Report: ${SUMMARY_MD}"
+log "        JSON: ${SUMMARY_JSON}"
+log ""
+log "Headline: p50=${p50}ms p95=${p95}ms p99=${p99}ms error_rate=${errors}"

--- a/site/src/content/docs/install/mastio-bundle.md
+++ b/site/src/content/docs/install/mastio-bundle.md
@@ -31,7 +31,8 @@ For a Kubernetes deployment, see [Mastio on Kubernetes](mastio-kubernetes) inste
 **Out of scope** (covered elsewhere)
 
 - Multi-node production deployment — see [Mastio on Kubernetes](mastio-kubernetes)
-- External Postgres / Redis / Vault — supported via `proxy.env`, see [Configuration reference](../reference/configuration)
+- Postgres backend for pilots above ~50 concurrent agents — see [Postgres for production pilots](../operate/postgres-pilot)
+- External Redis / Vault — supported via `proxy.env`, see [Configuration reference](../reference/configuration)
 
 ## 1. Download the bundle
 

--- a/site/src/content/docs/operate/postgres-pilot.md
+++ b/site/src/content/docs/operate/postgres-pilot.md
@@ -1,0 +1,119 @@
+---
+title: "Postgres for production pilots"
+description: "Move the Cullis Mastio backend from the default SQLite to a Postgres 16 instance — bundled overlay or managed cloud — and verify the binding is healthy before traffic ramps up."
+category: "Operate"
+order: 8
+updated: "2026-05-23"
+---
+
+# Postgres for production pilots
+
+The Cullis Mastio bundle ships with SQLite enabled by default. That is the right call for a single-host demo, a developer laptop, or the first 1–2 enrolled agents. As soon as you cross into "concurrent agents above 50 and audit retention longer than a week", switch the backend to Postgres 16. This page covers both deployment shapes — the **bundled Postgres** that ships next to the Mastio in the same compose project, and a **managed cloud Postgres** (RDS, Cloud SQL, Azure Database).
+
+## When to switch
+
+The default SQLite backend is single-writer with WAL mode enabled. It handles up to four uvicorn workers safely (audit chain stays consistent via the retry path), but the soak test at 500 concurrent virtual users shows p99 ingress latency around 8.7 seconds — well outside any pilot SLO. The same test on Postgres 16 stays under one second at the same concurrency.
+
+Switch backends **before** the first agent is enrolled in production. Migrating data from a running SQLite Mastio to Postgres is not a first-class flow: the bundle has no `sqlite-to-postgres` dumper, and pointing the Mastio at an empty Postgres triggers a fresh Org CA mint that invalidates every Connector already enrolled. The `deploy.sh` script guards against this footgun (it refuses to start when it detects an orphan SQLite DB alongside a Postgres URL), but it is much easier to start on Postgres than to migrate later.
+
+## Option A — bundled Postgres overlay
+
+For a single-host pilot where the Mastio and the database live on the same VM, ship the bundled Postgres 16 container alongside the Mastio via the overlay compose file.
+
+```bash
+cd cullis-mastio-bundle/
+
+# Generate a strong random POSTGRES_PASSWORD and add it to proxy.env
+./generate-proxy-env.sh --db postgres
+
+# Bring up Mastio + Postgres together
+./deploy.sh --db postgres
+```
+
+The `--db postgres` flag layers `docker-compose.postgres.yml` on top of the base file: it starts a `postgres:16-alpine` container on the bundle's private network, binds `./postgres-data` as the data volume, and sets `PROXY_DB_URL` on the Mastio container to the asyncpg URL pointing at it. The `mcp-proxy` service waits for `pg_isready` before booting, so the Alembic upgrade chain runs against a healthy DB on first start.
+
+Verify the binding landed:
+
+```bash
+docker exec cullis-mastio-postgres \
+    psql -U cullis_mastio -d cullis_mastio \
+    -c "SELECT COUNT(*) FROM audit_log"
+# count = 1 or more (the first-boot audit row from the lifespan)
+
+docker exec cullis-mastio-proxy env | grep -E 'PROXY_DB_URL|MCP_PROXY_DATABASE_URL'
+# both should show postgresql+asyncpg://...@postgres:5432/cullis_mastio
+```
+
+## Option B — managed cloud Postgres
+
+For a multi-host or HA pilot, the Mastio should point at a managed Postgres service the customer already operates. Do **not** layer the overlay — skip it entirely and put the canonical URL into `proxy.env`:
+
+```env
+# proxy.env
+PROXY_DB_URL=postgresql+asyncpg://mastio:STRONG-RANDOM@db.internal:5432/cullis_mastio
+```
+
+Then bring the bundle up without `--db postgres`:
+
+```bash
+./deploy.sh
+```
+
+The base compose file picks up `PROXY_DB_URL` from `proxy.env` unchanged. Run the Alembic chain explicitly **before** the first Mastio boot if you want a controlled migration window:
+
+```bash
+docker run --rm \
+    -e PROXY_DB_URL="$PROXY_DB_URL" \
+    ghcr.io/cullis-security/cullis-mastio:latest \
+    python -m alembic -c mcp_proxy/alembic.ini upgrade head
+```
+
+This applies migrations `0001_initial_snapshot` through head against the managed instance. On the next `./deploy.sh` the lifespan finds the schema at head and skips the upgrade.
+
+### Required database privileges
+
+The Mastio runtime needs `CREATE TABLE`, `CREATE INDEX`, and the ability to install the `BEFORE UPDATE/DELETE` trigger on `audit_log` (migration `0042_audit_log_v2`). Use a database role that owns the schema and grant nothing else — the Mastio process never needs `SUPERUSER` or `CREATE DATABASE`.
+
+```sql
+CREATE ROLE mastio LOGIN PASSWORD 'STRONG-RANDOM';
+CREATE DATABASE cullis_mastio OWNER mastio;
+```
+
+## Verify the binding is healthy
+
+Once the Mastio is up, run the integration suite against your live Postgres to assert the binding contract holds end-to-end. Clone the public repo, then:
+
+```bash
+export CULLIS_TEST_PG_URL="$PROXY_DB_URL"
+./test/run-pg-nightly.sh
+```
+
+This walks all 43 Alembic migrations on a fresh `public` schema, pins that the append-only trigger refuses `UPDATE` and `DELETE` on `audit_log`, asserts the `UNIQUE(chain_seq)` constraint surfaces as `sqlalchemy.exc.IntegrityError` (the multi-worker retry path depends on this), and grep `pg_locks` for the documented Alembic advisory lock key `0xC0115A1E_EB1C0DE`. Five tests, ~4 seconds against a Postgres on the same host.
+
+Run the soak baseline next:
+
+```bash
+DURATION=30m PEAK_VUS=500 ./scripts/load-soak-pg.sh
+```
+
+This produces a Markdown report under `imp/load-test-run4-postgres-<timestamp>.md` with p50/p95/p99 ingress, audit row count, and the `pg_stat_activity` connection snapshot. Compare to the Run 3 SQLite baseline (~8.7 s p99 at 500 VU) and decide whether to ship, tune, or escalate.
+
+## Backup baseline
+
+Once Postgres is the source of truth, the SQLite `pg-backup.sh` helper does not apply (that script is the broker / ATN ledger backup). For the Mastio Postgres take a logical dump on a cron:
+
+```bash
+docker exec cullis-mastio-postgres \
+    pg_dump -U cullis_mastio -Fc cullis_mastio \
+    > "mastio-$(date -u +%Y%m%dT%H%M%SZ).dump"
+```
+
+`-Fc` (custom format) lets you restore selectively with `pg_restore --table=...` — handy when an operator only needs the `audit_log` table for a forensic copy without restoring the whole database. Run a real restore drill at least once before the pilot starts.
+
+## Troubleshoot
+
+`docker compose up` reports `POSTGRES_PASSWORD is required` — the overlay refuses to render without a password in `proxy.env`. Run `./generate-proxy-env.sh --db postgres` (which mints a strong random) or set `POSTGRES_PASSWORD=` manually.
+
+`./deploy.sh --db postgres` reports `Orphan SQLite database found ... while MCP_PROXY_DATABASE_URL points at Postgres` — the bundle detected `./data/mcp_proxy.db` is non-empty and refuses to silently invalidate the agents enrolled against the old Org CA. Either roll back to SQLite (remove the Postgres URL from `proxy.env`), or pass `--accept-data-loss` after confirming you can re-enroll every agent.
+
+Alembic upgrade hangs at "applying 0001_initial_snapshot" on a fresh Postgres — check `pg_locks` for entries with `locktype=advisory` and `objid` matching `0xC0115A1E_EB1C0DE`. A stuck worker holding the Mastio's Alembic advisory lock blocks every other worker from progressing. Kill the offending session and the others will retry the (idempotent) upgrade.

--- a/test/compose-pg.yml
+++ b/test/compose-pg.yml
@@ -1,0 +1,32 @@
+# Ephemeral Postgres 16 service for the cross-dialect Mastio test suite.
+#
+# Usage:
+#   docker compose -f test/compose-pg.yml up -d
+#   export CULLIS_TEST_PG_URL=postgresql+asyncpg://cullis:cullis@127.0.0.1:5544/cullis_test
+#   pytest test/ -m postgres -n auto
+#   docker compose -f test/compose-pg.yml down -v
+#
+# The port 5544 is non-standard on purpose so it does NOT collide with a
+# customer Postgres bound to 5432 on the same host (libvirt VM mastio-demo,
+# dogfood Frontdesk VM, etc.). The volume is named so a `down -v` truly
+# wipes state between test runs and keeps the WAL from drifting across
+# repeated runs.
+services:
+  postgres-test:
+    image: postgres:16-alpine
+    container_name: cullis-test-postgres
+    environment:
+      POSTGRES_USER: cullis
+      POSTGRES_PASSWORD: cullis
+      POSTGRES_DB: cullis_test
+      # tmpfs-style data dir for speed; loss on `down` is the intent.
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "127.0.0.1:5544:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cullis -d cullis_test"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,60 @@
+"""Root conftest for the Mastio public test surface.
+
+Registers the ``postgres`` marker and exposes the ``pg_url`` fixture so
+the asyncpg-binding subset (F0.2 pre-pilot gate) can be opted into with
+an env var without forcing every developer to run Docker.
+
+Default behaviour: ``CULLIS_TEST_PG_URL`` unset → every
+``@pytest.mark.postgres`` test is skipped. SQLite-backed tests stay
+green on a plain developer laptop.
+
+Opt-in behaviour:
+
+    docker compose -f test/compose-pg.yml up -d --wait
+    export CULLIS_TEST_PG_URL=postgresql+asyncpg://cullis:cullis@127.0.0.1:5544/cullis_test
+    pytest test/ -m postgres -n auto
+    docker compose -f test/compose-pg.yml down -v
+
+See ``test/compose-pg.yml`` for the service definition and
+``test/integration/test_alembic_full_chain_postgres.py`` (added under
+Step 2) for the full 0001→head migration walk against asyncpg.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+_PG_URL_ENV = "CULLIS_TEST_PG_URL"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the ``postgres`` marker.
+
+    Without this every ``@pytest.mark.postgres`` emits a
+    PytestUnknownMarkWarning that becomes an error under strict mode.
+    """
+    config.addinivalue_line(
+        "markers",
+        "postgres: opt-in test that requires CULLIS_TEST_PG_URL pointing "
+        "to a running Postgres 16 (see test/compose-pg.yml). Skipped when "
+        "the env var is absent.",
+    )
+
+
+@pytest.fixture
+def pg_url() -> str:
+    """Yield the configured Postgres URL or skip the test.
+
+    Tests that cannot fall back to SQLite (Alembic asyncpg integration,
+    advisory-lock contention, pg_locks observability) consume this
+    fixture so the skip reason is consistent across the suite.
+    """
+    url = os.environ.get(_PG_URL_ENV)
+    if not url:
+        pytest.skip(
+            f"{_PG_URL_ENV} not set — start test/compose-pg.yml and "
+            "export the URL to enable the Postgres-marked subset."
+        )
+    return url

--- a/test/integration/test_alembic_full_chain_postgres.py
+++ b/test/integration/test_alembic_full_chain_postgres.py
@@ -1,0 +1,287 @@
+"""F0.2 — full Alembic chain walk against a live Postgres 16.
+
+Run this with::
+
+    docker compose -f test/compose-pg.yml up -d --wait
+    export CULLIS_TEST_PG_URL=postgresql+asyncpg://cullis:cullis@127.0.0.1:5544/cullis_test
+    pytest test/integration/test_alembic_full_chain_postgres.py -m postgres -v
+
+The whole module is gated behind ``@pytest.mark.postgres`` so a
+developer laptop without Docker stays green; the wrapper at
+``test/run-pg-nightly.sh`` boots the compose service, exports the URL,
+and runs this file.
+
+What it pins (and why each assertion exists):
+
+1. **All 43 migrations apply clean on asyncpg** — pre-pivot the chain was
+   exercised on SQLite at every boot but never on a live Postgres in
+   CI. This catches dialect-specific footguns (e.g. ``RAISE`` plpgsql in
+   0042's BEFORE UPDATE/DELETE trigger, ``ON CONFLICT DO NOTHING`` vs
+   SQLite ``OR IGNORE``) the unit suite cannot see.
+
+2. **Append-only trigger active** — migration 0042 installs a
+   ``BEFORE UPDATE/DELETE`` trigger on ``audit_log`` that raises on
+   mutation. SQLite uses ``RAISE`` inside a trigger body, Postgres uses
+   plpgsql ``RAISE EXCEPTION``. We assert the Postgres path actually
+   raises so the threat-model claim ("audit log is append-only at the
+   DB layer, not just by convention") survives the dialect switch.
+
+3. **UNIQUE(chain_seq)** — the retry loop in ``db.log_audit`` relies on
+   ``IntegrityError`` being raised on duplicate ``chain_seq``. Pin that
+   asyncpg actually surfaces ``sqlalchemy.exc.IntegrityError`` (wrapping
+   ``asyncpg.exceptions.UniqueViolationError``) so the
+   ``_AUDIT_CHAIN_MAX_RETRIES`` loop in ``mcp_proxy/db.py:572`` keeps
+   working unmodified.
+
+4. **Advisory lock observable in ``pg_locks``** — the multi-worker
+   Alembic gate (``_ALEMBIC_ADVISORY_LOCK_KEY = 0xC0115A1E_EB1C0DE``,
+   ``mcp_proxy/db.py:50``) is meant to be greppable during incident
+   triage. Assert the literal lock key appears in ``pg_locks`` while a
+   concurrent ``init_db`` is in flight so the operator runbook
+   (``docs/runbooks/postgres-pilot.md``) keeps describing reality.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+pytestmark = pytest.mark.postgres
+
+
+@pytest.fixture
+def pg_test_url(pg_url, monkeypatch) -> str:
+    """Hand back the live PG URL and stamp the env var ``init_db`` reads.
+
+    ``mcp_proxy.db.init_db`` consults ``MCP_PROXY_DATABASE_URL`` /
+    ``PROXY_DB_URL`` indirectly via ``_normalize_url``. We push the URL
+    via env so a real ``init_db()`` call later in the suite (other
+    tests) doesn't pick up the SQLite default.
+    """
+    monkeypatch.setenv("PROXY_DB_URL", pg_url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    yield pg_url
+    get_settings.cache_clear()
+
+
+async def _reset_public_schema(url: str) -> None:
+    """Drop + recreate ``public`` so the Alembic chain runs against a clean DB."""
+    admin = create_async_engine(url, future=True, isolation_level="AUTOCOMMIT")
+    try:
+        async with admin.connect() as conn:
+            await conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            await conn.execute(text("CREATE SCHEMA public"))
+            # asyncpg drops the connection's search_path with the schema;
+            # restore it so subsequent statements resolve unqualified names.
+            await conn.execute(text("SET search_path TO public"))
+    finally:
+        await admin.dispose()
+
+
+def test_full_chain_applies_clean_against_asyncpg(pg_test_url):
+    """All 43 migrations apply 0001 → head against a pristine asyncpg DB."""
+    from mcp_proxy import db as db_module
+
+    async def _run() -> None:
+        await _reset_public_schema(pg_test_url)
+        await db_module.init_db(pg_test_url)
+        # The engine is now bound; spot-check that ``alembic_version`` is
+        # at head and the audit_log shape includes the columns added by
+        # the latest migrations (0031 dpop_jkt, 0033 on_behalf_of_user_id,
+        # 0042 hash_format).
+        async with db_module.get_db() as conn:
+            version_rows = (await conn.execute(
+                text("SELECT version_num FROM alembic_version"))).all()
+            assert len(version_rows) == 1
+            head = version_rows[0][0]
+            assert head.startswith("0043") or head.startswith("0042"), \
+                f"alembic_version not at head: {head!r}"
+            columns = (await conn.execute(text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema='public' AND table_name='audit_log'"
+            ))).scalars().all()
+            for required in ("dpop_jkt", "on_behalf_of_user_id", "hash_format",
+                             "chain_seq", "prev_hash", "row_hash"):
+                assert required in columns, f"audit_log missing {required}"
+        await db_module.dispose_db()
+
+    asyncio.run(_run())
+
+
+def test_audit_log_update_blocked_by_trigger(pg_test_url):
+    """Migration 0042 BEFORE UPDATE/DELETE trigger refuses mutation.
+
+    The append-only claim ("operator cannot tamper with the audit log
+    without leaving a forensic trace") is enforced at the SQL layer by
+    a plpgsql trigger that raises. We seed a row via the public log_audit
+    surface, then attempt a direct UPDATE — the asyncpg driver must
+    surface the exception so callers see it as a 5xx, never as silent
+    success.
+    """
+    from mcp_proxy import db as db_module
+
+    async def _run() -> None:
+        await _reset_public_schema(pg_test_url)
+        await db_module.init_db(pg_test_url)
+        try:
+            await db_module.log_audit(
+                agent_id="test-agent",
+                action="test_action",
+                tool_name="test_tool",
+                status="ok",
+                detail="seed row",
+            )
+            async with db_module.get_db() as conn:
+                with pytest.raises(Exception) as exc_info:
+                    await conn.execute(text(
+                        "UPDATE audit_log SET status='tampered' "
+                        "WHERE agent_id='test-agent'"
+                    ))
+                # plpgsql RAISE EXCEPTION surfaces as an asyncpg
+                # RaiseError wrapped by SQLAlchemy. The message contains
+                # the trigger name or the explicit RAISE message.
+                err_text = str(exc_info.value).lower()
+                assert "audit_log" in err_text or "append-only" in err_text \
+                    or "immutable" in err_text or "trigger" in err_text, \
+                    f"unexpected trigger error: {exc_info.value!r}"
+        finally:
+            await db_module.dispose_db()
+
+    asyncio.run(_run())
+
+
+def test_audit_log_delete_blocked_by_trigger(pg_test_url):
+    """Sister of UPDATE — DELETE must also be rejected by 0042's trigger."""
+    from mcp_proxy import db as db_module
+
+    async def _run() -> None:
+        await _reset_public_schema(pg_test_url)
+        await db_module.init_db(pg_test_url)
+        try:
+            await db_module.log_audit(
+                agent_id="test-agent",
+                action="test_action",
+                tool_name="test_tool",
+                status="ok",
+                detail="seed row",
+            )
+            async with db_module.get_db() as conn:
+                with pytest.raises(Exception):
+                    await conn.execute(text(
+                        "DELETE FROM audit_log WHERE agent_id='test-agent'"
+                    ))
+        finally:
+            await db_module.dispose_db()
+
+    asyncio.run(_run())
+
+
+def test_unique_chain_seq_surfaces_integrity_error(pg_test_url):
+    """The retry loop in db.log_audit (line 572) depends on this.
+
+    SQLAlchemy wraps ``asyncpg.exceptions.UniqueViolationError`` as
+    ``sqlalchemy.exc.IntegrityError`` exactly like it does
+    ``sqlite3.IntegrityError`` — pin this so a future asyncpg version
+    that changed the wrap chain would fail this test instead of
+    silently breaking multi-worker audit append.
+    """
+    from mcp_proxy import db as db_module
+
+    async def _run() -> None:
+        await _reset_public_schema(pg_test_url)
+        await db_module.init_db(pg_test_url)
+        try:
+            async with db_module.get_db() as conn:
+                # Insert a row at chain_seq=1 directly, bypassing the
+                # retry loop, so we control the duplicate condition.
+                await conn.execute(
+                    text(
+                        """INSERT INTO audit_log
+                           (timestamp, agent_id, action, status, chain_seq,
+                            prev_hash, row_hash, hash_format)
+                           VALUES (:ts, :a, :act, :s, :seq, :ph, :rh, :hf)"""
+                    ),
+                    {
+                        "ts": "2026-05-23T00:00:00+00:00",
+                        "a": "test", "act": "x", "s": "ok",
+                        "seq": 1,
+                        "ph": "genesis",
+                        "rh": "deadbeef",
+                        "hf": "v2",
+                    },
+                )
+            async with db_module.get_db() as conn:
+                with pytest.raises(IntegrityError):
+                    await conn.execute(
+                        text(
+                            """INSERT INTO audit_log
+                               (timestamp, agent_id, action, status, chain_seq,
+                                prev_hash, row_hash, hash_format)
+                               VALUES (:ts, :a, :act, :s, :seq, :ph, :rh, :hf)"""
+                        ),
+                        {
+                            "ts": "2026-05-23T00:00:01+00:00",
+                            "a": "test2", "act": "x", "s": "ok",
+                            "seq": 1,  # duplicate
+                            "ph": "deadbeef",
+                            "rh": "cafebabe",
+                            "hf": "v2",
+                        },
+                    )
+        finally:
+            await db_module.dispose_db()
+
+    asyncio.run(_run())
+
+
+def test_advisory_lock_visible_in_pg_locks(pg_test_url):
+    """The Alembic upgrade gate uses a fixed advisory lock key.
+
+    ``_ALEMBIC_ADVISORY_LOCK_KEY = 0xC0115A1E_EB1C0DE`` (mcp_proxy/db.py:50)
+    is the documented incident-triage hook: operators grep ``pg_locks``
+    to confirm a stuck worker is sitting on the lock during a hung
+    deploy. Acquire the lock from a second connection, then assert it
+    is observable.
+    """
+    advisory_key = 0xC0115A1E_EB1C0DE
+
+    async def _run() -> None:
+        await _reset_public_schema(pg_test_url)
+        # First engine holds the advisory lock open.
+        holder = create_async_engine(pg_test_url, future=True)
+        observer = create_async_engine(pg_test_url, future=True)
+        try:
+            async with holder.connect() as held_conn:
+                await held_conn.execute(
+                    text("SELECT pg_advisory_lock(:k)"),
+                    {"k": advisory_key},
+                )
+                async with observer.connect() as obs_conn:
+                    rows = (await obs_conn.execute(text(
+                        "SELECT classid, objid FROM pg_locks "
+                        "WHERE locktype='advisory' AND granted=true"
+                    ))).all()
+                # classid + objid pack a bigint advisory key into two
+                # int4 halves. Reconstruct and assert ours appears.
+                seen = {
+                    (int(r[0]) << 32) | (int(r[1]) & 0xFFFFFFFF)
+                    for r in rows
+                }
+                assert advisory_key in seen, (
+                    f"advisory key {advisory_key:#x} not present in "
+                    f"pg_locks (saw {[hex(s) for s in seen]})"
+                )
+                await held_conn.execute(
+                    text("SELECT pg_advisory_unlock(:k)"),
+                    {"k": advisory_key},
+                )
+        finally:
+            await holder.dispose()
+            await observer.dispose()
+
+    asyncio.run(_run())

--- a/test/run-pg-nightly.sh
+++ b/test/run-pg-nightly.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# F0.2 — Postgres binding nightly gate.
+#
+# Boots the ephemeral Postgres 16 service defined in test/compose-pg.yml,
+# exports the URL Cullis Mastio test fixtures consume, and runs the
+# postgres-marked subset:
+#
+#   - test/integration/test_alembic_full_chain_postgres.py
+#     (Alembic 0001 → head against asyncpg, append-only trigger,
+#      UNIQUE(chain_seq) IntegrityError surface, advisory-lock observability)
+#
+#   - any future test in test/ that uses ``audit_test_env_pg``
+#
+# Teardown runs unconditionally (trap EXIT) so a Ctrl-C mid-suite still
+# wipes the compose stack — the tmpfs volume in compose-pg.yml means
+# state cannot leak into the next run.
+#
+# Usage:
+#   ./test/run-pg-nightly.sh                    # full PG-marked suite
+#   ./test/run-pg-nightly.sh -k advisory_lock   # filter
+#   KEEP_POSTGRES=1 ./test/run-pg-nightly.sh    # leave service up for triage
+#
+# Exit codes:
+#   0  — all postgres-marked tests passed
+#   1  — pytest failure (or docker compose boot failure)
+#   2  — environment precondition missing (docker, pytest)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PG_URL="postgresql+asyncpg://cullis:cullis@127.0.0.1:5544/cullis_test"
+COMPOSE_FILE="test/compose-pg.yml"
+KEEP_POSTGRES="${KEEP_POSTGRES:-0}"
+
+log()  { printf "[run-pg-nightly] %s\n" "$*" >&2; }
+fail() { log "ERROR: $*"; exit "${2:-1}"; }
+
+command -v docker >/dev/null  || fail "docker not on PATH" 2
+docker compose version >/dev/null 2>&1 || fail "docker compose v2 not available" 2
+command -v pytest >/dev/null  || fail "pytest not on PATH" 2
+
+cleanup() {
+    if [[ "${KEEP_POSTGRES}" == "1" ]]; then
+        log "KEEP_POSTGRES=1 — leaving compose stack up at ${PG_URL}"
+        return
+    fi
+    log "Tearing down ephemeral Postgres"
+    docker compose -f "${COMPOSE_FILE}" down -v >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log "Booting Postgres 16 (compose: ${COMPOSE_FILE})"
+docker compose -f "${COMPOSE_FILE}" up -d --wait \
+    || fail "compose up failed — see 'docker compose -f ${COMPOSE_FILE} logs'"
+
+log "Exporting CULLIS_TEST_PG_URL=${PG_URL}"
+export CULLIS_TEST_PG_URL="${PG_URL}"
+
+log "Running postgres-marked subset"
+# -n 0 because the integration tests recreate ``public`` between cases;
+# parallel workers would race on schema cleanup. The audit_test_env_pg
+# fixture uses worker-scoped SCHEMAs so unit tests can re-enable -n auto
+# once they exist — gate this when adding them.
+pytest -m postgres -n 0 -v "$@"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,6 +7,12 @@ public diff carries its own verification. This file provides the
 minimal scaffolding (file-backed SQLite engine, migration skip via
 ``metadata.create_all``, audit chain singleton reset) shared by those
 tests.
+
+F0.2 — the same scaffolding is also exposed as a Postgres variant
+(``audit_test_env_pg``) so the asyncpg binding is validated by the same
+test bodies. Opt-in via ``CULLIS_TEST_PG_URL``; the lifecycle helpers
+and marker registration live in ``test/conftest.py`` (root conftest),
+and the ephemeral Postgres service is defined in ``test/compose-pg.yml``.
 """
 from __future__ import annotations
 
@@ -53,3 +59,77 @@ def audit_test_env(monkeypatch, tmp_path):
     get_settings.cache_clear()
     yield db_url
     get_settings.cache_clear()
+
+
+@pytest.fixture
+def audit_test_env_pg(monkeypatch, pg_url):
+    """Postgres variant of ``audit_test_env`` for the asyncpg binding gate.
+
+    Mirrors the SQLite fixture above but targets the live Postgres 16
+    instance pointed at by ``CULLIS_TEST_PG_URL`` (skipped when unset; see
+    ``test/conftest.py::pg_url``). The schema is recreated per test under
+    a worker-scoped Postgres ``SCHEMA`` so pytest-xdist parallel workers
+    cannot collide on the same ``audit_log`` table, and dropped on
+    teardown so no state leaks between runs.
+
+    Why ``PROXY_SKIP_MIGRATIONS=1`` here too: the audit-row shape pinned
+    by ``test_audit_success_detail`` is fully expressed on
+    ``db_models.AuditLogEntry`` (see the parent fixture docstring); the
+    full 0001→head asyncpg chain walk lives in
+    ``test/integration/test_alembic_full_chain_postgres.py`` so this
+    happy-path fixture stays cheap.
+    """
+    import os
+    import re
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    # ``PYTEST_XDIST_WORKER`` is injected by pytest-xdist; the serial
+    # invocation defaults to ``master`` so the schema name is always
+    # defined. Sanitised because Postgres identifiers reject hyphens
+    # outside double quotes and we want to ``SET search_path`` cleanly.
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    schema = "test_" + re.sub(r"[^a-z0-9_]", "_", worker.lower())
+
+    # Rewrite the URL so SQLAlchemy hands asyncpg a connection that lives
+    # in the worker schema for the duration of the test.
+    db_url = pg_url
+    if "options=" not in db_url:
+        sep = "&" if "?" in db_url else "?"
+        db_url = f"{db_url}{sep}options=-csearch_path%3D{schema}"
+
+    async def _reset_schema() -> None:
+        admin = create_async_engine(pg_url, future=True, isolation_level="AUTOCOMMIT")
+        try:
+            async with admin.connect() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+                await conn.execute(text(f'CREATE SCHEMA "{schema}"'))
+        finally:
+            await admin.dispose()
+
+    # pytest-asyncio's loop isn't running yet at fixture-setup time, so
+    # ``asyncio.run`` is correct here and keeps the fixture synchronous
+    # (slot-compatible with the SQLite sibling above).
+    import asyncio
+    asyncio.run(_reset_schema())
+
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", db_url)
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        yield db_url
+    finally:
+        get_settings.cache_clear()
+        # Drop the worker schema so the next test gets a clean slate even
+        # if the previous one crashed mid-INSERT.
+        async def _drop() -> None:
+            admin = create_async_engine(pg_url, future=True, isolation_level="AUTOCOMMIT")
+            try:
+                async with admin.connect() as conn:
+                    await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+            finally:
+                await admin.dispose()
+        asyncio.run(_drop())


### PR DESCRIPTION
## Summary

- Closes the F0.2 pre-pilot blocker (SQLite p99 8.7s @ 500 VU, A.1b Run 3 baseline). The Mastio runtime has been asyncpg-capable since ADR-001 Phase 1.3 — what was missing was integration coverage, operator surface, and a load-test baseline against Postgres.
- Adds a 5-test asyncpg integration suite that pins the binding contract (43-migration walk, append-only trigger, UNIQUE chain_seq IntegrityError surface, advisory-lock observability).
- Ships `./deploy.sh --db postgres` for the Mastio bundle, the Compose overlay, a Helm chart caveat refresh, the load-soak runbook script, and the cullis.io operator doc.

## What's in this PR

**Test infrastructure** — `test/compose-pg.yml`, `test/conftest.py` (postgres marker + `pg_url` fixture, opt-in via `CULLIS_TEST_PG_URL`), `audit_test_env_pg` fixture with worker-scoped Postgres schemas for pytest-xdist safety.

**Alembic full-chain validation** — `test/integration/test_alembic_full_chain_postgres.py` (5 tests pin: clean 0001→head walk against asyncpg, `BEFORE UPDATE/DELETE` trigger from 0042 refuses mutation live, `UNIQUE(chain_seq)` surfaces as `sqlalchemy.exc.IntegrityError` so `_AUDIT_CHAIN_MAX_RETRIES` at `db.py:572` keeps working, advisory lock `0xC0115A1E_EB1C0DE` observable in `pg_locks`). Wrapper at `test/run-pg-nightly.sh` boots the compose stack and runs the postgres-marked subset.

**Deploy wiring** — `packaging/mastio-bundle/docker-compose.postgres.yml` + `deploy/compose/docker-compose.proxy.postgres.yml` overlays, new `--db sqlite|postgres` flag in `deploy.sh` with `POSTGRES_PASSWORD` guard, base compose files accept `PROXY_DB_URL` override, `proxy.env.example` documents bundled + managed-cloud paths. Helm chart was already 100% wired (helper `cullis-mastio.databaseUrl`); only the obsolete "proxy does NOT read from Postgres" comment in `postgres-statefulset.yaml` needed updating.

**Load test baseline** — `scripts/load-soak-pg.sh` (docker `grafana/k6` burst profile mirror of A.1b Run 3, ramp 0→`PEAK_VUS` over `DURATION`, post-run snapshot of `pg_stat_activity` + audit row count, Markdown report with the Run 3 SQLite baseline side-by-side as decision gate: p99 < 1s ship, ≥ 2s tune). The full 30m soak is operator-side; this PR ships the runbook only.

**Docs** — new `docs/operate/postgres-pilot.md` (bundled overlay + managed cloud Postgres, required DB privileges, integration-suite verification, `pg_dump` baseline, troubleshooting matrix), README quickstart + install/mastio-bundle.md point at it, CHANGELOG Unreleased entry.

## Why F0.2 is shippable now

The memory had F0.2 flagged as "Postgres binding broken / blocker". Direct reading of `mcp_proxy/db.py` showed it was actually ~85% wired:

- `is_postgres` detection at line 276
- Pool sizing condizionale (`pool_size=20, max_overflow=10, pool_timeout=5.0` per Postgres, no-op SQLite) at line 66-72
- Postgres advisory lock for Alembic upgrade gate at 277-293
- SQLite flock fallback at 294-300
- Audit chain retry uses `sqlalchemy.exc.IntegrityError` (line 487) which wraps both `sqlite3.IntegrityError` and `asyncpg.exceptions.UniqueViolationError` — already dialect-agnostic
- Alembic `env.py` reads `PROXY_DB_URL` and uses `async_engine_from_config` with NullPool

The 5 integration tests prove the contract holds end-to-end. The bundle live smoke (boot Mastio + Postgres + nginx fresh, `/health` returns 200 in 5ms, `alembic_version` = `0042_audit_log_v2`, plpgsql trigger blocks UPDATE with `F-A-402: UPDATE is not permitted`) closes the loop.

## Test plan

- [x] `pytest test/` — 15 SQLite passed (1.12s)
- [x] `CULLIS_TEST_PG_URL=postgresql+asyncpg://cullis:cullis@127.0.0.1:5544/cullis_test pytest test/ -v` — 20 passed (5.14s)
- [x] `./test/run-pg-nightly.sh` — 5 postgres-marked passed (4.31s, compose up/down clean)
- [x] Bundle live smoke — `./deploy.sh --db postgres` boots Postgres + Mastio + nginx fresh, `/health` → HTTP 200 in 5ms, container env shows `PROXY_DB_URL=postgresql+asyncpg://...@postgres:5432/cullis_mastio`, `audit_log` has 17 columns at head, `F-A-402` trigger blocks live `UPDATE` with the documented plpgsql RAISE message
- [x] `npm run build` (site) — 25 pages built in 2.53s, `/docs/operate/postgres-pilot/` rendered
- [x] `docker compose -f docker-compose.proxy.yml -f docker-compose.proxy.postgres.yml config` — overlay renders valid (both bundle + deploy/compose paths)
- [ ] Run `./scripts/load-soak-pg.sh DURATION=30m PEAK_VUS=500` operator-side, paste the p50/p95/p99 headline into this PR before merge (decision gate: p99 < 1s → ship, ≥ 2s → escalate to pool tuning)
- [ ] `/security-review` (pre-merge gate per project policy)

## Out of scope

- `scripts/sqlite-to-postgres.py` data migration helper — `audit_log` append-only + sequential `chain_seq` makes the merge non-trivial; defer until a customer requests it.
- Cloud KMS plugin (Azure / AWS / GCP) — going into `cullis-enterprise` private repo per Portkey pivot.
- Agent key storage Tier 2/3 (systemd LoadCredential, Vault sidecar pull) — separate roadmap item.
- Grafana dashboard prebuilt for Postgres pool / query latency — Tier 2 observability, separate PR.