### PR TITLE
feat(sdk): CullisClient.from_systemd_credentials (Tier 2 agent key storage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### SDK — `from_systemd_credentials` factory (Tier 2 agent key storage)
+
+- **New `CullisClient.from_systemd_credentials()` factory** for the
+  Linux production deployment pattern that replaces plain 0600 files
+  on a writable disk. The factory reads systemd's
+  `$CREDENTIALS_DIRECTORY` (set automatically by the unit's
+  `LoadCredential=` lines), loads cert + key + DPoP key from there,
+  and optionally lifts `mastio_url` / `agent_id` / `org_id` out of
+  an `agent.json` metadata file shipped alongside the credentials.
+  Credentials live on tmpfs only for the unit's lifetime; the agent
+  never reads from a writable disk at runtime.
+
+- **13 new unit tests** in `test/unit/test_sdk_systemd_credentials.py`
+  cover the resolution order ($CREDENTIALS_DIRECTORY → argument →
+  RuntimeError), eager file-existence checks (named errors on missing
+  cert / key, DPoP optional), metadata auto-population vs explicit
+  arg precedence, malformed `agent.json` surfaces a clear
+  `RuntimeError`, custom credential names (`cert_name=`,
+  `key_name=`, `dpop_key_name=`) for operators who deviated from the
+  SDK's persisted layout.
+
+- **Docs**: new "Production: systemd LoadCredential" section in
+  [Python SDK quickstart](https://cullis.io/docs/quickstart/sdk)
+  with a complete unit-file example and the matching agent code.
+
 ### Mastio — production-ready Postgres binding (F0.2)
 
 - **Bundle ships `--db postgres` flag** for `deploy.sh`. Brings up a

--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -288,6 +288,174 @@ class _EnrollmentMixin:
                    f"agent={instance._label})")
         return instance
 
+    @classmethod
+    def from_systemd_credentials(
+        cls,
+        mastio_url: str | None = None,
+        *,
+        credentials_dir: "str | Path | None" = None,
+        cert_name: str = "cert.pem",
+        key_name: str = "key.pem",
+        dpop_key_name: str | None = "dpop.jwk",
+        metadata_name: str | None = "agent.json",
+        agent_id: str | None = None,
+        org_id: str | None = None,
+        verify_tls: bool = True,
+        timeout: float = 10.0,
+        ca_chain_path: "str | Path | None" = None,
+    ) -> "CullisClient":
+        """Bootstrap from systemd ``LoadCredential=`` material.
+
+        The production deployment pattern that replaces the demo-VM file
+        layout (``cert.pem`` + ``key.pem`` at 0600 on a writable disk):
+        a systemd unit declares one ``LoadCredential=`` line per file,
+        and systemd materialises them under ``$CREDENTIALS_DIRECTORY``
+        with restrictive perms — readable only by the unit's user,
+        gone when the unit stops, never written to a writable disk
+        (the credentials live on tmpfs and only for the process
+        lifetime). The SDK reads ``$CREDENTIALS_DIRECTORY`` and points
+        ``from_identity_dir`` at it.
+
+        Example unit file::
+
+            [Unit]
+            Description=KYC screener agent
+            Wants=cullis-mastio.service
+
+            [Service]
+            ExecStart=/usr/bin/python /opt/kyc-agent/main.py
+            LoadCredential=cert.pem:/etc/cullis/kyc-screener/cert.pem
+            LoadCredential=key.pem:/etc/cullis/kyc-screener/key.pem
+            LoadCredential=dpop.jwk:/etc/cullis/kyc-screener/dpop.jwk
+            LoadCredential=agent.json:/etc/cullis/kyc-screener/agent.json
+
+        And inside the agent::
+
+            client = CullisClient.from_systemd_credentials()
+            # mastio_url + agent_id + org_id are loaded from agent.json
+            # cert/key/dpop are read from $CREDENTIALS_DIRECTORY/<name>
+
+        Args:
+            mastio_url: optional override. When ``None``, the value is
+                read from ``agent.json`` under ``$CREDENTIALS_DIRECTORY``.
+                Pass explicitly when no ``agent.json`` ships in the unit
+                or when the operator wants the URL pinned in code.
+            credentials_dir: where to read the files from. When ``None``
+                (default), the SDK reads ``$CREDENTIALS_DIRECTORY`` —
+                the env var systemd injects for any service that
+                declares at least one ``LoadCredential=`` line. Pass
+                explicitly to run the agent outside systemd (e.g. in a
+                container that mounts a similar tmpfs).
+            cert_name, key_name: the basenames inside the credentials
+                directory. Defaults match the SDK's persisted layout
+                (``cert.pem`` + ``key.pem``) so an operator who
+                ``LoadCredential=cert.pem:...`` does not need to override
+                them. Adjust when the unit names credentials differently
+                (e.g. when reusing an existing PKI bundle layout).
+            dpop_key_name: name of the DPoP private JWK file. ``None``
+                skips DPoP loading entirely — only safe while the
+                Mastio's ``egress_dpop_mode`` is ``off`` or ``optional``.
+            metadata_name: name of the JSON metadata file holding
+                ``{agent_id, org_id, mastio_url}``. ``None`` skips the
+                metadata read (caller passes mastio_url + agent_id +
+                org_id directly). The persisted file from
+                ``from_enrollment`` is named ``agent.json``.
+            agent_id, org_id: optional overrides. When ``None`` and a
+                metadata file is present, the value comes from JSON.
+
+        Raises:
+            RuntimeError: when ``credentials_dir`` is unset AND
+                ``$CREDENTIALS_DIRECTORY`` is not in the environment
+                (the unit forgot to declare ``LoadCredential=``).
+            FileNotFoundError: when one of the declared files
+                (``cert_name``, ``key_name``) is missing from the
+                credentials directory.
+            RuntimeError: when ``mastio_url`` cannot be resolved (no
+                argument passed, no metadata file present, or the JSON
+                file is missing the ``mastio_url`` field).
+        """
+        import json as _json
+        import os as _os
+
+        # Resolve the credentials directory: explicit arg wins, otherwise
+        # read systemd's ``$CREDENTIALS_DIRECTORY``. Crashing with a
+        # specific message beats letting ``open()`` raise a vague
+        # FileNotFoundError two stack frames down.
+        if credentials_dir is None:
+            env_dir = _os.environ.get("CREDENTIALS_DIRECTORY")
+            if not env_dir:
+                raise RuntimeError(
+                    "from_systemd_credentials: $CREDENTIALS_DIRECTORY is "
+                    "not set and no credentials_dir argument was passed. "
+                    "Either declare at least one LoadCredential= in the "
+                    "systemd unit, or pass credentials_dir= explicitly.",
+                )
+            credentials_dir = env_dir
+        creds_path = Path(credentials_dir)
+
+        cert_path = creds_path / cert_name
+        key_path = creds_path / key_name
+        dpop_path: Path | None = (
+            creds_path / dpop_key_name if dpop_key_name else None
+        )
+
+        # Eager existence check so the error mentions the missing
+        # credential by name rather than failing inside httpx's
+        # ssl.SSLContext.load_cert_chain with an opaque OSError.
+        for required in (cert_path, key_path):
+            if not required.exists():
+                raise FileNotFoundError(
+                    f"from_systemd_credentials: missing {required.name} "
+                    f"under {creds_path}. Confirm the unit's "
+                    f"``LoadCredential={required.name}:<host-path>`` line.",
+                )
+        if dpop_path is not None and not dpop_path.exists():
+            # DPoP optional: don't crash when the operator chose not to
+            # ship a DPoP key. Behave like ``from_identity_dir`` with
+            # ``dpop_key_path=None``.
+            dpop_path = None
+
+        # Optional metadata: when the operator ships agent.json next to
+        # the credentials, lift mastio_url + agent_id + org_id out of
+        # it so the caller's ``from_systemd_credentials()`` call stays
+        # zero-argument in the common case. Explicit kwargs still win.
+        if metadata_name:
+            meta_path = creds_path / metadata_name
+            if meta_path.exists():
+                try:
+                    meta = _json.loads(meta_path.read_text())
+                except (OSError, _json.JSONDecodeError) as exc:
+                    raise RuntimeError(
+                        f"from_systemd_credentials: failed to read "
+                        f"metadata file {meta_path}: {exc}",
+                    ) from exc
+                if mastio_url is None:
+                    mastio_url = meta.get("mastio_url")
+                if agent_id is None:
+                    agent_id = meta.get("agent_id")
+                if org_id is None:
+                    org_id = meta.get("org_id")
+
+        if not mastio_url:
+            raise RuntimeError(
+                "from_systemd_credentials: mastio_url is required but "
+                "neither the argument nor the metadata file resolved "
+                "one. Pass mastio_url= explicitly or ship agent.json "
+                "with a ``mastio_url`` field next to the credentials.",
+            )
+
+        return cls.from_identity_dir(
+            mastio_url,
+            cert_path=cert_path,
+            key_path=key_path,
+            dpop_key_path=dpop_path,
+            agent_id=agent_id,
+            org_id=org_id,
+            verify_tls=verify_tls,
+            timeout=timeout,
+            ca_chain_path=ca_chain_path,
+        )
+
     # Backwards-compat alias — deprecated. Existing callers that pass
     # ``api_key_path`` get a clear deprecation warning. Prefer
     # ``from_identity_dir(cert_path=..., key_path=..., dpop_key_path=...)``.

--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -166,6 +166,60 @@ client.login_via_proxy_with_local_key()
 
 `from_identity_dir` is the only runtime constructor you need. Production agents that load credentials from Vault, K8s secrets, HSMs, or any other secret store use this same call once the material has been read into the three file paths.
 
+### Production: systemd LoadCredential
+
+For Linux production deployments, prefer systemd's `LoadCredential=` mechanism over plain 0600 files. systemd materialises the credentials on tmpfs under `$CREDENTIALS_DIRECTORY` only for the lifetime of the unit, with `0400 root:root` perms, gone the moment the service stops. The agent never reads from a writable disk.
+
+Unit file (`/etc/systemd/system/cullis-kyc-agent.service`):
+
+```ini
+[Unit]
+Description=KYC screener agent (Cullis-authenticated)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=cullis-kyc
+ExecStart=/opt/kyc-agent/venv/bin/python /opt/kyc-agent/main.py
+
+# systemd reads these from disk once at unit start and re-materialises them
+# on tmpfs under /run/credentials/cullis-kyc-agent.service/<name>. The
+# source paths can be 0400 root:root — only systemd needs to read them.
+LoadCredential=cert.pem:/etc/cullis/kyc-screener/cert.pem
+LoadCredential=key.pem:/etc/cullis/kyc-screener/key.pem
+LoadCredential=dpop.jwk:/etc/cullis/kyc-screener/dpop.jwk
+LoadCredential=agent.json:/etc/cullis/kyc-screener/agent.json
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Inside the agent, replace `from_identity_dir(...)` with the zero-argument `from_systemd_credentials()`:
+
+```python
+from cullis_sdk import CullisClient
+
+# Reads $CREDENTIALS_DIRECTORY, loads cert + key + dpop, lifts
+# mastio_url / agent_id / org_id from agent.json.
+client = CullisClient.from_systemd_credentials()
+client.login_via_proxy_with_local_key()
+```
+
+The factory accepts the same `verify_tls`, `timeout`, and `ca_chain_path` arguments as `from_identity_dir`, plus overrides if your unit names the credentials differently (`cert_name=`, `key_name=`, `dpop_key_name=`). Setting `dpop_key_name=None` skips DPoP loading entirely — only safe while the Mastio's `egress_dpop_mode` is `off` or `optional`.
+
+The `agent.json` file ships the runtime metadata the SDK needs to talk to your Mastio:
+
+```json
+{
+  "mastio_url": "https://mastio.acme.corp",
+  "agent_id": "orga::kyc-screener",
+  "org_id": "orga"
+}
+```
+
+It's the same JSON the `enroll_via_byoca` / `enroll_via_spiffe` helpers persist under `persist_to/agent.json`, so an operator who provisioned with the SDK can copy it verbatim to `/etc/cullis/kyc-screener/`. Operators who provisioned with `curl` write it by hand.
+
 ## What's next
 
 - [BYOCA enrollment](../enroll/byoca) — full cert chain rules and CA attach flow

--- a/test/unit/test_sdk_systemd_credentials.py
+++ b/test/unit/test_sdk_systemd_credentials.py
@@ -1,0 +1,281 @@
+"""Tests for ``CullisClient.from_systemd_credentials`` — the Tier 2
+agent key storage path that replaces the plain-file 0600 layout with
+systemd's ``LoadCredential=`` mechanism.
+
+The factory itself is a thin wrapper around ``from_identity_dir`` —
+the only logic worth exercising is the resolution of the credentials
+directory, the optional metadata read, and the eager existence /
+config errors. The tests monkey-patch ``from_identity_dir`` so they
+don't depend on a real cert pair or an httpx client construction.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_creds(tmp_path) -> Path:
+    """Materialise the credential layout systemd would create.
+
+    Files are zero-byte placeholders; ``from_identity_dir`` is patched
+    out, so no real cert / key parsing happens. Tests that care about
+    metadata write a non-empty ``agent.json``.
+    """
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    (creds / "dpop.jwk").write_text("{\"kty\": \"FAKE\"}")
+    return creds
+
+
+@pytest.fixture
+def patched_from_identity_dir(monkeypatch):
+    """Capture the kwargs ``from_systemd_credentials`` forwards.
+
+    Returns a list that each test inspects after the factory call. The
+    patched method returns a sentinel ``object()`` so callers can still
+    assert "got a client back".
+    """
+    calls: list[dict] = []
+
+    def _fake(cls, mastio_url: str, **kwargs):  # noqa: ARG001 — mimic classmethod signature
+        calls.append({"mastio_url": mastio_url, **kwargs})
+        return object()  # opaque sentinel — represents the client
+
+    from cullis_sdk._client._enrollment import _EnrollmentMixin
+    monkeypatch.setattr(
+        _EnrollmentMixin, "from_identity_dir", classmethod(_fake),
+    )
+    return calls
+
+
+# ── credentials directory resolution ──────────────────────────────────────
+
+
+def test_explicit_credentials_dir_wins(
+    monkeypatch, fake_creds, patched_from_identity_dir,
+):
+    """Passing credentials_dir= overrides $CREDENTIALS_DIRECTORY."""
+    monkeypatch.setenv("CREDENTIALS_DIRECTORY", "/run/credentials/UNRELATED")
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://mastio.local:9443",
+        credentials_dir=fake_creds,
+    )
+    call = patched_from_identity_dir[0]
+    assert Path(call["cert_path"]).parent == fake_creds
+
+
+def test_falls_back_to_env(monkeypatch, fake_creds, patched_from_identity_dir):
+    """No explicit arg → read $CREDENTIALS_DIRECTORY."""
+    monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(fake_creds))
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials("https://mastio.local:9443")
+    call = patched_from_identity_dir[0]
+    assert Path(call["cert_path"]).parent == fake_creds
+
+
+def test_raises_when_neither_arg_nor_env_set(monkeypatch):
+    """No way to find the credentials → explicit RuntimeError."""
+    monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
+    from cullis_sdk import CullisClient
+
+    with pytest.raises(RuntimeError, match="CREDENTIALS_DIRECTORY"):
+        CullisClient.from_systemd_credentials("https://mastio.local:9443")
+
+
+# ── file existence pre-flight ─────────────────────────────────────────────
+
+
+def test_missing_cert_raises_named_error(tmp_path):
+    """Operator forgot a ``LoadCredential=cert.pem`` line."""
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "key.pem").write_text("FAKE-KEY")  # cert.pem absent
+    from cullis_sdk import CullisClient
+
+    with pytest.raises(FileNotFoundError, match="cert.pem"):
+        CullisClient.from_systemd_credentials(
+            "https://mastio.local:9443", credentials_dir=creds,
+        )
+
+
+def test_missing_key_raises_named_error(tmp_path):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    from cullis_sdk import CullisClient
+
+    with pytest.raises(FileNotFoundError, match="key.pem"):
+        CullisClient.from_systemd_credentials(
+            "https://mastio.local:9443", credentials_dir=creds,
+        )
+
+
+def test_missing_dpop_is_tolerated(
+    tmp_path, patched_from_identity_dir,
+):
+    """DPoP key absent → ``dpop_key_path=None`` to from_identity_dir.
+
+    Matches the ``egress_dpop_mode=off|optional`` server posture. The
+    factory must not refuse to construct just because the operator
+    chose not to ship a DPoP key.
+    """
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    # dpop.jwk absent on purpose.
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://mastio.local:9443", credentials_dir=creds,
+    )
+    call = patched_from_identity_dir[0]
+    assert call["dpop_key_path"] is None
+
+
+def test_dpop_disabled_explicitly(
+    fake_creds, patched_from_identity_dir,
+):
+    """dpop_key_name=None skips DPoP loading even when the file exists."""
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://mastio.local:9443",
+        credentials_dir=fake_creds,
+        dpop_key_name=None,
+    )
+    call = patched_from_identity_dir[0]
+    assert call["dpop_key_path"] is None
+
+
+# ── metadata (agent.json) auto-population ─────────────────────────────────
+
+
+def test_metadata_populates_mastio_url(
+    tmp_path, patched_from_identity_dir,
+):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    (creds / "agent.json").write_text(json.dumps({
+        "agent_id": "kyc-screener",
+        "org_id": "acme",
+        "mastio_url": "https://mastio.acme.local:9443",
+    }))
+    from cullis_sdk import CullisClient
+
+    # mastio_url= NOT passed → resolved from agent.json
+    CullisClient.from_systemd_credentials(credentials_dir=creds)
+    call = patched_from_identity_dir[0]
+    assert call["mastio_url"] == "https://mastio.acme.local:9443"
+    assert call["agent_id"] == "kyc-screener"
+    assert call["org_id"] == "acme"
+
+
+def test_explicit_args_win_over_metadata(
+    tmp_path, patched_from_identity_dir,
+):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    (creds / "agent.json").write_text(json.dumps({
+        "agent_id": "metadata-agent",
+        "org_id": "metadata-org",
+        "mastio_url": "https://metadata.local:9443",
+    }))
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://explicit.local:9443",
+        credentials_dir=creds,
+        agent_id="explicit-agent",
+        org_id="explicit-org",
+    )
+    call = patched_from_identity_dir[0]
+    assert call["mastio_url"] == "https://explicit.local:9443"
+    assert call["agent_id"] == "explicit-agent"
+    assert call["org_id"] == "explicit-org"
+
+
+def test_metadata_absent_requires_explicit_mastio_url(tmp_path):
+    """No agent.json + no mastio_url= → RuntimeError with a clear hint."""
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    from cullis_sdk import CullisClient
+
+    with pytest.raises(RuntimeError, match="mastio_url"):
+        CullisClient.from_systemd_credentials(credentials_dir=creds)
+
+
+def test_metadata_disabled_via_metadata_name_none(
+    tmp_path, patched_from_identity_dir,
+):
+    """metadata_name=None skips the agent.json read even when present."""
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    (creds / "agent.json").write_text(json.dumps({
+        "mastio_url": "https://from-metadata.local:9443",
+    }))
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://explicit.local:9443",
+        credentials_dir=creds,
+        metadata_name=None,
+    )
+    call = patched_from_identity_dir[0]
+    # metadata file was NOT consulted even though present on disk.
+    assert call["mastio_url"] == "https://explicit.local:9443"
+
+
+def test_malformed_metadata_surfaces_runtime_error(tmp_path):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "cert.pem").write_text("FAKE-CERT")
+    (creds / "key.pem").write_text("FAKE-KEY")
+    (creds / "agent.json").write_text("not-json{")
+    from cullis_sdk import CullisClient
+
+    with pytest.raises(RuntimeError, match="metadata"):
+        CullisClient.from_systemd_credentials(
+            "https://mastio.local:9443", credentials_dir=creds,
+        )
+
+
+# ── custom file names (operator deviated from the SDK layout) ─────────────
+
+
+def test_custom_credential_names(tmp_path, patched_from_identity_dir):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "client.crt").write_text("FAKE-CERT")
+    (creds / "client.key").write_text("FAKE-KEY")
+    (creds / "dpop.json").write_text("{\"kty\": \"FAKE\"}")
+    from cullis_sdk import CullisClient
+
+    CullisClient.from_systemd_credentials(
+        "https://mastio.local:9443",
+        credentials_dir=creds,
+        cert_name="client.crt",
+        key_name="client.key",
+        dpop_key_name="dpop.json",
+        metadata_name=None,
+    )
+    call = patched_from_identity_dir[0]
+    assert Path(call["cert_path"]).name == "client.crt"
+    assert Path(call["key_path"]).name == "client.key"
+    assert Path(call["dpop_key_path"]).name == "dpop.json"


### PR DESCRIPTION
## Summary

- Closes the Tier 2 gap in the agent key storage roadmap (memory note: `feedback_agent_key_storage_demo_vs_prod`): Linux production agents should not run off plain 0600 files on a writable disk.
- New `CullisClient.from_systemd_credentials()` factory loads cert + key + DPoP from systemd's `$CREDENTIALS_DIRECTORY` (tmpfs, 0400 root:root, gone with the unit), with optional `agent.json` metadata auto-population so the common-case call is literally zero-argument.
- Thin wrapper around `from_identity_dir`; no breaking changes to existing callers.

## API

```python
@classmethod
def from_systemd_credentials(
    cls,
    mastio_url: str | None = None,
    *,
    credentials_dir: str | Path | None = None,
    cert_name: str = "cert.pem",
    key_name: str = "key.pem",
    dpop_key_name: str | None = "dpop.jwk",
    metadata_name: str | None = "agent.json",
    agent_id: str | None = None,
    org_id: str | None = None,
    verify_tls: bool = True,
    timeout: float = 10.0,
    ca_chain_path: str | Path | None = None,
) -> CullisClient
```

Three resolution rules worth calling out:

1. **Credentials dir** — `credentials_dir=` arg wins, otherwise `$CREDENTIALS_DIRECTORY` (the env var systemd injects whenever the unit declares at least one `LoadCredential=`). When both are absent: `RuntimeError` with a hint pointing at the missing `LoadCredential=` line, not a vague `FileNotFoundError` two stack frames down.

2. **Eager existence pre-flight** — cert + key required (named error on either); DPoP optional (factory forwards `dpop_key_path=None` when the file is absent, matching `egress_dpop_mode=off|optional`).

3. **Metadata auto-population** — when `agent.json` ships next to the credentials, the factory lifts `mastio_url` / `agent_id` / `org_id` out of it. File layout matches what `_persist_enrollment` already writes (the persisted directory from `enroll_via_byoca` / `enroll_via_spiffe` is drop-in compatible). Explicit kwargs still win.

Operator escape hatches: `metadata_name=None` skips the JSON read; `cert_name=` / `key_name=` / `dpop_key_name=` override the credential basenames when the unit named the credentials differently from the SDK's persisted layout.

## Why systemd LoadCredential

Quoting the new doc subsection (`docs/quickstart/sdk.md` § "Production: systemd LoadCredential"): systemd materialises the credentials on tmpfs under `$CREDENTIALS_DIRECTORY` only for the lifetime of the unit, with `0400 root:root` perms, gone the moment the service stops. The agent never reads from a writable disk. Compared to the plain-file 0600 demo layout:

- **At rest**: nothing on a writable disk while the unit isn't running.
- **In transit (in-memory)**: read by systemd (privileged process) → written to tmpfs → opened by the agent. Same number of hops as the demo path, fewer disk-resident copies.
- **On crash**: tmpfs vanishes with the unit. No stale `agent.key` left behind for a `cat` to slurp later.

Tier 3 (Vault sidecar pull, ~3-5 days effort) stays on the roadmap as a separate PR — this PR is the right minimum for any Linux pilot.

## Test plan

- [x] `pytest test/unit/test_sdk_systemd_credentials.py -v` — **13 passed in 0.14s**
- [x] `pytest test/unit/` — **28 passed in 1.24s** (no regression on the existing 15 audit-detail tests)
- [x] `npm run build` (Astro site) — **25 pages in 2.54s**, `/docs/quickstart/sdk/` now renders the new "Production: systemd LoadCredential" subsection
- [x] Manual eyeball of the unit-file example in the doc page (declares all four `LoadCredential=` lines, sample `agent.json` matches the SDK's persisted shape)

## Out of scope

- Tier 3: Vault sidecar pull agent-side. The agent watches a Vault Agent template render or makes a direct `vault.read()` call at boot. Separate PR (3-5 days effort, includes retry on TTL refresh).
- TPM / HSM-backed key storage (the key never enters the process address space). Long-term roadmap.
- Container / Kubernetes `projected: secret` mounts. These already work transparently with `from_identity_dir(...)` once the mount is in place — operators can also pass `credentials_dir=` explicitly to point at a non-systemd tmpfs mount.