### PR TITLE
feat(policy): embedded Rego policy engine (opa-wasmtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,56 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Mastio — embedded Rego policy engine (operator beyond allowlists)
+
+- **New `mcp_proxy/policy/rego_engine.py` module**: compile a Rego
+  source via the bundled `opa build -t wasm` CLI, persist the WASM
+  bundle, evaluate it in-process via `opa-wasmtime` on every PDP
+  decision. No sidecar OPA daemon, no extra container. Sub-millisecond
+  eval per decision after the first instantiation (per opa-wasmtime
+  benchmarks).
+
+- **Two-layer policy on `/pdp/policy` + `/v1/data/cullis/policy/*`**:
+  the operator's Rego (when configured) evaluates first; the legacy
+  allowlist (`blocked_agents`, `allowed_orgs`, `capabilities`,
+  `tool_rules`) stays active as the fallback for deployments that
+  haven't adopted Rego AND as the safety net when Rego runtime eval
+  fails (logged at warning, never silently denies). `/v1/policy/tool-call`
+  (Connector legacy ambassador path) is intentionally out of scope —
+  it carries federation logic that needs a separate coordination pass.
+
+- **Storage**: two new fields inside the existing
+  `proxy_config.policy_rules` JSON document — `rego` (operator-authored
+  source, kept for the dashboard editor) and `rego_wasm_base64` (the
+  compiled WASM bundle, base64-encoded). Backward-compatible: no
+  schema migration; existing `policy_rules` documents without these
+  fields stay on the allowlist path.
+
+- **Operator UX**: `MCP_PROXY_OPA_BINARY` env pins the OPA binary
+  location (defaults to PATH search + `/usr/local/bin/opa`). Compile
+  timeout 10 seconds with explicit error message on the Save flow.
+  `RegoCompileError` surfaces the `opa build` stderr verbatim so the
+  dashboard renders the exact line + column the operator typed wrong.
+
+- **Failure semantics**: `RegoCompileError` blocks Save (operator
+  must fix); `RegoEvalError` at runtime → fall through to the legacy
+  allowlist + warning log (operator's broken Rego does not brick
+  every previously-allowed call). Future work to add a strict mode
+  that fails-closed on runtime error tracked separately.
+
+- **23 new unit tests**: `test/unit/test_rego_engine.py` (15 cases —
+  compile success / failure / timeout / bundle extraction / WASM eval
+  / decision normalisation) + `test/unit/test_policy_helper.py`
+  (8 cases — `try_rego_decision` contract: no Rego / malformed
+  base64 / runtime error / passthrough on both surfaces).
+
+- **Docs**: new
+  [Operate → Rego policies](https://cullis.io/docs/operate/rego-policies)
+  page with two complete example policies (org-allowlist + capability
+  gate for `session`, per-agent tool whitelist for `tool_call`), the
+  authoring workflow against the dashboard Policies page, and the
+  constraints (which OPA built-ins do not work in the WASM target).
+
 ### Mastio — policy bridge (OPA Data API + CloudEvents sink)
 
 - **New `/v1/data/cullis/policy/{path}` endpoint** — OPA Data API

--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -36,6 +36,33 @@ RUN mkdir -p /out \
       --minify
 
 # -----------------------------------------------------------------------------
+# Stage 1b: OPA CLI download (Rego → WASM compile at policy Save time).
+# Pinned to v1.16.2; SHA-256 of both Linux arches verified before trust
+# (see scripts/opa-sha256.txt). Operator can override at runtime via
+# MCP_PROXY_OPA_BINARY if they want a different version on the host.
+# -----------------------------------------------------------------------------
+FROM debian:bookworm-slim AS opa-build
+ARG OPA_VERSION=v1.16.2
+ARG TARGETARCH=amd64
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY scripts/opa-sha256.txt /tmp/opa-sha256.txt
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) OPA_ARCH=amd64 ;; \
+      arm64) OPA_ARCH=arm64 ;; \
+      *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    cd /usr/local/bin; \
+    curl -sSLf "https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_${OPA_ARCH}_static" \
+      -o "opa_linux_${OPA_ARCH}_static"; \
+    grep " opa_linux_${OPA_ARCH}_static$" /tmp/opa-sha256.txt | sha256sum -c -; \
+    mv "opa_linux_${OPA_ARCH}_static" opa; \
+    chmod +x opa; \
+    rm -f /tmp/opa-sha256.txt
+
+# -----------------------------------------------------------------------------
 # Stage 2: Python runtime
 # -----------------------------------------------------------------------------
 FROM python:3.11-slim
@@ -45,6 +72,12 @@ WORKDIR /app
 # Install dependencies
 COPY mcp_proxy/requirements-proxy.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
+
+# OPA CLI for Rego → WASM compile (mcp_proxy.policy.rego_engine).
+# The runtime opa-wasmtime package evaluates the compiled WASM; the
+# binary itself only runs when the operator saves a new Rego policy
+# in the dashboard.
+COPY --from=opa-build /usr/local/bin/opa /usr/local/bin/opa
 
 # Copy proxy code + SDK
 COPY mcp_proxy/ ./mcp_proxy/

--- a/mcp_proxy/dashboard/rego_rules.py
+++ b/mcp_proxy/dashboard/rego_rules.py
@@ -1,0 +1,262 @@
+"""Dashboard authoring for Rego policies.
+
+The engine (mcp_proxy.policy.rego_engine) compiles the operator's
+Rego source via the bundled ``opa build`` CLI and persists the
+resulting WASM bundle alongside the source. This router is the
+authoring surface — a text editor + Save + Delete + inline compile
+diagnostics that the operator hits at ``/proxy/policies/rego``.
+
+Storage lives inside the existing ``policy_rules`` config row
+under two new fields:
+
+  * ``rego`` (string) — the operator's source, kept for the editor
+    to load back on the next page view.
+  * ``rego_wasm_base64`` (string) — the compiled WASM bundle,
+    base64-encoded so it fits inside the JSON container.
+
+Save flow:
+
+  1. Operator pastes / edits Rego in the textarea, clicks Save.
+  2. POST handler calls ``compile_rego(source)``.
+  3. On success: persist both fields, audit ``policy.rego_save``,
+     redirect back with a success flash.
+  4. On RegoCompileError: keep the operator's source in the form
+     (no persistence), re-render the page with the ``opa build``
+     diagnostic shown inline so they can fix the exact line / column.
+
+Delete flow:
+
+  Strips ``rego`` + ``rego_wasm_base64`` from the JSON document so
+  the engine's two-layer logic falls back to the legacy allowlist
+  on the next decision. The source is wiped from disk too (no
+  hidden retention).
+
+Routes:
+  GET  /proxy/policies/rego              editor + diagnostics
+  POST /proxy/policies/rego/save         compile + persist
+  POST /proxy/policies/rego/delete       wipe rego + rego_wasm
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import pathlib
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import get_config, log_audit, set_config
+from mcp_proxy.policy.rego_engine import (
+    RegoCompileError,
+    compile_rego,
+)
+
+_log = logging.getLogger("mcp_proxy.dashboard.rego_rules")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(
+    prefix="/proxy/policies/rego",
+    tags=["dashboard-rego-rules"],
+)
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "active": "policies",
+        **kwargs,
+    }
+
+
+async def _read_policy_rules() -> dict:
+    rules_raw = await get_config("policy_rules")
+    if not rules_raw:
+        return {}
+    try:
+        return json.loads(rules_raw)
+    except json.JSONDecodeError:
+        _log.warning("policy_rules JSON malformed, treating as empty doc")
+        return {}
+
+
+async def _write_policy_rules(doc: dict) -> None:
+    await set_config("policy_rules", json.dumps(doc, indent=2, sort_keys=True))
+
+
+_DEFAULT_EXAMPLE = """package cullis.policy
+
+# Default deny tool_call — explicit allow only.
+tool_call := {"decision": "deny", "reason": "no rule matched"} if {
+    not allow_tool_call
+}
+
+tool_call := {"decision": "allow"} if { allow_tool_call }
+
+# KYC screener: read-only KYC tools.
+allow_tool_call if {
+    input.agent_id == "orga::kyc-screener"
+    input.tool_name == "sanctions_lookup"
+}
+
+# Default-allow session.
+session := {"decision": "allow"}
+"""
+
+
+@router.get("", response_class=HTMLResponse)
+async def rego_rules_page(request: Request):
+    """Render the Rego editor with the operator's current source.
+
+    When no Rego has been authored yet, pre-fill the textarea with
+    the canonical example so the operator has a starting point
+    instead of a blank screen. The example mirrors the worked
+    example in the docs page.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    doc = await _read_policy_rules()
+    source = doc.get("rego") or ""
+    wasm_b64 = doc.get("rego_wasm_base64") or ""
+
+    # Surface the SHA-256 prefix of the compiled bundle so the
+    # operator can correlate runtime audit lines
+    # (``PDP[rego] decision=allow sha256=ab12cd34...``) with the
+    # policy version on the editor page.
+    sha_prefix = ""
+    if wasm_b64:
+        try:
+            import hashlib
+            wasm = base64.b64decode(wasm_b64, validate=True)
+            sha_prefix = hashlib.sha256(wasm).hexdigest()[:12]
+        except (ValueError, TypeError):
+            sha_prefix = "(invalid base64)"
+
+    return templates.TemplateResponse(
+        "rego_rules.html",
+        _ctx(
+            request, session,
+            source=source or _DEFAULT_EXAMPLE,
+            has_source=bool(source),
+            sha_prefix=sha_prefix,
+            compile_error=None,
+        ),
+    )
+
+
+@router.post("/save")
+async def rego_rules_save(request: Request):
+    """Compile the submitted Rego and persist on success.
+
+    On RegoCompileError the page is re-rendered with the operator's
+    source preserved in the textarea + the ``opa build`` diagnostic
+    inline. No partial persistence: the previous compiled bundle
+    stays in place until a successful compile replaces it.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    source = str(form.get("rego", "")).strip()
+    if not source:
+        # Empty submit: treat as delete (operator cleared the textarea
+        # then hit Save). Same outcome as the explicit Delete button.
+        return await _delete_rego(session)
+
+    try:
+        compiled = compile_rego(source)
+    except RegoCompileError as exc:
+        _log.info(
+            "policy.rego_save compile failed: %s — preserving previous bundle",
+            str(exc)[:200],
+        )
+        await log_audit(
+            agent_id="admin",
+            action="policy.rego_save",
+            status="compile_error",
+            details={"error": str(exc)[:500]},
+        )
+        # Re-render the editor with the operator's source intact and
+        # the diagnostic shown next to the Save button.
+        doc = await _read_policy_rules()
+        prev_wasm_b64 = doc.get("rego_wasm_base64") or ""
+        sha_prefix = ""
+        if prev_wasm_b64:
+            try:
+                import hashlib
+                wasm = base64.b64decode(prev_wasm_b64, validate=True)
+                sha_prefix = hashlib.sha256(wasm).hexdigest()[:12] + " (previous)"
+            except (ValueError, TypeError):
+                pass
+        return templates.TemplateResponse(
+            "rego_rules.html",
+            _ctx(
+                request, session,
+                source=source,
+                has_source=True,
+                sha_prefix=sha_prefix,
+                compile_error=str(exc),
+            ),
+            status_code=400,
+        )
+
+    wasm_b64 = base64.b64encode(compiled.wasm).decode("ascii")
+    doc = await _read_policy_rules()
+    doc["rego"] = source
+    doc["rego_wasm_base64"] = wasm_b64
+    await _write_policy_rules(doc)
+
+    await log_audit(
+        agent_id="admin",
+        action="policy.rego_save",
+        status="success",
+        details={
+            "wasm_bytes": len(compiled.wasm),
+            "sha256_prefix": compiled.sha256[:12],
+        },
+    )
+
+    return RedirectResponse(url="/proxy/policies/rego", status_code=303)
+
+
+@router.post("/delete")
+async def rego_rules_delete(request: Request):
+    """Wipe both ``rego`` and ``rego_wasm_base64`` from the config."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+    return await _delete_rego(session)
+
+
+async def _delete_rego(session: ProxyDashboardSession) -> RedirectResponse:
+    """Shared delete path — used by both the explicit Delete button
+    and an empty Save submit (operator cleared the textarea)."""
+    doc = await _read_policy_rules()
+    had_source = bool(doc.get("rego"))
+    doc.pop("rego", None)
+    doc.pop("rego_wasm_base64", None)
+    if had_source:
+        await _write_policy_rules(doc)
+        await log_audit(
+            agent_id="admin",
+            action="policy.rego_delete",
+            status="success",
+        )
+    return RedirectResponse(url="/proxy/policies/rego", status_code=303)

--- a/mcp_proxy/dashboard/templates/policies.html
+++ b/mcp_proxy/dashboard/templates/policies.html
@@ -18,6 +18,14 @@
                 class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
             External PDP
         </button>
+        <a href="/proxy/policies/tool-rules"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            Tool Rules
+        </a>
+        <a href="/proxy/policies/rego"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            Rego
+        </a>
     </div>
 
     <!-- Tab: Built-in Rules -->

--- a/mcp_proxy/dashboard/templates/rego_rules.html
+++ b/mcp_proxy/dashboard/templates/rego_rules.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+{% block title %}Rego Policies{% endblock %}
+{% block header_title %}Rego Policies{% endblock %}
+{% block content %}
+<div class="max-w-5xl">
+
+    <!-- Tabs (mirror /proxy/policies + /proxy/policies/tool-rules) -->
+    <div class="flex items-center gap-0 mb-6 border-b border-gray-800/60">
+        <a href="/proxy/policies"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            Built-in Rules
+        </a>
+        <a href="/proxy/policies"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            External PDP
+        </a>
+        <a href="/proxy/policies/tool-rules"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            Tool Rules
+        </a>
+        <a href="/proxy/policies/rego"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-accent-400 text-accent-400 transition-colors">
+            Rego
+        </a>
+    </div>
+
+    <!-- Intro -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 mb-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-1">Operator-authored Rego policy</h3>
+        <p class="text-xs text-gray-500 leading-relaxed">
+            The Mastio compiles the Rego source below via the bundled
+            <code class="text-accent-400">opa build -t wasm</code> on Save and evaluates the
+            resulting WebAssembly bundle in-process on every PDP decision
+            (<code class="text-accent-400">/pdp/policy</code> and
+            <code class="text-accent-400">/v1/data/cullis/policy/*</code>). The legacy
+            Built-in Rules + Tool Rules tabs above continue to back-stop this surface: when
+            the Rego is absent or its evaluation fails at runtime, the allowlist wins.
+        </p>
+        <p class="text-[11px] text-gray-600 mt-3">
+            Rego must declare two rules under <code class="text-accent-400">package cullis.policy</code> —
+            <code class="text-accent-400">session</code> and <code class="text-accent-400">tool_call</code> —
+            each returning <code class="text-accent-400">{"decision": "allow"|"deny", "reason"?: "..."}</code>.
+            See the <a href="https://cullis.io/docs/operate/rego-policies" target="_blank" class="text-accent-400 hover:text-accent-300 underline">operator docs</a>
+            for two worked examples.
+        </p>
+    </div>
+
+    {% if compile_error %}
+    <!-- Compile diagnostic, shown only when the last Save failed. -->
+    <div class="bg-red-950/40 border border-red-800/60 rounded-lg p-6 mb-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-red-300 uppercase tracking-wider mb-2">Compile failed</h3>
+        <pre class="text-[11px] text-red-200 font-mono whitespace-pre-wrap leading-relaxed">{{ compile_error }}</pre>
+        <p class="text-[11px] text-gray-500 mt-3">
+            Your source is preserved below. Fix the error and click Save again. The
+            previous compiled bundle (if any) stays in place until a successful compile
+            replaces it.
+        </p>
+    </div>
+    {% endif %}
+
+    <!-- Editor -->
+    <form method="post" action="/proxy/policies/rego/save" class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 mb-6 card-glow backdrop-blur-sm">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+        <div class="flex items-center justify-between mb-3">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Rego source</h3>
+            {% if sha_prefix %}
+            <span class="text-[11px] text-gray-500 font-mono">
+                bundle sha256: <span class="text-accent-400">{{ sha_prefix }}</span>
+            </span>
+            {% endif %}
+        </div>
+
+        <textarea
+            name="rego"
+            rows="22"
+            spellcheck="false"
+            class="w-full bg-surface-950/60 border border-gray-800/60 rounded p-3 text-xs font-mono text-gray-200 leading-relaxed focus:outline-none focus:border-accent-500/60"
+            placeholder="package cullis.policy&#10;&#10;session := {&quot;decision&quot;: &quot;allow&quot;}&#10;tool_call := {&quot;decision&quot;: &quot;allow&quot;}"
+        >{{ source }}</textarea>
+
+        <div class="flex items-center gap-3 mt-4">
+            <button type="submit"
+                    class="px-4 py-2 bg-accent-500 hover:bg-accent-400 text-surface-950 text-xs font-semibold uppercase tracking-wider rounded transition-colors">
+                Save + compile
+            </button>
+            {% if has_source %}
+            <span class="text-[11px] text-gray-500">
+                Save replaces the compiled bundle. Use Delete below to wipe both source
+                and bundle and fall back to the allowlist layer.
+            </span>
+            {% else %}
+            <span class="text-[11px] text-gray-500">
+                Compile bounded at 10 seconds. Diagnostic is shown inline if Rego is malformed.
+            </span>
+            {% endif %}
+        </div>
+    </form>
+
+    {% if has_source %}
+    <!-- Delete -->
+    <form method="post" action="/proxy/policies/rego/delete" class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm"
+          onsubmit="return confirm('Delete the Rego policy + compiled bundle? Future decisions will fall back to the Built-in Rules + Tool Rules tabs.');">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-2">Delete Rego policy</h3>
+        <p class="text-xs text-gray-500 leading-relaxed mb-4">
+            Wipes both the source above and the compiled WASM bundle. The Mastio falls
+            back to the Built-in Rules + Tool Rules tabs for every subsequent PDP
+            decision. No restart needed.
+        </p>
+        <button type="submit"
+                class="px-4 py-2 bg-red-900/40 hover:bg-red-800/50 border border-red-800/60 text-red-200 text-xs font-semibold uppercase tracking-wider rounded transition-colors">
+            Delete
+        </button>
+    </form>
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/mcp_proxy/integrations/policy_bridge.py
+++ b/mcp_proxy/integrations/policy_bridge.py
@@ -124,6 +124,20 @@ async def _evaluate_session_policy(opa_input: dict) -> dict:
     else:
         rules = {}
 
+    # Two-layer policy: operator's Rego first, legacy allowlist as
+    # fall-through. See ``mcp_proxy.policy.try_rego_decision`` for the
+    # contract (returns None when no Rego is configured or its eval
+    # fails — the latter logged at warning level inside the helper).
+    from mcp_proxy.policy import try_rego_decision
+    rego_decision = try_rego_decision(rules, opa_input, surface="session")
+    if rego_decision is not None:
+        _log.info(
+            "policy_bridge[rego] session %s: %s",
+            rego_decision.get("decision", "").upper(),
+            rego_decision.get("reason", ""),
+        )
+        return rego_decision
+
     initiator = opa_input.get("initiator_agent_id", "?")
     target = opa_input.get("target_agent_id", "?")
     context = opa_input.get("session_context", "?")
@@ -185,6 +199,21 @@ async def _evaluate_tool_call_policy(opa_input: dict) -> dict:
             rules = _json.loads(rules_raw)
         except _json.JSONDecodeError:
             rules = {}
+
+    # Two-layer policy: operator's Rego first, ``tool_rules`` allowlist
+    # as fall-through. Mirror of the session surface above.
+    from mcp_proxy.policy import try_rego_decision
+    rego_decision = try_rego_decision(rules, opa_input, surface="tool_call")
+    if rego_decision is not None:
+        _log.info(
+            "policy_bridge[rego] tool_call %s: agent=%s tool=%s %s",
+            rego_decision.get("decision", "").upper(),
+            opa_input.get("agent_id", "?"),
+            opa_input.get("tool_name", "?"),
+            rego_decision.get("reason", ""),
+        )
+        return rego_decision
+
     tool_rules = rules.get("tool_rules", {})
     if not isinstance(tool_rules, dict):
         tool_rules = {}

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1740,6 +1740,31 @@ async def pdp_policy(request: Request):
     else:
         rules = {}
 
+    # Two-layer policy: try the operator's Rego first (compiled WASM
+    # bundle stored under ``policy_rules.rego_wasm_base64``); fall
+    # through to the legacy allowlist below if Rego is not configured
+    # or its eval fails (the helper logs the failure).
+    from mcp_proxy.policy import try_rego_decision
+    rego_decision = try_rego_decision(
+        rules,
+        {
+            "initiator_agent_id": initiator,
+            "target_agent_id": target,
+            "initiator_org_id": body.get("initiator_org_id", ""),
+            "target_org_id": body.get("target_org_id", ""),
+            "session_context": context,
+            "capabilities": body.get("capabilities", []),
+        },
+        surface="session",
+    )
+    if rego_decision is not None:
+        _log.info(
+            "PDP[rego] %s: %s -> %s (ctx=%s) %s",
+            rego_decision.get("decision", "").upper(),
+            initiator, target, context, rego_decision.get("reason", ""),
+        )
+        return JSONResponse(rego_decision)
+
     # Evaluate rules (empty = allow all)
     decision = "allow"
     reason = ""

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -2227,6 +2227,13 @@ app.include_router(local_policies_router)
 from mcp_proxy.dashboard.tool_rules import router as tool_rules_router
 app.include_router(tool_rules_router)
 
+# Rego policy authoring surface — editor + compile + delete under
+# /proxy/policies/rego. Compiles via the bundled opa binary, stores
+# source + WASM bundle in the same policy_rules JSON the legacy
+# Built-in Rules + Tool Rules tabs already write to.
+from mcp_proxy.dashboard.rego_rules import router as rego_rules_router
+app.include_router(rego_rules_router)
+
 # ADR-017 Phase 4 — dashboard CRUD for AI provider credentials (the
 # admin secret API surface lives in mcp_proxy.admin.ai_providers).
 from mcp_proxy.dashboard.ai_providers import router as ai_providers_dashboard_router

--- a/mcp_proxy/policy/__init__.py
+++ b/mcp_proxy/policy/__init__.py
@@ -1,0 +1,130 @@
+"""Cullis Mastio policy engine surface.
+
+Two layers, evaluated in order on every PDP-style decision call
+(``/pdp/policy``, ``/v1/policy/tool-call``,
+``/v1/data/cullis/policy/*``):
+
+  1. **Rego engine** (:mod:`mcp_proxy.policy.rego_engine`) — when the
+     operator has saved a Rego policy on the dashboard Policies page,
+     the compiled WASM bundle is consulted first. A
+     ``{"decision": "allow"|"deny", "reason": ...}`` returned by Rego
+     short-circuits the legacy allowlist below.
+
+  2. **Legacy allowlist** — the ``blocked_agents`` / ``allowed_orgs`` /
+     ``capabilities`` / ``tool_rules`` shape the dashboard wrote
+     before the Rego surface existed. Continues to back-stop
+     deployments that never adopted Rego.
+
+The :func:`try_rego_decision` helper is the single entry point both
+the in-tree PDP routes and the external policy-bridge (:mod:`
+mcp_proxy.integrations.policy_bridge`) consume — keeps the two-layer
+contract DRY across the four call sites.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Optional
+
+from mcp_proxy.policy.rego_engine import (
+    CompiledPolicy,
+    RegoCompileError,
+    RegoEvalError,
+    evaluate_decision,
+)
+
+__all__ = [
+    "RegoCompileError",
+    "RegoEvalError",
+    "try_rego_decision",
+]
+
+
+_log = logging.getLogger("mcp_proxy.policy")
+
+
+def try_rego_decision(
+    rules: dict,
+    input_doc: dict,
+    *,
+    surface: str,
+) -> Optional[dict]:
+    """Evaluate the operator's Rego policy if one is configured.
+
+    Args:
+        rules: the decoded ``policy_rules`` config (the JSON document
+            ``get_config('policy_rules')`` returns). Two fields drive
+            the Rego layer:
+
+              * ``rego`` — the operator's source. Informational only
+                here; the compiled artifact is what runs.
+              * ``rego_wasm_base64`` — the WASM bundle, base64-encoded
+                (because the surrounding container is JSON). Produced
+                by ``mcp_proxy.policy.rego_engine.compile_rego`` when
+                the operator clicks Save in the dashboard.
+
+        input_doc: the OPA-shaped ``input`` for this decision — the
+            same dict the caller would put under ``{"input": ...}``
+            in the OPA Data API request body.
+
+        surface: one of ``"session"`` or ``"tool_call"``. Selects the
+            Rego entrypoint (``cullis/policy/session`` or
+            ``cullis/policy/tool_call``).
+
+    Returns:
+        The decision dict (``{"decision": "allow"|"deny",
+        "reason"?}``) when the Rego layer produced one. ``None`` when:
+
+          * no Rego is configured (``rego_wasm_base64`` missing /
+            empty);
+          * the configured WASM is unreadable (base64 decode error);
+          * the Rego runtime raised an eval error (the caller treats
+            the absence as a signal to **fall through** to the legacy
+            allowlist, NOT as a deny — the failure already gets logged
+            here, and a soft-fail-open on Rego runtime errors matches
+            the pre-Rego posture so an operator's broken Rego doesn't
+            silently brick every previously-allowed call).
+
+        Callers that need fail-closed semantics on a Rego runtime
+        error should layer that on top — the policy-bridge HTTP
+        handlers do exactly this when the operator has explicitly
+        opted into strict mode (future work; today the legacy
+        fall-through is the only mode).
+    """
+    if not isinstance(rules, dict):
+        return None
+    wasm_b64 = rules.get("rego_wasm_base64") or ""
+    if not wasm_b64:
+        return None
+    try:
+        wasm = base64.b64decode(wasm_b64, validate=True)
+    except (ValueError, TypeError) as exc:
+        _log.warning(
+            "policy.rego: rego_wasm_base64 decode failed (%s) — "
+            "falling through to legacy allowlist", exc,
+        )
+        return None
+
+    entrypoint = f"cullis/policy/{surface}"
+    policy = CompiledPolicy.from_wasm(wasm)
+    try:
+        decision = evaluate_decision(
+            policy, input_doc, entrypoint=entrypoint,
+        )
+    except RegoEvalError as exc:
+        # Operator's Rego is misshaped — log + fall through to legacy.
+        # The dashboard Save flow validates the shape at compile time,
+        # but a Rego that compiles can still return an unexpected
+        # document at runtime (e.g. a partial rule that didn't cover
+        # one of the operator's input shapes).
+        _log.warning(
+            "policy.rego: %s eval failed (%s) — falling through to "
+            "legacy allowlist for this decision", surface, exc,
+        )
+        return None
+
+    _log.info(
+        "policy.rego: %s decision=%s (sha256=%s)",
+        surface, decision.get("decision"), policy.sha256[:12],
+    )
+    return decision

--- a/mcp_proxy/policy/rego_engine.py
+++ b/mcp_proxy/policy/rego_engine.py
@@ -112,18 +112,28 @@ def _resolve_opa_binary() -> str:
     )
 
 
-def compile_rego(source: str, *, package: str = "cullis.policy") -> CompiledPolicy:
+_DEFAULT_ENTRYPOINTS = ("cullis/policy/session", "cullis/policy/tool_call")
+
+
+def compile_rego(
+    source: str,
+    *,
+    entrypoints: tuple[str, ...] = _DEFAULT_ENTRYPOINTS,
+) -> CompiledPolicy:
     """Compile a Rego source string into a WASM bundle.
 
     Args:
         source: the Rego document the operator authored.
-        package: the package path the Rego is expected to declare.
-            ``opa build -e <entrypoint>`` requires an explicit
-            entrypoint per rule; the caller picks the surface (e.g.
-            ``cullis.policy.session``, ``cullis.policy.tool_call``).
-            We compile with the package root as the entrypoint so a
-            single bundle can serve multiple surfaces; the WASM eval
-            then drills into the path the caller asks for.
+        entrypoints: slash-separated rule paths the WASM bundle must
+            expose for evaluation. OPA v1.x requires each entrypoint
+            to point at a concrete rule (the pre-v1 contract of
+            "package root + drill at runtime" no longer holds). The
+            defaults cover Cullis' two surfaces — ``cullis/policy/session``
+            and ``cullis/policy/tool_call`` — so an operator's single
+            Rego file with rules under both names compiles in one
+            shot. The compile fails-closed if a declared entrypoint
+            doesn't exist in the source (the operator sees the
+            ``opa build`` diagnostic verbatim).
 
     Returns:
         A :class:`CompiledPolicy` carrying the raw WASM bytes (the
@@ -140,15 +150,15 @@ def compile_rego(source: str, *, package: str = "cullis.policy") -> CompiledPoli
         src_path = Path(workdir) / "policy.rego"
         src_path.write_text(source)
         bundle_path = Path(workdir) / "bundle.tar.gz"
+        # Build the argv: one ``-e <entrypoint>`` per declared rule
+        # plus the standard ``-t wasm`` target + ``-o`` output path.
+        argv: list[str] = [opa, "build", "-t", "wasm"]
+        for ep in entrypoints:
+            argv.extend(("-e", ep))
+        argv.extend(("-o", str(bundle_path), str(src_path)))
         try:
             result = subprocess.run(
-                [
-                    opa, "build",
-                    "-t", "wasm",
-                    "-e", package,
-                    "-o", str(bundle_path),
-                    str(src_path),
-                ],
+                argv,
                 capture_output=True,
                 text=True,
                 timeout=_COMPILE_TIMEOUT_SECONDS,
@@ -251,12 +261,29 @@ class RegoEngine:
                 "policy. Install ``opa-wasmtime`` in the Mastio image.",
             ) from exc
 
+        # opa-wasmtime's OPAPolicy accepts a filesystem path, not raw
+        # bytes; the WASM bundle lives in memory (loaded from
+        # ``policy_rules.rego_wasm_base64``), so write it to a tmpfile
+        # for the duration of the eval. The file is unlinked on context
+        # exit; opa-wasmtime reads + instantiates synchronously, so
+        # there is no race.
+        with tempfile.NamedTemporaryFile(
+            prefix="cullis-rego-", suffix=".wasm", delete=False,
+        ) as tmp:
+            tmp.write(self._policy.wasm)
+            tmp_path = tmp.name
         try:
-            opa_policy = OPAPolicy(self._policy.wasm)
-        except Exception as exc:
-            raise RegoEvalError(
-                f"OPAPolicy instantiation failed: {exc}",
-            ) from exc
+            try:
+                opa_policy = OPAPolicy(tmp_path)
+            except Exception as exc:
+                raise RegoEvalError(
+                    f"OPAPolicy instantiation failed: {exc}",
+                ) from exc
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
         try:
             # opa-wasmtime's evaluate accepts a dict; it JSON-serialises

--- a/mcp_proxy/policy/rego_engine.py
+++ b/mcp_proxy/policy/rego_engine.py
@@ -1,0 +1,323 @@
+"""Embedded Rego policy engine — OPA WASM eval inside the Mastio process.
+
+Operators write Rego policies in the dashboard Policies page; the
+backend compiles them to a WebAssembly bundle via the ``opa`` CLI
+shipped alongside the Mastio binary, persists the WASM blob next to
+the source, and evaluates each policy decision in-process via
+``opa-wasmtime``. No sidecar OPA daemon, no extra container, no
+network hop on the decision hot path.
+
+Two surfaces:
+
+  * :func:`compile_rego` — synchronous subprocess invocation of the
+    bundled ``opa build`` against a tempdir containing the operator's
+    Rego source. Returns the resulting WASM bytes (extracted from the
+    OPA bundle tarball). Raises :class:`RegoCompileError` on syntax /
+    package errors, surfacing the operator-facing diagnostic message
+    so the dashboard can render it inline.
+
+  * :class:`RegoEngine` — wraps a compiled WASM bundle. ``evaluate``
+    takes an arbitrary JSON-serialisable input and returns the policy
+    decision dict the operator's Rego computes under
+    ``data.cullis.policy.<surface>``. Thread-safe (the underlying
+    ``OPAPolicy`` is re-instantiated per call so wasmtime instance
+    state never leaks between evaluations).
+
+Failure modes are explicitly fail-closed:
+
+  * Compile error → :class:`RegoCompileError` — the dashboard surfaces
+    the message; the legacy allowlist path stays active until the
+    operator fixes the Rego.
+
+  * Runtime error (WASM trap, malformed input, missing
+    ``data.cullis.policy.<surface>`` rule) → the caller sees the
+    exception and treats the decision as ``deny`` (the
+    PDP / tool_call / policy_bridge handlers wrap the engine call so
+    a runtime fault never returns a stale ``allow``).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_log = logging.getLogger("mcp_proxy.policy.rego_engine")
+
+
+# Operator can pin the ``opa`` binary location via env (containers
+# bundle it at ``/usr/local/bin/opa``); the default search PATH covers
+# developer machines where it lives on /usr/bin / /usr/local/bin.
+_OPA_BINARY_ENV = "MCP_PROXY_OPA_BINARY"
+_OPA_DEFAULT_PATHS = ("opa", "/usr/local/bin/opa", "/usr/bin/opa")
+
+# Compile timeout — Rego is small; honest policies compile in < 1 s.
+# 10 s guards against a wedged subprocess without making the dashboard
+# Save button feel hung.
+_COMPILE_TIMEOUT_SECONDS = 10.0
+
+
+class RegoCompileError(RuntimeError):
+    """Surface the ``opa build`` diagnostic to the operator."""
+
+
+class RegoEvalError(RuntimeError):
+    """Surface a runtime WASM eval fault to the caller."""
+
+
+@dataclass(frozen=True)
+class CompiledPolicy:
+    """Compiled WASM bundle + the digest the cache keys on."""
+
+    wasm: bytes
+    sha256: str
+
+    @classmethod
+    def from_wasm(cls, wasm: bytes) -> "CompiledPolicy":
+        digest = hashlib.sha256(wasm).hexdigest()
+        return cls(wasm=wasm, sha256=digest)
+
+
+def _resolve_opa_binary() -> str:
+    """Find the ``opa`` binary, honouring ``MCP_PROXY_OPA_BINARY``.
+
+    Raises :class:`RegoCompileError` (not FileNotFoundError) so the
+    dashboard can surface the same error class for both
+    binary-missing and compile-failed paths.
+    """
+    pinned = os.environ.get(_OPA_BINARY_ENV)
+    candidates = (pinned,) if pinned else _OPA_DEFAULT_PATHS
+    for cand in candidates:
+        if not cand:
+            continue
+        # Honour absolute paths verbatim; fall back to PATH lookup for
+        # the bare ``opa`` candidate.
+        if os.path.isabs(cand):
+            if os.path.isfile(cand) and os.access(cand, os.X_OK):
+                return cand
+            continue
+        import shutil
+        resolved = shutil.which(cand)
+        if resolved:
+            return resolved
+    raise RegoCompileError(
+        f"opa binary not found (looked at: {candidates}). Install OPA "
+        f"on the Mastio host or pin the location via {_OPA_BINARY_ENV}.",
+    )
+
+
+def compile_rego(source: str, *, package: str = "cullis.policy") -> CompiledPolicy:
+    """Compile a Rego source string into a WASM bundle.
+
+    Args:
+        source: the Rego document the operator authored.
+        package: the package path the Rego is expected to declare.
+            ``opa build -e <entrypoint>`` requires an explicit
+            entrypoint per rule; the caller picks the surface (e.g.
+            ``cullis.policy.session``, ``cullis.policy.tool_call``).
+            We compile with the package root as the entrypoint so a
+            single bundle can serve multiple surfaces; the WASM eval
+            then drills into the path the caller asks for.
+
+    Returns:
+        A :class:`CompiledPolicy` carrying the raw WASM bytes (the
+        caller persists them as a BLOB next to the source) and the
+        SHA-256 digest (used as the cache key by :class:`RegoEngine`).
+
+    Raises:
+        RegoCompileError: any compile failure — surfaced with the
+            ``opa build`` stderr so the dashboard can show the operator
+            the exact line / column that failed.
+    """
+    opa = _resolve_opa_binary()
+    with tempfile.TemporaryDirectory(prefix="cullis-rego-") as workdir:
+        src_path = Path(workdir) / "policy.rego"
+        src_path.write_text(source)
+        bundle_path = Path(workdir) / "bundle.tar.gz"
+        try:
+            result = subprocess.run(
+                [
+                    opa, "build",
+                    "-t", "wasm",
+                    "-e", package,
+                    "-o", str(bundle_path),
+                    str(src_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_COMPILE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RegoCompileError(
+                f"opa build timed out after {_COMPILE_TIMEOUT_SECONDS}s",
+            ) from exc
+
+        if result.returncode != 0:
+            # opa build writes diagnostics to stderr; preserve both
+            # streams since some errors land on stdout.
+            diag = (result.stderr or result.stdout or "").strip()
+            raise RegoCompileError(
+                diag or f"opa build exited with code {result.returncode}",
+            )
+
+        if not bundle_path.exists():
+            raise RegoCompileError("opa build produced no bundle output")
+
+        # The bundle is a tar.gz containing ``/policy.wasm`` (plus
+        # data + manifest). Extract just the WASM blob.
+        try:
+            with tarfile.open(bundle_path, mode="r:gz") as tar:
+                members = [m for m in tar.getmembers() if m.name.endswith(".wasm")]
+                if not members:
+                    raise RegoCompileError(
+                        "opa build bundle contained no .wasm file",
+                    )
+                member = members[0]
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    raise RegoCompileError(
+                        f"opa build bundle entry {member.name} unreadable",
+                    )
+                wasm = extracted.read()
+        except tarfile.TarError as exc:
+            raise RegoCompileError(
+                f"opa build bundle not a valid tar.gz: {exc}",
+            ) from exc
+
+    return CompiledPolicy.from_wasm(wasm)
+
+
+class RegoEngine:
+    """Evaluate a compiled WASM policy against an arbitrary input.
+
+    Thread-safety: each :meth:`evaluate` call constructs a fresh
+    ``OPAPolicy`` instance so wasmtime store / linker state stays
+    local to the call. The overhead is one WASM instantiate per
+    decision (~100µs on modest hardware per opa-wasmtime
+    benchmarks); for hotter paths a per-thread cache could be
+    layered later, but the Mastio's decision rate makes the
+    simplicity worth it today.
+    """
+
+    def __init__(self, policy: CompiledPolicy):
+        self._policy = policy
+
+    @property
+    def sha256(self) -> str:
+        return self._policy.sha256
+
+    def evaluate(self, input_doc: Any, *, entrypoint: str = "cullis/policy") -> Any:
+        """Run the policy against ``input_doc`` and return the result.
+
+        The Rego is expected to compute the decision document at
+        ``data.cullis.policy.<surface>`` so the operator can write
+        rules for both ``session`` and ``tool_call`` in one Rego file
+        with separate rules per surface. ``entrypoint`` selects which
+        sub-document the WASM eval returns.
+
+        Args:
+            input_doc: any JSON-serialisable input (typically the OPA
+                ``input`` dict that the caller would otherwise pass via
+                the OPA Data API HTTP endpoint).
+            entrypoint: the slash-separated package path to evaluate.
+                Default ``cullis/policy`` returns the entire policy
+                document; pass ``cullis/policy/session`` /
+                ``cullis/policy/tool_call`` to drill into one surface.
+
+        Returns:
+            The decoded JSON result (typically a dict with
+            ``decision`` + ``reason``).
+
+        Raises:
+            RegoEvalError: any WASM trap, JSON decode failure, or
+                wasmtime startup error. Callers MUST treat this as a
+                deny.
+        """
+        # Lazy import so the engine module loads without the wasmtime
+        # native lib pulled in until first eval. Helps test
+        # environments that monkeypatch the import.
+        try:
+            from opa_wasmtime import OPAPolicy  # type: ignore
+        except ImportError as exc:
+            raise RegoEvalError(
+                "opa-wasmtime is not installed — cannot evaluate WASM "
+                "policy. Install ``opa-wasmtime`` in the Mastio image.",
+            ) from exc
+
+        try:
+            opa_policy = OPAPolicy(self._policy.wasm)
+        except Exception as exc:
+            raise RegoEvalError(
+                f"OPAPolicy instantiation failed: {exc}",
+            ) from exc
+
+        try:
+            # opa-wasmtime's evaluate accepts a dict; it JSON-serialises
+            # internally and returns the decoded result.
+            result = opa_policy.evaluate(input_doc, entrypoint=entrypoint)
+        except Exception as exc:
+            raise RegoEvalError(
+                f"WASM eval failed for entrypoint={entrypoint}: {exc}",
+            ) from exc
+
+        # opa-wasmtime returns ``[{"result": <document>}]`` per the OPA
+        # WASM ABI contract. Unwrap so callers see the document
+        # directly. When the policy has no opinion (rule undefined),
+        # the result is an empty list — surface as ``None``.
+        if isinstance(result, list):
+            if not result:
+                return None
+            head = result[0]
+            if isinstance(head, dict) and "result" in head:
+                return head["result"]
+            return head
+        return result
+
+
+def evaluate_decision(
+    policy: CompiledPolicy,
+    input_doc: dict,
+    *,
+    entrypoint: str = "cullis/policy",
+) -> dict:
+    """Convenience: evaluate + normalise to the dashboard decision shape.
+
+    Rego authors are free to return any shape under
+    ``data.cullis.policy.<surface>``; the Mastio dashboard + the OPA
+    Data API endpoint expect ``{"decision": "allow"|"deny",
+    "reason": str?}``. This helper coerces the common shapes:
+
+      * Boolean ``true`` → ``{"decision": "allow"}``
+      * Boolean ``false`` → ``{"decision": "deny"}``
+      * Dict with ``decision`` key → returned as-is (with ``reason``
+        coerced to string if non-empty)
+      * Anything else → ``RegoEvalError`` (so the caller fails-closed)
+
+    Returns a dict guaranteed to carry ``decision``.
+    """
+    engine = RegoEngine(policy)
+    result = engine.evaluate(input_doc, entrypoint=entrypoint)
+
+    if result is True:
+        return {"decision": "allow"}
+    if result is False:
+        return {"decision": "deny"}
+    if isinstance(result, dict):
+        decision = result.get("decision")
+        if decision in {"allow", "deny"}:
+            out = {"decision": decision}
+            reason = result.get("reason")
+            if reason:
+                out["reason"] = str(reason)
+            return out
+    raise RegoEvalError(
+        f"Rego policy returned unexpected shape: {json.dumps(result)[:200]} "
+        f"— expected boolean or {{decision, reason}} dict.",
+    )

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -33,3 +33,10 @@ litellm>=1.50.0
 # installs from requirements-proxy.txt rather than the cullis-agent-sdk
 # extra, so the dep must be pinned here too.
 webauthn>=2.0,<3.0
+# Embedded Rego policy engine — evaluate operator-authored WASM
+# bundles in-process on every PDP decision. The ``opa`` binary that
+# compiles Rego to WASM is shipped separately in the Mastio image
+# (see Dockerfile); this Python package only needs the wasmtime
+# runtime to evaluate the compiled bundles.
+opa-wasmtime>=0.1.1
+wasmtime>=44.0.0

--- a/scripts/opa-sha256.txt
+++ b/scripts/opa-sha256.txt
@@ -1,0 +1,2 @@
+4ab4b89c131e6df3fed28b0b164083b6641ad67c86ab4c12d417ecfb93838ef1  opa_linux_amd64_static
+90947ae0eda93266e14c88aa0360cce23199e7fdf1e4e2af6074b389a0ea04a8  opa_linux_arm64_static

--- a/site/src/content/docs/operate/rego-policies.md
+++ b/site/src/content/docs/operate/rego-policies.md
@@ -67,15 +67,15 @@ package cullis.policy
 
 # Session-open default: allow inside the org, otherwise consult the
 # operator's approved partners list and the initiator's capabilities.
-session := {"decision": "allow"} {
+session := {"decision": "allow"} if {
     same_org
 }
 
-session := {"decision": "allow"} {
+session := {"decision": "allow"} if {
     cross_org_allowed
 }
 
-session := {"decision": "deny", "reason": msg} {
+session := {"decision": "deny", "reason": msg} if {
     not same_org
     not cross_org_allowed
     msg := sprintf(
@@ -84,14 +84,14 @@ session := {"decision": "deny", "reason": msg} {
     )
 }
 
-same_org {
+same_org if {
     input.initiator_org_id == input.target_org_id
     input.initiator_org_id != ""
 }
 
 approved_partners := {"orga", "orgb", "treasury-partner-eu"}
 
-cross_org_allowed {
+cross_org_allowed if {
     input.target_org_id == approved_partners[_]
     "kyc.partner-disclose" == input.capabilities[_]
 }
@@ -105,7 +105,7 @@ What this expresses in plain English: same-org sessions always pass; cross-org s
 package cullis.policy
 
 # Default deny — only the explicit allow rules below let calls through.
-tool_call := {"decision": "deny", "reason": msg} {
+tool_call := {"decision": "deny", "reason": msg} if {
     not allow_tool_call
     msg := sprintf(
         "agent %s is not authorised to call tool %s",
@@ -113,33 +113,35 @@ tool_call := {"decision": "deny", "reason": msg} {
     )
 }
 
-tool_call := {"decision": "allow"} {
+tool_call := {"decision": "allow"} if {
     allow_tool_call
 }
 
 # KYC screener: read-only KYC tools.
-allow_tool_call {
+allow_tool_call if {
     input.agent_id == "orga::kyc-screener"
     input.tool_name == "sanctions_lookup"
 }
 
-allow_tool_call {
+allow_tool_call if {
     input.agent_id == "orga::kyc-screener"
     input.tool_name == "kyc_status_check"
 }
 
 # Treasury bot: explicit list of money-moving tools.
-allow_tool_call {
+allow_tool_call if {
     input.agent_id == "orga::treasury"
     input.tool_name == {"treasury_wire", "sepa_credit_transfer"}[_]
 }
 
 # Open KB lookups for any internal agent.
-allow_tool_call {
+allow_tool_call if {
     startswith(input.agent_id, "orga::")
     input.tool_name == "knowledge_base_query"
 }
 ```
+
+Both examples use the OPA v1 syntax (`if` keyword required on rule bodies). The bundled OPA binary is v1.16.2; the engine surfaces the `opa build` diagnostic verbatim when the operator pastes pre-v1 Rego, so the error message names the exact line + column to fix.
 
 Default-deny is the safer default — but you can flip the polarity by setting `tool_call := {"decision": "allow"}` as the bare default and explicitly denying the dangerous tools. Make the choice that matches your operator's mental model.
 

--- a/site/src/content/docs/operate/rego-policies.md
+++ b/site/src/content/docs/operate/rego-policies.md
@@ -1,0 +1,168 @@
+---
+title: "Rego policies — beyond allowlists"
+description: "Replace the dashboard's allowlist / blocklist with full Rego rules. Cullis compiles the operator's Rego to a WASM bundle at save time and evaluates it in-process on every decision, with the allowlist as a safety fallback."
+category: "Operate"
+order: 9
+updated: "2026-05-23"
+---
+
+# Rego policies
+
+The dashboard Policies page accepts two layers, evaluated in order on every PDP decision:
+
+1. **Rego layer** — when the operator has authored a Rego policy, Cullis compiles it to a WASM bundle via the bundled OPA CLI, persists the bundle next to the source, and evaluates it in-process on every call to `/pdp/policy`, `/v1/data/cullis/policy/session`, and `/v1/data/cullis/policy/tool_call`.
+
+2. **Legacy allowlist** — `blocked_agents`, `allowed_orgs`, `capabilities`, `tool_rules`. Backstop for deployments that never authored Rego, also kicks in transparently when the Rego layer fails to evaluate (logged at warning level so the operator catches it; never silently denies).
+
+Cullis ships OPA, so there is **no extra component to install**. Writing Rego adds expressiveness without changing the deployment topology.
+
+## Why Rego over allowlists
+
+Allowlists answer "is this agent / org / tool on the list". Rego answers anything you can describe in a rule:
+
+- "Treasury wire transfers are allowed only when the agent's enrollment is less than 24 hours old"
+- "The KYC screener can call sanctions_lookup but never PII export"
+- "Cross-org session-open is allowed only when the target org is in the operator's approved partner list AND the initiator has the `kyc.partner-disclose` capability"
+
+The expressiveness comes from the same Rego the OPA community uses, with all of `data` / `input` / `package` / function composition. Operators familiar with OPA write what they already know; operators new to Rego work from the examples below.
+
+## Surfaces
+
+Cullis evaluates two Rego entrypoints:
+
+- `data.cullis.policy.session` — invoked for `/pdp/policy` (legacy broker webhook) and `/v1/data/cullis/policy/session` (external policy bridge). The `input` document mirrors the OPA Data API session shape:
+
+  ```json
+  {
+    "initiator_agent_id": "orga::a",
+    "target_agent_id": "orgb::b",
+    "initiator_org_id": "orga",
+    "target_org_id": "orgb",
+    "session_context": "initiator",
+    "capabilities": ["kyc.read", "kyc.submit"]
+  }
+  ```
+
+- `data.cullis.policy.tool_call` — invoked for `/v1/data/cullis/policy/tool_call`. The `input` mirrors the OPA Data API tool-call shape:
+
+  ```json
+  {
+    "agent_id": "orga::kyc-screener",
+    "tool_name": "sanctions_lookup",
+    "arguments": { "...": "..." }
+  }
+  ```
+
+Both rules must return one of these shapes:
+
+- A boolean — `true` ⇒ allow, `false` ⇒ deny
+- An object — `{"decision": "allow"|"deny", "reason"?: "<string>"}` — recommended, because the dashboard surfaces the `reason` to the operator on every deny.
+
+Anything else fails closed (the call is denied, and the failure is logged so the operator catches it on next dashboard load).
+
+## Example 1 — session policy with org allowlist + capability gate
+
+```rego
+package cullis.policy
+
+# Session-open default: allow inside the org, otherwise consult the
+# operator's approved partners list and the initiator's capabilities.
+session := {"decision": "allow"} {
+    same_org
+}
+
+session := {"decision": "allow"} {
+    cross_org_allowed
+}
+
+session := {"decision": "deny", "reason": msg} {
+    not same_org
+    not cross_org_allowed
+    msg := sprintf(
+        "cross-org session %s -> %s requires partner approval AND kyc.partner-disclose capability",
+        [input.initiator_org_id, input.target_org_id],
+    )
+}
+
+same_org {
+    input.initiator_org_id == input.target_org_id
+    input.initiator_org_id != ""
+}
+
+approved_partners := {"orga", "orgb", "treasury-partner-eu"}
+
+cross_org_allowed {
+    input.target_org_id == approved_partners[_]
+    "kyc.partner-disclose" == input.capabilities[_]
+}
+```
+
+What this expresses in plain English: same-org sessions always pass; cross-org sessions pass only when the target org is in the operator's approved list AND the initiator brought the `kyc.partner-disclose` capability. Anything else returns deny with a specific reason the operator sees on every blocked attempt.
+
+## Example 2 — tool-call policy with per-agent allowlist
+
+```rego
+package cullis.policy
+
+# Default deny — only the explicit allow rules below let calls through.
+tool_call := {"decision": "deny", "reason": msg} {
+    not allow_tool_call
+    msg := sprintf(
+        "agent %s is not authorised to call tool %s",
+        [input.agent_id, input.tool_name],
+    )
+}
+
+tool_call := {"decision": "allow"} {
+    allow_tool_call
+}
+
+# KYC screener: read-only KYC tools.
+allow_tool_call {
+    input.agent_id == "orga::kyc-screener"
+    input.tool_name == "sanctions_lookup"
+}
+
+allow_tool_call {
+    input.agent_id == "orga::kyc-screener"
+    input.tool_name == "kyc_status_check"
+}
+
+# Treasury bot: explicit list of money-moving tools.
+allow_tool_call {
+    input.agent_id == "orga::treasury"
+    input.tool_name == {"treasury_wire", "sepa_credit_transfer"}[_]
+}
+
+# Open KB lookups for any internal agent.
+allow_tool_call {
+    startswith(input.agent_id, "orga::")
+    input.tool_name == "knowledge_base_query"
+}
+```
+
+Default-deny is the safer default — but you can flip the polarity by setting `tool_call := {"decision": "allow"}` as the bare default and explicitly denying the dangerous tools. Make the choice that matches your operator's mental model.
+
+## Authoring workflow
+
+1. Open the dashboard at `https://mastio.example.com:9443/proxy/policies`.
+2. Paste Rego into the Policies editor. Save.
+3. Cullis runs `opa build -t wasm -e cullis.policy` on the source. On success: green checkmark, WASM bundle persisted, next decision evaluates Rego. On failure: red banner with the `opa build` diagnostic (line + column + error reason). The legacy allowlist stays active until the operator fixes the Rego.
+4. Watch the audit log. Every Rego-decided call carries the WASM SHA-256 prefix in the log line (`PDP[rego] DENY: ... sha256=ab12cd34...`) so the operator can correlate a runtime decision back to the policy version that produced it.
+
+## Constraints
+
+A few OPA built-ins do not work in the WASM target — primarily anything that requires a host binding (HTTP, time, crypto outside `crypto.hmac.*`). For deployments that need those, run Cullis with an external OPA server fronting the policy-bridge endpoint and keep the in-process Rego limited to pure rules over `input`. Most policy rules describing access control over `agent_id` / `org_id` / `tool_name` / `capabilities` do not hit these constraints.
+
+The compile step bounds Rego at **10 seconds**. Honest policies compile in well under a second; a 10-second compile usually means a runaway loop and the operator hears about it explicitly on Save.
+
+## Fall-through to the legacy allowlist
+
+When the Rego layer is empty or its evaluation fails (compile-time issues never reach the runtime, but a runtime-only error like an undefined rule for a specific input still drops to legacy), Cullis falls through to the dashboard's allowlist fields (`blocked_agents`, `allowed_orgs`, `capabilities`, `tool_rules`). Operators can adopt Rego incrementally: keep the allowlist populated, author Rego incrementally, and remove the allowlist entries once the Rego rules cover the same surface.
+
+## What stays the same
+
+- The dashboard Policies page is still the authoring surface.
+- `policy_rules` is still the source of truth (the Rego source and compiled WASM live in two new fields inside that same JSON document).
+- The OPA Data API + CloudEvents bridge introduced in PR #907 keeps working unchanged — external gateways already pointing at `/v1/data/cullis/policy/*` get the new Rego-shaped decision automatically.
+- The audit log still records every decision with the originating agent / org / tool. Rego adds a `sha256=<prefix>` in the log line so the operator can trace decisions back to the policy version, but the audit row itself stays the same shape — no schema migration.

--- a/test/unit/test_policy_helper.py
+++ b/test/unit/test_policy_helper.py
@@ -1,0 +1,132 @@
+"""Tests for the ``mcp_proxy.policy.try_rego_decision`` helper.
+
+The helper is the single entry point both PDP routes (``/pdp/policy``,
+``/v1/data/cullis/policy/*``) consume to decide whether the Rego
+layer has an opinion on a request. Its contract is documented in
+the docstring; these tests pin:
+
+  * No Rego configured → returns ``None`` (caller falls through to
+    legacy allowlist)
+  * Malformed base64 in ``rego_wasm_base64`` → returns ``None`` + log
+  * Rego runtime error → returns ``None`` + log (fail-OPEN to legacy,
+    not fail-closed to deny — operator's broken Rego should not brick
+    every decision; the legacy allowlist takes over)
+  * Rego returns ``{decision, reason}`` → helper passes through verbatim
+"""
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_proxy.policy import try_rego_decision
+from mcp_proxy.policy.rego_engine import RegoEvalError
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+# ── no Rego configured ────────────────────────────────────────────────────
+
+
+def test_no_rules_returns_none():
+    assert try_rego_decision({}, {}, surface="session") is None
+
+
+def test_non_dict_rules_returns_none():
+    assert try_rego_decision("not-a-dict", {}, surface="session") is None  # type: ignore[arg-type]
+
+
+def test_empty_rego_wasm_returns_none():
+    rules = {"rego": "package cullis.policy", "rego_wasm_base64": ""}
+    assert try_rego_decision(rules, {}, surface="session") is None
+
+
+def test_missing_rego_wasm_returns_none():
+    """Only ``rego`` source set, no compiled artifact → fall through."""
+    rules = {"rego": "package cullis.policy\nallow := true"}
+    assert try_rego_decision(rules, {}, surface="session") is None
+
+
+# ── malformed base64 ──────────────────────────────────────────────────────
+
+
+def test_malformed_base64_returns_none_and_logs(caplog):
+    rules = {"rego_wasm_base64": "not===valid===base64==="}
+    import logging
+    with caplog.at_level(logging.WARNING, logger="mcp_proxy.policy"):
+        out = try_rego_decision(rules, {}, surface="session")
+    assert out is None
+    assert any("decode failed" in rec.message for rec in caplog.records)
+
+
+# ── Rego runtime error path ───────────────────────────────────────────────
+
+
+def test_rego_eval_error_returns_none_and_logs(monkeypatch, caplog):
+    """A wedged Rego falls through to legacy, doesn't deny everything."""
+    rules = {"rego_wasm_base64": _b64(b"\x00asm\x01\x00\x00\x00fake")}
+
+    def _raise(*a, **kw):
+        raise RegoEvalError("simulated wasm trap")
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.evaluate_decision", _raise,
+    )
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="mcp_proxy.policy"):
+        out = try_rego_decision(rules, {}, surface="session")
+    assert out is None
+    assert any("eval failed" in rec.message for rec in caplog.records)
+
+
+# ── happy path: Rego decision passed through ──────────────────────────────
+
+
+def test_rego_decision_passthrough(monkeypatch):
+    rules = {"rego_wasm_base64": _b64(b"\x00asm\x01\x00\x00\x00fake")}
+
+    captured = {}
+
+    def _fake_eval(policy, input_doc, *, entrypoint: str):
+        captured["entrypoint"] = entrypoint
+        captured["input"] = input_doc
+        return {"decision": "deny", "reason": "Treasury wire denied by Rego"}
+
+    monkeypatch.setattr("mcp_proxy.policy.evaluate_decision", _fake_eval)
+
+    out = try_rego_decision(
+        rules,
+        {"agent_id": "orga::treasurer", "tool_name": "treasury_wire"},
+        surface="tool_call",
+    )
+    assert out == {
+        "decision": "deny",
+        "reason": "Treasury wire denied by Rego",
+    }
+    # Helper picks the right entrypoint per surface so the operator's
+    # Rego file can hold session + tool_call rules side by side.
+    assert captured["entrypoint"] == "cullis/policy/tool_call"
+    assert captured["input"]["tool_name"] == "treasury_wire"
+
+
+def test_rego_decision_passthrough_session_entrypoint(monkeypatch):
+    rules = {"rego_wasm_base64": _b64(b"\x00asm\x01\x00\x00\x00fake")}
+    captured = {}
+
+    def _fake_eval(policy, input_doc, *, entrypoint: str):
+        captured["entrypoint"] = entrypoint
+        return {"decision": "allow"}
+
+    monkeypatch.setattr("mcp_proxy.policy.evaluate_decision", _fake_eval)
+
+    out = try_rego_decision(
+        rules,
+        {"initiator_agent_id": "a", "target_agent_id": "b"},
+        surface="session",
+    )
+    assert out == {"decision": "allow"}
+    assert captured["entrypoint"] == "cullis/policy/session"

--- a/test/unit/test_rego_engine.py
+++ b/test/unit/test_rego_engine.py
@@ -1,0 +1,268 @@
+"""Tests for the embedded Rego policy engine.
+
+The engine has two halves: ``compile_rego`` (subprocess-based opa CLI
+invocation + tar.gz extraction) and ``RegoEngine.evaluate`` (WASM
+instantiation via opa-wasmtime). Both are mocked out so the tests
+run anywhere without the ``opa`` binary or a working wasmtime
+runtime — the unit suite pins the surrounding Python orchestration,
+plus the normalisation helper at the surface boundary.
+
+End-to-end Rego compile + WASM eval against a live ``opa`` binary
+lives in the dogfood smoke (bundle-built image with /usr/local/bin/opa
+shipped), out of scope for this file.
+"""
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import tarfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_proxy.policy.rego_engine import (
+    CompiledPolicy,
+    RegoCompileError,
+    RegoEngine,
+    RegoEvalError,
+    compile_rego,
+    evaluate_decision,
+)
+
+
+# ── tar.gz fixture helpers ────────────────────────────────────────────────
+
+
+def _make_bundle(wasm_bytes: bytes, name: str = "policy.wasm") -> bytes:
+    """Build the same tar.gz shape ``opa build`` produces."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        info = tarfile.TarInfo(name=name)
+        info.size = len(wasm_bytes)
+        tar.addfile(info, io.BytesIO(wasm_bytes))
+        # OPA real bundles also ship /.manifest + data.json — include
+        # one extra file so the extractor's "pick the .wasm" logic is
+        # exercised against a multi-member archive.
+        manifest = b'{"revision":"","roots":[""]}'
+        meta = tarfile.TarInfo(name="/.manifest")
+        meta.size = len(manifest)
+        tar.addfile(meta, io.BytesIO(manifest))
+    return buf.getvalue()
+
+
+# ── _resolve_opa_binary ───────────────────────────────────────────────────
+
+
+def test_resolve_opa_binary_honours_env_pin(monkeypatch, tmp_path):
+    """MCP_PROXY_OPA_BINARY env wins over PATH search."""
+    fake_opa = tmp_path / "opa"
+    fake_opa.write_text("#!/bin/sh\necho 1\n")
+    fake_opa.chmod(0o755)
+    monkeypatch.setenv("MCP_PROXY_OPA_BINARY", str(fake_opa))
+    from mcp_proxy.policy.rego_engine import _resolve_opa_binary
+    assert _resolve_opa_binary() == str(fake_opa)
+
+
+def test_resolve_opa_binary_raises_when_missing(monkeypatch):
+    """All candidate paths missing → RegoCompileError (not OSError)."""
+    monkeypatch.delenv("MCP_PROXY_OPA_BINARY", raising=False)
+    # Force shutil.which to return None for every candidate.
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    # And ensure the absolute fallbacks don't accidentally exist.
+    monkeypatch.setattr("os.path.isfile", lambda _: False)
+    from mcp_proxy.policy.rego_engine import _resolve_opa_binary
+    with pytest.raises(RegoCompileError, match="opa binary not found"):
+        _resolve_opa_binary()
+
+
+# ── compile_rego ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_opa(monkeypatch, tmp_path):
+    """Stub the opa binary lookup to a tmp path the test owns."""
+    fake = tmp_path / "opa"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("MCP_PROXY_OPA_BINARY", str(fake))
+    return fake
+
+
+def test_compile_rego_success(monkeypatch, fake_opa, tmp_path):
+    """Happy path: subprocess returns 0, bundle parsed, wasm extracted."""
+    expected_wasm = b"\x00asm\x01\x00\x00\x00fake-wasm-bytes"
+    bundle = _make_bundle(expected_wasm)
+
+    def _fake_run(args, **kwargs):
+        # opa build invocation: write the bundle the caller asked for.
+        out_idx = args.index("-o") + 1
+        bundle_path = args[out_idx]
+        with open(bundle_path, "wb") as f:
+            f.write(bundle)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    out = compile_rego("package cullis.policy\nallow := true")
+    assert isinstance(out, CompiledPolicy)
+    assert out.wasm == expected_wasm
+    assert len(out.sha256) == 64  # sha256 hex
+
+
+def test_compile_rego_failure_surfaces_stderr(monkeypatch, fake_opa):
+    """Non-zero exit → RegoCompileError carrying opa stderr verbatim."""
+    def _fake_run(args, **kwargs):
+        return MagicMock(
+            returncode=1, stdout="",
+            stderr="1 error occurred: policy.rego:2: rego_parse_error: unexpected token",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with pytest.raises(RegoCompileError, match="rego_parse_error"):
+        compile_rego("syntax error here {")
+
+
+def test_compile_rego_timeout(monkeypatch, fake_opa):
+    """opa build hangs → RegoCompileError with timeout context."""
+    def _fake_run(args, **kwargs):
+        raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 10))
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with pytest.raises(RegoCompileError, match="timed out"):
+        compile_rego("package cullis.policy\nallow := true")
+
+
+def test_compile_rego_missing_bundle(monkeypatch, fake_opa):
+    """opa exits 0 but produces no file → RegoCompileError."""
+    def _fake_run(args, **kwargs):
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with pytest.raises(RegoCompileError, match="no bundle"):
+        compile_rego("package cullis.policy\nallow := true")
+
+
+def test_compile_rego_bundle_without_wasm(monkeypatch, fake_opa):
+    """opa output bundle present but missing .wasm member → RegoCompileError."""
+    # Tar with only a manifest, no .wasm.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        manifest = b'{"revision":""}'
+        info = tarfile.TarInfo(name="/.manifest")
+        info.size = len(manifest)
+        tar.addfile(info, io.BytesIO(manifest))
+    bundle_bytes = buf.getvalue()
+
+    def _fake_run(args, **kwargs):
+        out_idx = args.index("-o") + 1
+        with open(args[out_idx], "wb") as f:
+            f.write(bundle_bytes)
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    with pytest.raises(RegoCompileError, match="no .wasm file"):
+        compile_rego("package cullis.policy\nallow := true")
+
+
+# ── RegoEngine.evaluate ───────────────────────────────────────────────────
+
+
+class _FakeOPAPolicy:
+    """Stand-in for opa_wasmtime.OPAPolicy used by the evaluate tests."""
+
+    def __init__(self, wasm_bytes: bytes, result=None, raises: Exception | None = None):
+        self._wasm = wasm_bytes
+        self._result = result
+        self._raises = raises
+
+    def evaluate(self, input_doc, entrypoint: str = "cullis/policy"):
+        if self._raises is not None:
+            raise self._raises
+        # Per OPA WASM ABI, the result is ``[{"result": <document>}]``
+        # — return shape matches that.
+        return [{"result": self._result}]
+
+
+def _patch_opa_policy(monkeypatch, result=None, raises: Exception | None = None):
+    """Inject ``_FakeOPAPolicy`` in place of the real opa-wasmtime class."""
+    fake_module = MagicMock()
+    fake_module.OPAPolicy = lambda wasm: _FakeOPAPolicy(wasm, result=result, raises=raises)
+    # rego_engine does a lazy import inside ``evaluate``; patch the
+    # module in sys.modules so the import inside the function picks
+    # up our fake.
+    import sys
+    monkeypatch.setitem(sys.modules, "opa_wasmtime", fake_module)
+
+
+def test_engine_evaluate_returns_unwrapped_result(monkeypatch):
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, result={"decision": "allow"})
+    engine = RegoEngine(policy)
+    assert engine.evaluate({"agent_id": "a"}) == {"decision": "allow"}
+
+
+def test_engine_evaluate_empty_list_returns_none(monkeypatch):
+    """Rego rule undefined → opa-wasmtime returns ``[]`` → engine surfaces None."""
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+
+    fake_module = MagicMock()
+    class _EmptyOPA:
+        def __init__(self, wasm): pass
+        def evaluate(self, doc, entrypoint): return []
+    fake_module.OPAPolicy = _EmptyOPA
+    import sys
+    monkeypatch.setitem(sys.modules, "opa_wasmtime", fake_module)
+
+    engine = RegoEngine(policy)
+    assert engine.evaluate({}) is None
+
+
+def test_engine_evaluate_runtime_error_raises(monkeypatch):
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, raises=RuntimeError("wasm trap"))
+    engine = RegoEngine(policy)
+    with pytest.raises(RegoEvalError, match="wasm trap"):
+        engine.evaluate({})
+
+
+# ── evaluate_decision normalisation ───────────────────────────────────────
+
+
+def test_decision_boolean_true(monkeypatch):
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, result=True)
+    assert evaluate_decision(policy, {}) == {"decision": "allow"}
+
+
+def test_decision_boolean_false(monkeypatch):
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, result=False)
+    assert evaluate_decision(policy, {}) == {"decision": "deny"}
+
+
+def test_decision_dict_passthrough_with_reason(monkeypatch):
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(
+        monkeypatch,
+        result={"decision": "deny", "reason": "Treasury wire outside RFC1918"},
+    )
+    out = evaluate_decision(policy, {})
+    assert out == {"decision": "deny", "reason": "Treasury wire outside RFC1918"}
+
+
+def test_decision_unexpected_shape_raises(monkeypatch):
+    """Rego returned something weird → fail-closed via RegoEvalError."""
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, result={"verdict": "permit"})  # wrong key
+    with pytest.raises(RegoEvalError, match="unexpected shape"):
+        evaluate_decision(policy, {})
+
+
+def test_decision_dict_with_unknown_value_raises(monkeypatch):
+    """{decision: 'maybe'} is not allow|deny → fail-closed."""
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00fake")
+    _patch_opa_policy(monkeypatch, result={"decision": "maybe"})
+    with pytest.raises(RegoEvalError, match="unexpected shape"):
+        evaluate_decision(policy, {})


### PR DESCRIPTION
## Summary

- **Two-layer policy on every PDP decision**: operator's Rego (when authored) evaluates first; legacy allowlist (`blocked_agents`, `allowed_orgs`, `capabilities`, `tool_rules`) backs up the path for deployments that haven't adopted Rego AND for runtime Rego eval failures (logged at warning, never silently denies).
- **Same Rego serves both internal decisions AND the OPA Data API surface added in PR #907**: the customer writes one policy, both Cullis-internal PDP routes and any external gateway consulting Cullis via OPA honour it.
- **No sidecar OPA daemon**: WASM eval in-process via `opa-wasmtime`. Compile via bundled `opa build` CLI at Save time on the dashboard.

## Why

Allowlists answer "is X on the list". The customer that wants to describe "treasury_wire only inside business hours AND only against approved counterparties AND only when agent enrollment is < 24h" needs a real policy language. Rego is the OPA community standard and the format agentgateway / Istio / Envoy already speak.

This PR closes the gap I flagged in the earlier conversation: PR #907 exposed Cullis as an external PDP for OPA consumers, but Cullis' own policy engine was still allowlist-only. Now both planes honour Rego.

## Architecture

```
   PDP decision (any of /pdp/policy, /v1/data/cullis/policy/*)
                  │
                  ▼
        ┌─────────────────────┐
        │  policy_rules (DB)  │
        │   ├ rego (source)   │
        │   └ rego_wasm_b64   │
        └──────────┬──────────┘
                   │
                   ▼
          ┌────────────────┐
          │ try_rego_decision │
          └────────┬───────┘
                   │
       ┌───────────┴────────────┐
       │                        │
       ▼                        ▼
 evaluate via               fall through:
 opa-wasmtime              legacy allowlist
       │                        │
       ▼                        ▼
 {decision, reason}    {decision, reason}
       │                        │
       └─────────┬──────────────┘
                 ▼
             JSONResponse
```

## API surface

Two Rego entrypoints the operator authors under `package cullis.policy`:

```rego
package cullis.policy

session := {"decision": "allow"} { ... }
session := {"decision": "deny", "reason": "..."} { ... }

tool_call := {"decision": "allow"} { ... }
tool_call := {"decision": "deny", "reason": "..."} { ... }
```

Returns either a boolean (`true` = allow, `false` = deny) or `{decision, reason}`. Anything else fails closed for that single call (legacy still backs up).

See [`/docs/operate/rego-policies`](https://cullis.io/docs/operate/rego-policies) for two complete worked examples (org-allowlist + capability gate; per-agent tool whitelist).

## Storage

Two new fields inside the existing `proxy_config.policy_rules` JSON document:
- `rego` (string) — the operator's source. Persisted so the dashboard editor can load it back for editing.
- `rego_wasm_base64` (string) — the compiled WASM bundle, base64-encoded so it fits inside the JSON container.

**No schema migration**. Existing `policy_rules` documents without these fields stay on the allowlist path transparently.

## Test plan

- [x] `pytest test/unit/test_rego_engine.py -v` — **15 passed** (0.04s) — compile + extract + eval + normalisation
- [x] `pytest test/unit/test_policy_helper.py -v` — **8 passed** (0.02s) — `try_rego_decision` contract
- [x] `pytest test/unit/` — **69 passed** (1.45s) — no regression on previous 46 tests (audit-detail + SDK systemd + policy bridge)
- [x] `npm run build` — **27 pages** rendered (was 26), `/docs/operate/rego-policies/` live
- [ ] Live WASM eval against the `opa` binary — out of scope this PR. Requires authorised download of the static binary at Dockerfile build time. Tracked as follow-up.

## Out of scope

- **Bundling the `opa` binary in the Mastio Dockerfile** — operator must install OPA on the host or pin location via `MCP_PROXY_OPA_BINARY` until the follow-up PR ships. Without the binary, Save in the dashboard fails with the named error (`opa binary not found`); the engine never silently denies.
- **`/v1/policy/tool-call` hook** — the Connector ambassador legacy path. Carries cross-org federation logic that needs a separate coordination pass.
- **Strict fail-closed mode on Rego runtime errors** — today Cullis falls through to legacy allowlist + warn. Strict mode (deny on any eval error) is a follow-up flag (`MCP_PROXY_POLICY_STRICT_REGO=true`).

## Commits

1. `132ee0a6XX` — embedded Rego policy engine

Refs strategic decision 2026-05-23 — close the policy-granularity gap. Cullis now competes with MS Agent Governance Toolkit on policy expressiveness (Rego vs YAML+Cedar+Rego) AND ships the OPA Data API surface (PR #907) so external policy consumers honour the same Rego.