### PR TITLE
perf(policy): Rego engine instance cache + bench tool (p99 19.9ms → 0.29ms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Mastio — Rego engine perf: OPAPolicy instance cache + bench tool
+
+- **Process-wide `OPAPolicy` instance cache** keyed on
+  `compiled.sha256`. First evaluate per WASM bundle pays the
+  wasmtime instantiation cost (~15-25ms on dev hardware); every
+  subsequent decision on the same bundle reuses the cached
+  instance. Cache trims at 32 entries (operator policies rotate at
+  human pace, FIFO trim is enough).
+
+  Measured impact on a representative 58-line Rego (default-deny
+  tool_call + per-agent allowlist + cross-org session gate):
+
+  | metric                  | pre-cache | post-cache | delta |
+  |-------------------------|-----------|------------|-------|
+  | `evaluate` p50          | 16.23 ms  | **0.21 ms** | **-77×** |
+  | `evaluate` p99          | 19.93 ms  | **0.29 ms** | **-68×** |
+  | `evaluate` throughput   | 60 op/s   | **4 650 op/s** | **+77×** |
+  | `evaluate_decision` p99 | 19.47 ms  | **0.30 ms** | **-65×** |
+
+- **New `scripts/bench-rego-eval.py`** — reproducible bench the
+  operator (or anyone evaluating Cullis vs alternatives) can run
+  from a clean checkout. Compile time, per-decision latency
+  percentiles, throughput. Writes a Markdown report under `imp/` for
+  retention.
+
+- **Two new unit tests** in `test_rego_engine.py`: cache reuse on
+  same SHA, distinct instances on different SHAs. Autouse fixture
+  resets the cache between tests.
+
 ### Mastio — embedded Rego policy engine (operator beyond allowlists)
 
 - **New `mcp_proxy/policy/rego_engine.py` module**: compile a Rego

--- a/mcp_proxy/policy/rego_engine.py
+++ b/mcp_proxy/policy/rego_engine.py
@@ -44,6 +44,7 @@ import os
 import subprocess
 import tarfile
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -204,16 +205,125 @@ def compile_rego(
     return CompiledPolicy.from_wasm(wasm)
 
 
+_INSTANCE_CACHE: dict[str, Any] = {}
+_INSTANCE_CACHE_LOCK = threading.Lock()
+_INSTANCE_CACHE_MAX = 32  # operator policies rotate rarely; LRU-style trim is enough
+
+
+def _build_opa_policy(wasm: bytes) -> Any:
+    """Materialise the WASM bytes to disk and instantiate ``OPAPolicy``.
+
+    Factored out so the cache hit path (below) can avoid the tempfile
+    + native instantiation cost (~15-20ms on a modest dev laptop)
+    every decision after the first.
+    """
+    try:
+        from opa_wasmtime import OPAPolicy  # type: ignore
+    except ImportError as exc:
+        raise RegoEvalError(
+            "opa-wasmtime is not installed — cannot evaluate WASM "
+            "policy. Install ``opa-wasmtime`` in the Mastio image.",
+        ) from exc
+
+    with tempfile.NamedTemporaryFile(
+        prefix="cullis-rego-", suffix=".wasm", delete=False,
+    ) as tmp:
+        tmp.write(wasm)
+        tmp_path = tmp.name
+    try:
+        return OPAPolicy(tmp_path)
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _get_cached_policy(wasm: bytes, sha256: str) -> Any:
+    """Return a process-wide cached ``OPAPolicy`` for this WASM bundle.
+
+    Cache key is the SHA-256 of the WASM bytes — when the operator
+    saves a new Rego policy in the dashboard, the new bundle has a
+    different hash and gets its own instance; the old one is evicted
+    on the LRU trim below.
+
+    Why module-level + ``threading.Lock`` and not ``asyncio.Lock``:
+
+      * The wasmtime store / linker behind ``OPAPolicy`` is a native
+        object with mutable internal state. Two concurrent calls into
+        ``opa_policy.evaluate(...)`` on the same instance race on the
+        store and can produce corrupt output (observed on opa-wasmtime
+        0.1.1 + wasmtime 44.0.0 — the wasmtime engine is thread-safe
+        but the store on top of it is not).
+
+      * FastAPI under uvicorn runs the request handlers on the asyncio
+        event loop. ``OPAPolicy.evaluate`` is synchronous; if two
+        in-flight requests hit the same cached instance in the same
+        event loop iteration, they would NOT actually overlap (the
+        event loop is single-threaded). The lock is here as
+        defence-in-depth for the day someone moves the eval onto a
+        thread pool via ``asyncio.to_thread`` — the cost on the
+        single-threaded hot path is one un-contended mutex
+        acquisition (~tens of ns).
+    """
+    # Fast path — read under lock so the cache map is consistent.
+    with _INSTANCE_CACHE_LOCK:
+        cached = _INSTANCE_CACHE.get(sha256)
+        if cached is not None:
+            return cached
+
+    # Slow path — instantiate outside the lock (native I/O), then
+    # re-check + insert. The double-check avoids two threads racing to
+    # build for the same hash.
+    fresh = _build_opa_policy(wasm)
+    with _INSTANCE_CACHE_LOCK:
+        if sha256 in _INSTANCE_CACHE:
+            return _INSTANCE_CACHE[sha256]
+        # Trim oldest entries when the cache fills. A real LRU would be
+        # cleaner but operator policies rotate at human pace, not per-
+        # request — a simple FIFO trim under the cap is enough.
+        if len(_INSTANCE_CACHE) >= _INSTANCE_CACHE_MAX:
+            for k in list(_INSTANCE_CACHE.keys())[:-_INSTANCE_CACHE_MAX + 1]:
+                _INSTANCE_CACHE.pop(k, None)
+        _INSTANCE_CACHE[sha256] = fresh
+        return fresh
+
+
+def _reset_instance_cache() -> None:
+    """Test hook — clear the process-wide cache between unit tests."""
+    with _INSTANCE_CACHE_LOCK:
+        _INSTANCE_CACHE.clear()
+
+
 class RegoEngine:
     """Evaluate a compiled WASM policy against an arbitrary input.
 
-    Thread-safety: each :meth:`evaluate` call constructs a fresh
-    ``OPAPolicy`` instance so wasmtime store / linker state stays
-    local to the call. The overhead is one WASM instantiate per
-    decision (~100µs on modest hardware per opa-wasmtime
-    benchmarks); for hotter paths a per-thread cache could be
-    layered later, but the Mastio's decision rate makes the
-    simplicity worth it today.
+    Performance characteristics:
+
+      * **First evaluate per WASM bundle** — instantiates an
+        ``OPAPolicy`` (writes a tempfile + native wasmtime engine
+        startup), takes ~15-25ms on modest hardware.
+
+      * **Subsequent evaluates of the same bundle** — re-uses the
+        cached instance via :func:`_get_cached_policy`. Hot-path
+        latency drops to ~100µs (the cost of the
+        :meth:`OPAPolicy.evaluate` JSON serialisation + WASM call).
+
+    The cache key is the SHA-256 of the compiled WASM bytes — when
+    the operator saves a new Rego policy in the dashboard, the new
+    bundle has a different hash and gets its own instance; the old
+    one is evicted on the LRU trim. Operators on the dashboard never
+    see a stale decision.
+
+    Thread-safety: ``OPAPolicy.evaluate`` on a single store is NOT
+    safe under concurrent native invocation. The cache guards the
+    instance lookup with a ``threading.Lock`` so the map stays
+    consistent, but a per-instance lock is left out today because
+    FastAPI under uvicorn runs handlers on a single-threaded asyncio
+    loop and the eval is synchronous — two in-flight requests never
+    overlap on the same instance in that runtime model. A future PR
+    that moves eval onto ``asyncio.to_thread`` should add a
+    per-instance lock here.
     """
 
     def __init__(self, policy: CompiledPolicy):
@@ -250,40 +360,20 @@ class RegoEngine:
                 wasmtime startup error. Callers MUST treat this as a
                 deny.
         """
-        # Lazy import so the engine module loads without the wasmtime
-        # native lib pulled in until first eval. Helps test
-        # environments that monkeypatch the import.
+        # Cache hit on the second+ evaluate of the same WASM bundle —
+        # the cost of the OPAPolicy instantiation (tempfile +
+        # wasmtime engine startup) is amortised across every decision
+        # that runs against this operator policy version.
         try:
-            from opa_wasmtime import OPAPolicy  # type: ignore
-        except ImportError as exc:
+            opa_policy = _get_cached_policy(
+                self._policy.wasm, self._policy.sha256,
+            )
+        except RegoEvalError:
+            raise
+        except Exception as exc:
             raise RegoEvalError(
-                "opa-wasmtime is not installed — cannot evaluate WASM "
-                "policy. Install ``opa-wasmtime`` in the Mastio image.",
+                f"OPAPolicy instantiation failed: {exc}",
             ) from exc
-
-        # opa-wasmtime's OPAPolicy accepts a filesystem path, not raw
-        # bytes; the WASM bundle lives in memory (loaded from
-        # ``policy_rules.rego_wasm_base64``), so write it to a tmpfile
-        # for the duration of the eval. The file is unlinked on context
-        # exit; opa-wasmtime reads + instantiates synchronously, so
-        # there is no race.
-        with tempfile.NamedTemporaryFile(
-            prefix="cullis-rego-", suffix=".wasm", delete=False,
-        ) as tmp:
-            tmp.write(self._policy.wasm)
-            tmp_path = tmp.name
-        try:
-            try:
-                opa_policy = OPAPolicy(tmp_path)
-            except Exception as exc:
-                raise RegoEvalError(
-                    f"OPAPolicy instantiation failed: {exc}",
-                ) from exc
-        finally:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
 
         try:
             # opa-wasmtime's evaluate accepts a dict; it JSON-serialises

--- a/scripts/bench-rego-eval.py
+++ b/scripts/bench-rego-eval.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Bench the embedded Rego policy engine — compile + per-decision eval.
+
+Produces three honest numbers that operators (and CISOs comparing
+Cullis to other agent-policy products) can quote:
+
+  * **Compile time** — one-shot ``opa build -t wasm`` invocation for
+    a representative Rego policy. Operator-visible at Save time on
+    the dashboard Policies page.
+
+  * **Per-eval latency** — p50 / p95 / p99 / max wall-clock for one
+    ``evaluate_decision`` call against the compiled WASM bundle.
+    Each iteration instantiates a fresh ``OPAPolicy`` so the number
+    reflects the hot-path the runtime actually walks (today there
+    is no shared instance cache; future work to add one is tracked
+    separately).
+
+  * **Throughput** — total iterations / total wall-clock seconds.
+
+Run::
+
+    python scripts/bench-rego-eval.py
+    python scripts/bench-rego-eval.py --iterations 5000 --warmup 100
+    MCP_PROXY_OPA_BINARY=/opt/opa python scripts/bench-rego-eval.py
+
+The script does NOT touch any DB, network, or Mastio process. Pure
+in-Python orchestration of ``mcp_proxy.policy.rego_engine`` against a
+fixed in-source Rego policy. Reproducible from a clean checkout.
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# The bench needs the in-tree engine. When the script is invoked from
+# the repo root (``python scripts/bench-rego-eval.py``) the import
+# resolves naturally; from an installed wheel the package is on
+# PYTHONPATH already.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from mcp_proxy.policy.rego_engine import (  # noqa: E402
+    RegoEngine,
+    compile_rego,
+    evaluate_decision,
+)
+
+
+# Representative policy — same shape the operator docs example uses,
+# enough rules that the WASM bundle is non-trivial (the trivial
+# ``always-allow`` policy compiles to a tiny module that doesn't
+# reflect realistic workloads).
+_REGO_SOURCE = """package cullis.policy
+
+# Default-deny tool_call surface — explicit allowlist below.
+tool_call := {"decision": "deny", "reason": "no rule matched"} if {
+    not allow_tool_call
+}
+
+tool_call := {"decision": "allow"} if {
+    allow_tool_call
+}
+
+# KYC screener: read-only KYC tools.
+allow_tool_call if {
+    input.agent_id == "orga::kyc-screener"
+    input.tool_name == "sanctions_lookup"
+}
+
+allow_tool_call if {
+    input.agent_id == "orga::kyc-screener"
+    input.tool_name == "kyc_status_check"
+}
+
+# Treasury bot: explicit money-moving tools.
+allow_tool_call if {
+    input.agent_id == "orga::treasury"
+    input.tool_name == "treasury_wire"
+}
+
+allow_tool_call if {
+    input.agent_id == "orga::treasury"
+    input.tool_name == "sepa_credit_transfer"
+}
+
+# Open knowledge-base lookups for any in-org agent.
+allow_tool_call if {
+    startswith(input.agent_id, "orga::")
+    input.tool_name == "knowledge_base_query"
+}
+
+# Session surface — cross-org gated, same-org always allowed.
+session := {"decision": "allow"} if {
+    input.initiator_org_id == input.target_org_id
+}
+
+session := {"decision": "allow"} if {
+    input.target_org_id == "approved-partner"
+    "kyc.partner-disclose" == input.capabilities[_]
+}
+
+session := {"decision": "deny", "reason": "cross-org session not permitted"} if {
+    input.initiator_org_id != input.target_org_id
+    not partner_allowed
+}
+
+partner_allowed if {
+    input.target_org_id == "approved-partner"
+    "kyc.partner-disclose" == input.capabilities[_]
+}
+"""
+
+
+# Inputs cycled across iterations so the bench doesn't fall into
+# trivial cache hits in any layer (CPU branch predictor, OPA
+# WASM cache, allocator hot-paths). Two represent the allow case
+# (KYC screener + sanctions_lookup, same-org session), one the deny
+# case (Treasury asking for forbidden KB tool — no allowed_tool rule
+# matches), and one the partner-allow case.
+_INPUTS = [
+    {"agent_id": "orga::kyc-screener", "tool_name": "sanctions_lookup"},
+    {"agent_id": "orga::treasury", "tool_name": "knowledge_base_query"},
+    {
+        "initiator_agent_id": "orga::scout",
+        "target_agent_id": "approved-partner::vendor",
+        "initiator_org_id": "orga",
+        "target_org_id": "approved-partner",
+        "session_context": "initiator",
+        "capabilities": ["kyc.partner-disclose"],
+    },
+    {"agent_id": "orga::kyc-screener", "tool_name": "kyc_status_check"},
+]
+
+_ENTRYPOINTS = [
+    "cullis/policy/tool_call",
+    "cullis/policy/tool_call",
+    "cullis/policy/session",
+    "cullis/policy/tool_call",
+]
+
+
+def _percentile(samples: list[float], pct: float) -> float:
+    """p50/p95/p99 over the sample list (ms)."""
+    if not samples:
+        return float("nan")
+    sorted_samples = sorted(samples)
+    k = (len(sorted_samples) - 1) * (pct / 100.0)
+    f = int(k)
+    c = min(f + 1, len(sorted_samples) - 1)
+    if f == c:
+        return sorted_samples[f]
+    d = k - f
+    return sorted_samples[f] + (sorted_samples[c] - sorted_samples[f]) * d
+
+
+def _fmt_ms(value: float) -> str:
+    """Format a millisecond figure: ``0.12ms`` vs ``42.3ms``."""
+    if value < 1.0:
+        return f"{value:.3f}ms"
+    return f"{value:.2f}ms"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=2000,
+                        help="number of eval calls to time (default: 2000)")
+    parser.add_argument("--warmup", type=int, default=50,
+                        help="warmup eval calls to discard before timing "
+                        "(default: 50)")
+    parser.add_argument("--report-md", type=Path,
+                        help="optional path to write a Markdown report")
+    args = parser.parse_args()
+
+    print(f"=== Cullis Rego eval bench ===")
+    print(f"Source: in-script representative policy "
+          f"({len(_REGO_SOURCE.splitlines())} lines)")
+    print(f"Iterations: {args.iterations} (+ {args.warmup} warmup, discarded)")
+    print()
+
+    # Phase 1 — compile.
+    t0 = time.perf_counter()
+    compiled = compile_rego(_REGO_SOURCE)
+    compile_ms = (time.perf_counter() - t0) * 1000
+    print(f"Compile:    {_fmt_ms(compile_ms)} (wasm {len(compiled.wasm):,} bytes, "
+          f"sha256={compiled.sha256[:12]})")
+
+    # Phase 2 — warmup.
+    engine = RegoEngine(compiled)
+    for i in range(args.warmup):
+        inp = _INPUTS[i % len(_INPUTS)]
+        ep = _ENTRYPOINTS[i % len(_INPUTS)]
+        engine.evaluate(inp, entrypoint=ep)
+
+    # Phase 3 — timed.
+    samples_ms: list[float] = []
+    start_wall = time.perf_counter()
+    for i in range(args.iterations):
+        inp = _INPUTS[i % len(_INPUTS)]
+        ep = _ENTRYPOINTS[i % len(_INPUTS)]
+        t = time.perf_counter()
+        engine.evaluate(inp, entrypoint=ep)
+        samples_ms.append((time.perf_counter() - t) * 1000)
+    total_wall = time.perf_counter() - start_wall
+
+    # Phase 4 — also time the higher-level ``evaluate_decision`` (which
+    # adds the result-normalisation layer on top of ``engine.evaluate``)
+    # so the operator-visible API has its own number, separate from
+    # the raw wasmtime call.
+    norm_samples: list[float] = []
+    for i in range(min(args.iterations, 500)):  # bounded — same shape
+        inp = _INPUTS[i % len(_INPUTS)]
+        ep = _ENTRYPOINTS[i % len(_INPUTS)]
+        t = time.perf_counter()
+        evaluate_decision(compiled, inp, entrypoint=ep)
+        norm_samples.append((time.perf_counter() - t) * 1000)
+
+    # Report.
+    p50 = _percentile(samples_ms, 50)
+    p95 = _percentile(samples_ms, 95)
+    p99 = _percentile(samples_ms, 99)
+    max_ms = max(samples_ms)
+    mean_ms = statistics.fmean(samples_ms)
+    throughput = args.iterations / total_wall
+
+    n50 = _percentile(norm_samples, 50)
+    n95 = _percentile(norm_samples, 95)
+    n99 = _percentile(norm_samples, 99)
+
+    print()
+    print("RegoEngine.evaluate (raw wasmtime call):")
+    print(f"  p50      {_fmt_ms(p50)}")
+    print(f"  p95      {_fmt_ms(p95)}")
+    print(f"  p99      {_fmt_ms(p99)}")
+    print(f"  max      {_fmt_ms(max_ms)}")
+    print(f"  mean     {_fmt_ms(mean_ms)}")
+    print(f"  ops/sec  {throughput:,.0f}")
+    print()
+    print("evaluate_decision (raw + result normalisation):")
+    print(f"  p50      {_fmt_ms(n50)}")
+    print(f"  p95      {_fmt_ms(n95)}")
+    print(f"  p99      {_fmt_ms(n99)}")
+
+    if args.report_md:
+        args.report_md.parent.mkdir(parents=True, exist_ok=True)
+        with args.report_md.open("w") as f:
+            f.write("# Rego eval bench\n\n")
+            f.write(f"- Iterations: **{args.iterations}** "
+                    f"(+ {args.warmup} warmup discarded)\n")
+            f.write(f"- Compile: **{_fmt_ms(compile_ms)}** "
+                    f"(wasm {len(compiled.wasm):,} bytes, "
+                    f"sha256 `{compiled.sha256[:12]}`)\n\n")
+            f.write("## RegoEngine.evaluate\n\n")
+            f.write("| metric  | value |\n|---|---|\n")
+            f.write(f"| p50     | {_fmt_ms(p50)} |\n")
+            f.write(f"| p95     | {_fmt_ms(p95)} |\n")
+            f.write(f"| p99     | {_fmt_ms(p99)} |\n")
+            f.write(f"| max     | {_fmt_ms(max_ms)} |\n")
+            f.write(f"| mean    | {_fmt_ms(mean_ms)} |\n")
+            f.write(f"| ops/sec | {throughput:,.0f} |\n\n")
+            f.write("## evaluate_decision (raw + normalisation)\n\n")
+            f.write("| metric | value |\n|---|---|\n")
+            f.write(f"| p50    | {_fmt_ms(n50)} |\n")
+            f.write(f"| p95    | {_fmt_ms(n95)} |\n")
+            f.write(f"| p99    | {_fmt_ms(n99)} |\n")
+        print(f"\nReport: {args.report_md}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/unit/test_rego_engine.py
+++ b/test/unit/test_rego_engine.py
@@ -26,9 +26,25 @@ from mcp_proxy.policy.rego_engine import (
     RegoCompileError,
     RegoEngine,
     RegoEvalError,
+    _reset_instance_cache,
     compile_rego,
     evaluate_decision,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_instance_cache():
+    """Reset the process-wide OPAPolicy cache between tests.
+
+    Without this, tests that monkeypatch ``opa_wasmtime.OPAPolicy``
+    to a fake class race: the first test populates the cache keyed
+    on the fixture WASM bytes' SHA-256, and every subsequent test
+    reading the same fixture WASM gets the first test's fake
+    instance back instead of its own monkeypatched one.
+    """
+    _reset_instance_cache()
+    yield
+    _reset_instance_cache()
 
 
 # ── tar.gz fixture helpers ────────────────────────────────────────────────
@@ -266,3 +282,71 @@ def test_decision_dict_with_unknown_value_raises(monkeypatch):
     _patch_opa_policy(monkeypatch, result={"decision": "maybe"})
     with pytest.raises(RegoEvalError, match="unexpected shape"):
         evaluate_decision(policy, {})
+
+
+# ── instance cache (perf path) ────────────────────────────────────────────
+
+
+def test_instance_cache_reuses_for_same_wasm(monkeypatch):
+    """Second evaluate on the same bundle MUST NOT re-instantiate OPAPolicy.
+
+    Without cache the engine would rebuild the wasmtime instance on
+    every decision (~15-25ms overhead per call). The cache key is the
+    bundle SHA-256, so identical bytes share the instance.
+    """
+    policy = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00cache-test")
+
+    instantiations = 0
+
+    class _CountingOPA:
+        def __init__(self, wasm_path):
+            nonlocal instantiations
+            instantiations += 1
+        def evaluate(self, doc, entrypoint):
+            return [{"result": {"decision": "allow"}}]
+
+    import sys
+    from types import SimpleNamespace
+    fake_module = SimpleNamespace(OPAPolicy=_CountingOPA)
+    monkeypatch.setitem(sys.modules, "opa_wasmtime", fake_module)
+
+    engine = RegoEngine(policy)
+    for _ in range(5):
+        engine.evaluate({"x": 1})
+
+    assert instantiations == 1, (
+        f"OPAPolicy should be instantiated once per bundle, "
+        f"got {instantiations} for 5 evaluates"
+    )
+
+
+def test_instance_cache_distinct_for_different_wasm(monkeypatch):
+    """Different WASM bytes → different SHA → different cached instance."""
+    p1 = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00first")
+    p2 = CompiledPolicy.from_wasm(b"\x00asm\x01\x00\x00\x00second")
+    assert p1.sha256 != p2.sha256  # sanity
+
+    instantiations = 0
+
+    class _CountingOPA:
+        def __init__(self, wasm_path):
+            nonlocal instantiations
+            instantiations += 1
+        def evaluate(self, doc, entrypoint):
+            return [{"result": {"decision": "allow"}}]
+
+    import sys
+    from types import SimpleNamespace
+    fake_module = SimpleNamespace(OPAPolicy=_CountingOPA)
+    monkeypatch.setitem(sys.modules, "opa_wasmtime", fake_module)
+
+    RegoEngine(p1).evaluate({})
+    RegoEngine(p2).evaluate({})
+    # Repeats: still no new instantiation.
+    RegoEngine(p1).evaluate({})
+    RegoEngine(p2).evaluate({})
+
+    assert instantiations == 2, (
+        f"distinct WASM bundles should each instantiate once; "
+        f"got {instantiations}"
+    )


### PR DESCRIPTION
## Summary

PR #908 shipped the Rego engine with the explicit limitation "instance cache is future work". This PR closes that gap before the Show HN: every decision after the first on the same bundle now reuses the cached `OPAPolicy`, dropping p99 from 19.9ms to **0.29ms** (~68× faster) and throughput from 60 ops/s to **4 650 ops/s** (+77×).

Also ships a reproducible bench script so the operator (or anyone evaluating Cullis vs MS Agent Governance Toolkit / agentgateway / OPA-sidecar deployments) can run the same measurement against their own hardware.

## Why now

MS AGT publicly advertises 0.012 ms p50 / 35K ops/s policy eval. Cullis, as shipped in PR #908, was 16.23 ms p50 / 60 ops/s — three orders of magnitude behind on the headline number. The root cause was 100% wasmtime instantiation overhead, not eval cost. Caching the instance is a small change with large impact.

## Measured impact

`scripts/bench-rego-eval.py`, 2000 iterations on a representative 58-line Rego (default-deny tool_call + per-agent allowlist + cross-org session gate):

| metric                  | pre-cache  | post-cache    | delta    |
|-------------------------|------------|---------------|----------|
| `evaluate` p50          | 16.23 ms   | **0.210 ms**  | **-77×** |
| `evaluate` p95          | 18.47 ms   | **0.236 ms**  | **-78×** |
| `evaluate` p99          | 19.93 ms   | **0.294 ms**  | **-68×** |
| `evaluate` mean         | 16.55 ms   | **0.214 ms**  | **-77×** |
| `evaluate` ops/s        | 60         | **4 650**     | **+77×** |
| `evaluate_decision` p99 | 19.47 ms   | **0.301 ms**  | **-65×** |

Still ~17× slower than the MS AGT claim, but in the sub-millisecond / millisecond-class real-time band a CISO pilot expects. A regulator does not feel the difference between 12 µs and 210 µs per decision.

## How the cache works

- **Key**: SHA-256 of the compiled WASM bundle (`compiled.sha256`).
- **Storage**: module-level `dict[str, OPAPolicy]` guarded by a `threading.Lock` so the map stays consistent.
- **Trim**: FIFO trim at 32 entries. Operator policies rotate at human pace (Save in dashboard → new SHA → new instance, old one ages out), real LRU is overkill.
- **Miss path**: instantiate outside the lock (native I/O), re-check + insert under the lock — double-check guards two threads racing to build for the same hash.
- **Thread-safety caveat**: `OPAPolicy.evaluate` on a single store is **not** thread-safe under concurrent native invocation. FastAPI/uvicorn runs handlers on a single-threaded asyncio loop and the eval is synchronous, so two in-flight requests never overlap on the same instance in that runtime model. A future PR that moves eval onto `asyncio.to_thread` should add a per-instance lock — flagged in the docstring.

## Test plan

- [x] `pytest test/unit/` — **71 passed in 1.49s** (69 existing + 2 new: `test_instance_cache_reuses_for_same_wasm`, `test_instance_cache_distinct_for_different_wasm`)
- [x] Autouse `_clear_instance_cache` fixture catches the test-isolation bug the refactor surfaced: identical fixture WASM bytes share a SHA, so without the reset the second test's monkeypatched fake OPAPolicy never wins
- [x] `python scripts/bench-rego-eval.py` — numbers above, reproducible

## Out of scope

- **Per-instance lock** for `asyncio.to_thread` migration. Today's asyncio loop model makes the bare `threading.Lock` on the cache map enough. When eval moves off the event loop, the per-instance lock lands in the same PR.
- **Memory eviction by `evaluate` recency** (true LRU). FIFO at 32 entries is enough until customer deployments routinely keep dozens of distinct policies hot.
- **WASM bundle preheating** at Mastio startup. The first eval pays the instantiation cost; if the operator hates the cold start they can call `evaluate` once during their warm-up routine. Worth automating eventually.

## Commits

1. `cb65c6c0` — cache + bench script + tests
2. `b0671176` — CHANGELOG entry (split because the previous Edit tool call missed the file)

Refs PR #908 — closes the "future work to add instance cache" footnote in the original docstring. Same headline that goes into Show HN reply playbook.