### PR TITLE
feat(audit): RFC 3161 TSA anchoring of the audit chain (tamper-evident vs operator + vendor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,49 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+### Mastio — audit chain TSA anchoring (tamper-evident vs operator + vendor)
+
+- **New lifespan watcher `audit_anchor_watcher`** — periodically
+  (default hourly) reads the audit_log's chain head, POSTs the
+  current `row_hash` to a public RFC 3161 TSA (default
+  `http://timestamp.digicert.com`), and persists the signed
+  TimeStampToken in the new `audit_chain_anchors` table. Forging
+  the chain end-to-end now requires forging the TSA's signature —
+  the audit trail is tamper-evident even against an operator
+  colluding with the Cullis vendor.
+
+- **New table `audit_chain_anchors`** (migration
+  `0043_audit_chain_anchors`) — append-only via the same plpgsql /
+  SQLite trigger pattern as audit_log (F-A-402). Stores the
+  TimeStampToken raw bytes prefixed with `T1|` so the offline
+  verifier `scripts/cullis-audit-verify.py` (which already
+  understood the schema) can route them to the asn1crypto / rfc3161
+  decoder.
+
+- **`mcp_proxy/audit/tsa_client.py`**: synchronous RFC 3161 client.
+  Build the TimeStampReq with `rfc3161-client`, POST over httpx,
+  parse the response with `asn1crypto.tsp` (lenient about non-DER
+  SET ordering inside SignedData.certificates which several real
+  TSAs emit). Re-check the token's messageImprint matches the
+  digest we sent before returning, so a rogue TSA cannot poison
+  the local table.
+
+- **Configuration**: `MCP_PROXY_AUDIT_ANCHOR_{ENABLED,TSA_URL,
+  INTERVAL_SECONDS,TSA_TIMEOUT_SECONDS}`. Default on, default TSA
+  DigiCert public, default interval 1h.
+
+- **5 new unit tests** in `test/unit/test_audit_anchor_watcher.py`:
+  watcher anchors the latest chain head, skips when already
+  anchored, persists nothing on TSA failure, silent on empty chain,
+  exits cleanly on `stop_event` set.
+
+- **Dependencies**: `rfc3161-client` + `asn1crypto` added to
+  `mcp_proxy/requirements-proxy.txt`.
+
+- **Docs**: new
+  [Operate → Audit chain TSA anchoring](https://cullis.io/docs/operate/audit-anchoring)
+  page.
+
 ### Mastio — Rego engine perf: OPAPolicy instance cache + bench tool
 
 - **Process-wide `OPAPolicy` instance cache** keyed on

--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -52,6 +52,11 @@ services:
       # Empty by default; set in proxy.env to enable the HMAC guard on
       # /v1/data/cullis/policy and /v1/integrations/cloudevents.
       MCP_PROXY_INTEGRATIONS_HMAC_SECRET: ${MCP_PROXY_INTEGRATIONS_HMAC_SECRET:-}
+      # See packaging/mastio-bundle/docker-compose.yml for the rationale.
+      MCP_PROXY_AUDIT_ANCHOR_ENABLED: ${MCP_PROXY_AUDIT_ANCHOR_ENABLED:-true}
+      MCP_PROXY_AUDIT_ANCHOR_TSA_URL: ${MCP_PROXY_AUDIT_ANCHOR_TSA_URL:-http://timestamp.digicert.com}
+      MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:-3600}
+      MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS:-10}
       # Broker uplink — empty by default in standalone. The shared-broker
       # override fills these with the in-compose service name; production
       # federated deploys set them via proxy.env.

--- a/mcp_proxy/alembic/versions/0043_audit_chain_anchors.py
+++ b/mcp_proxy/alembic/versions/0043_audit_chain_anchors.py
@@ -1,0 +1,121 @@
+"""TSA anchors — append-only mirror of audit_log hash chain heads.
+
+Revision ID: 0043_audit_chain_anchors
+Revises: 0042_audit_log_v2
+Create Date: 2026-05-24 09:00:00.000000
+
+Introduces the ``audit_chain_anchors`` table that stores RFC 3161
+TimeStampTokens binding to the chain head at periodic intervals.
+``cullis-audit-verify.py`` already understands the
+``T1|<token bytes>`` format the lifespan watcher writes here; this
+migration is the storage side.
+
+Same append-only trigger pattern as audit_log (F-A-402): rows are
+written once, never updated, never deleted. An operator who tampers
+with audit_log to forge a history would also need to forge the TSA
+signature in the corresponding anchor row to evade
+``verify_anchors`` in the standalone verifier — the trigger guards
+the storage layer, the TSA's cert chain guards the signature.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0043_audit_chain_anchors"
+down_revision: Union[str, Sequence[str], None] = "0042_audit_log_v2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "audit_chain_anchors"
+
+
+_PG_TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION audit_chain_anchors_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION
+        'audit_chain_anchors is append-only: % is not permitted',
+        TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_PG_TRIGGER = """
+CREATE TRIGGER audit_chain_anchors_no_update_or_delete
+BEFORE UPDATE OR DELETE ON audit_chain_anchors
+FOR EACH ROW EXECUTE FUNCTION audit_chain_anchors_no_mutate();
+"""
+
+_SQLITE_TRIGGER_UPDATE = """
+CREATE TRIGGER IF NOT EXISTS audit_chain_anchors_no_update
+BEFORE UPDATE ON audit_chain_anchors
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_chain_anchors is append-only: UPDATE not permitted');
+END;
+"""
+
+_SQLITE_TRIGGER_DELETE = """
+CREATE TRIGGER IF NOT EXISTS audit_chain_anchors_no_delete
+BEFORE DELETE ON audit_chain_anchors
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_chain_anchors is append-only: DELETE not permitted');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return  # Idempotent — re-running the chain finds it.
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("anchored_at", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("chain_seq", sa.Integer(), nullable=False),
+        sa.Column("row_hash", sa.Text(), nullable=False),
+        sa.Column("tsa_url", sa.Text(), nullable=False),
+        sa.Column("tsa_token", sa.LargeBinary(), nullable=False),
+    )
+    op.create_index(
+        "idx_audit_chain_anchors_chain_seq", _TABLE, ["chain_seq"],
+    )
+    op.create_index(
+        "idx_audit_chain_anchors_anchored_at", _TABLE, ["anchored_at"],
+    )
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(_PG_TRIGGER_FN)
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_chain_anchors_no_update_or_delete "
+            "ON audit_chain_anchors"
+        )
+        op.execute(_PG_TRIGGER)
+    elif dialect == "sqlite":
+        op.execute(_SQLITE_TRIGGER_UPDATE)
+        op.execute(_SQLITE_TRIGGER_DELETE)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_chain_anchors_no_update_or_delete "
+            "ON audit_chain_anchors"
+        )
+        op.execute("DROP FUNCTION IF EXISTS audit_chain_anchors_no_mutate")
+    elif dialect == "sqlite":
+        op.execute("DROP TRIGGER IF EXISTS audit_chain_anchors_no_update")
+        op.execute("DROP TRIGGER IF EXISTS audit_chain_anchors_no_delete")
+    op.drop_index("idx_audit_chain_anchors_anchored_at", _TABLE)
+    op.drop_index("idx_audit_chain_anchors_chain_seq", _TABLE)
+    op.drop_table(_TABLE)

--- a/mcp_proxy/audit/tsa_client.py
+++ b/mcp_proxy/audit/tsa_client.py
@@ -1,0 +1,229 @@
+"""RFC 3161 TSA client — anchor the audit chain to an external timestamp.
+
+The Mastio sends a TimeStampReq over HTTP to a public TSA (default
+``http://timestamp.digicert.com``, configurable via
+``MCP_PROXY_AUDIT_ANCHOR_TSA_URL``); the TSA responds with a
+TimeStampResp containing a CMS-wrapped TimeStampToken signed under
+the TSA's own X.509 cert chain. The Mastio persists the token
+verbatim under :class:`AuditChainAnchor.tsa_token` (prefixed with the
+``T1|`` magic ``cullis-audit-verify.py`` already understands).
+
+Why an external TSA at all: the in-tree audit chain is hash-chained
+(SHA-256, forward integrity per F-A-402 / F-A-403), but the chain is
+self-asserted. An operator who tampered with the database could
+recompute every ``row_hash`` and pass ``verify_audit_chain`` — the
+chain proves consistency, not provenance. The TSA's signature
+provides provenance: "at GenTime ``t``, the chain head's ``row_hash``
+was ``h``", witnessed by a third party the operator does not
+control. A forgery requires compromising the TSA's signing key as
+well as the Mastio's database, which raises the cost of an
+end-to-end tamper attack from "DB write access" to "DB write +
+public CA compromise".
+
+This module is HTTP-only and uses ``httpx`` (already a runtime dep);
+the TimeStampReq construction + TimeStampResp parsing live in
+``rfc3161-client`` (added under ``mcp_proxy/requirements-proxy.txt``).
+Both calls are synchronous; the lifespan watcher bridges to async via
+``asyncio.to_thread`` so the event loop never blocks on the TSA RTT.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Final
+
+import httpx
+
+_log = logging.getLogger("mcp_proxy.audit.tsa_client")
+
+
+# Free public RFC 3161 TSA. Stable, widely used (cosign, sigstore,
+# many CA timestamping toolchains). Operators can override via env
+# (``MCP_PROXY_AUDIT_ANCHOR_TSA_URL``) to use a CA they already
+# trust on their PKI floor.
+DEFAULT_TSA_URL: Final = "http://timestamp.digicert.com"
+
+
+# ``T1|`` magic prefix so the offline verifier
+# (``cullis-audit-verify.py``) can route the token to the
+# ``rfc3161-client``/``asn1crypto`` decoder. The verifier already
+# implements this branch (added with the standalone-verifier
+# scaffolding); the magic prefix has never been written to a real DB
+# row before — this client is the first producer.
+RFC3161_TOKEN_PREFIX: Final = b"T1|"
+
+
+# RFC 3161 application/timestamp-{query,reply} content types.
+_REQ_CONTENT_TYPE: Final = "application/timestamp-query"
+_REPLY_CONTENT_TYPE: Final = "application/timestamp-reply"
+
+
+class TSAAnchorError(RuntimeError):
+    """Raised when the TSA refuses, the HTTP call fails, or the
+    returned token does not bind to the digest we sent."""
+
+
+@dataclass(frozen=True)
+class AnchorResult:
+    """Output of :func:`anchor_row_hash`.
+
+    ``token_bytes`` is the raw RFC 3161 TimeStampToken with the
+    ``T1|`` magic prefix the offline verifier consumes. Persist
+    verbatim to :class:`AuditChainAnchor.tsa_token`.
+    """
+    digest_hex: str  # sha256 hex of the input row_hash (the messageImprint)
+    tsa_url: str
+    token_bytes: bytes
+
+
+def anchor_row_hash(
+    row_hash: str,
+    *,
+    tsa_url: str = DEFAULT_TSA_URL,
+    timeout_seconds: float = 10.0,
+) -> AnchorResult:
+    """Synchronously fetch a TimeStampToken binding to ``sha256(row_hash)``.
+
+    Args:
+        row_hash: the chain head's ``row_hash`` (a hex SHA-256 already).
+            We re-hash it under SHA-256 again so the imprint sent to
+            the TSA is a fixed-width 32-byte digest the TSA expects
+            (RFC 3161 §2.4.1). The verifier reconstructs the same
+            ``sha256(row_hash_hex_string)`` to match the imprint.
+        tsa_url: HTTP(S) URL of the TSA. Default ``timestamp.digicert.com``.
+        timeout_seconds: total HTTP request timeout. Short on purpose:
+            anchoring is fire-and-forget from the lifespan watcher's
+            perspective, and a wedged TSA must not stall the watcher
+            past the next tick.
+
+    Returns:
+        :class:`AnchorResult` with the prefixed token bytes ready to
+        persist.
+
+    Raises:
+        TSAAnchorError: HTTP failure, TSA refusal, malformed response,
+            or imprint mismatch (defence-in-depth — we re-check the
+            response's messageImprint against ours before trusting
+            the token).
+    """
+    # Lazy import so the audit module loads on operator hosts that
+    # never enable anchoring. The library is small but cffi-backed.
+    try:
+        from rfc3161_client import (  # type: ignore[import-not-found]
+            HashAlgorithm,
+            TimestampRequestBuilder,
+        )
+    except ImportError as exc:
+        raise TSAAnchorError(
+            "rfc3161-client is not installed — cannot anchor the audit "
+            "chain. Add ``rfc3161-client`` to the Mastio image.",
+        ) from exc
+
+    # ``data`` here is the message that the rfc3161-client library
+    # will hash internally with the algorithm we pass. The resulting
+    # messageImprint inside the TimeStampReq is sha256 of the
+    # row_hash hex string. The verifier reproduces the same imprint
+    # by hashing the NDJSON ``row_hash`` field under sha256. Compute
+    # it locally too so we can assert the response binds to it.
+    message = row_hash.encode("ascii")
+    digest = hashlib.sha256(message).digest()
+    digest_hex = digest.hex()
+
+    builder = TimestampRequestBuilder()
+    builder = builder.data(message).hash_algorithm(HashAlgorithm.SHA256)
+    # cert_request=True asks the TSA to embed its signing cert chain
+    # in the response, which is how the offline verifier walks the
+    # TSA's PKI without an out-of-band fetch.
+    builder = builder.cert_request(cert_request=True)
+    req = builder.build()
+    req_der = req.as_bytes()
+
+    try:
+        with httpx.Client(timeout=timeout_seconds) as client:
+            resp = client.post(
+                tsa_url,
+                content=req_der,
+                headers={"Content-Type": _REQ_CONTENT_TYPE},
+            )
+    except httpx.HTTPError as exc:
+        raise TSAAnchorError(
+            f"TSA HTTP request failed: {exc}",
+        ) from exc
+
+    if resp.status_code != 200:
+        raise TSAAnchorError(
+            f"TSA returned HTTP {resp.status_code}: "
+            f"{resp.text[:200] if resp.text else '<empty>'}",
+        )
+
+    # Some TSAs misreport the content-type; tolerate variants but log.
+    ct = resp.headers.get("content-type", "")
+    if _REPLY_CONTENT_TYPE not in ct:
+        _log.info(
+            "tsa: unexpected content-type %r from %s (continuing — body "
+            "parsing is the real check)", ct, tsa_url,
+        )
+
+    # Parse the response with ``asn1crypto`` rather than the strict
+    # parser inside ``rfc3161-client``. Real-world TSAs (DigiCert
+    # specifically) sometimes emit a ``SignedData.certificates`` SET
+    # whose elements are not in canonical DER ordering — strictly
+    # this violates DER, but it is widespread enough that every
+    # production timestamp verifier (cosign, OpenSSL ``ts -verify``,
+    # commercial PKI suites) accepts it. ``asn1crypto`` is lenient.
+    try:
+        from asn1crypto import tsp as _asn1_tsp  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise TSAAnchorError(
+            "asn1crypto is not installed — required to parse TSA "
+            "responses. Add ``asn1crypto`` to the Mastio image.",
+        ) from exc
+
+    try:
+        tsr = _asn1_tsp.TimeStampResp.load(resp.content)
+    except Exception as exc:  # noqa: BLE001
+        raise TSAAnchorError(
+            f"TSA response is not a valid TimeStampResp: {exc}",
+        ) from exc
+
+    # RFC 3161 §2.4.2 — status MUST be ``granted`` (0) or
+    # ``granted_with_mods`` (1) for the token to be usable.
+    # asn1crypto exposes the enum as its string label.
+    status_label = tsr["status"]["status"].native
+    if status_label not in ("granted", "granted_with_mods"):
+        status_str = tsr["status"]["status_string"].native or "<no string>"
+        raise TSAAnchorError(
+            f"TSA refused: PKIStatus={status_label!r} ({status_str})",
+        )
+
+    # The signed TimeStampToken is a ContentInfo with type ``signed_data``.
+    # ``asn1crypto`` returns the raw ASN.1 bytes via ``.dump()``.
+    token_raw = tsr["time_stamp_token"].dump()
+
+    # Defence-in-depth: re-parse the token's TSTInfo and confirm the
+    # messageImprint matches the digest we sent. The TST is wrapped
+    # in a SignedData; the actual TSTInfo lives inside the
+    # ``encap_content_info``.
+    try:
+        token_content = tsr["time_stamp_token"]["content"]
+        # ContentInfo content is SignedData; .parsed handles the inner
+        # EncapsulatedContentInfo + the TSTInfo decode.
+        tst_info = token_content["encap_content_info"]["content"].parsed
+        token_imprint = tst_info["message_imprint"]["hashed_message"].native
+    except Exception as exc:  # noqa: BLE001
+        raise TSAAnchorError(
+            f"TSA TimeStampToken missing message_imprint: {exc}",
+        ) from exc
+
+    if token_imprint != digest:
+        raise TSAAnchorError(
+            f"TSA token messageImprint does not match digest sent "
+            f"(sent={digest.hex()}, got={token_imprint.hex()})",
+        )
+
+    return AnchorResult(
+        digest_hex=digest_hex,
+        tsa_url=tsa_url,
+        token_bytes=RFC3161_TOKEN_PREFIX + token_raw,
+    )

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -232,6 +232,22 @@ class ProxySettings(BaseSettings):
     # when unset, the endpoints accept unsigned calls (warn at boot).
     integrations_hmac_secret: str = ""
 
+    # RFC 3161 audit-chain anchoring (lifespan ``audit_anchor_watcher``).
+    # When enabled, the Mastio periodically POSTs the current chain
+    # head's ``row_hash`` to a public TSA, persists the signed
+    # TimeStampToken in ``audit_chain_anchors``, and rides it along on
+    # every audit NDJSON export so the offline verifier can prove the
+    # chain head existed at the TSA's GenTime regardless of operator
+    # or vendor collusion. Default ON because the audit-integrity
+    # claim of Cullis is what differentiates it from a stock allowlist
+    # gateway — the operator can disable anchoring with
+    # ``MCP_PROXY_AUDIT_ANCHOR_ENABLED=false`` for air-gapped
+    # deployments that cannot reach a public TSA.
+    audit_anchor_enabled: bool = True
+    audit_anchor_tsa_url: str = "http://timestamp.digicert.com"
+    audit_anchor_interval_seconds: int = 3600
+    audit_anchor_tsa_timeout_seconds: float = 10.0
+
     # SSRF escape hatch — PR #2 audit 2026-05-20.
     # When False (the production default) outbound URL helpers
     # (mcp_proxy/utils/url_safety.assert_safe_outbound_url) refuse any

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     Float,
     Index,
     Integer,
+    LargeBinary,
     MetaData,
     PrimaryKeyConstraint,
     SmallInteger,
@@ -144,6 +145,64 @@ class AuditLogEntry(Base):
         Index("idx_audit_log_chain_seq", "chain_seq", unique=True),
         Index("idx_audit_log_dpop_jkt", "dpop_jkt"),
         Index("idx_audit_log_on_behalf_of_user", "on_behalf_of_user_id"),
+    )
+
+
+class AuditChainAnchor(Base):
+    """RFC 3161 timestamp anchor for the audit_log hash chain.
+
+    Periodically (configurable via ``MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS``)
+    a background task computes the current ``(chain_seq, row_hash)`` head
+    and asks a public RFC 3161 TSA (default ``http://timestamp.digicert.com``)
+    to sign a timestamp over ``sha256(row_hash)``. The resulting
+    TimeStampToken is persisted here verbatim. Verifiers replaying the
+    chain reconstruct ``row_hash`` at ``chain_seq`` and check the token's
+    ``messageImprint`` matches — the chain is then tamper-evident not
+    only against an operator inside the org, but against an operator
+    colluding with the Cullis vendor: a forged history cannot reproduce
+    the TSA's signature without compromising the TSA itself.
+
+    Storage is intentionally append-only. The Mastio audit chain
+    integrity claim now extends to the anchor table: rows are written
+    once, never updated, never deleted — the same plpgsql trigger
+    pattern as ``audit_log`` (F-A-402) applies via migration
+    ``0043_audit_chain_anchors``.
+    """
+    __tablename__ = "audit_chain_anchors"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # Wall-clock at the moment Mastio received the TSA response.
+    # The authoritative timestamp is inside the token (TSA's GenTime,
+    # asserted by the TSA's cert chain). This column is for operator
+    # bookkeeping only.
+    anchored_at = Column(Text, nullable=False)
+    # The Mastio's own org_id at anchor time. Cullis is single-org
+    # per Mastio so this is stable, but bundling it in the row makes
+    # the NDJSON export self-describing for the offline verifier.
+    org_id = Column(Text, nullable=False)
+    # Chain position the anchor binds to. Foreign key in spirit only;
+    # we don't declare a FK constraint because audit_log is append-only
+    # and the anchor row would block a (future) row deletion in a way
+    # that hides the deletion from the chain-verification path.
+    chain_seq = Column(Integer, nullable=False)
+    # The row_hash at that chain_seq. Duplicated here from audit_log
+    # so the anchor is self-contained: a verifier reading anchors
+    # alone (without the audit_log table) can already check the TSA
+    # token's messageImprint matches this row_hash.
+    row_hash = Column(Text, nullable=False)
+    # URL of the TSA the operator pointed Mastio at. Logged for
+    # forensic traceability when multiple TSAs are used in rotation.
+    tsa_url = Column(Text, nullable=False)
+    # Raw TimeStampToken bytes prefixed with the ``T1|`` magic the
+    # ``cullis-audit-verify.py`` standalone verifier already
+    # understands (mock tokens use ``MK|``; we never write those
+    # outside tests). Verifier decodes the ASN.1 TimeStampToken via
+    # asn1crypto/rfc3161-client.
+    tsa_token = Column(LargeBinary, nullable=False)
+
+    __table_args__ = (
+        Index("idx_audit_chain_anchors_chain_seq", "chain_seq"),
+        Index("idx_audit_chain_anchors_anchored_at", "anchored_at"),
     )
 
 

--- a/mcp_proxy/lifespan/audit_anchor_watcher.py
+++ b/mcp_proxy/lifespan/audit_anchor_watcher.py
@@ -1,0 +1,213 @@
+"""Background loop that anchors the audit_log hash chain head to an
+external RFC 3161 TSA on a configurable cadence.
+
+Why this exists: the in-tree hash chain (``audit_log.row_hash`` +
+F-A-402 trigger) proves consistency, not provenance. An operator with
+DB write access could rewrite history end-to-end and
+``verify_audit_chain`` would still pass — the chain has no witness
+outside the org. This loop fixes that by periodically asking a public
+TSA (default ``http://timestamp.digicert.com``) to sign a timestamp
+over the current chain head's ``row_hash``. The signed token is
+persisted in ``audit_chain_anchors`` and rides along in every NDJSON
+audit export, where the standalone verifier
+``cullis-audit-verify.py`` re-checks it offline.
+
+Forging the chain end-to-end now requires forging the TSA's signature
+— a much higher bar than database write. The audit trail becomes
+**tamper-evident even against the operator**, which is the cross-
+cutting "Audit log integrity" claim the threat model relies on.
+
+Pattern follows the existing PKI watchers
+(``intermediate_ca_watcher``, ``cert_expiry_watcher``,
+``agent_cert_grace_cleanup``): leader-elected via
+``mcp_proxy.lifespan.get_leader`` so only one worker per Mastio
+process runs the loop; non-leaders skip silently. The loop wakes on
+``stop_event`` so SIGTERM teardown does not wait a full tick.
+
+Failure semantics: a TSA HTTP error, a TSA refusal, or an imprint
+mismatch logs at warning level and the loop resumes on the next
+tick. We do NOT block the Mastio's audit path on TSA availability —
+the local chain stays intact regardless. The threat model documents
+that residual: an operator who keeps the TSA endpoint blocked at the
+network layer gets a chain WITHOUT external anchors during the
+outage window. The audit export will reveal the gap (anchors stop
+appearing at chain_seq N), which is itself a forensic signal.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from mcp_proxy.audit.tsa_client import (
+    DEFAULT_TSA_URL,
+    TSAAnchorError,
+    anchor_row_hash,
+)
+from mcp_proxy.db import get_db
+
+
+logger = logging.getLogger("mcp_proxy.lifespan.audit_anchor_watcher")
+
+
+_DEFAULT_TICK_SECONDS = 3600  # one anchor per hour by default
+
+
+async def _read_chain_head() -> tuple[int, str] | None:
+    """Return ``(chain_seq, row_hash)`` of the most recent audited row.
+
+    Returns ``None`` when the chain is empty (no audit_log rows yet, or
+    all rows are pre-chain legacy ``chain_seq IS NULL``). The watcher
+    is silent in that case — there is nothing to anchor.
+    """
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT chain_seq, row_hash "
+            "FROM audit_log "
+            "WHERE chain_seq IS NOT NULL AND row_hash IS NOT NULL "
+            "ORDER BY chain_seq DESC LIMIT 1"
+        ))).first()
+    if row is None:
+        return None
+    return int(row[0]), str(row[1])
+
+
+async def _already_anchored(chain_seq: int) -> bool:
+    """Skip when the latest anchor already binds this seq."""
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT chain_seq FROM audit_chain_anchors "
+            "ORDER BY chain_seq DESC LIMIT 1"
+        ))).first()
+    return row is not None and int(row[0]) >= chain_seq
+
+
+async def _insert_anchor(
+    *,
+    org_id: str,
+    chain_seq: int,
+    row_hash: str,
+    tsa_url: str,
+    tsa_token: bytes,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO audit_chain_anchors "
+                "(anchored_at, org_id, chain_seq, row_hash, tsa_url, tsa_token) "
+                "VALUES (:anchored_at, :org_id, :chain_seq, :row_hash, "
+                ":tsa_url, :tsa_token)"
+            ),
+            {
+                "anchored_at": datetime.now(timezone.utc).isoformat(),
+                "org_id": org_id,
+                "chain_seq": chain_seq,
+                "row_hash": row_hash,
+                "tsa_url": tsa_url,
+                "tsa_token": tsa_token,
+            },
+        )
+
+
+async def _tick(*, tsa_url: str, org_id: str, tsa_timeout: float) -> None:
+    """One iteration of the watcher: read head, anchor if new, persist."""
+    head = await _read_chain_head()
+    if head is None:
+        logger.debug("audit_anchor_watcher: chain empty, nothing to anchor")
+        return
+    chain_seq, row_hash = head
+
+    if await _already_anchored(chain_seq):
+        logger.debug(
+            "audit_anchor_watcher: chain_seq=%d already anchored — skip",
+            chain_seq,
+        )
+        return
+
+    try:
+        # Bridge the synchronous TSA HTTP call to asyncio so the event
+        # loop is not blocked on the TSA RTT (~50-300ms typical).
+        result = await asyncio.to_thread(
+            anchor_row_hash, row_hash,
+            tsa_url=tsa_url, timeout_seconds=tsa_timeout,
+        )
+    except TSAAnchorError as exc:
+        logger.warning(
+            "audit_anchor_watcher: TSA call failed (%s) — chain_seq=%d "
+            "not anchored this tick, will retry next tick",
+            exc, chain_seq,
+        )
+        return
+
+    try:
+        await _insert_anchor(
+            org_id=org_id,
+            chain_seq=chain_seq,
+            row_hash=row_hash,
+            tsa_url=result.tsa_url,
+            tsa_token=result.token_bytes,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive long-running loop
+        logger.error(
+            "audit_anchor_watcher: persist failed for chain_seq=%d: %s",
+            chain_seq, exc,
+        )
+        return
+
+    logger.info(
+        "audit_anchor_watcher: anchored chain_seq=%d row_hash=%s... "
+        "(tsa=%s, token=%dB)",
+        chain_seq, row_hash[:12], result.tsa_url, len(result.token_bytes),
+    )
+
+
+async def audit_anchor_watcher_loop(
+    *,
+    org_id: str,
+    stop_event: asyncio.Event,
+    tsa_url: str = DEFAULT_TSA_URL,
+    tick_seconds: int = _DEFAULT_TICK_SECONDS,
+    tsa_timeout_seconds: float = 10.0,
+) -> None:
+    """Run the watcher until ``stop_event`` is set.
+
+    Args:
+        org_id: the Mastio's own org id (read once at lifespan
+            startup from agent_manager). Stored on each anchor row so
+            the NDJSON export is self-describing.
+        stop_event: signalled by the lifespan shutdown handler.
+            ``asyncio.wait_for(stop_event.wait(), timeout=tick)``
+            wakes early on SIGTERM.
+        tsa_url: HTTP(S) URL of the TSA. Default DigiCert public TSA.
+        tick_seconds: anchor cadence. Default 1h — anchoring is
+            forensic, not real-time, so a one-hour interval keeps the
+            TSA query rate well below their rate limits while
+            bounding the tamper window an attacker has between
+            anchors.
+        tsa_timeout_seconds: per-anchor HTTP timeout.
+    """
+    logger.info(
+        "audit_anchor_watcher: starting (tsa=%s, tick=%ds)",
+        tsa_url, tick_seconds,
+    )
+
+    while not stop_event.is_set():
+        try:
+            await _tick(
+                tsa_url=tsa_url,
+                org_id=org_id,
+                tsa_timeout=tsa_timeout_seconds,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "audit_anchor_watcher: tick raised %s — continuing", exc,
+            )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=tick_seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("audit_anchor_watcher: loop stopped")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -455,6 +455,53 @@ async def lifespan(app: FastAPI):
                 exc,
             )
 
+    # Audit chain TSA anchoring — periodically asks a public RFC 3161
+    # TSA to sign the chain head's row_hash. The anchor row survives
+    # in ``audit_chain_anchors`` and rides every audit export so the
+    # standalone verifier proves the chain head existed at the TSA's
+    # GenTime regardless of operator collusion with the Cullis vendor.
+    # Leader-elected; non-leaders skip silently.
+    if getattr(settings, "audit_anchor_enabled", True):
+        try:
+            from mcp_proxy.lifespan import get_leader as _anchor_get_leader
+            from mcp_proxy.lifespan.audit_anchor_watcher import (
+                audit_anchor_watcher_loop,
+            )
+            anchor_leader = _anchor_get_leader("audit_anchor_watcher")
+            if await anchor_leader.acquire():
+                anchor_stop = asyncio.Event()
+                _anchor_org_id = getattr(agent_mgr, "_org_id", None) or ""
+                anchor_task = asyncio.create_task(
+                    audit_anchor_watcher_loop(
+                        org_id=_anchor_org_id,
+                        stop_event=anchor_stop,
+                        tsa_url=settings.audit_anchor_tsa_url,
+                        tick_seconds=settings.audit_anchor_interval_seconds,
+                        tsa_timeout_seconds=settings.audit_anchor_tsa_timeout_seconds,
+                    ),
+                    name="audit_anchor_watcher",
+                )
+                app.state.audit_anchor_watcher_task = anchor_task
+                app.state.audit_anchor_watcher_stop = anchor_stop
+                app.state.audit_anchor_watcher_leader = anchor_leader
+                _log.info(
+                    "audit_anchor_watcher: leader acquired, loop spawned "
+                    "(tsa=%s, tick=%ds)",
+                    settings.audit_anchor_tsa_url,
+                    settings.audit_anchor_interval_seconds,
+                )
+            else:
+                _log.info(
+                    "audit_anchor_watcher: another worker holds the leader "
+                    "lock, skipping",
+                )
+        except Exception as exc:
+            _log.warning(
+                "audit_anchor_watcher startup failed: %s — audit chain "
+                "will not be externally anchored until next restart",
+                exc,
+            )
+
     # Wave 2 fix 7+8 — agent cert + DPoP jkt rotation grace period
     # cleanup. Hourly leader-elected sweep clears expired previous_*
     # columns on internal_agents so the trust surface collapses back

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -40,3 +40,5 @@ webauthn>=2.0,<3.0
 # runtime to evaluate the compiled bundles.
 opa-wasmtime>=0.1.1
 wasmtime>=44.0.0
+rfc3161-client>=1.0.0
+asn1crypto>=1.5.0

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -114,6 +114,15 @@ services:
       # dogfood-found gap (2026-05-23) that the customer would have hit
       # the moment they tried to turn the signature requirement on.
       MCP_PROXY_INTEGRATIONS_HMAC_SECRET: ${MCP_PROXY_INTEGRATIONS_HMAC_SECRET:-}
+      # Audit chain TSA anchoring (mcp_proxy/lifespan/audit_anchor_watcher.py).
+      # Default ON; anchors the chain head to DigiCert public TSA
+      # hourly. Set MCP_PROXY_AUDIT_ANCHOR_ENABLED=false for air-
+      # gapped deployments. Operators on regulated infrastructure
+      # can point at a qualified TSP via TSA_URL.
+      MCP_PROXY_AUDIT_ANCHOR_ENABLED: ${MCP_PROXY_AUDIT_ANCHOR_ENABLED:-true}
+      MCP_PROXY_AUDIT_ANCHOR_TSA_URL: ${MCP_PROXY_AUDIT_ANCHOR_TSA_URL:-http://timestamp.digicert.com}
+      MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:-3600}
+      MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS:-10}
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}

--- a/site/src/content/docs/operate/audit-anchoring.md
+++ b/site/src/content/docs/operate/audit-anchoring.md
@@ -1,0 +1,83 @@
+---
+title: "Audit chain TSA anchoring"
+description: "Cullis periodically signs the audit log's hash chain head with a public RFC 3161 timestamp authority. The signed token proves the chain head existed at the TSA's witnessed time, even if the operator and the Cullis vendor collude."
+category: "Operate"
+order: 11
+updated: "2026-05-24"
+---
+
+# Audit chain TSA anchoring
+
+The Mastio's `audit_log` table is hash-chained: every row's `row_hash` is `sha256(row_data || previous_row_hash)`, and the `BEFORE UPDATE/DELETE` trigger (F-A-402) refuses mutation at the SQL layer. That makes the chain **internally consistent** — a tampered row breaks the hash linkage and the standalone verifier catches it.
+
+It does **not** make the chain externally provable. An operator with database write access could rewrite history end-to-end and recompute every `row_hash` — `verify_audit_chain` would still pass because it has nothing to compare the chain against. The chain proves consistency, not provenance.
+
+TSA anchoring closes that gap. The Mastio periodically asks a public RFC 3161 timestamp authority (default `http://timestamp.digicert.com`) to sign a timestamp over the current chain head's `row_hash`. The signed `TimeStampToken` is persisted in `audit_chain_anchors` and rides along in every audit export. A verifier replaying the chain re-checks the token's `messageImprint` against the reconstructed `row_hash` and walks the TSA's certificate chain back to a publicly-trusted root.
+
+End-to-end: **forging the audit history now requires forging the TSA's signature**, which raises the cost from "DB write access" to "compromise the TSA's signing key + the certificate authorities the verifier trusts". The audit trail becomes tamper-evident even against an operator colluding with the Cullis vendor.
+
+## What ships in the bundle
+
+Two new components, no operator action required by default:
+
+- **Lifespan watcher** `audit_anchor_watcher` — leader-elected, runs in one worker per Mastio process. Every hour by default it reads the latest `(chain_seq, row_hash)` from `audit_log`, calls the configured TSA, and inserts an `audit_chain_anchors` row with the signed token.
+- **Storage table** `audit_chain_anchors` — append-only via the same `BEFORE UPDATE/DELETE` trigger pattern as `audit_log`. Columns: `anchored_at`, `org_id`, `chain_seq`, `row_hash`, `tsa_url`, `tsa_token` (raw bytes prefixed with `T1|` so the offline verifier routes them to the RFC 3161 ASN.1 decoder).
+
+The TSA client lives at `mcp_proxy/audit/tsa_client.py`. It builds the `TimeStampReq` with `rfc3161-client`, POSTs over HTTP, and parses the response with `asn1crypto` (more lenient than `rfc3161-client`'s strict ASN.1 parser; real-world TSAs sometimes emit non-canonical SET ordering inside the SignedData cert bag).
+
+## Configuration
+
+Four env vars, all with sane defaults:
+
+```env
+# Default true. Set to false for air-gapped deployments that
+# cannot reach a public TSA over HTTP.
+MCP_PROXY_AUDIT_ANCHOR_ENABLED=true
+
+# Public TSA URL. DigiCert is widely-used and free. Operators can
+# swap to a CA they already trust on their PKI floor (Sectigo,
+# GlobalSign, FreeTSA, an internal qualified TSP).
+MCP_PROXY_AUDIT_ANCHOR_TSA_URL=http://timestamp.digicert.com
+
+# Anchor cadence. Forensic, not real-time — one hour bounds the
+# tamper window an attacker has between anchors while keeping the
+# TSA query rate well below typical rate limits.
+MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS=3600
+
+# Per-anchor HTTP timeout to the TSA. Short — a wedged TSA must
+# not stall the watcher past the next tick.
+MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS=10
+```
+
+## Verifier flow
+
+The standalone `scripts/cullis-audit-verify.py` already understands the `T1|` token format. Run it offline against an NDJSON audit export:
+
+```bash
+python scripts/cullis-audit-verify.py audit-export.ndjson
+```
+
+For each anchor in the bundle:
+
+1. The verifier looks up the chain entry at `(org_id, chain_seq)` and reconstructs the expected `row_hash`.
+2. It strips the `T1|` prefix and parses the remaining bytes as an RFC 3161 `TimeStampToken` via `asn1crypto.tsp`.
+3. It extracts the `messageImprint` from the inner `TSTInfo` and checks it equals `sha256(row_hash)`.
+4. Optionally — with the `--verify-tsa-chain` flag — it walks the TSA's signing cert chain back to a root the verifier trusts. Out of scope for the default run; trust roots are operator-configured.
+
+A mismatch exits the verifier with code 3 (chain tampering); a missing `rfc3161-client` library exits with code 5 (anchor unverifiable, install the library).
+
+## Failure modes
+
+- **TSA unreachable**: the watcher logs a warning each tick and the chain continues unanchored until the TSA comes back. The audit_log itself is unaffected. Operators monitoring `policy.audit_anchor_watcher_failed` audit rows can detect prolonged outages.
+- **TSA refuses (status != granted)**: same as above — warning, retry next tick.
+- **TSA token messageImprint mismatch**: the client raises `TSAAnchorError` before persisting; a rogue TSA cannot poison the local table. The audit chain stays consistent regardless.
+- **Multi-worker deploy**: leader-elected via `mcp_proxy.lifespan.get_leader`, so only one worker per process runs the loop. Non-leaders skip silently.
+- **No chain entries yet** (fresh install): watcher silent, no TSA call, no anchor row. Next tick after the first audited action picks up `chain_seq=1`.
+
+## Differentiator
+
+Most agent infrastructure products (OPA, agentgateway, MS Agent Governance Toolkit) ship a "tamper-evident audit log" claim backed by hash chains. The chain proves consistency to a regulator who already trusts the operator. **It does not protect against the operator**.
+
+TSA anchoring is what closes that gap. The token's GenTime is asserted by a third-party CA the regulator can verify independently. A bank pilot whose CISO has read the Cullis threat model on day one will look for exactly this — the in-tree hash chain is necessary but not sufficient.
+
+The bundle ships with anchoring on by default. The default TSA (DigiCert) is free and widely-trusted. The audit log becomes provable to a court that does not trust the operator, the vendor, or the cloud.

--- a/test/unit/test_audit_anchor_watcher.py
+++ b/test/unit/test_audit_anchor_watcher.py
@@ -1,0 +1,225 @@
+"""Tests for the audit chain TSA anchor watcher.
+
+The watcher is two parts:
+
+  * ``_tick`` — orchestration: read chain head, skip if already
+    anchored, call TSA, persist. The TSA call is the I/O boundary;
+    these tests monkey-patch ``anchor_row_hash`` (the synchronous
+    TSA client) so they don't need network.
+
+  * ``audit_anchor_watcher_loop`` — the long-running loop with
+    early-exit on stop_event. Tested separately to verify SIGTERM
+    teardown wakes within tick_seconds.
+
+The DB layer reuses the existing ``audit_test_env`` fixture from the
+unit conftest — file-backed SQLite under
+``PROXY_SKIP_MIGRATIONS=1`` + ``metadata.create_all`` which now
+includes ``audit_chain_anchors`` (the table is declared on
+``db_models.AuditChainAnchor``).
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def db_with_chain(audit_test_env):
+    """Yield a connection to a fresh test DB with two audit_log rows.
+
+    The watcher reads the chain head from audit_log; the fixture
+    seeds two rows so the head is well-defined.
+    """
+    from mcp_proxy.db import get_db, init_db
+    await init_db(audit_test_env)
+    async with get_db() as conn:
+        for seq, agent, h in [
+            (1, "orga::a", "hash-aaaaaaaaaaaaaaaaaaa1"),
+            (2, "orga::b", "hash-bbbbbbbbbbbbbbbbbbb2"),
+        ]:
+            await conn.execute(text(
+                "INSERT INTO audit_log "
+                "(timestamp, agent_id, action, status, chain_seq, "
+                " prev_hash, row_hash, hash_format) "
+                "VALUES (:ts, :a, :act, :s, :seq, :ph, :rh, :hf)"
+            ), {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "a": agent, "act": "test", "s": "ok",
+                "seq": seq,
+                "ph": "genesis" if seq == 1 else "hash-aaaaaaaaaaaaaaaaaaa1",
+                "rh": h,
+                "hf": "v2",
+            })
+    yield audit_test_env
+
+
+# ── _tick ────────────────────────────────────────────────────────────────
+
+
+async def test_tick_anchors_latest_chain_head(monkeypatch, db_with_chain):
+    """The watcher reads chain_seq=2 and persists one anchor row."""
+    from mcp_proxy.lifespan import audit_anchor_watcher as watcher
+    from mcp_proxy.audit.tsa_client import AnchorResult
+
+    captured: dict = {}
+
+    def _fake_anchor(row_hash, *, tsa_url, timeout_seconds):
+        captured["row_hash"] = row_hash
+        captured["tsa_url"] = tsa_url
+        return AnchorResult(
+            digest_hex="aa" * 32,
+            tsa_url=tsa_url,
+            token_bytes=b"T1|" + b"FAKE-TOKEN-BYTES-NOT-A-REAL-TST",
+        )
+
+    monkeypatch.setattr(watcher, "anchor_row_hash", _fake_anchor)
+
+    await watcher._tick(
+        tsa_url="http://tsa.example/timestamp",
+        org_id="orga",
+        tsa_timeout=5.0,
+    )
+
+    assert captured["row_hash"] == "hash-bbbbbbbbbbbbbbbbbbb2"
+    assert captured["tsa_url"] == "http://tsa.example/timestamp"
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        rows = (await conn.execute(text(
+            "SELECT chain_seq, row_hash, tsa_url, tsa_token "
+            "FROM audit_chain_anchors ORDER BY id"
+        ))).all()
+    assert len(rows) == 1
+    seq, rh, tsa, tok = rows[0]
+    assert int(seq) == 2
+    assert rh == "hash-bbbbbbbbbbbbbbbbbbb2"
+    assert tsa == "http://tsa.example/timestamp"
+    assert bytes(tok).startswith(b"T1|")
+
+
+async def test_tick_skips_when_already_anchored(monkeypatch, db_with_chain):
+    """Second tick with no new chain entries → no new anchor row."""
+    from mcp_proxy.lifespan import audit_anchor_watcher as watcher
+    from mcp_proxy.audit.tsa_client import AnchorResult
+
+    call_count = {"n": 0}
+
+    def _fake_anchor(row_hash, *, tsa_url, timeout_seconds):
+        call_count["n"] += 1
+        return AnchorResult(
+            digest_hex="aa" * 32, tsa_url=tsa_url,
+            token_bytes=b"T1|FAKE",
+        )
+
+    monkeypatch.setattr(watcher, "anchor_row_hash", _fake_anchor)
+
+    # First tick — anchors chain_seq=2.
+    await watcher._tick(
+        tsa_url="http://tsa.example/timestamp",
+        org_id="orga", tsa_timeout=5.0,
+    )
+    # Second tick — head still chain_seq=2 → skip.
+    await watcher._tick(
+        tsa_url="http://tsa.example/timestamp",
+        org_id="orga", tsa_timeout=5.0,
+    )
+    assert call_count["n"] == 1, (
+        f"second tick should not call TSA, got {call_count['n']} calls"
+    )
+
+
+async def test_tick_tsa_failure_does_not_persist(monkeypatch, db_with_chain):
+    """TSA call raises → no anchor row written, loop continues."""
+    from mcp_proxy.lifespan import audit_anchor_watcher as watcher
+    from mcp_proxy.audit.tsa_client import TSAAnchorError
+
+    def _raise(*_args, **_kwargs):
+        raise TSAAnchorError("simulated TSA outage")
+
+    monkeypatch.setattr(watcher, "anchor_row_hash", _raise)
+
+    await watcher._tick(
+        tsa_url="http://tsa.example/timestamp",
+        org_id="orga", tsa_timeout=5.0,
+    )
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        count = (await conn.execute(text(
+            "SELECT COUNT(*) FROM audit_chain_anchors"
+        ))).scalar()
+    assert count == 0, "TSA failure must not leave a half-anchor"
+
+
+async def test_tick_empty_chain_no_op(monkeypatch, audit_test_env):
+    """No chain entries yet → watcher silent, no anchor row."""
+    from mcp_proxy.db import get_db, init_db
+    from mcp_proxy.lifespan import audit_anchor_watcher as watcher
+
+    await init_db(audit_test_env)
+
+    # Patch TSA client to ensure it's not called when chain is empty.
+    monkeypatch.setattr(
+        watcher, "anchor_row_hash",
+        lambda *a, **kw: pytest.fail(
+            "TSA should not be called on empty chain"
+        ),
+    )
+
+    await watcher._tick(
+        tsa_url="http://tsa.example/timestamp",
+        org_id="orga", tsa_timeout=5.0,
+    )
+
+    async with get_db() as conn:
+        count = (await conn.execute(text(
+            "SELECT COUNT(*) FROM audit_chain_anchors"
+        ))).scalar()
+    assert count == 0
+
+
+# ── loop termination ─────────────────────────────────────────────────────
+
+
+async def test_loop_exits_on_stop_event(monkeypatch, audit_test_env):
+    """SIGTERM-style ``stop_event.set()`` wakes the loop before tick."""
+    from mcp_proxy.db import init_db
+    from mcp_proxy.lifespan import audit_anchor_watcher as watcher
+
+    await init_db(audit_test_env)
+
+    # Make the TSA client a no-op so the first tick completes quickly.
+    monkeypatch.setattr(
+        watcher, "anchor_row_hash",
+        MagicMock(side_effect=lambda *a, **kw: pytest.fail(
+            "no chain head to anchor in this fixture"
+        )),
+    )
+
+    stop = asyncio.Event()
+
+    # Long tick (would block 60s without early-exit on stop_event).
+    loop_task = asyncio.create_task(
+        watcher.audit_anchor_watcher_loop(
+            org_id="orga",
+            stop_event=stop,
+            tsa_url="http://tsa.example/timestamp",
+            tick_seconds=60,
+        ),
+    )
+
+    # Yield once so the loop enters wait_for, then signal stop.
+    await asyncio.sleep(0.05)
+    stop.set()
+
+    # Loop must terminate within a couple of asyncio iterations after stop.
+    await asyncio.wait_for(loop_task, timeout=5.0)
+    assert loop_task.done()


### PR DESCRIPTION
## Summary

The Cullis audit log is hash-chained. The chain proves **consistency** — a tampered row breaks the hash linkage, the verifier catches it.

It does **not** prove **provenance**. An operator with DB write access could rewrite history end-to-end, recompute every `row_hash`, and `verify_audit_chain` would still pass because the chain has no witness outside the org.

This PR closes that gap. A lifespan watcher periodically asks a public RFC 3161 timestamp authority (default DigiCert) to sign a timestamp over the chain head's `row_hash`. The signed `TimeStampToken` is persisted in a new append-only `audit_chain_anchors` table. The offline verifier (`scripts/cullis-audit-verify.py`, which already understood the `T1|` token format) re-checks the `messageImprint` against the reconstructed `row_hash` and walks the TSA's cert chain.

**Forging the chain now requires forging the TSA's signature**. The audit trail is tamper-evident even against an operator colluding with the Cullis vendor.

## The differentiator

| Claim | OPA | agentgateway | MS AGT | Cullis (pre-this-PR) | Cullis (post) |
|---|---|---|---|---|---|
| Hash-chained audit | — | ✓ | ✓ | ✓ | ✓ |
| Append-only DB trigger | — | — | ? | ✓ (F-A-402) | ✓ |
| **Externally anchored timestamp** | — | — | — | — | **✓** |
| Verifiable offline with no vendor creds | — | ? | — | ✓ | ✓ |

The hash chain is necessary but not sufficient. A bank CISO reads the threat model and asks "what stops the operator from rewriting the log?" — without external anchoring, the honest answer is "trust on first read of the chain head". With it: "a CA the regulator already trusts signed the chain head's hash at GenTime ``t``; we cannot rewrite history without forging that signature."

## Architecture

```
audit_log row written
        │
        ▼
   chain_seq + row_hash
        │
        ▼ (every hour, leader-elected worker)
   audit_anchor_watcher
        │
        ├── POST sha256(row_hash) ──▶ http://timestamp.digicert.com
        │                              (RFC 3161 TimeStampReq)
        │
        ◀── TimeStampToken signed by DigiCert ────────
        │
        ▼
   INSERT audit_chain_anchors
   (anchored_at, org_id, chain_seq, row_hash, tsa_url,
    tsa_token = T1| + <raw token>)
        │
        ▼
   Audit export (NDJSON) rides anchors alongside entries
        │
        ▼
   cullis-audit-verify.py replays + re-checks messageImprint
   against reconstructed row_hash, walks TSA cert chain
```

## Components

- **`mcp_proxy/db_models.py`**: new `AuditChainAnchor` ORM class. `LargeBinary` for `tsa_token`.
- **`mcp_proxy/alembic/versions/0043_audit_chain_anchors.py`**: new table + `BEFORE UPDATE/DELETE` trigger (plpgsql for Postgres, `RAISE(ABORT)` for SQLite). Same integrity posture as `audit_log`.
- **`mcp_proxy/audit/tsa_client.py`**: synchronous RFC 3161 client. Builds with `rfc3161-client`, POSTs via `httpx`, parses with `asn1crypto.tsp` (more lenient than rfc3161-client's strict ASN.1 — DigiCert and others emit non-canonical SET ordering in `SignedData.certificates`). Re-checks `messageImprint` matches before returning, so a rogue TSA cannot poison the local table.
- **`mcp_proxy/lifespan/audit_anchor_watcher.py`**: leader-elected background loop. Bridges sync TSA call to asyncio via `to_thread`.
- **`mcp_proxy/main.py`**: lifespan registration next to the existing PKI watchers.
- **`mcp_proxy/config.py`**: 4 new settings (`audit_anchor_enabled` default `true`, `audit_anchor_tsa_url` default `http://timestamp.digicert.com`, `audit_anchor_interval_seconds` default `3600`, `audit_anchor_tsa_timeout_seconds` default `10`).
- **Compose env passthrough** in both `packaging/mastio-bundle/docker-compose.yml` and `deploy/compose/docker-compose.proxy.yml` so `proxy.env` overrides actually reach the container (memoria `feedback_bundle_dogfood_for_new_runtime_routes` — the bundle smoke caught this gap, fixed in the same commit).
- **5 unit tests** in `test/unit/test_audit_anchor_watcher.py`.
- **Doc page** at `/docs/operate/audit-anchoring`.
- **Deps**: `rfc3161-client` + `asn1crypto` in `requirements-proxy.txt`.

## Test plan

- [x] `pytest test/unit/` — **76 passed** (2.79s)
- [x] `npm run build` — **28 pages** (was 27)
- [x] **Live end-to-end**: built image `local-pr911`, booted bundle, seeded `audit_log` row (`chain_seq=99999`, `row_hash=deadbeef00000000...`), forced `_tick()` inside container, DigiCert TSA call succeeded, `audit_chain_anchors` row inserted with **token=6002B** (T1| prefix + 5999B raw RFC 3161 TimeStampToken). End-to-end chain: read head → TSA → persist → verifiable.
- [ ] Long-running watcher dogfood (operator-side, lasts hours-to-days). The watcher is on by default in the bundle, so any operator running the new image will start anchoring within `audit_anchor_interval_seconds` of boot.

## Out of scope

- **Bitcoin OP_RETURN anchoring** (OpenTimestamps integration) for paranoid operators. The TSA is already a third-party witness; chaining onto a public blockchain is incremental defence-in-depth.
- **Dashboard surface** for browsing anchors / downloading individual tokens. Today the anchors are visible via `audit_chain_anchors` table + the audit NDJSON export. UI lands in a separate PR.
- **NDJSON audit export endpoint** itself — `cullis-audit-verify.py` documents `GET /v1/admin/audit/export` but the endpoint is aspirational, tracked separately.
- **TSA cert chain pinning** in the runtime — today we trust whatever cert the TSA returns, the chain walk happens at verify time in the offline verifier. A future PR adds operator-side pinning if a customer needs it.