### PR TITLE
fix(audit): reject audit_tsa_backend=mock in production (F-A-406)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -1196,6 +1196,74 @@ def validate_config(settings: ProxySettings) -> None:
                 )
                 raise SystemExit(1)
 
+        # F-A-406 (audit 2026-05-20) — refuse mock-equivalent TSA anchor
+        # configuration in production. The legacy ``app/`` codebase shipped
+        # ``audit_tsa_backend="mock"`` whose ``MockTsaClient`` returned an
+        # opaque blob "trust-equivalent to the broker database itself" —
+        # production must declare intent (real RFC 3161 TSA, or anchoring
+        # disabled outright). The current ``mcp_proxy`` audit-anchor
+        # implementation is RFC 3161-only (no ``mock`` backend literal),
+        # so the operator-reachable mock-equivalent vector is pointing
+        # ``MCP_PROXY_AUDIT_ANCHOR_TSA_URL`` at a localhost / private-IP
+        # service the operator (or attacker on the LAN) controls. Such a
+        # TSA can emit signed tokens for any digest and the dispute-grade
+        # claim of the audit chain (CWE-1188) silently collapses.
+        #
+        # Pattern reference (feedback_h4_convergent_pattern_fallback_
+        # insecure_default): every new gate must have a validator in
+        # ``validate_config(production)`` that raises rather than
+        # silently accepting the insecure default. PR #830 was the first
+        # H4 sweep — F-A-406 is one of the recurrences that pattern did
+        # not yet cover.
+        if settings.audit_anchor_enabled:
+            tsa_url = (settings.audit_anchor_tsa_url or "").strip()
+            if not tsa_url:
+                _log.critical(
+                    "MCP_PROXY_AUDIT_ANCHOR_ENABLED=true but "
+                    "MCP_PROXY_AUDIT_ANCHOR_TSA_URL is empty in "
+                    "production. Set the URL of a real RFC 3161 TSA "
+                    "(e.g. http://timestamp.digicert.com) or disable "
+                    "anchoring with MCP_PROXY_AUDIT_ANCHOR_ENABLED=false "
+                    "(audit F-A-406)."
+                )
+                raise SystemExit(1)
+
+            try:
+                from mcp_proxy.utils.url_safety import (
+                    UnsafeUrlError,
+                    assert_safe_outbound_url,
+                )
+            except ImportError:
+                # Defensive: utils.url_safety has been a runtime dep
+                # since PR #831 (SSRF helper). Refuse to start rather
+                # than skip the gate silently if the import ever breaks.
+                _log.critical(
+                    "mcp_proxy.utils.url_safety unavailable — cannot "
+                    "validate MCP_PROXY_AUDIT_ANCHOR_TSA_URL safety "
+                    "(audit F-A-406)."
+                )
+                raise SystemExit(1)
+
+            try:
+                assert_safe_outbound_url(tsa_url, allow_private=False)
+            except UnsafeUrlError as exc:
+                _log.critical(
+                    "MCP_PROXY_AUDIT_ANCHOR_TSA_URL=%r is not permitted "
+                    "in production: %s. A TSA on a private / loopback "
+                    "address is trust-equivalent to the broker database "
+                    "itself (mock-equivalent backend, audit F-A-406) — "
+                    "set the URL of a real public RFC 3161 TSA (e.g. "
+                    "http://timestamp.digicert.com), allowlist the "
+                    "internal FQDN explicitly via "
+                    "MCP_PROXY_INTERNAL_HOST_ALLOWLIST if you run a "
+                    "qualified TSP on a private network, or disable "
+                    "anchoring with "
+                    "MCP_PROXY_AUDIT_ANCHOR_ENABLED=false.",
+                    tsa_url,
+                    exc,
+                )
+                raise SystemExit(1)
+
         # Audit F-A-404 — background flush retry exhaustion must surface.
         # ``audit_chain_background_fail_deny`` and
         # ``audit_chain_background_fail_open`` are mutually exclusive: the

--- a/test/unit/test_audit_anchor_tsa_url_validation.py
+++ b/test/unit/test_audit_anchor_tsa_url_validation.py
@@ -1,0 +1,208 @@
+"""Production validator rejects mock-equivalent TSA anchor configurations.
+
+Audit finding F-A-406 (2026-05-20) — the legacy ``app/config.py`` shipped
+``audit_tsa_backend="mock"`` whose ``MockTsaClient`` returned an opaque
+blob that was operationally "trust-equivalent to the broker database
+itself". Production must declare intent (real RFC 3161 TSA or anchoring
+disabled outright).
+
+The current ``mcp_proxy`` audit-anchor implementation is RFC 3161-only,
+so the operator-reachable mock-equivalent vector is pointing
+``MCP_PROXY_AUDIT_ANCHOR_TSA_URL`` at a localhost / private-IP service
+the operator (or an attacker on the LAN) controls. ``validate_config``
+must refuse such configurations in production with a critical log and
+``SystemExit(1)`` so the boot fails loudly rather than silently
+collapsing the dispute-grade claim.
+
+These tests pin the H4 sweep recurrence: production + private-IP TSA →
+raise, production + real TSA URL → ok, non-production + private TSA → ok
+(dev / sandbox stacks may run a local mock TSA on purpose).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+_ADMIN_OK = "test-admin-secret-not-the-default"
+_DB_ENC_OK = "0" * 64
+_DASHBOARD_KEY_OK = "1" * 64
+_PDP_HMAC_OK = "2" * 64
+_VAULT_ADDR_OK = "https://vault.test.example:8200"
+_VAULT_TOKEN_OK = "s.test-token"
+_REAL_TSA_URL = "http://timestamp.digicert.com"
+_PRIVATE_TSA_URL = "http://127.0.0.1:8080/tsr"
+
+
+def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the minimum production env vars so ``validate_config`` reaches
+    the F-A-406 gate. Each individual H4 gate refuses earlier without
+    these — the test is targeted at the audit-anchor URL gate alone.
+    """
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", _DASHBOARD_KEY_OK)
+    monkeypatch.setenv("MCP_PROXY_SECRET_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", _VAULT_ADDR_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", _VAULT_TOKEN_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_VERIFY_TLS", "true")
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _DB_ENC_OK)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "false")
+
+
+def _fresh_settings():
+    """Return a fresh ``ProxySettings`` snapshot bypassing the lru_cache.
+
+    ``get_settings`` is cached so a previous test (or the import-time
+    boot) would otherwise pin a stale snapshot for the lifetime of the
+    process.
+    """
+    from mcp_proxy.config import ProxySettings, get_settings
+
+    get_settings.cache_clear()
+    return ProxySettings()
+
+
+@pytest.fixture(autouse=True)
+def _require_webauthn(monkeypatch: pytest.MonkeyPatch):
+    """Skip the test silently if the optional webauthn extra isn't
+    installed in the runner — ``validate_config`` refuses to start with
+    ``WEBAUTHN_ENFORCEMENT=required`` when the library is missing, which
+    would mask the F-A-406 gate under test.
+    """
+    pytest.importorskip("webauthn")
+    yield
+
+
+def test_production_rejects_loopback_tsa_url(monkeypatch: pytest.MonkeyPatch):
+    """Production + loopback TSA URL → SystemExit(1) with F-A-406 in log.
+
+    A loopback / private-IP TSA is the operator-reachable
+    mock-equivalent vector: the broker writes signed-looking tokens
+    whose signer the operator (or an attacker on the same host)
+    controls outright. The dispute-grade claim of the audit chain
+    collapses silently. ``validate_config`` must refuse to start.
+    """
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_TSA_URL", _PRIVATE_TSA_URL)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_production_rejects_empty_tsa_url_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Production + enabled anchoring + empty URL → SystemExit(1).
+
+    The default ``MCP_PROXY_AUDIT_ANCHOR_TSA_URL`` is the real DigiCert
+    public TSA, so an empty value is an explicit operator opt-out that
+    contradicts ``AUDIT_ANCHOR_ENABLED=true``. Surface the contradiction
+    at startup rather than booting clean with no anchoring target.
+    """
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_TSA_URL", "")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_production_accepts_real_public_tsa_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Production + DigiCert public TSA URL → no raise.
+
+    The default ``http://timestamp.digicert.com`` resolves to a public
+    IP and is the documented production target. The gate must not fire
+    on the happy path or the bundle compose would fail to boot.
+    """
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_TSA_URL", _REAL_TSA_URL)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_production_accepts_anchoring_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Production + ``AUDIT_ANCHOR_ENABLED=false`` → URL irrelevant.
+
+    Air-gapped deploys disable anchoring outright; the gate must not
+    inspect the URL in that case (operators may legitimately leave the
+    URL pointing anywhere — even a private placeholder — when the
+    feature is off).
+    """
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "false")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_TSA_URL", _PRIVATE_TSA_URL)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_development_accepts_loopback_tsa_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-production + loopback TSA URL → no raise.
+
+    Dev / sandbox stacks may run a local mock TSA on purpose (offline
+    end-to-end tests, docker compose with a fake TSA service). The H4
+    pattern only refuses in production — dev keeps the convenience.
+    """
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_TSA_URL", _PRIVATE_TSA_URL)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_production_rejects_private_ip_literal_tsa(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Production + RFC 1918 private-IP literal TSA URL → SystemExit(1).
+
+    Covers the alternate vector where the operator points the TSA URL
+    at a private network range (192.168.0.0/16 / 10.0.0.0/8 / 172.16/12)
+    instead of literal loopback — the trust model is the same: an
+    attacker on the same LAN can spin up a fake TSA on that address and
+    fabricate signed-looking tokens for any digest.
+    """
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_ANCHOR_ENABLED", "true")
+    monkeypatch.setenv(
+        "MCP_PROXY_AUDIT_ANCHOR_TSA_URL", "http://192.168.42.7/tsr",
+    )
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary

Closes finding **F-A-406** (HIGH) from the 2026-05-20 Cullis full re-audit
(`imp/audits/2026-05-20/findings/track-a/F-A-406.md`).

The legacy `app/config.py` shipped `audit_tsa_backend="mock"` whose
`MockTsaClient` returned an opaque blob explicitly documented as
"trust-equivalent to the broker database itself". A production deploy
with `AUDIT_TSA_ENABLED=true` and the default `AUDIT_TSA_BACKEND=mock`
booted clean and silently collapsed the dispute-grade claim of the
audit chain (CWE-1188).

The current `mcp_proxy` audit-anchor implementation is RFC 3161-only
(no `mock` backend literal in the code path), so the operator-reachable
mock-equivalent vector is pointing `MCP_PROXY_AUDIT_ANCHOR_TSA_URL` at
a localhost / private-IP service the operator (or an attacker on the
same LAN) controls. Such a TSA can emit signed-looking tokens for any
digest and the dispute-grade claim collapses just the same.

`validate_config` now refuses in production when
`MCP_PROXY_AUDIT_ANCHOR_ENABLED=true` AND the configured TSA URL is:

- empty (operator enabled the feature without a target), or
- a loopback / private-IP / link-local / reserved address (mock-
  equivalent), or
- otherwise unsafe per the shared `assert_safe_outbound_url` SSRF
  helper (PR #831).

Operators running a qualified TSP on a private network (eIDAS
qualified-trust-service case) can opt the internal FQDN into the
shared SSRF allowlist via `MCP_PROXY_INTERNAL_HOST_ALLOWLIST`. Non-
production envs keep the convenience of a local mock TSA for sandbox
/ docker compose end-to-end tests.

### H4 pattern context

Closes one of the recurring H4 fail-open insecure-default findings.
PR #830 was the first H4 sweep (admin secret, BROKER_JWKS_URL,
KMS_BACKEND, etc.); F-A-406 is one of the recurrences that sweep did
not yet cover. Reference: `feedback_h4_convergent_pattern_fallback_
insecure_default` — every new gate must surface as `raise SystemExit(1)`
in `validate_config(production)` rather than silently boot with the
insecure default.

## Test plan

- [x] `pytest test/unit/test_audit_anchor_tsa_url_validation.py -xvs` (6 new tests)
  - production + loopback TSA URL -> SystemExit(1)
  - production + empty TSA URL when enabled -> SystemExit(1)
  - production + RFC 1918 private-IP literal -> SystemExit(1)
  - production + DigiCert public TSA -> no raise (happy path / bundle default)
  - production + `AUDIT_ANCHOR_ENABLED=false` -> URL irrelevant, no raise
  - development + loopback TSA URL -> no raise (dev opt-in mock)
- [x] `pytest test/unit/` -> 82 passed
- [ ] Bundle dogfood (`packaging/mastio-bundle/deploy.sh`) with
      `MCP_PROXY_ENVIRONMENT=production` + a local mock TSA URL ->
      container must fail boot with the F-A-406 critical log line.

## Out of scope / gaps this PR does NOT close

- **F-A-405 trust anchor**: the audit dossier's recommendation #3 says
  "after F-A-405 lands, also gate on the presence of an operator-
  configured trust anchor PEM (`audit_tsa_trust_anchor_path`)". The
  `app/` version of F-A-405 shipped in PR #835; the `mcp_proxy` port
  (and the matching `audit_tsa_trust_anchor_path` setting) is still
  pending and is not added here.
- **Cleartext-HTTP TSA refuse**: recommendation #2 ("refuse
  `audit_tsa_url=http://...` cleartext in production") is intentionally
  not implemented because the default `http://timestamp.digicert.com`
  IS the documented production target (RFC 3161 over plain HTTP is
  protocol-compliant — the token is CMS-signed). Worth a separate
  discussion if operators want HTTPS-only TSAs.
- **Other H4 recurrences**: F-A-406 closes one of the H4 recurrences
  the 2026-05-20 audit catalogued. Other entries in that pattern bucket
  are tracked under their own finding IDs and remain open.
- **Threat-model doc update** (recommendation #4): the
  `docs/operate/security/threat-model.md` update to clarify the
  anchoring threat model is a separate docs PR.

Audit ref: `imp/audits/2026-05-20/findings/track-a/F-A-406.md`