### PR TITLE
docs(bundle): document MCP_PROXY_DATABASE_URL legacy contract in proxy.env.example

### DIFF
--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -165,6 +165,13 @@ MASTIO_NGINX_CERTS_DIR=./nginx-certs
 #
 #PROXY_DB_URL=postgresql+asyncpg://cullis:secret@db.internal:5432/cullis_mastio
 
+# Legacy contract: ``MCP_PROXY_DATABASE_URL`` is the original env var
+# the Mastio reads at boot. ``PROXY_DB_URL`` (no prefix) takes
+# precedence when set (ADR-001 Phase 1.3) so Helm and the smoke can
+# point at managed Postgres without renaming. Set ``MCP_PROXY_DATABASE_URL``
+# directly only if you have legacy automation that already targets it.
+#MCP_PROXY_DATABASE_URL=sqlite+aiosqlite:////var/lib/mastio/data/mcp_proxy.db
+
 # Bundled Postgres overlay credentials — only honoured when running
 # ``./deploy.sh --db postgres`` (the overlay is otherwise inactive).
 # Mint a strong random via ``./generate-proxy-env.sh --db postgres`` or


### PR DESCRIPTION
## Summary

The bundle's \`proxy.env.example\` documented \`PROXY_DB_URL\` (the ADR-001 Phase 1.3 override) but not the original \`MCP_PROXY_DATABASE_URL\` that the Mastio reads at boot (\`mcp_proxy/config.py:192\`). Operators with legacy automation targeting \`MCP_PROXY_DATABASE_URL\` had no template hint.

Adds a commented \`MCP_PROXY_DATABASE_URL=sqlite+aiosqlite:////var/lib/mastio/data/mcp_proxy.db\` line plus an explainer block calling out the precedence (\`config.py:843\` applies \`PROXY_DB_URL\` over \`MCP_PROXY_DATABASE_URL\` when both are set).

## Test plan

- [x] enterprise contract test \`tests/test_bundle_db_swap_guard.py::test_proxy_env_example_documents_database_url\` now PASSES against the updated template
- [x] no functional change to bundle behavior — pure documentation