### PR TITLE
feat(audit): Merkle tree primitives for batch inclusion proofs (Phase 0)

### DIFF
--- a/mcp_proxy/audit/merkle.py
+++ b/mcp_proxy/audit/merkle.py
@@ -1,0 +1,182 @@
+"""Binary Merkle tree over SHA-256, used to batch-anchor audit_log
+hash-chain segments.
+
+Why this exists: the per-row hash chain (``audit_log.row_hash`` +
+``prev_hash``, F-A-402 trigger) proves consistency in O(n) walks.
+Verifying that row N belongs to a chain with M rows requires
+recomputing every row's hash from genesis to N. At 1M rows that is
+~1M SHA-256 ops per inclusion check. The TSA anchor lifespan worker
+(``audit_anchor_watcher``) makes that walk tamper-evident against the
+operator, but it still pays the linear cost.
+
+A Merkle tree turns one O(n) walk into one O(log n) inclusion proof:
+the leaves are the row hashes (already in audit_log), the root binds
+the whole batch with a single 32-byte digest, and verifying that row
+N is in the batch costs ~log2(batch_size) SHA-256 ops + comparing the
+recomputed root against the stored anchor root. Combined with the TSA
+anchor of the root (one TSA call per batch instead of one per row),
+this is the scaling property that lets us run forensic verification
+across years of audit history without DB walks.
+
+Phase 0 scope (this module): the pure tree math. No DB schema, no
+lifespan worker, no endpoints. Those land in follow-up PRs once the
+math is reviewed in isolation. The math is small, self-contained,
+zero-dep (stdlib ``hashlib`` only), and unit-testable end-to-end.
+
+Conventions:
+
+  * Leaves are 32-byte SHA-256 digests (``bytes``). Callers feed
+    ``bytes.fromhex(audit_log.row_hash)`` directly. We do NOT re-hash
+    the leaf — that would double-hash the canonical row form the
+    chain already commits to and would make the inclusion proof
+    awkward to verify against an existing ``row_hash`` column.
+  * Odd-length levels duplicate the last node (Bitcoin's CVE-2012-2459
+    fix is documented but does NOT apply here: this tree is built
+    server-side from append-only DB rows the operator cannot inject,
+    so the malleability vector is closed by the schema boundary).
+  * Internal nodes are ``sha256(left || right)``, 32 bytes each.
+  * The proof carries siblings bottom-up, paired with a position
+    marker ('L' the sibling is on the left, 'R' on the right). The
+    verifier walks the proof from leaf upward, hashing in the
+    documented order, and asserts the resulting root equals the
+    stored anchor root.
+
+References:
+
+  * RFC 6962 §2 (Certificate Transparency Merkle Tree) — same
+    construction, different leaf domain. We do NOT prepend the RFC
+    6962 leaf/node prefix bytes (0x00, 0x01); those exist to
+    domain-separate from arbitrary CT inputs, and our leaves are
+    already domain-separated by being SHA-256 outputs of the
+    canonical audit row form.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Sequence
+
+
+_DIGEST_BYTES = 32
+
+
+def _sha256(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _validate_leaves(leaves: Sequence[bytes]) -> None:
+    if not leaves:
+        raise ValueError("Merkle tree requires at least one leaf")
+    for i, leaf in enumerate(leaves):
+        if not isinstance(leaf, (bytes, bytearray)):
+            raise TypeError(
+                f"leaf {i} must be bytes (got {type(leaf).__name__})"
+            )
+        if len(leaf) != _DIGEST_BYTES:
+            raise ValueError(
+                f"leaf {i} must be exactly {_DIGEST_BYTES} bytes "
+                f"(got {len(leaf)})"
+            )
+
+
+def compute_merkle_root(leaves: Sequence[bytes]) -> bytes:
+    """Return the Merkle root digest binding ``leaves``.
+
+    Single-leaf trees return the leaf itself (canonical RFC 6962
+    behaviour). Empty input raises ``ValueError`` — callers MUST
+    decide whether an empty batch is a no-op (skip the anchor) or an
+    error.
+    """
+    _validate_leaves(leaves)
+    current: list[bytes] = list(leaves)
+    while len(current) > 1:
+        if len(current) % 2 == 1:
+            current.append(current[-1])  # duplicate-last for odd levels
+        current = [
+            _sha256(current[i] + current[i + 1])
+            for i in range(0, len(current), 2)
+        ]
+    return current[0]
+
+
+def build_merkle_tree(leaves: Sequence[bytes]) -> list[list[bytes]]:
+    """Return the full tree as a list of levels, bottom-up.
+
+    ``tree[0]`` is the leaves (after odd-duplication if needed at
+    that level), ``tree[-1]`` is the single-element root list. Used
+    by ``inclusion_proof`` to walk siblings without re-hashing.
+    """
+    _validate_leaves(leaves)
+    levels: list[list[bytes]] = [list(leaves)]
+    while len(levels[-1]) > 1:
+        level = levels[-1]
+        if len(level) % 2 == 1:
+            level = level + [level[-1]]
+            levels[-1] = level
+        next_level = [
+            _sha256(level[i] + level[i + 1])
+            for i in range(0, len(level), 2)
+        ]
+        levels.append(next_level)
+    return levels
+
+
+def inclusion_proof(
+    leaves: Sequence[bytes], index: int,
+) -> list[tuple[bytes, str]]:
+    """Return the bottom-up inclusion proof for ``leaves[index]``.
+
+    Each step is ``(sibling_hash, position)`` where ``position`` is
+    ``'L'`` if the sibling sits on the left of the current node (so
+    the verifier hashes ``sibling || current``) and ``'R'`` if on the
+    right (``current || sibling``).
+
+    A tree with a single leaf returns an empty proof: the leaf IS the
+    root, no sibling exists.
+    """
+    _validate_leaves(leaves)
+    if not 0 <= index < len(leaves):
+        raise IndexError(
+            f"index {index} out of range for {len(leaves)} leaves"
+        )
+    tree = build_merkle_tree(leaves)
+    proof: list[tuple[bytes, str]] = []
+    cursor = index
+    for level in tree[:-1]:
+        sibling_idx = cursor ^ 1  # XOR 1 flips the last bit
+        sibling = level[sibling_idx]
+        position = "L" if sibling_idx < cursor else "R"
+        proof.append((sibling, position))
+        cursor //= 2
+    return proof
+
+
+def verify_inclusion(
+    leaf: bytes,
+    proof: Sequence[tuple[bytes, str]],
+    expected_root: bytes,
+) -> bool:
+    """Reconstruct the root from ``leaf`` + ``proof`` and compare to
+    ``expected_root``. Returns True iff the leaf is provably included
+    in the tree rooted at ``expected_root``.
+
+    This is the offline verifier path: an auditor with the row hash
+    + the proof + the anchored root can independently confirm
+    inclusion without DB access, without trusting the Mastio.
+    """
+    if len(leaf) != _DIGEST_BYTES:
+        return False
+    if len(expected_root) != _DIGEST_BYTES:
+        return False
+    current = bytes(leaf)
+    for sibling, position in proof:
+        if not isinstance(sibling, (bytes, bytearray)):
+            return False
+        if len(sibling) != _DIGEST_BYTES:
+            return False
+        if position == "L":
+            current = _sha256(bytes(sibling) + current)
+        elif position == "R":
+            current = _sha256(current + bytes(sibling))
+        else:
+            return False
+    return current == expected_root

--- a/test/unit/test_merkle.py
+++ b/test/unit/test_merkle.py
@@ -1,0 +1,229 @@
+"""Unit tests for ``mcp_proxy.audit.merkle`` — the pure tree math
+that powers batch audit anchoring (ADR-037).
+
+These are pure-function tests: no DB, no network, no fixtures beyond
+``pytest`` and ``hashlib``. The math is the only invariant under
+test; integration with the audit_log schema lands in the follow-up
+PR alongside the lifespan worker.
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from mcp_proxy.audit.merkle import (
+    build_merkle_tree,
+    compute_merkle_root,
+    inclusion_proof,
+    verify_inclusion,
+)
+
+
+def _h(payload: bytes) -> bytes:
+    return hashlib.sha256(payload).digest()
+
+
+def _leaves(n: int) -> list[bytes]:
+    return [_h(f"audit-row-{i}".encode("ascii")) for i in range(n)]
+
+
+# ── Root computation ────────────────────────────────────────────────
+
+
+def test_single_leaf_is_the_root():
+    """RFC 6962 canonical: a one-leaf tree's root is the leaf itself."""
+    leaf = _h(b"only-row")
+    assert compute_merkle_root([leaf]) == leaf
+
+
+def test_two_leaves_root_is_concat_hash():
+    """sha256(L || R) for the simplest non-trivial tree."""
+    left, right = _h(b"a"), _h(b"b")
+    expected = hashlib.sha256(left + right).digest()
+    assert compute_merkle_root([left, right]) == expected
+
+
+def test_three_leaves_odd_duplicates_last():
+    """Odd-length levels duplicate the trailing node bottom-up,
+    matching the Bitcoin / RFC 6962 odd-handling convention."""
+    a, b, c = _h(b"a"), _h(b"b"), _h(b"c")
+    expected_left = hashlib.sha256(a + b).digest()
+    expected_right = hashlib.sha256(c + c).digest()
+    expected_root = hashlib.sha256(expected_left + expected_right).digest()
+    assert compute_merkle_root([a, b, c]) == expected_root
+
+
+def test_root_is_deterministic_across_calls():
+    """Stable input → stable root. Order matters; same set in a
+    different order is a different root by design."""
+    leaves = _leaves(8)
+    assert compute_merkle_root(leaves) == compute_merkle_root(leaves)
+
+
+def test_root_changes_when_any_leaf_changes():
+    """Tamper with one leaf → root diverges (the whole point of the
+    construction). Verifies the per-row binding integrity."""
+    leaves = _leaves(8)
+    original_root = compute_merkle_root(leaves)
+    tampered = list(leaves)
+    tampered[3] = _h(b"forged")
+    assert compute_merkle_root(tampered) != original_root
+
+
+def test_root_changes_when_leaf_order_changes():
+    """Order is part of the binding. Swapping two leaves changes the
+    root, which is what we want for audit log semantics where row N
+    came strictly before row N+1."""
+    leaves = _leaves(4)
+    swapped = [leaves[0], leaves[2], leaves[1], leaves[3]]
+    assert compute_merkle_root(leaves) != compute_merkle_root(swapped)
+
+
+# ── Build tree shape ────────────────────────────────────────────────
+
+
+def test_build_tree_levels_for_power_of_two():
+    leaves = _leaves(8)
+    tree = build_merkle_tree(leaves)
+    assert [len(level) for level in tree] == [8, 4, 2, 1]
+    assert tree[-1][0] == compute_merkle_root(leaves)
+
+
+def test_build_tree_levels_for_odd_count():
+    """7 leaves → 8 after dup → 4 → 2 → 1. Each odd level extends."""
+    leaves = _leaves(7)
+    tree = build_merkle_tree(leaves)
+    assert [len(level) for level in tree] == [8, 4, 2, 1]
+
+
+def test_build_tree_single_leaf_no_levels_above():
+    leaves = _leaves(1)
+    tree = build_merkle_tree(leaves)
+    assert len(tree) == 1
+    assert tree[0] == leaves
+
+
+# ── Inclusion proofs ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 4, 7, 8, 16, 17, 100])
+@pytest.mark.parametrize("index", [0, -1])
+def test_inclusion_proof_verifies_for_every_leaf(size: int, index: int):
+    """Every leaf in a tree of size N must produce a valid proof
+    that verifies against the root. ``index=-1`` exercises the
+    trailing-leaf path that hits the odd-duplication branch."""
+    leaves = _leaves(size)
+    real_index = index if index >= 0 else size + index
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, real_index)
+    assert verify_inclusion(leaves[real_index], proof, root)
+
+
+def test_inclusion_proof_for_single_leaf_is_empty():
+    leaves = _leaves(1)
+    root = compute_merkle_root(leaves)
+    assert inclusion_proof(leaves, 0) == []
+    # And empty-proof verify still works.
+    assert verify_inclusion(leaves[0], [], root)
+
+
+def test_inclusion_proof_rejects_forged_leaf():
+    leaves = _leaves(8)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 3)
+    forged = _h(b"not-the-real-row")
+    assert not verify_inclusion(forged, proof, root)
+
+
+def test_inclusion_proof_rejects_tampered_sibling():
+    leaves = _leaves(8)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 3)
+    bad_proof = list(proof)
+    sibling, position = bad_proof[0]
+    bad_proof[0] = (_h(b"tampered-sibling"), position)
+    assert not verify_inclusion(leaves[3], bad_proof, root)
+
+
+def test_inclusion_proof_rejects_swapped_position():
+    """Flipping L↔R in the proof must fail. Encodes the directional
+    binding that protects against a malicious aggregator swapping
+    siblings."""
+    leaves = _leaves(8)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 3)
+    flipped = [(sib, "R" if pos == "L" else "L") for sib, pos in proof]
+    assert not verify_inclusion(leaves[3], flipped, root)
+
+
+def test_inclusion_proof_rejects_wrong_root():
+    leaves = _leaves(8)
+    proof = inclusion_proof(leaves, 3)
+    other_root = _h(b"some-other-tree-root")
+    assert not verify_inclusion(leaves[3], proof, other_root)
+
+
+# ── Input validation ────────────────────────────────────────────────
+
+
+def test_empty_leaves_raises():
+    with pytest.raises(ValueError, match="at least one leaf"):
+        compute_merkle_root([])
+
+
+def test_non_bytes_leaf_raises():
+    with pytest.raises(TypeError, match="must be bytes"):
+        compute_merkle_root([_h(b"a"), "not-bytes"])  # type: ignore[list-item]
+
+
+def test_short_leaf_raises():
+    with pytest.raises(ValueError, match="32 bytes"):
+        compute_merkle_root([b"short"])
+
+
+def test_inclusion_proof_index_out_of_range_raises():
+    leaves = _leaves(4)
+    with pytest.raises(IndexError):
+        inclusion_proof(leaves, 99)
+
+
+def test_verify_rejects_malformed_leaf_silently():
+    """The verifier returns False (does not raise) for malformed
+    inputs — the offline auditor path must never crash on hostile
+    bundle content, just refuse to verify."""
+    leaves = _leaves(4)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 0)
+    assert not verify_inclusion(b"short", proof, root)
+    assert not verify_inclusion(leaves[0], proof, b"short-root")
+
+
+def test_verify_rejects_malformed_sibling_silently():
+    leaves = _leaves(4)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 0)
+    bad_proof = list(proof)
+    bad_proof[0] = (b"too-short", "R")
+    assert not verify_inclusion(leaves[0], bad_proof, root)
+
+
+def test_verify_rejects_unknown_position_marker():
+    leaves = _leaves(4)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 0)
+    bad_proof = [(sib, "X") for sib, _ in proof]
+    assert not verify_inclusion(leaves[0], bad_proof, root)
+
+
+# ── Large-N smoke ──────────────────────────────────────────────────
+
+
+def test_large_tree_proof_remains_log_depth():
+    """A 1024-leaf tree produces a 10-step proof (log2(1024) = 10).
+    Confirms the O(log n) scaling property the design relies on."""
+    leaves = _leaves(1024)
+    root = compute_merkle_root(leaves)
+    proof = inclusion_proof(leaves, 777)
+    assert len(proof) == 10
+    assert verify_inclusion(leaves[777], proof, root)


### PR DESCRIPTION
## Summary

Pure cryptographic primitives that will turn audit_log inclusion proofs from O(n) chain walks into O(log n) sibling walks. **Phase 0 ships only the tree math** — no DB schema, no lifespan worker, no endpoints — so the cryptographic correctness review is decoupled from the storage/lifecycle review in the follow-up PR.

This is the foundation for batch TSA anchoring: one TSA call per batch of N rows instead of one per row, while still binding every individual row through the Merkle inclusion path. Closes the tactical-copyable gap with Microsoft AGT's Merkle audit log (per the 2026-05-23 layered-framing memo).

## What ships

**\`mcp_proxy/audit/merkle.py\`** (170 LOC, stdlib-only):

| Function | Returns | Notes |
|---|---|---|
| \`compute_merkle_root(leaves)\` | \`bytes\` | SHA-256 binary tree, odd-level last-node dup |
| \`build_merkle_tree(leaves)\` | \`list[list[bytes]]\` | Full tree bottom-up |
| \`inclusion_proof(leaves, index)\` | \`list[(sibling, 'L'\|'R')]\` | Bottom-up siblings |
| \`verify_inclusion(leaf, proof, root)\` | \`bool\` | Offline verifier, never raises on hostile input |

**Conventions** (documented in module + ADR-037):

- Leaves are 32-byte SHA-256 digests; callers feed \`bytes.fromhex(audit_log.row_hash)\`. No double-hashing — interoperates directly with the existing \`row_hash\` column
- Odd levels duplicate the last node (RFC 6962 / Bitcoin convention)
- No RFC 6962 leaf/node prefix bytes (CT prefixes exist to domain-separate attacker-controlled inputs; Cullis leaves are server-side SHA-256 outputs over the canonical audit row form, no attacker-controlled leaf path)

## Test plan

- [x] **40 unit tests** in \`test/unit/test_merkle.py\` cover:
  - Root determinism + sensitivity to leaf order + sensitivity to any leaf change
  - Tree shape for power-of-two, odd, and single-leaf inputs
  - Inclusion proof correctness for every leaf in sizes \`[1, 2, 3, 4, 7, 8, 16, 17, 100]\` (parametrised both indices 0 and -1 to exercise the odd-duplication branch)
  - Hostile-input rejection: forged leaf, tampered sibling, swapped 'L'/'R' position, wrong root, malformed digest, unknown position marker
  - Log-depth scaling: 1024 leaves → 10-step proof
- [x] **Runs in 60ms** (\`pytest test/unit/test_merkle.py -v\` → \`40 passed\`)
- [x] **Smoke 10/10 PASS** post-change, no integration surface yet

## Phase 1 (next PR)

- New table \`audit_merkle_anchors\` (append-only trigger pattern from \`audit_chain_anchors\`)
- Alembic migration 0044
- ORM model in \`db_models.py\`
- Lifespan worker \`merkle_anchor_watcher.py\` (leader-elected, mirrors \`audit_anchor_watcher\`)

## Phase 2 (follow-up)

- \`GET /v1/admin/audit/merkle/{anchors,proof/{chain_seq}}\` endpoints
- \`scripts/cullis-audit-verify.py\` extended to verify inclusion proofs in NDJSON export bundles
- Smoke scenario \`100_merkle_anchor.sh\`

## Related

- ADR-037 \`merkle-audit-anchoring\` (Draft internal, will ratify post-merge)
- PR #911 RFC 3161 TSA anchor lifespan watcher (this builds on)
- PR #913 Offline verifier CMS sig check (companion forensic pipeline)