### PR TITLE
feat(audit): Merkle batch anchor watcher + table (ADR-037 Phase 1)

### DIFF
--- a/mcp_proxy/alembic/versions/0044_audit_merkle_anchors.py
+++ b/mcp_proxy/alembic/versions/0044_audit_merkle_anchors.py
@@ -1,0 +1,143 @@
+"""Merkle batch anchors — append-only Merkle roots over audit_log
+chain_seq batches (ADR-037 Phase 1).
+
+Revision ID: 0044_audit_merkle_anchors
+Revises: 0043_audit_chain_anchors
+Create Date: 2026-05-24 14:00:00.000000
+
+Introduces ``audit_merkle_anchors``, the storage side for Phase 1 of
+the Merkle audit anchoring design. Each row binds a contiguous batch
+of audit_log chain_seq values to a single Merkle root, with the
+optional TSA TimeStampToken over the root for tamper-evidence
+against the operator.
+
+The pure tree math lives in ``mcp_proxy.audit.merkle`` (Phase 0,
+PR #918). This migration is the persistence layer; the lifespan
+watcher (this PR) reads audit_log, computes the root, and writes
+one row here per batch.
+
+Same append-only trigger pattern as audit_log (F-A-402) and
+audit_chain_anchors (PR #911): rows are written once, never
+updated, never deleted. An operator who tampers with audit_log to
+forge history would also need to forge the Merkle root match in
+the corresponding anchor row to evade the offline verifier (Phase 2
+follow-up).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0044_audit_merkle_anchors"
+down_revision: Union[str, Sequence[str], None] = "0043_audit_chain_anchors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "audit_merkle_anchors"
+
+
+_PG_TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION audit_merkle_anchors_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION
+        'audit_merkle_anchors is append-only: % is not permitted',
+        TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_PG_TRIGGER = """
+CREATE TRIGGER audit_merkle_anchors_no_update_or_delete
+BEFORE UPDATE OR DELETE ON audit_merkle_anchors
+FOR EACH ROW EXECUTE FUNCTION audit_merkle_anchors_no_mutate();
+"""
+
+_SQLITE_TRIGGER_UPDATE = """
+CREATE TRIGGER IF NOT EXISTS audit_merkle_anchors_no_update
+BEFORE UPDATE ON audit_merkle_anchors
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_merkle_anchors is append-only: UPDATE not permitted');
+END;
+"""
+
+_SQLITE_TRIGGER_DELETE = """
+CREATE TRIGGER IF NOT EXISTS audit_merkle_anchors_no_delete
+BEFORE DELETE ON audit_merkle_anchors
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'audit_merkle_anchors is append-only: DELETE not permitted');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return  # Idempotent — re-running the chain finds it.
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        # Range of audit_log.chain_seq covered by this anchor, inclusive
+        # on both ends. The watcher walks forward by starting the next
+        # batch at chain_seq_end + 1.
+        sa.Column("chain_seq_start", sa.Integer(), nullable=False),
+        sa.Column("chain_seq_end", sa.Integer(), nullable=False),
+        sa.Column("leaf_count", sa.Integer(), nullable=False),
+        # 64 lowercase hex chars = SHA-256 binary tree root over the
+        # row_hash bytes of every audit_log row in [start, end].
+        sa.Column("merkle_root", sa.Text(), nullable=False),
+        # Optional RFC 3161 TSA TimeStampToken over the merkle_root.
+        # NULL when the worker ran with TSA anchoring disabled or when
+        # the TSA call failed at batch time (the local batch is still
+        # written; the TSA retry is "next batch", not "stop the loop").
+        sa.Column("tsa_url", sa.Text(), nullable=True),
+        sa.Column("tsa_token", sa.LargeBinary(), nullable=True),
+    )
+    # Lookup the most recent anchor for an org (the watcher's hot path).
+    op.create_index(
+        "idx_audit_merkle_anchors_org_chain_seq_end",
+        _TABLE, ["org_id", "chain_seq_end"],
+    )
+    # Lookup the anchor covering a specific chain_seq (the offline
+    # verifier's hot path: "which Merkle anchor includes chain_seq N?").
+    op.create_index(
+        "idx_audit_merkle_anchors_chain_seq_start",
+        _TABLE, ["chain_seq_start"],
+    )
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(_PG_TRIGGER_FN)
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_merkle_anchors_no_update_or_delete "
+            "ON audit_merkle_anchors"
+        )
+        op.execute(_PG_TRIGGER)
+    elif dialect == "sqlite":
+        op.execute(_SQLITE_TRIGGER_UPDATE)
+        op.execute(_SQLITE_TRIGGER_DELETE)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(
+            "DROP TRIGGER IF EXISTS audit_merkle_anchors_no_update_or_delete "
+            "ON audit_merkle_anchors"
+        )
+        op.execute("DROP FUNCTION IF EXISTS audit_merkle_anchors_no_mutate")
+    elif dialect == "sqlite":
+        op.execute("DROP TRIGGER IF EXISTS audit_merkle_anchors_no_update")
+        op.execute("DROP TRIGGER IF EXISTS audit_merkle_anchors_no_delete")
+    op.drop_index("idx_audit_merkle_anchors_chain_seq_start", _TABLE)
+    op.drop_index("idx_audit_merkle_anchors_org_chain_seq_end", _TABLE)
+    op.drop_table(_TABLE)

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -248,6 +248,42 @@ class ProxySettings(BaseSettings):
     audit_anchor_interval_seconds: int = 3600
     audit_anchor_tsa_timeout_seconds: float = 10.0
 
+    # ADR-037 Phase 1 — Merkle batch anchoring of audit_log row_hash
+    # segments. Where audit_anchor_* binds a single chain head per
+    # tick, the Merkle watcher batches a contiguous range of audit_log
+    # rows under one SHA-256 Merkle root and persists it in
+    # ``audit_merkle_anchors`` (one row per batch). Two scaling wins:
+    # (a) inclusion proof becomes O(log batch_size) instead of an
+    # O(n) chain walk, and (b) the optional TSA token covers the
+    # whole batch root — one TSA call per batch instead of one per
+    # row. Default ON, but only activates once the chain has at least
+    # ``audit_merkle_min_batch`` un-anchored rows so the first ticks
+    # on an idle install do not emit single-leaf trees.
+    audit_merkle_enabled: bool = True
+    # Maximum rows per Merkle batch. 1024 keeps the proof depth at
+    # ceil(log2(1024)) = 10 siblings = 320 bytes per inclusion proof,
+    # a comfortable balance between proof size and the per-tick
+    # SHA-256 work the watcher does (~1024 hashes per batch).
+    audit_merkle_batch_size: int = 1024
+    # Minimum rows required before the watcher emits an anchor. Same
+    # math as audit_merkle_batch_size: at 256 the proof is at most 8
+    # siblings, which keeps even idle Mastios from producing 1-leaf
+    # trees in their first tick window after install.
+    audit_merkle_min_batch: int = 256
+    # Anchor cadence. Default 5 minutes — Merkle batches are forensic
+    # not real-time, and a 5-minute cadence keeps the per-anchor
+    # latency-to-evidence window short enough for DORA Art. 12 record-
+    # keeping without hammering the watcher or (when enabled) the TSA.
+    audit_merkle_interval_seconds: int = 300
+    # Whether to anchor each Merkle root via the same TSA the
+    # audit_anchor watcher uses. The math (PR #918) doesn't need a TSA
+    # to be sound — the local chain still proves consistency — but the
+    # TSA token on the root makes the batch tamper-evident against the
+    # operator. Default ON to mirror audit_anchor_enabled; set to false
+    # when the operator wants Merkle batching without any external
+    # network dependency.
+    audit_merkle_tsa_enabled: bool = True
+
     # SSRF escape hatch — PR #2 audit 2026-05-20.
     # When False (the production default) outbound URL helpers
     # (mcp_proxy/utils/url_safety.assert_safe_outbound_url) refuse any

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -206,6 +206,71 @@ class AuditChainAnchor(Base):
     )
 
 
+class AuditMerkleAnchor(Base):
+    """Merkle batch anchor over a contiguous range of audit_log rows.
+
+    Where ``AuditChainAnchor`` proves a single chain_seq head existed
+    at the TSA's GenTime, this anchor binds an entire batch
+    [chain_seq_start, chain_seq_end] via a SHA-256 binary Merkle tree
+    over the row_hash bytes of every audited row in the batch. The
+    tree math is in ``mcp_proxy.audit.merkle`` (ADR-037 Phase 0).
+
+    Two scaling properties this unlocks (vs anchoring every row):
+
+      * **Inclusion proof O(log n)** instead of O(n) chain walk. An
+        auditor with merkle_root + ceil(log2(batch_size)) sibling
+        digests reconstructs the root and asserts inclusion without
+        touching DB rows beyond the batch's audit_log range.
+      * **TSA anchoring amortised**: one TSA call per batch instead
+        of one per row, while every individual row still inherits
+        the tamper-evidence through the inclusion path.
+
+    Storage is append-only, same trigger pattern as audit_log
+    (F-A-402) and audit_chain_anchors. The lifespan watcher walks
+    forward only — never rewrites an existing anchor — so the
+    append-only constraint matches the worker's intent.
+    """
+    __tablename__ = "audit_merkle_anchors"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # Wall-clock at insertion. Not the authoritative timestamp when a
+    # TSA token is present (the TSA's GenTime inside the token is).
+    created_at = Column(Text, nullable=False)
+    # Mastio's own org_id at anchor time, mirroring AuditChainAnchor.
+    org_id = Column(Text, nullable=False)
+    # Inclusive bounds of the audit_log.chain_seq range covered. The
+    # watcher starts the next batch at chain_seq_end + 1, so an
+    # operator inspecting two adjacent anchors sees exact contiguity:
+    # anchor[i].chain_seq_end + 1 == anchor[i+1].chain_seq_start.
+    chain_seq_start = Column(Integer, nullable=False)
+    chain_seq_end = Column(Integer, nullable=False)
+    # Equals chain_seq_end - chain_seq_start + 1. Stored explicitly so
+    # the audit export does not have to recompute it for the inclusion
+    # proof depth (ceil(log2(leaf_count))).
+    leaf_count = Column(Integer, nullable=False)
+    # 64 lowercase hex chars: the SHA-256 Merkle root over the
+    # row_hash bytes of every row in [start, end], computed by
+    # ``mcp_proxy.audit.merkle.compute_merkle_root``.
+    merkle_root = Column(Text, nullable=False)
+    # Optional RFC 3161 TSA TimeStampToken over the merkle_root.
+    # NULL when the worker ran with TSA anchoring disabled or when
+    # the TSA call failed at batch time (the batch row is still
+    # written; the retry is "next batch", not "stop the loop").
+    tsa_url = Column(Text, nullable=True)
+    tsa_token = Column(LargeBinary, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "idx_audit_merkle_anchors_org_chain_seq_end",
+            "org_id", "chain_seq_end",
+        ),
+        Index(
+            "idx_audit_merkle_anchors_chain_seq_start",
+            "chain_seq_start",
+        ),
+    )
+
+
 class ProxyConfig(Base):
     __tablename__ = "proxy_config"
 

--- a/mcp_proxy/lifespan/merkle_anchor_watcher.py
+++ b/mcp_proxy/lifespan/merkle_anchor_watcher.py
@@ -1,0 +1,287 @@
+"""Background loop that batches contiguous audit_log row_hash ranges
+into Merkle anchors (ADR-037 Phase 1).
+
+Where ``audit_anchor_watcher`` anchors one chain head per tick, this
+watcher walks forward through ``audit_log`` and emits one
+``audit_merkle_anchors`` row per contiguous batch. The Merkle root
+binds every row in the batch via SHA-256 inclusion paths
+(``mcp_proxy.audit.merkle.compute_merkle_root``), so:
+
+  * Inclusion proof scales O(log batch_size) instead of an O(n)
+    chain walk. At batch_size 1024 that is at most 10 sibling
+    digests per proof.
+  * TSA anchoring (optional, ``audit_merkle_tsa_enabled``) is
+    amortised: one TSA call per batch instead of one per row, while
+    every individual row still inherits tamper-evidence through the
+    Merkle path.
+
+Concurrency: leader-elected via ``mcp_proxy.lifespan.get_leader`` so
+only one worker per Mastio process runs the loop (same pattern as
+``audit_anchor_watcher``, ``intermediate_ca_watcher``, etc).
+
+Idempotency: the watcher computes the next batch start as
+``MAX(chain_seq_end) + 1`` from existing ``audit_merkle_anchors``
+rows. A worker that crashes mid-batch leaves no half-written state
+(the INSERT is atomic; the chain_seq_start derivation is consistent
+with whatever the previous successful insert wrote). The next tick
+picks up exactly where the previous one stopped.
+
+Backpressure: the watcher pulls ``audit_merkle_batch_size`` rows
+per tick and emits a single anchor. If audit_log produces rows
+faster than the watcher emits batches, the gap simply grows and
+the next tick covers the new range. The watcher never blocks on
+TSA availability: a TSA HTTP error logs a warning and the batch
+row is written without the TSA token (NULL). The retry is "next
+batch", not "stop the loop".
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from mcp_proxy.audit.merkle import compute_merkle_root
+from mcp_proxy.audit.tsa_client import (
+    DEFAULT_TSA_URL,
+    TSAAnchorError,
+    anchor_row_hash,
+)
+from mcp_proxy.db import get_db
+
+
+logger = logging.getLogger("mcp_proxy.lifespan.merkle_anchor_watcher")
+
+
+_DEFAULT_TICK_SECONDS = 300  # 5 minutes
+_DEFAULT_BATCH_SIZE = 1024
+_DEFAULT_MIN_BATCH = 256
+
+
+async def _last_anchored_seq() -> int:
+    """Return the highest ``chain_seq_end`` already covered by an
+    existing Merkle anchor, or 0 when the table is empty.
+
+    The watcher walks forward only: the next batch starts at
+    ``last_anchored_seq + 1``. Returning 0 on empty makes the first
+    batch start at chain_seq=1, which matches the audit_log chain
+    numbering (chain_seq starts at 1 in the F-A-402 trigger).
+    """
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT chain_seq_end FROM audit_merkle_anchors "
+            "ORDER BY chain_seq_end DESC LIMIT 1"
+        ))).first()
+    if row is None:
+        return 0
+    return int(row[0])
+
+
+async def _fetch_next_batch(
+    *, start_seq: int, batch_size: int,
+) -> list[tuple[int, str]]:
+    """Return up to ``batch_size`` rows from audit_log with chain_seq
+    >= start_seq, ordered ascending. Each tuple is ``(chain_seq,
+    row_hash)``. Empty list means the watcher has caught up.
+
+    We pull both columns even though only row_hash feeds the tree —
+    chain_seq drives the contiguity guarantee that the anchor's
+    [chain_seq_start, chain_seq_end] range encodes.
+    """
+    async with get_db() as conn:
+        rows = (await conn.execute(text(
+            "SELECT chain_seq, row_hash "
+            "FROM audit_log "
+            "WHERE chain_seq IS NOT NULL "
+            "  AND row_hash IS NOT NULL "
+            "  AND chain_seq >= :start_seq "
+            "ORDER BY chain_seq ASC "
+            "LIMIT :batch_size"
+        ), {"start_seq": start_seq, "batch_size": batch_size})).all()
+    return [(int(r[0]), str(r[1])) for r in rows]
+
+
+async def _insert_anchor(
+    *,
+    org_id: str,
+    chain_seq_start: int,
+    chain_seq_end: int,
+    leaf_count: int,
+    merkle_root_hex: str,
+    tsa_url: str | None,
+    tsa_token: bytes | None,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO audit_merkle_anchors "
+                "(created_at, org_id, chain_seq_start, chain_seq_end, "
+                " leaf_count, merkle_root, tsa_url, tsa_token) "
+                "VALUES (:created_at, :org_id, :chain_seq_start, "
+                ":chain_seq_end, :leaf_count, :merkle_root, "
+                ":tsa_url, :tsa_token)"
+            ),
+            {
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "org_id": org_id,
+                "chain_seq_start": chain_seq_start,
+                "chain_seq_end": chain_seq_end,
+                "leaf_count": leaf_count,
+                "merkle_root": merkle_root_hex,
+                "tsa_url": tsa_url,
+                "tsa_token": tsa_token,
+            },
+        )
+
+
+def _row_hashes_to_leaves(row_hashes: list[str]) -> list[bytes]:
+    """Convert the audit_log.row_hash hex strings to the 32-byte
+    leaves the Merkle module expects. Caller validated that every
+    row_hash is a non-empty SHA-256 hex string (selected with
+    ``row_hash IS NOT NULL`` in the SQL above).
+    """
+    return [bytes.fromhex(h) for h in row_hashes]
+
+
+async def _tick(
+    *,
+    org_id: str,
+    batch_size: int,
+    min_batch: int,
+    tsa_enabled: bool,
+    tsa_url: str,
+    tsa_timeout: float,
+) -> None:
+    """One iteration: read last anchored seq, pull next batch, emit
+    Merkle anchor (with optional TSA token over the root).
+    """
+    last_seq = await _last_anchored_seq()
+    start_seq = last_seq + 1
+    batch = await _fetch_next_batch(
+        start_seq=start_seq, batch_size=batch_size,
+    )
+
+    if len(batch) < min_batch:
+        logger.debug(
+            "merkle_anchor_watcher: only %d rows in [%d, ...] "
+            "(min=%d) — defer to next tick",
+            len(batch), start_seq, min_batch,
+        )
+        return
+
+    chain_seq_start = batch[0][0]
+    chain_seq_end = batch[-1][0]
+    leaf_count = len(batch)
+
+    # Compute Merkle root over the row_hash bytes. The pure tree
+    # math validates input shape (32 bytes each); we rely on that
+    # to catch any non-SHA-256 hex slipping through SELECT.
+    leaves = _row_hashes_to_leaves([rh for (_, rh) in batch])
+    root_bytes = compute_merkle_root(leaves)
+    root_hex = root_bytes.hex()
+
+    # Optionally anchor the root at a TSA. Failure does NOT block
+    # the batch row from being written — the local Merkle tree is
+    # sound without the TSA, and the next batch retries.
+    persisted_tsa_url: str | None = None
+    persisted_tsa_token: bytes | None = None
+    if tsa_enabled:
+        try:
+            result = await asyncio.to_thread(
+                anchor_row_hash, root_hex,
+                tsa_url=tsa_url, timeout_seconds=tsa_timeout,
+            )
+            persisted_tsa_url = result.tsa_url
+            persisted_tsa_token = result.token_bytes
+        except TSAAnchorError as exc:
+            logger.warning(
+                "merkle_anchor_watcher: TSA call failed (%s) for "
+                "batch [%d, %d] — persisting anchor without TSA "
+                "token, retry on next tick",
+                exc, chain_seq_start, chain_seq_end,
+            )
+
+    try:
+        await _insert_anchor(
+            org_id=org_id,
+            chain_seq_start=chain_seq_start,
+            chain_seq_end=chain_seq_end,
+            leaf_count=leaf_count,
+            merkle_root_hex=root_hex,
+            tsa_url=persisted_tsa_url,
+            tsa_token=persisted_tsa_token,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive long-running loop
+        logger.error(
+            "merkle_anchor_watcher: persist failed for batch "
+            "[%d, %d]: %s",
+            chain_seq_start, chain_seq_end, exc,
+        )
+        return
+
+    logger.info(
+        "merkle_anchor_watcher: anchored batch [%d, %d] "
+        "(leaves=%d, root=%s..., tsa=%s)",
+        chain_seq_start, chain_seq_end, leaf_count, root_hex[:12],
+        "yes" if persisted_tsa_token else "no",
+    )
+
+
+async def merkle_anchor_watcher_loop(
+    *,
+    org_id: str,
+    stop_event: asyncio.Event,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    min_batch: int = _DEFAULT_MIN_BATCH,
+    tsa_enabled: bool = True,
+    tsa_url: str = DEFAULT_TSA_URL,
+    tick_seconds: int = _DEFAULT_TICK_SECONDS,
+    tsa_timeout_seconds: float = 10.0,
+) -> None:
+    """Run the watcher until ``stop_event`` is set.
+
+    Args:
+        org_id: Mastio's own org id, stored on each anchor for
+            self-describing NDJSON exports.
+        stop_event: signalled by the lifespan shutdown handler.
+        batch_size: maximum rows per Merkle batch.
+        min_batch: minimum rows required before a batch is emitted.
+            Until the chain has at least this many un-anchored rows,
+            the watcher defers — avoids emitting trivially small
+            trees on idle Mastios.
+        tsa_enabled: whether to anchor each Merkle root at a TSA.
+            False keeps the math purely local — useful for air-gapped
+            deployments.
+        tsa_url: HTTP(S) URL of the TSA (default DigiCert public).
+        tick_seconds: anchor cadence. Default 5 minutes.
+        tsa_timeout_seconds: per-anchor TSA HTTP timeout.
+    """
+    logger.info(
+        "merkle_anchor_watcher: starting (tick=%ds, batch_size=%d, "
+        "min_batch=%d, tsa=%s)",
+        tick_seconds, batch_size, min_batch,
+        tsa_url if tsa_enabled else "disabled",
+    )
+
+    while not stop_event.is_set():
+        try:
+            await _tick(
+                org_id=org_id,
+                batch_size=batch_size,
+                min_batch=min_batch,
+                tsa_enabled=tsa_enabled,
+                tsa_url=tsa_url,
+                tsa_timeout=tsa_timeout_seconds,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "merkle_anchor_watcher: tick raised %s — continuing", exc,
+            )
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=tick_seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    logger.info("merkle_anchor_watcher: loop stopped")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -502,6 +502,59 @@ async def lifespan(app: FastAPI):
                 exc,
             )
 
+    # ADR-037 Phase 1 — Merkle batch anchoring. Companion to the
+    # audit_anchor watcher above: where audit_anchor binds a single
+    # chain head per tick, this loop batches contiguous chain_seq
+    # ranges under a SHA-256 Merkle root and persists one row per
+    # batch in audit_merkle_anchors. Inclusion proof drops from
+    # O(n) chain walk to O(log batch_size); the optional TSA token
+    # over the root amortises the TSA cost. Leader-elected like the
+    # other watchers; non-leaders skip silently.
+    if getattr(settings, "audit_merkle_enabled", True):
+        try:
+            from mcp_proxy.lifespan import get_leader as _merkle_get_leader
+            from mcp_proxy.lifespan.merkle_anchor_watcher import (
+                merkle_anchor_watcher_loop,
+            )
+            merkle_leader = _merkle_get_leader("merkle_anchor_watcher")
+            if await merkle_leader.acquire():
+                merkle_stop = asyncio.Event()
+                _merkle_org_id = getattr(agent_mgr, "_org_id", None) or ""
+                merkle_task = asyncio.create_task(
+                    merkle_anchor_watcher_loop(
+                        org_id=_merkle_org_id,
+                        stop_event=merkle_stop,
+                        batch_size=settings.audit_merkle_batch_size,
+                        min_batch=settings.audit_merkle_min_batch,
+                        tsa_enabled=settings.audit_merkle_tsa_enabled,
+                        tsa_url=settings.audit_anchor_tsa_url,
+                        tick_seconds=settings.audit_merkle_interval_seconds,
+                        tsa_timeout_seconds=settings.audit_anchor_tsa_timeout_seconds,
+                    ),
+                    name="merkle_anchor_watcher",
+                )
+                app.state.merkle_anchor_watcher_task = merkle_task
+                app.state.merkle_anchor_watcher_stop = merkle_stop
+                app.state.merkle_anchor_watcher_leader = merkle_leader
+                _log.info(
+                    "merkle_anchor_watcher: leader acquired, loop spawned "
+                    "(tick=%ds, batch_size=%d, min_batch=%d)",
+                    settings.audit_merkle_interval_seconds,
+                    settings.audit_merkle_batch_size,
+                    settings.audit_merkle_min_batch,
+                )
+            else:
+                _log.info(
+                    "merkle_anchor_watcher: another worker holds the leader "
+                    "lock, skipping",
+                )
+        except Exception as exc:
+            _log.warning(
+                "merkle_anchor_watcher startup failed: %s — Merkle batch "
+                "anchoring disabled until next restart",
+                exc,
+            )
+
     # Wave 2 fix 7+8 — agent cert + DPoP jkt rotation grace period
     # cleanup. Hourly leader-elected sweep clears expired previous_*
     # columns on internal_agents so the trust surface collapses back

--- a/test/unit/test_merkle_anchor_watcher.py
+++ b/test/unit/test_merkle_anchor_watcher.py
@@ -1,0 +1,293 @@
+"""Unit tests for ``mcp_proxy.lifespan.merkle_anchor_watcher``.
+
+The watcher's interesting properties are around batch boundary
+math: which chain_seq range gets emitted, when the loop defers
+for under-sized batches, idempotency on restart. We exercise
+``_tick`` directly with an ephemeral SQLite DB so the assertions
+are end-to-end against the real persistence layer (init_db +
+get_db) without touching the lifespan / leader_election layers,
+which are mirrored from audit_anchor_watcher and already covered
+upstream.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.audit.merkle import compute_merkle_root, verify_inclusion
+from mcp_proxy.audit.merkle import inclusion_proof
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.lifespan import merkle_anchor_watcher as mw
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path):
+    db_path = tmp_path / "merkle_watcher.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+
+
+async def _seed_audit_log(rows: list[tuple[int, str]]) -> None:
+    """Bypass the F-A-402 hash-chain trigger for test convenience:
+    insert rows with pre-computed chain_seq + row_hash so the
+    watcher has a deterministic chain to walk. The trigger only
+    forbids UPDATE/DELETE, not INSERT, so this is allowed."""
+    async with get_db() as conn:
+        for chain_seq, row_hash in rows:
+            await conn.execute(
+                text(
+                    "INSERT INTO audit_log "
+                    "(timestamp, agent_id, action, status, chain_seq, "
+                    " row_hash, prev_hash) "
+                    "VALUES ('2026-05-24T00:00:00Z', 'test::agent', "
+                    "'test_action', 'ok', :chain_seq, :row_hash, '')"
+                ),
+                {"chain_seq": chain_seq, "row_hash": row_hash},
+            )
+
+
+def _hex_hash(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _seed_payloads(start: int, count: int) -> list[tuple[int, str]]:
+    return [
+        (start + i, _hex_hash(f"row-{start + i}".encode()))
+        for i in range(count)
+    ]
+
+
+# ── Tick behaviour ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_defers_when_chain_empty(proxy_db):
+    """Empty audit_log → no rows to batch → no anchor written."""
+    await mw._tick(
+        org_id="acme",
+        batch_size=4,
+        min_batch=2,
+        tsa_enabled=False,
+        tsa_url="http://unused",
+        tsa_timeout=1.0,
+    )
+    async with get_db() as conn:
+        count = (await conn.execute(text(
+            "SELECT COUNT(*) FROM audit_merkle_anchors"
+        ))).scalar()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_tick_defers_under_min_batch(proxy_db):
+    """Only 3 rows present but min_batch=5 → defer, no anchor row."""
+    await _seed_audit_log(_seed_payloads(start=1, count=3))
+    await mw._tick(
+        org_id="acme",
+        batch_size=8,
+        min_batch=5,
+        tsa_enabled=False,
+        tsa_url="http://unused",
+        tsa_timeout=1.0,
+    )
+    async with get_db() as conn:
+        count = (await conn.execute(text(
+            "SELECT COUNT(*) FROM audit_merkle_anchors"
+        ))).scalar()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_tick_emits_anchor_when_min_reached(proxy_db):
+    """Min satisfied → one anchor row, root matches independent
+    computation, range is [1, count]."""
+    rows = _seed_payloads(start=1, count=8)
+    await _seed_audit_log(rows)
+
+    await mw._tick(
+        org_id="acme",
+        batch_size=8,
+        min_batch=4,
+        tsa_enabled=False,
+        tsa_url="http://unused",
+        tsa_timeout=1.0,
+    )
+
+    async with get_db() as conn:
+        anchors = (await conn.execute(text(
+            "SELECT chain_seq_start, chain_seq_end, leaf_count, "
+            "       merkle_root, tsa_token "
+            "FROM audit_merkle_anchors"
+        ))).all()
+    assert len(anchors) == 1
+    start, end, count, root_hex, tsa_token = anchors[0]
+    assert start == 1
+    assert end == 8
+    assert count == 8
+    assert tsa_token is None  # TSA disabled
+    expected_root = compute_merkle_root(
+        [bytes.fromhex(rh) for _, rh in rows]
+    ).hex()
+    assert root_hex == expected_root
+
+
+@pytest.mark.asyncio
+async def test_tick_caps_at_batch_size(proxy_db):
+    """100 rows available, batch_size=4 → first anchor covers
+    [1, 4] only, leaves the remaining 96 for subsequent ticks."""
+    rows = _seed_payloads(start=1, count=100)
+    await _seed_audit_log(rows)
+
+    await mw._tick(
+        org_id="acme",
+        batch_size=4,
+        min_batch=2,
+        tsa_enabled=False,
+        tsa_url="http://unused",
+        tsa_timeout=1.0,
+    )
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT chain_seq_start, chain_seq_end, leaf_count "
+            "FROM audit_merkle_anchors ORDER BY id ASC LIMIT 1"
+        ))).first()
+    assert row == (1, 4, 4)
+
+
+@pytest.mark.asyncio
+async def test_consecutive_ticks_advance_contiguously(proxy_db):
+    """Three ticks against a 12-row chain with batch_size=4 produce
+    three anchors at [1,4], [5,8], [9,12]. No gaps, no overlaps."""
+    rows = _seed_payloads(start=1, count=12)
+    await _seed_audit_log(rows)
+
+    for _ in range(3):
+        await mw._tick(
+            org_id="acme",
+            batch_size=4,
+            min_batch=2,
+            tsa_enabled=False,
+            tsa_url="http://unused",
+            tsa_timeout=1.0,
+        )
+
+    async with get_db() as conn:
+        anchors = (await conn.execute(text(
+            "SELECT chain_seq_start, chain_seq_end "
+            "FROM audit_merkle_anchors ORDER BY id ASC"
+        ))).all()
+    assert anchors == [(1, 4), (5, 8), (9, 12)]
+
+
+@pytest.mark.asyncio
+async def test_tick_resumes_after_partial_chain_growth(proxy_db):
+    """First tick anchors [1, 4]. New rows arrive. Second tick
+    picks up at chain_seq=5 without re-anchoring [1, 4]."""
+    await _seed_audit_log(_seed_payloads(start=1, count=4))
+    await mw._tick(
+        org_id="acme", batch_size=4, min_batch=2,
+        tsa_enabled=False, tsa_url="http://unused", tsa_timeout=1.0,
+    )
+
+    await _seed_audit_log(_seed_payloads(start=5, count=4))
+    await mw._tick(
+        org_id="acme", batch_size=4, min_batch=2,
+        tsa_enabled=False, tsa_url="http://unused", tsa_timeout=1.0,
+    )
+
+    async with get_db() as conn:
+        anchors = (await conn.execute(text(
+            "SELECT chain_seq_start, chain_seq_end "
+            "FROM audit_merkle_anchors ORDER BY id ASC"
+        ))).all()
+    assert anchors == [(1, 4), (5, 8)]
+
+
+@pytest.mark.asyncio
+async def test_tick_handles_tsa_failure_persists_anchor(
+    proxy_db, monkeypatch,
+):
+    """TSA call fails → the Merkle anchor row is still written
+    (tsa_token NULL); next tick will retry on the next batch.
+    The local chain math is sound without the TSA."""
+    rows = _seed_payloads(start=1, count=4)
+    await _seed_audit_log(rows)
+
+    def _boom(*_args, **_kwargs):
+        from mcp_proxy.audit.tsa_client import TSAAnchorError
+        raise TSAAnchorError("TSA unreachable")
+    monkeypatch.setattr(mw, "anchor_row_hash", _boom)
+
+    await mw._tick(
+        org_id="acme", batch_size=4, min_batch=2,
+        tsa_enabled=True, tsa_url="http://no-such-tsa",
+        tsa_timeout=1.0,
+    )
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT leaf_count, tsa_token "
+            "FROM audit_merkle_anchors"
+        ))).first()
+    assert row[0] == 4
+    assert row[1] is None  # No token persisted on TSA failure.
+
+
+@pytest.mark.asyncio
+async def test_anchored_root_admits_inclusion_proof_for_every_leaf(
+    proxy_db,
+):
+    """End-to-end check that the anchored root is the same root the
+    Phase 0 math would produce, by exercising the inclusion proof
+    path for every leaf in the batch."""
+    rows = _seed_payloads(start=1, count=8)
+    await _seed_audit_log(rows)
+    await mw._tick(
+        org_id="acme", batch_size=8, min_batch=4,
+        tsa_enabled=False, tsa_url="http://unused", tsa_timeout=1.0,
+    )
+
+    async with get_db() as conn:
+        root_hex = (await conn.execute(text(
+            "SELECT merkle_root FROM audit_merkle_anchors"
+        ))).scalar()
+
+    leaves = [bytes.fromhex(rh) for _, rh in rows]
+    root = bytes.fromhex(root_hex)
+    for i, leaf in enumerate(leaves):
+        proof = inclusion_proof(leaves, i)
+        assert verify_inclusion(leaf, proof, root), (
+            f"inclusion failed for leaf {i}"
+        )
+
+
+# ── _last_anchored_seq helper ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_last_anchored_seq_empty_returns_zero(proxy_db):
+    assert await mw._last_anchored_seq() == 0
+
+
+@pytest.mark.asyncio
+async def test_last_anchored_seq_returns_latest_end(proxy_db):
+    """When multiple anchors exist, the helper returns the highest
+    chain_seq_end so the next batch starts at end + 1."""
+    rows = _seed_payloads(start=1, count=12)
+    await _seed_audit_log(rows)
+    for _ in range(3):
+        await mw._tick(
+            org_id="acme", batch_size=4, min_batch=2,
+            tsa_enabled=False, tsa_url="http://unused", tsa_timeout=1.0,
+        )
+    assert await mw._last_anchored_seq() == 12


### PR DESCRIPTION
## Summary

Builds on the Phase 0 tree math (PR #918, \`mcp_proxy/audit/merkle.py\`) with the storage and lifecycle pieces that turn it into a live audit-chain feature.

The lifespan worker walks forward through \`audit_log\` and emits one \`audit_merkle_anchors\` row per contiguous \`chain_seq\` batch. The Merkle root binds every row in the batch via SHA-256 inclusion paths; the optional TSA token over the root amortises the TSA cost (one call per batch vs one per row).

## What ships

| Layer | Files | What |
|---|---|---|
| **Migration** | \`mcp_proxy/alembic/versions/0044_audit_merkle_anchors.py\` | New table + append-only trigger (plpgsql + sqlite, same pattern as audit_log F-A-402 and audit_chain_anchors). 2 indexes |
| **ORM** | \`mcp_proxy/db_models.py\` | \`AuditMerkleAnchor\` model mirroring the migration |
| **Config** | \`mcp_proxy/config.py\` | 5 new settings: \`audit_merkle_enabled\` (default True), \`audit_merkle_batch_size\` (1024), \`audit_merkle_min_batch\` (256), \`audit_merkle_interval_seconds\` (300), \`audit_merkle_tsa_enabled\` (True). TSA URL/timeout reuse the existing \`audit_anchor_*\` knobs |
| **Worker** | \`mcp_proxy/lifespan/merkle_anchor_watcher.py\` | Leader-elected loop. Per tick: SELECT MAX(chain_seq_end) → fetch next batch → defer if under \`min_batch\` → compute root → optional TSA call → INSERT. Failure semantics: TSA error persists anchor with NULL token, retry next batch |
| **Wire-in** | \`mcp_proxy/main.py\` | Mirrors \`audit_anchor_watcher\` startup block (feature flag → leader election → create_task → stash on app.state) |
| **Tests** | \`test/unit/test_merkle_anchor_watcher.py\` | 10 unit tests, end-to-end against ephemeral SQLite |

## Test plan

- [x] **Audit unit suite 50/50 PASS** in ~24s (40 Phase 0 + 10 Phase 1):
  - Empty chain defers
  - Under \`min_batch\` defers
  - Full batch emits one anchor with the expected \`(start, end, leaf_count, root)\`
  - \`batch_size\` cap holds (100 rows + batch_size=4 → first anchor [1,4] only)
  - Consecutive ticks advance contiguously: [1,4] [5,8] [9,12], no gaps/overlaps
  - Restart-resume: tick after partial chain growth picks up at \`last_end + 1\`
  - TSA failure path: anchor persisted with \`tsa_token IS NULL\`, log warning
  - **Every anchored leaf admits a valid inclusion proof** against the persisted root via Phase 0 \`verify_inclusion\`
- [x] **Smoke 10/10 PASS** post-change in 58s (boot, admin bootstrap, enroll, policy, chat, mcp, audit chain, TSA anchor, audit verify, multiworker)

## Phase 2 (follow-up)

- \`GET /v1/admin/audit/merkle/anchors?org_id=...\`
- \`GET /v1/admin/audit/merkle/proof/{chain_seq}?org_id=...\` returning \`{anchor_id, root, leaf_hash, proof}\`
- \`scripts/cullis-audit-verify.py\` extended to consume inclusion proofs in NDJSON bundles + verify offline against anchored roots (and optional TSA token)
- Smoke scenario \`100_merkle_anchor.sh\`: produce audit rows → wait batch anchor → fetch inclusion proof → verify offline

## Related

- PR #918 — Phase 0 Merkle tree math (this PR's foundation)
- PR #911 — RFC 3161 TSA anchor lifespan watcher (companion + reused TSA client + reused config knobs)
- ADR-037 \`merkle-audit-anchoring\` (\`imp/adrs/\`, will ratify post-merge)

877 insertions, 6 files changed.