### PR TITLE
feat(audit): Merkle inclusion proof endpoints + smoke scenario (ADR-037 Phase 2)

### DIFF
--- a/mcp_proxy/admin/audit_merkle.py
+++ b/mcp_proxy/admin/audit_merkle.py
@@ -1,0 +1,288 @@
+"""Admin endpoints for the Merkle batch audit anchor (ADR-037 Phase 2).
+
+Two read-only endpoints, both gated by the shared ``X-Admin-Secret``
+header (same pattern as the rest of ``mcp_proxy/admin/``):
+
+* ``GET /v1/admin/audit/merkle/anchors`` — list anchors with their
+  ``(chain_seq_start, chain_seq_end, leaf_count, merkle_root)`` and
+  optional TSA metadata. Used by the dashboard and by the offline
+  verifier to fetch the trusted roots before walking proofs.
+* ``GET /v1/admin/audit/merkle/proof/{chain_seq}`` — return the
+  inclusion proof for the audit_log row at ``chain_seq``. Response
+  carries the matched anchor id, the merkle root, the leaf hash,
+  and the bottom-up sibling list with ``L``/``R`` positions, so the
+  caller (offline verifier, auditor, dashboard) can replay
+  ``mcp_proxy.audit.merkle.verify_inclusion`` without any DB
+  access of its own.
+
+The proof is computed lazily by rebuilding the tree over the
+``audit_log.row_hash`` rows in the anchor's covered range. The
+anchor row stores only the root; sibling material is recomputed on
+demand. This keeps the storage cost flat (one row per batch) while
+the per-request CPU is bounded by the batch size (1024 rows ≈ 1024
+SHA-256 ops, single-digit milliseconds).
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from mcp_proxy.audit.merkle import inclusion_proof
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db
+
+
+logger = logging.getLogger("mcp_proxy.admin.audit_merkle")
+
+router = APIRouter(
+    prefix="/v1/admin/audit/merkle",
+    tags=["admin", "audit", "merkle"],
+)
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+class MerkleAnchorEntry(BaseModel):
+    """One row of ``audit_merkle_anchors`` flattened for JSON.
+
+    Field names mirror the table schema 1:1 so the offline verifier
+    can map directly. ``tsa_token_b64`` is base64-encoded when
+    present (the table stores raw bytes); ``None`` when the worker
+    persisted the anchor without an external TSA witness (TSA
+    disabled, TSA unreachable at batch time, etc).
+    """
+    id: int
+    created_at: str
+    org_id: str
+    chain_seq_start: int
+    chain_seq_end: int
+    leaf_count: int
+    merkle_root: str
+    tsa_url: str | None
+    tsa_token_b64: str | None
+
+
+class MerkleAnchorListResponse(BaseModel):
+    anchors: list[MerkleAnchorEntry]
+    count: int
+
+
+class InclusionProofStep(BaseModel):
+    """One sibling on the path from leaf to root.
+
+    ``position`` is ``"L"`` if the sibling sits on the LEFT of the
+    current node (verifier hashes ``sibling || current``) and
+    ``"R"`` if on the right (``current || sibling``). The verifier
+    walks the steps bottom-up.
+    """
+    sibling_hex: str
+    position: str  # "L" or "R"
+
+
+class InclusionProofResponse(BaseModel):
+    """Everything an offline verifier needs to assert that a given
+    ``chain_seq`` row is included in the anchored Merkle root.
+
+    The verifier does not need to trust the Mastio: it can
+    independently compute the leaf hash from the row content,
+    rebuild the root by walking the proof, and compare against
+    the ``merkle_root`` it pulled from the anchor list (or from
+    the NDJSON export bundle).
+    """
+    anchor_id: int
+    chain_seq: int
+    chain_seq_start: int
+    chain_seq_end: int
+    leaf_count: int
+    merkle_root: str
+    leaf_hex: str
+    proof: list[InclusionProofStep]
+
+
+def _row_to_entry(row) -> MerkleAnchorEntry:
+    import base64
+
+    tsa_token = row[7]
+    if isinstance(tsa_token, memoryview):
+        tsa_token = bytes(tsa_token)
+    return MerkleAnchorEntry(
+        id=int(row[0]),
+        created_at=str(row[1]),
+        org_id=str(row[2]),
+        chain_seq_start=int(row[3]),
+        chain_seq_end=int(row[4]),
+        leaf_count=int(row[5]),
+        merkle_root=str(row[6]),
+        tsa_url=str(row[7 - 0]) if False else (str(row[8]) if row[8] is not None else None),
+        tsa_token_b64=(base64.b64encode(tsa_token).decode("ascii")
+                       if tsa_token else None),
+    )
+
+
+@router.get(
+    "/anchors",
+    response_model=MerkleAnchorListResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_merkle_anchors(
+    org_id: str | None = Query(
+        default=None,
+        description="Filter to a single org_id. Empty returns all anchors.",
+    ),
+    limit: int = Query(
+        default=100, ge=1, le=1000,
+        description="Cap rows returned. Most recent first.",
+    ),
+) -> MerkleAnchorListResponse:
+    """List recent Merkle batch anchors, most recent first.
+
+    Bounded by ``limit`` (default 100, max 1000) so a single
+    request cannot serialise unbounded rows.
+    """
+    sql_base = (
+        "SELECT id, created_at, org_id, chain_seq_start, chain_seq_end, "
+        "       leaf_count, merkle_root, tsa_url, tsa_token "
+        "FROM audit_merkle_anchors "
+    )
+    params: dict[str, object] = {"limit": limit}
+    if org_id:
+        sql = sql_base + "WHERE org_id = :org_id ORDER BY id DESC LIMIT :limit"
+        params["org_id"] = org_id
+    else:
+        sql = sql_base + "ORDER BY id DESC LIMIT :limit"
+
+    async with get_db() as conn:
+        rows = (await conn.execute(text(sql), params)).all()
+
+    import base64
+
+    entries = []
+    for r in rows:
+        tsa_token = r[8]
+        if isinstance(tsa_token, memoryview):
+            tsa_token = bytes(tsa_token)
+        entries.append(MerkleAnchorEntry(
+            id=int(r[0]),
+            created_at=str(r[1]),
+            org_id=str(r[2]),
+            chain_seq_start=int(r[3]),
+            chain_seq_end=int(r[4]),
+            leaf_count=int(r[5]),
+            merkle_root=str(r[6]),
+            tsa_url=str(r[7]) if r[7] is not None else None,
+            tsa_token_b64=(base64.b64encode(tsa_token).decode("ascii")
+                           if tsa_token else None),
+        ))
+
+    return MerkleAnchorListResponse(anchors=entries, count=len(entries))
+
+
+@router.get(
+    "/proof/{chain_seq}",
+    response_model=InclusionProofResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def get_inclusion_proof(chain_seq: int) -> InclusionProofResponse:
+    """Return the inclusion proof for the audit_log row at
+    ``chain_seq``.
+
+    Locates the anchor covering ``chain_seq``, replays the tree
+    over the anchor's full chain_seq range, and returns the
+    bottom-up sibling list plus the matched ``merkle_root``. The
+    caller can verify by replaying
+    ``mcp_proxy.audit.merkle.verify_inclusion(leaf_bytes,
+    proof_steps, root_bytes)``.
+
+    404 when no anchor covers the chain_seq (either not anchored
+    yet, or chain_seq predates the first anchor).
+    """
+    async with get_db() as conn:
+        anchor = (await conn.execute(text(
+            "SELECT id, chain_seq_start, chain_seq_end, leaf_count, "
+            "       merkle_root "
+            "FROM audit_merkle_anchors "
+            "WHERE chain_seq_start <= :chain_seq "
+            "  AND chain_seq_end >= :chain_seq "
+            "ORDER BY id DESC LIMIT 1"
+        ), {"chain_seq": chain_seq})).first()
+
+        if anchor is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"no Merkle anchor covers chain_seq={chain_seq}; "
+                    "either the row predates the first anchor or the "
+                    "batch covering it has not yet been emitted by "
+                    "the watcher (defaults to one batch every 5 min)"
+                ),
+            )
+
+        anchor_id, start, end, leaf_count, root_hex = anchor
+        start, end, leaf_count = int(start), int(end), int(leaf_count)
+        anchor_id = int(anchor_id)
+        root_hex = str(root_hex)
+
+        # Pull every row_hash in the anchor's covered range, in the
+        # SAME chain_seq order the watcher used at anchor time. The
+        # leaf index relative to the batch is (chain_seq - start).
+        rows = (await conn.execute(text(
+            "SELECT chain_seq, row_hash FROM audit_log "
+            "WHERE chain_seq IS NOT NULL "
+            "  AND row_hash IS NOT NULL "
+            "  AND chain_seq >= :start AND chain_seq <= :end "
+            "ORDER BY chain_seq ASC"
+        ), {"start": start, "end": end})).all()
+
+    if len(rows) != leaf_count:
+        # The anchored batch and the current audit_log range disagree
+        # on leaf count. Either audit_log rows have been deleted
+        # (forbidden by the F-A-402 append-only trigger but worth
+        # surfacing) or chain_seq numbering is non-monotonic. Refuse
+        # to compute a proof against a known-inconsistent input.
+        logger.error(
+            "merkle proof: anchor id=%d covers [%d, %d] (leaf_count=%d) "
+            "but audit_log returned %d rows — chain integrity broken",
+            anchor_id, start, end, leaf_count, len(rows),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "audit_log row count disagrees with anchored leaf_count — "
+                "chain integrity broken; refusing to emit proof"
+            ),
+        )
+
+    leaves = [bytes.fromhex(str(r[1])) for r in rows]
+    target_index = chain_seq - start
+    leaf_hex = leaves[target_index].hex()
+    proof_steps = inclusion_proof(leaves, target_index)
+
+    return InclusionProofResponse(
+        anchor_id=anchor_id,
+        chain_seq=chain_seq,
+        chain_seq_start=start,
+        chain_seq_end=end,
+        leaf_count=leaf_count,
+        merkle_root=root_hex,
+        leaf_hex=leaf_hex,
+        proof=[
+            InclusionProofStep(
+                sibling_hex=sibling.hex(),
+                position=position,
+            )
+            for sibling, position in proof_steps
+        ],
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -2141,6 +2141,10 @@ app.include_router(admin_mastio_ca_router)
 from mcp_proxy.admin.observability import router as admin_observability_router
 app.include_router(admin_observability_router)
 
+# ADR-037 Phase 2 — /v1/admin/audit/merkle/{anchors,proof/{chain_seq}}.
+from mcp_proxy.admin.audit_merkle import router as admin_audit_merkle_router
+app.include_router(admin_audit_merkle_router)
+
 # ADR-009 sandbox — Connector JSON API for MCP resources + bindings.
 from mcp_proxy.admin.mcp_resources import router as admin_mcp_resources_router
 app.include_router(admin_mcp_resources_router)

--- a/test/smoke/compose.yml
+++ b/test/smoke/compose.yml
@@ -125,6 +125,14 @@ services:
       MCP_PROXY_AUDIT_ANCHOR_TSA_URL:           ${MCP_PROXY_AUDIT_ANCHOR_TSA_URL:-http://mock-tsa:2560/tsr}
       MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:  ${MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:-30}
       MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS:-5}
+      # ADR-037 — Merkle batch anchor watcher (Phase 1/2). Tiny batches
+      # + short cadence so the smoke scenario hits an anchored batch
+      # within the test budget rather than waiting 5 min for 256 rows.
+      MCP_PROXY_AUDIT_MERKLE_ENABLED:           ${MCP_PROXY_AUDIT_MERKLE_ENABLED:-true}
+      MCP_PROXY_AUDIT_MERKLE_BATCH_SIZE:        ${MCP_PROXY_AUDIT_MERKLE_BATCH_SIZE:-8}
+      MCP_PROXY_AUDIT_MERKLE_MIN_BATCH:         ${MCP_PROXY_AUDIT_MERKLE_MIN_BATCH:-2}
+      MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS:  ${MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS:-15}
+      MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED:       ${MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED:-true}
       # AI gateway — point at the mock OpenAI-compatible endpoint on
       # mock-tsa:2561. The Portkey backend respects ai_gateway_url
       # (litellm_embedded uses provider SDKs directly).

--- a/test/smoke/env.smoke
+++ b/test/smoke/env.smoke
@@ -72,6 +72,16 @@ MCP_PROXY_AUDIT_ANCHOR_TSA_URL=http://mock-tsa:2560/tsr
 MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS=30
 MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS=5
 
+# ADR-037 Phase 1/2 — Merkle batch anchor watcher. Aggressive cadence
+# + tiny batch threshold so the smoke scenario hits an anchored batch
+# within the test budget rather than waiting for 256 audit rows at
+# the production-default 5-minute tick.
+MCP_PROXY_AUDIT_MERKLE_ENABLED=true
+MCP_PROXY_AUDIT_MERKLE_BATCH_SIZE=8
+MCP_PROXY_AUDIT_MERKLE_MIN_BATCH=2
+MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS=15
+MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED=true
+
 # ── AI gateway (mocked) ─────────────────────────────────────────────────────
 # Point LiteLLM at a mock OpenAI-compatible endpoint we stand up via
 # the mock-tsa container's second port (it doubles as a tiny HTTP

--- a/test/smoke/scenarios/91_merkle_anchor.sh
+++ b/test/smoke/scenarios/91_merkle_anchor.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 91_merkle_anchor — Merkle batch anchor + inclusion proof end-to-end
+# =============================================================================
+#
+# env.smoke configures the Merkle watcher with an aggressive cadence
+# so the scenario hits an anchored batch within the test budget:
+#   MCP_PROXY_AUDIT_MERKLE_BATCH_SIZE=8
+#   MCP_PROXY_AUDIT_MERKLE_MIN_BATCH=2
+#   MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS=15
+#
+# This scenario:
+#   * Waits up to 60s for the first anchor row to land
+#   * Fetches /v1/admin/audit/merkle/anchors and asserts shape
+#   * Picks a chain_seq inside the anchored range, fetches the
+#     inclusion proof via /v1/admin/audit/merkle/proof/{chain_seq}
+#   * Replays the Phase 0 verify_inclusion math in-container — the
+#     proof must verify against the returned root
+#   * Negative: chain_seq outside the anchored range → 404
+#   * Negative: wrong admin secret → 403
+#
+# JSON parsing uses python via docker exec (smoke framework guarantee
+# is "no host jq, no host python", everything runs in the Mastio
+# container).
+# =============================================================================
+set -euo pipefail
+
+SCENARIO_TAG="91_merkle_anchor"
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# shellcheck source=../lib/_common.sh
+source "$SMOKE_LIB_DIR/_common.sh"
+
+
+# ── Step 1: wait for the first Merkle anchor row ───────────────────
+deadline=$(( $(date +%s) + 60 ))
+anchors=0
+while (( $(date +%s) < deadline )); do
+    anchors="$(smoke_compose exec -T mcp-proxy python3 -c "
+import os, re
+url = os.environ.get('MCP_PROXY_DATABASE_URL', '')
+try:
+    if url.startswith('postgresql'):
+        import psycopg2
+        sync_url = re.sub(r'^postgresql\+asyncpg://', 'postgresql://', url)
+        conn = psycopg2.connect(sync_url)
+        cur = conn.cursor()
+        cur.execute('SELECT COUNT(*) FROM audit_merkle_anchors')
+        print(cur.fetchone()[0])
+    else:
+        import sqlite3
+        path = url.replace('sqlite+aiosqlite:////', '/').replace('sqlite+aiosqlite:///', '/')
+        conn = sqlite3.connect(path)
+        print(conn.execute('SELECT COUNT(*) FROM audit_merkle_anchors').fetchone()[0])
+except Exception:
+    print(0)
+" 2>/dev/null | tr -d '\r' || echo 0)"
+    [[ "$anchors" =~ ^[0-9]+$ ]] || anchors=0
+    if (( anchors >= 1 )); then
+        break
+    fi
+    sleep 2
+done
+
+(( anchors >= 1 )) \
+    || die "no Merkle anchor written within 60s — watcher silent"
+log_pass "merkle watcher emitted ${anchors} anchor(s) within 60s"
+
+
+# ── Step 2: GET /v1/admin/audit/merkle/anchors ────────────────────
+ADMIN_SECRET="$(smoke_admin_secret)"
+NGINX_URL="$(smoke_mastio_url)"
+
+response="$(curl -sk -X GET \
+    -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+    "${NGINX_URL}/v1/admin/audit/merkle/anchors?limit=5")"
+
+# Parse the JSON inside the Mastio container — no host jq needed.
+parsed="$(printf '%s' "$response" | smoke_compose exec -T mcp-proxy \
+    python3 -c "
+import json, sys
+body = json.loads(sys.stdin.read())
+count = body.get('count', 0)
+if not body.get('anchors'):
+    print(f'|||{count}')
+else:
+    a = body['anchors'][0]
+    print(f\"{a['chain_seq_start']}|{a['chain_seq_end']}|{a['merkle_root']}|{count}\")
+" 2>&1 | tr -d '\r')"
+
+IFS='|' read -r start end root_hex count <<<"$parsed"
+[[ "$count" =~ ^[0-9]+$ ]] && (( count >= 1 )) \
+    || die "admin endpoint returned count=${count:-empty}, response=$response"
+log_pass "GET /v1/admin/audit/merkle/anchors returned ${count} anchor(s)"
+
+[[ "$start" =~ ^[0-9]+$ ]] || die "chain_seq_start malformed: $start"
+[[ "$end" =~ ^[0-9]+$ ]] || die "chain_seq_end malformed: $end"
+[[ ${#root_hex} -eq 64 ]] || die "merkle_root not 64 hex chars: ${root_hex}"
+log_pass "anchor metadata sane (range=[${start}, ${end}], root=${root_hex:0:12}...)"
+
+
+# ── Step 3: GET /v1/admin/audit/merkle/proof/{chain_seq} ──────────
+target_seq="$start"
+if (( end > start )); then
+    target_seq=$(( start + 1 ))
+fi
+
+proof_response="$(curl -sk -X GET \
+    -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+    "${NGINX_URL}/v1/admin/audit/merkle/proof/${target_seq}")"
+
+proof_parse="$(printf '%s' "$proof_response" | smoke_compose exec -T mcp-proxy \
+    python3 -c "
+import json, sys
+body = json.loads(sys.stdin.read())
+print(f\"{body.get('chain_seq', '')}|{body.get('merkle_root', '')}|{body.get('leaf_hex', '')}\")
+" 2>&1 | tr -d '\r')"
+IFS='|' read -r proof_seq proof_root proof_leaf <<<"$proof_parse"
+[[ "$proof_seq" == "$target_seq" ]] \
+    || die "proof.chain_seq mismatch: got '$proof_seq', expected $target_seq"
+[[ "$proof_root" == "$root_hex" ]] \
+    || die "proof.merkle_root disagrees with anchor list root"
+[[ ${#proof_leaf} -eq 64 ]] \
+    || die "proof.leaf_hex not 64 hex chars: '$proof_leaf'"
+log_pass "GET /v1/admin/audit/merkle/proof/${target_seq} returned proof"
+
+
+# ── Step 4: replay verify_inclusion offline ───────────────────────
+verify_result="$(printf '%s' "$proof_response" | smoke_compose exec -T mcp-proxy \
+    python3 -c "
+import json, sys
+from mcp_proxy.audit.merkle import verify_inclusion
+
+body = json.loads(sys.stdin.read())
+leaf = bytes.fromhex(body['leaf_hex'])
+root = bytes.fromhex(body['merkle_root'])
+proof = [
+    (bytes.fromhex(step['sibling_hex']), step['position'])
+    for step in body['proof']
+]
+ok = verify_inclusion(leaf, proof, root)
+print('OK' if ok else 'FAIL')
+" 2>&1 | tr -d '\r')"
+
+[[ "$verify_result" == "OK" ]] \
+    || die "verify_inclusion replay failed: $verify_result"
+log_pass "verify_inclusion replay PASSED — Phase 0 math agrees with persisted root"
+
+
+# ── Step 5: negative — chain_seq outside anchored range → 404 ─────
+unanchored_seq=$(( end + 10000 ))
+http_status="$(curl -sk -o /dev/null -w '%{http_code}' \
+    -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+    "${NGINX_URL}/v1/admin/audit/merkle/proof/${unanchored_seq}")"
+[[ "$http_status" == "404" ]] \
+    || die "unanchored chain_seq=${unanchored_seq} returned ${http_status}, expected 404"
+log_pass "unanchored chain_seq correctly returned 404"
+
+
+# ── Step 6: negative — wrong admin secret → 403 ──────────────────
+http_status="$(curl -sk -o /dev/null -w '%{http_code}' \
+    -H "X-Admin-Secret: wrong-secret" \
+    "${NGINX_URL}/v1/admin/audit/merkle/anchors")"
+[[ "$http_status" == "403" ]] \
+    || die "wrong admin secret returned ${http_status}, expected 403"
+log_pass "wrong admin secret correctly returned 403"

--- a/test/unit/test_admin_audit_merkle.py
+++ b/test/unit/test_admin_audit_merkle.py
@@ -1,0 +1,318 @@
+"""Unit tests for ``mcp_proxy.admin.audit_merkle`` — the two
+read-only admin endpoints that expose ``audit_merkle_anchors``
+rows and inclusion proofs.
+
+Exercises the endpoints via the FastAPI TestClient against an
+ephemeral SQLite DB seeded with audit_log rows and one Merkle
+anchor produced by the Phase 1 watcher. Validates: auth gate,
+proof shape, root replay against the Phase 0 verifier, 404 on
+unanchored chain_seq, 409 on chain_count drift.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.admin.audit_merkle import router as admin_merkle_router
+from mcp_proxy.audit.merkle import verify_inclusion
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.lifespan import merkle_anchor_watcher as mw
+
+
+_ADMIN_SECRET = "test-admin-secret-merkle"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "admin_merkle.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def app(proxy_db) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_merkle_router)
+    return app
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+def _h(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+async def _seed_audit_log(start: int, count: int) -> list[tuple[int, str]]:
+    rows = [
+        (start + i, _h(f"row-{start + i}".encode()))
+        for i in range(count)
+    ]
+    async with get_db() as conn:
+        for chain_seq, row_hash in rows:
+            await conn.execute(
+                text(
+                    "INSERT INTO audit_log "
+                    "(timestamp, agent_id, action, status, chain_seq, "
+                    " row_hash, prev_hash) "
+                    "VALUES ('2026-05-24T00:00:00Z', 'test::agent', "
+                    "'test_action', 'ok', :chain_seq, :row_hash, '')"
+                ),
+                {"chain_seq": chain_seq, "row_hash": row_hash},
+            )
+    return rows
+
+
+async def _emit_anchor(batch_size: int = 8, min_batch: int = 4) -> None:
+    await mw._tick(
+        org_id="acme",
+        batch_size=batch_size,
+        min_batch=min_batch,
+        tsa_enabled=False,
+        tsa_url="http://unused",
+        tsa_timeout=1.0,
+    )
+
+
+# ── Auth gate ───────────────────────────────────────────────────────
+
+
+def test_anchors_requires_admin_secret(client):
+    resp = client.get("/v1/admin/audit/merkle/anchors")
+    assert resp.status_code == 422  # missing header
+
+
+def test_anchors_rejects_wrong_secret(client):
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors",
+        headers={"X-Admin-Secret": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+def test_proof_requires_admin_secret(client):
+    resp = client.get("/v1/admin/audit/merkle/proof/1")
+    assert resp.status_code == 422
+
+
+def test_proof_rejects_wrong_secret(client):
+    resp = client.get(
+        "/v1/admin/audit/merkle/proof/1",
+        headers={"X-Admin-Secret": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+# ── /anchors ────────────────────────────────────────────────────────
+
+
+def test_anchors_empty_returns_empty_list(client):
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"anchors": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_anchors_lists_recent_first(client):
+    """Three batches emitted; the endpoint returns them DESC by id."""
+    await _seed_audit_log(start=1, count=24)
+    for _ in range(3):
+        await _emit_anchor(batch_size=8, min_batch=4)
+
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 3
+    ranges = [
+        (a["chain_seq_start"], a["chain_seq_end"])
+        for a in body["anchors"]
+    ]
+    # Most recent (highest id) first.
+    assert ranges == [(17, 24), (9, 16), (1, 8)]
+    # Sanity on the rest of the schema for the most recent anchor.
+    most_recent = body["anchors"][0]
+    assert most_recent["leaf_count"] == 8
+    assert most_recent["org_id"] == "acme"
+    assert len(most_recent["merkle_root"]) == 64  # sha256 hex
+    assert most_recent["tsa_token_b64"] is None  # TSA disabled in fixture
+
+
+@pytest.mark.asyncio
+async def test_anchors_filters_by_org_id(client):
+    """Inserting a hand-crafted anchor for a second org and filtering."""
+    await _seed_audit_log(start=1, count=8)
+    await _emit_anchor()
+    # Hand-craft a second-org anchor directly.
+    async with get_db() as conn:
+        await conn.execute(text(
+            "INSERT INTO audit_merkle_anchors "
+            "(created_at, org_id, chain_seq_start, chain_seq_end, "
+            " leaf_count, merkle_root, tsa_url, tsa_token) "
+            "VALUES ('2026-05-24T00:00:00Z', 'other-org', 100, 107, 8, "
+            "'00'*32, NULL, NULL)"
+        ))
+
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors?org_id=acme",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["anchors"][0]["org_id"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_anchors_limit_caps_output(client):
+    await _seed_audit_log(start=1, count=24)
+    for _ in range(3):
+        await _emit_anchor(batch_size=8, min_batch=4)
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors?limit=2",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.json()["count"] == 2
+
+
+def test_anchors_limit_validation(client):
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors?limit=0",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 422
+    resp = client.get(
+        "/v1/admin/audit/merkle/anchors?limit=10000",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 422
+
+
+# ── /proof/{chain_seq} ──────────────────────────────────────────────
+
+
+def test_proof_404_when_no_anchor_exists(client):
+    resp = client.get(
+        "/v1/admin/audit/merkle/proof/1",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proof_404_when_chain_seq_outside_anchored_range(client):
+    """chain_seq 9 is outside the [1,8] anchor."""
+    await _seed_audit_log(start=1, count=8)
+    await _emit_anchor()
+    resp = client.get(
+        "/v1/admin/audit/merkle/proof/9",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proof_returns_valid_inclusion_for_anchored_seq(client):
+    """End-to-end: emit an anchor, fetch the proof for any leaf in
+    range, replay verify_inclusion against the returned root."""
+    rows = await _seed_audit_log(start=1, count=8)
+    await _emit_anchor()
+
+    # Pick an arbitrary middle leaf to exercise non-edge proof shape.
+    target_seq = 5
+    resp = client.get(
+        f"/v1/admin/audit/merkle/proof/{target_seq}",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["chain_seq"] == target_seq
+    assert body["chain_seq_start"] == 1
+    assert body["chain_seq_end"] == 8
+    assert body["leaf_count"] == 8
+
+    # Replay the math via the Phase 0 verifier — independent of any
+    # server-side trust.
+    leaf = bytes.fromhex(body["leaf_hex"])
+    root = bytes.fromhex(body["merkle_root"])
+    proof = [
+        (bytes.fromhex(step["sibling_hex"]), step["position"])
+        for step in body["proof"]
+    ]
+    assert verify_inclusion(leaf, proof, root), (
+        "server-returned proof must verify against server-returned root"
+    )
+
+    # The leaf the server returned must match the audit_log row_hash
+    # we seeded — otherwise the SELECT order disagreed with the
+    # anchor's leaf ordering at emission time.
+    expected_leaf_hex = rows[target_seq - 1][1]
+    assert body["leaf_hex"] == expected_leaf_hex
+
+
+@pytest.mark.asyncio
+async def test_proof_for_every_leaf_in_anchor(client):
+    """Every leaf in the anchored range must yield a valid proof
+    against the anchor's root. Catches off-by-one errors in the
+    server-side leaf index derivation."""
+    rows = await _seed_audit_log(start=1, count=8)
+    await _emit_anchor()
+    for chain_seq, expected_row_hash in rows:
+        resp = client.get(
+            f"/v1/admin/audit/merkle/proof/{chain_seq}",
+            headers={"X-Admin-Secret": _ADMIN_SECRET},
+        )
+        assert resp.status_code == 200, (
+            f"chain_seq={chain_seq} returned {resp.status_code}: "
+            f"{resp.text}"
+        )
+        body = resp.json()
+        assert body["leaf_hex"] == expected_row_hash
+        leaf = bytes.fromhex(body["leaf_hex"])
+        root = bytes.fromhex(body["merkle_root"])
+        proof = [
+            (bytes.fromhex(s["sibling_hex"]), s["position"])
+            for s in body["proof"]
+        ]
+        assert verify_inclusion(leaf, proof, root)
+
+
+@pytest.mark.asyncio
+async def test_proof_409_when_audit_log_disagrees_with_leaf_count(client):
+    """Hand-craft an anchor that claims leaf_count=8 but only 4
+    audit_log rows exist in its range. The endpoint refuses to
+    emit a proof against a known-inconsistent state."""
+    await _seed_audit_log(start=1, count=4)
+    async with get_db() as conn:
+        await conn.execute(text(
+            "INSERT INTO audit_merkle_anchors "
+            "(created_at, org_id, chain_seq_start, chain_seq_end, "
+            " leaf_count, merkle_root, tsa_url, tsa_token) "
+            "VALUES ('2026-05-24T00:00:00Z', 'acme', 1, 4, 8, "
+            "'00'*32, NULL, NULL)"
+        ))
+    resp = client.get(
+        "/v1/admin/audit/merkle/proof/1",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary

**Stacked on #920** (Phase 1). Adds the read-side: two admin endpoints + an end-to-end smoke scenario that walks the full Phase 0+1+2 pipeline (watcher writes → endpoint reads → offline \`verify_inclusion\` replays the Phase 0 math against the persisted root).

> ⚠️ **Stacked PR**: do NOT \`--delete-branch\` on #920 at merge. Per memory \`feedback_dual_repo_workflow.md\`: closing the parent branch would auto-close this PR. Merge #920 first (keep branch), then rebase this on main.

## Endpoints

Both gated by \`X-Admin-Secret\` (same pattern as the rest of \`mcp_proxy/admin/\`):

### \`GET /v1/admin/audit/merkle/anchors?org_id=&limit=\`

Lists \`audit_merkle_anchors\` rows, most recent first. \`tsa_token\` is base64-encoded; \`None\` when the worker persisted the anchor without an external TSA witness.

\`\`\`json
{
  "anchors": [
    {
      "id": 1,
      "created_at": "2026-05-24T...",
      "org_id": "acme",
      "chain_seq_start": 1,
      "chain_seq_end": 8,
      "leaf_count": 8,
      "merkle_root": "abf9...",
      "tsa_url": "http://timestamp.digicert.com",
      "tsa_token_b64": "VDF8M..."
    }
  ],
  "count": 1
}
\`\`\`

### \`GET /v1/admin/audit/merkle/proof/{chain_seq}\`

Locates the anchor covering \`chain_seq\`, replays the tree over its full \`chain_seq\` range, returns the bottom-up sibling list plus the matched root and leaf hash. An offline verifier can independently confirm inclusion by replaying \`mcp_proxy.audit.merkle.verify_inclusion(leaf, proof, root)\` from the response.

\`\`\`json
{
  "anchor_id": 1,
  "chain_seq": 5,
  "chain_seq_start": 1,
  "chain_seq_end": 8,
  "leaf_count": 8,
  "merkle_root": "abf9...",
  "leaf_hex": "9c8a...",
  "proof": [
    {"sibling_hex": "...", "position": "L"},
    {"sibling_hex": "...", "position": "R"},
    {"sibling_hex": "...", "position": "R"}
  ]
}
\`\`\`

Errors:
- **404** when no anchor covers the chain_seq
- **409** when \`audit_log\` row count disagrees with \`leaf_count\` (chain integrity broken — append-only trigger should make this impossible, but the endpoint refuses to emit a proof against a known-inconsistent state)

## Smoke scenario \`91_merkle_anchor.sh\`

Six steps, all in-container (no host jq — smoke invariant is "one host dep: docker compose"):

1. Wait up to 60s for the first Merkle anchor row
2. \`GET /anchors\`, assert \`count >= 1\` + shape (start, end, root format)
3. \`GET /proof/{chain_seq}\` for a seq in range, assert \`chain_seq + root + leaf\`
4. **Replay \`verify_inclusion\`** in-container against the persisted root — Phase 0 math must agree
5. Negative: \`chain_seq\` outside range → \`404\`
6. Negative: wrong admin secret → \`403\`

\`env.smoke\` + \`compose.yml\` updated to pass \`MCP_PROXY_AUDIT_MERKLE_*\` env vars explicitly (the smoke compose passes vars by name, not via env_file). Cadence is aggressive (\`batch_size=8\`, \`min_batch=2\`, \`interval=15s\`) so the scenario hits an anchored batch within the test budget instead of waiting the production-default 5 minutes for 256 rows.

## Test plan

- [x] **64/64 audit unit pass** in ~55s (40 Phase 0 + 10 Phase 1 + 14 Phase 2)
- [x] **Smoke 11/11 PASS** in 58s including the new \`91_merkle_anchor\`
- [x] **Cumulative**: Phase 0 math + Phase 1 storage/lifecycle + Phase 2 read API all live; an auditor with NDJSON export + the offline verifier (#918) and the inclusion proof endpoint (this PR) has the complete forensic envelope

## What ships

| Layer | Files | LOC |
|---|---|---|
| Endpoints | \`mcp_proxy/admin/audit_merkle.py\` | ~250 |
| Wire-in | \`mcp_proxy/main.py\` | +4 |
| Unit tests | \`test/unit/test_admin_audit_merkle.py\` | ~280 |
| Smoke scenario | \`test/smoke/scenarios/91_merkle_anchor.sh\` | ~130 |
| Smoke env | \`test/smoke/env.smoke\`, \`test/smoke/compose.yml\` | +15 |

**6 files, 793 insertions**.

## Closes out ADR-037

This is the last PR in the Merkle anchoring track. Storage (Phase 1), endpoints (Phase 2), and the offline verify math (Phase 0) are all in. The remaining follow-up is \`scripts/cullis-audit-verify.py\` CLI extension to consume the inclusion proof JSON in NDJSON export bundles — but that's a small chore, not a Phase 3.