### PR TITLE
feat(audit): cullis-audit-verify.py --merkle-proof flag (ADR-037 Phase 3)

### DIFF
--- a/scripts/cullis-audit-verify.py
+++ b/scripts/cullis-audit-verify.py
@@ -54,6 +54,10 @@ Exit codes:
   5  — unrecognized TSA format that cannot be verified, or RFC 3161
        anchor seen without ``--tsa-trust-store`` and
        ``--tsa-allow-unverified-signature`` not set
+  6  — Merkle inclusion proof failure (proof file unreadable or
+       malformed, no matching chain_seq entry in bundle, bundle
+       row_hash disagrees with proof leaf_hex, or reconstructed root
+       does not match anchored root) — ADR-037 Phase 3
 """
 from __future__ import annotations
 
@@ -829,6 +833,164 @@ def cross_reconcile(bundles: list[tuple[str, list[dict]]]) -> int:
     return verified
 
 
+# ── Merkle inclusion proof (ADR-037 Phase 3, offline path) ──────────
+#
+# The Mastio's /v1/admin/audit/merkle/proof/{chain_seq} endpoint
+# returns a JSON object with the shape:
+#
+#   {"anchor_id": int,
+#    "chain_seq": int,
+#    "chain_seq_start": int, "chain_seq_end": int, "leaf_count": int,
+#    "merkle_root": "<64 hex chars>",
+#    "leaf_hex": "<64 hex chars>",
+#    "proof": [{"sibling_hex": "<64 hex chars>", "position": "L"|"R"},
+#              ...]}
+#
+# An auditor with a bundle export + one or more such proof files can
+# replay this verifier offline (no Mastio access) and assert that the
+# row at ``chain_seq`` was included in the anchored Merkle root. The
+# math is inlined here so the CLI stays a single-file self-contained
+# script — the same math lives in ``mcp_proxy.audit.merkle`` for the
+# in-process path.
+
+
+def _merkle_verify_inclusion(
+    leaf: bytes, proof: list[tuple[bytes, str]], expected_root: bytes,
+) -> bool:
+    """Reconstruct the root from leaf + proof and compare to
+    ``expected_root``. Never raises on malformed input: returns False.
+    Mirrors ``mcp_proxy.audit.merkle.verify_inclusion`` byte-for-byte.
+    """
+    if not isinstance(leaf, (bytes, bytearray)) or len(leaf) != 32:
+        return False
+    if not isinstance(expected_root, (bytes, bytearray)) or len(expected_root) != 32:
+        return False
+    current = bytes(leaf)
+    for step in proof:
+        if not isinstance(step, tuple) or len(step) != 2:
+            return False
+        sibling, position = step
+        if not isinstance(sibling, (bytes, bytearray)) or len(sibling) != 32:
+            return False
+        if position == "L":
+            current = hashlib.sha256(bytes(sibling) + current).digest()
+        elif position == "R":
+            current = hashlib.sha256(current + bytes(sibling)).digest()
+        else:
+            return False
+    return current == expected_root
+
+
+def verify_merkle_proofs(
+    proof_paths: list[str],
+    bundles: list[tuple[str, list[dict]]],
+) -> int:
+    """Verify each inclusion proof JSON against the bundle entries.
+
+    For every proof file the verifier:
+      1. Loads the JSON and validates shape
+      2. Finds the matching ``chain_seq`` entry in the loaded bundles
+      3. Asserts the bundle's row_hash (or entry_hash legacy field)
+         equals the proof's ``leaf_hex``
+      4. Replays ``_merkle_verify_inclusion`` against the proof's root
+
+    Exit code 6 on any failure mode (no matching entry, leaf
+    disagreement, math fails). Distinct from chain (2) / anchor (3,5)
+    / cross (4) exit codes so an operator can wire the Merkle path
+    into a separate alarm without polluting the existing forensic
+    classifiers.
+
+    Returns the count of proofs verified successfully.
+    """
+    if not proof_paths:
+        return 0
+
+    # Flatten bundle entries into a single chain_seq → entry lookup.
+    by_seq: dict[int, dict] = {}
+    for _path, entries in bundles:
+        for e in entries:
+            seq = e.get("chain_seq")
+            if seq is None:
+                continue
+            try:
+                by_seq[int(seq)] = e
+            except (TypeError, ValueError):
+                continue
+
+    verified = 0
+    for path in proof_paths:
+        try:
+            with open(path) as f:
+                proof = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"MERKLE PROOF UNREADABLE path={path}: {exc}")
+            sys.exit(6)
+
+        try:
+            chain_seq = int(proof["chain_seq"])
+            leaf_hex = str(proof["leaf_hex"])
+            root_hex = str(proof["merkle_root"])
+            steps = proof["proof"]
+            if not isinstance(steps, list):
+                raise TypeError("proof.proof must be a list")
+        except (KeyError, TypeError, ValueError) as exc:
+            print(f"MERKLE PROOF MALFORMED path={path}: {exc}")
+            sys.exit(6)
+
+        entry = by_seq.get(chain_seq)
+        if entry is None:
+            print(
+                f"MERKLE PROOF UNMATCHED chain_seq={chain_seq}: "
+                f"no entry with that chain_seq in the loaded bundle(s) "
+                f"(path={path})"
+            )
+            sys.exit(6)
+
+        # Mastio bundles carry row_hash; legacy Court bundles may
+        # carry entry_hash. Accept either as long as it matches the
+        # proof's leaf_hex.
+        bundle_leaf = entry.get("row_hash") or entry.get("entry_hash")
+        if bundle_leaf is None:
+            print(
+                f"MERKLE PROOF UNMATCHED chain_seq={chain_seq}: "
+                f"bundle entry has no row_hash/entry_hash field"
+            )
+            sys.exit(6)
+        if str(bundle_leaf) != leaf_hex:
+            print(
+                f"MERKLE PROOF LEAF MISMATCH chain_seq={chain_seq}: "
+                f"bundle row_hash={bundle_leaf[:16]}... but proof "
+                f"leaf_hex={leaf_hex[:16]}... — either the proof was "
+                f"computed against a different audit_log or the bundle "
+                f"row has been tampered"
+            )
+            sys.exit(6)
+
+        try:
+            leaf_bytes = bytes.fromhex(leaf_hex)
+            root_bytes = bytes.fromhex(root_hex)
+            proof_steps = [
+                (bytes.fromhex(str(s["sibling_hex"])), str(s["position"]))
+                for s in steps
+            ]
+        except (KeyError, TypeError, ValueError) as exc:
+            print(f"MERKLE PROOF MALFORMED hex content: {exc}")
+            sys.exit(6)
+
+        if not _merkle_verify_inclusion(leaf_bytes, proof_steps, root_bytes):
+            print(
+                f"MERKLE PROOF FAIL chain_seq={chain_seq}: the proof "
+                f"reconstructed root does NOT match the anchored root "
+                f"{root_hex[:16]}... — either the proof, the leaf, or "
+                f"the anchored root has been tampered"
+            )
+            sys.exit(6)
+
+        verified += 1
+
+    return verified
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument(
@@ -882,6 +1044,20 @@ def main() -> int:
             "dated. (default: 300)"
         ),
     )
+    ap.add_argument(
+        "--merkle-proof", action="append", default=[],
+        metavar="PROOF_JSON",
+        help=(
+            "Path to a Merkle inclusion proof JSON file emitted by "
+            "GET /v1/admin/audit/merkle/proof/{chain_seq} (ADR-037 "
+            "Phase 2). For every file, the verifier asserts (a) the "
+            "matching chain_seq entry exists in the loaded bundle(s), "
+            "(b) its row_hash equals the proof's leaf_hex, and "
+            "(c) the reconstructed Merkle root matches the proof's "
+            "anchored root. Pass the flag multiple times to verify a "
+            "batch of proofs in one run. Exit code 6 on any failure."
+        ),
+    )
     args = ap.parse_args()
 
     bundles: list[tuple[str, list[dict]]] = []
@@ -912,6 +1088,7 @@ def main() -> int:
         bundles.append((path, entries))
 
     cross_n = cross_reconcile(bundles)
+    merkle_n = verify_merkle_proofs(args.merkle_proof, bundles)
 
     # CISO-readable PASS summary. The line breaks below are deliberate
     # so the auditor's terminal output reads like a verdict, not a CSV.
@@ -927,6 +1104,8 @@ def main() -> int:
     )
     if cross_n:
         print(f"  {cross_n} cross-org peer row{'s' if cross_n != 1 else ''} reconciled")
+    if merkle_n:
+        print(f"  {merkle_n} Merkle inclusion proof{'s' if merkle_n != 1 else ''} verified")
     print("")
     print("  Every entry_hash matches the SHA-256 of its canonical row.")
     print("  No previous_hash → next entry_hash break detected.")

--- a/test/unit/test_cullis_audit_verify_merkle.py
+++ b/test/unit/test_cullis_audit_verify_merkle.py
@@ -1,0 +1,250 @@
+"""Unit tests for ``scripts/cullis-audit-verify.py --merkle-proof``
+(ADR-037 Phase 3).
+
+The CLI is a standalone script the offline auditor runs from a
+shell. These tests import the script as a module (renamed from
+``cullis-audit-verify.py`` to a Python-importable path via
+``importlib``) and exercise the Merkle helpers + the
+``verify_merkle_proofs`` driver. We do NOT spawn a subprocess for
+every case — the helpers are pure functions and a SystemExit-based
+failure path is captured with ``pytest.raises(SystemExit)``.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ── Load the dash-named script as a module ──────────────────────────
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts" / "cullis-audit-verify.py"
+)
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "cullis_audit_verify_cli", str(_SCRIPT_PATH),
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cli = _load_cli_module()
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _h(payload: bytes) -> bytes:
+    return hashlib.sha256(payload).digest()
+
+
+def _build_proof(leaves: list[bytes], target_index: int) -> dict:
+    """Compute a Merkle root + inclusion proof using the same math
+    as the in-tree ``mcp_proxy.audit.merkle`` module (which the
+    CLI inlines). Returns a dict shaped like the
+    /v1/admin/audit/merkle/proof/{chain_seq} response."""
+    # Mirror compute + build from the script's inlined math via the
+    # _merkle_verify_inclusion → instead we use the in-tree module
+    # to construct expected, and verify the CLI agrees.
+    from mcp_proxy.audit.merkle import (
+        compute_merkle_root, inclusion_proof,
+    )
+    root = compute_merkle_root(leaves)
+    steps = inclusion_proof(leaves, target_index)
+    return {
+        "anchor_id": 42,
+        "chain_seq": target_index + 1,  # caller adjusts
+        "chain_seq_start": 1,
+        "chain_seq_end": len(leaves),
+        "leaf_count": len(leaves),
+        "merkle_root": root.hex(),
+        "leaf_hex": leaves[target_index].hex(),
+        "proof": [
+            {"sibling_hex": sib.hex(), "position": pos}
+            for sib, pos in steps
+        ],
+    }
+
+
+def _make_bundle(leaves: list[bytes]) -> list[tuple[str, list[dict]]]:
+    """Build the ``bundles`` shape verify_merkle_proofs expects:
+    one (path, entries) tuple, entries carrying chain_seq +
+    row_hash matching the leaves."""
+    entries = [
+        {"chain_seq": i + 1, "row_hash": leaf.hex(), "kind": "entry"}
+        for i, leaf in enumerate(leaves)
+    ]
+    return [("/dev/null", entries)]
+
+
+# ── _merkle_verify_inclusion (the inlined math) ─────────────────────
+
+
+def test_verify_inclusion_accepts_valid_proof():
+    leaves = [_h(f"r{i}".encode()) for i in range(8)]
+    proof = _build_proof(leaves, target_index=3)
+    leaf = bytes.fromhex(proof["leaf_hex"])
+    root = bytes.fromhex(proof["merkle_root"])
+    steps = [
+        (bytes.fromhex(s["sibling_hex"]), s["position"])
+        for s in proof["proof"]
+    ]
+    assert cli._merkle_verify_inclusion(leaf, steps, root) is True
+
+
+def test_verify_inclusion_rejects_forged_leaf():
+    leaves = [_h(f"r{i}".encode()) for i in range(8)]
+    proof = _build_proof(leaves, target_index=3)
+    forged = _h(b"not-real")
+    root = bytes.fromhex(proof["merkle_root"])
+    steps = [
+        (bytes.fromhex(s["sibling_hex"]), s["position"])
+        for s in proof["proof"]
+    ]
+    assert cli._merkle_verify_inclusion(forged, steps, root) is False
+
+
+def test_verify_inclusion_rejects_wrong_position_marker():
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    proof = _build_proof(leaves, target_index=0)
+    leaf = bytes.fromhex(proof["leaf_hex"])
+    root = bytes.fromhex(proof["merkle_root"])
+    bad_steps = [
+        (bytes.fromhex(s["sibling_hex"]), "X")  # invalid marker
+        for s in proof["proof"]
+    ]
+    assert cli._merkle_verify_inclusion(leaf, bad_steps, root) is False
+
+
+def test_verify_inclusion_rejects_malformed_inputs():
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    proof = _build_proof(leaves, target_index=0)
+    leaf = bytes.fromhex(proof["leaf_hex"])
+    root = bytes.fromhex(proof["merkle_root"])
+    steps = [
+        (bytes.fromhex(s["sibling_hex"]), s["position"])
+        for s in proof["proof"]
+    ]
+    # Short leaf.
+    assert cli._merkle_verify_inclusion(b"short", steps, root) is False
+    # Short root.
+    assert cli._merkle_verify_inclusion(leaf, steps, b"short") is False
+    # Short sibling.
+    bad_steps = [(b"short", "L")]
+    assert cli._merkle_verify_inclusion(leaf, bad_steps, root) is False
+
+
+# ── verify_merkle_proofs driver ─────────────────────────────────────
+
+
+def test_verify_merkle_proofs_empty_returns_zero():
+    assert cli.verify_merkle_proofs([], []) == 0
+
+
+def test_verify_merkle_proofs_valid_path_returns_count(tmp_path):
+    leaves = [_h(f"r{i}".encode()) for i in range(8)]
+    bundles = _make_bundle(leaves)
+    proof = _build_proof(leaves, target_index=4)
+    proof_path = tmp_path / "proof.json"
+    proof_path.write_text(json.dumps(proof))
+    assert cli.verify_merkle_proofs([str(proof_path)], bundles) == 1
+
+
+def test_verify_merkle_proofs_multiple_files(tmp_path):
+    leaves = [_h(f"r{i}".encode()) for i in range(8)]
+    bundles = _make_bundle(leaves)
+    paths = []
+    for i in [0, 3, 7]:
+        proof = _build_proof(leaves, target_index=i)
+        p = tmp_path / f"proof_{i}.json"
+        p.write_text(json.dumps(proof))
+        paths.append(str(p))
+    assert cli.verify_merkle_proofs(paths, bundles) == 3
+
+
+def test_verify_merkle_proofs_unmatched_chain_seq_exits_6(tmp_path):
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    bundles = _make_bundle(leaves)  # chain_seq 1..4
+    proof = _build_proof(leaves, target_index=0)
+    proof["chain_seq"] = 999  # not in bundle
+    proof_path = tmp_path / "proof.json"
+    proof_path.write_text(json.dumps(proof))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs([str(proof_path)], bundles)
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_leaf_disagreement_exits_6(tmp_path):
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    bundles = _make_bundle(leaves)
+    proof = _build_proof(leaves, target_index=1)
+    # Tamper: forge the leaf_hex (no longer matches bundle row_hash).
+    proof["leaf_hex"] = _h(b"tampered").hex()
+    proof_path = tmp_path / "proof.json"
+    proof_path.write_text(json.dumps(proof))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs([str(proof_path)], bundles)
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_wrong_root_exits_6(tmp_path):
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    bundles = _make_bundle(leaves)
+    proof = _build_proof(leaves, target_index=1)
+    # Tamper: replace root with something unrelated.
+    proof["merkle_root"] = _h(b"other-tree").hex()
+    proof_path = tmp_path / "proof.json"
+    proof_path.write_text(json.dumps(proof))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs([str(proof_path)], bundles)
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_unreadable_file_exits_6():
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs(
+            ["/nonexistent/path/proof.json"], [],
+        )
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_malformed_json_exits_6(tmp_path):
+    proof_path = tmp_path / "bad.json"
+    proof_path.write_text("{not valid json")
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs([str(proof_path)], [])
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_missing_required_field_exits_6(tmp_path):
+    proof_path = tmp_path / "incomplete.json"
+    proof_path.write_text(json.dumps({"chain_seq": 1}))  # no leaf_hex/root/proof
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_merkle_proofs([str(proof_path)], [])
+    assert exc_info.value.code == 6
+
+
+def test_verify_merkle_proofs_accepts_legacy_entry_hash_field(tmp_path):
+    """Legacy Court bundles carry ``entry_hash`` instead of
+    ``row_hash``. The Merkle path must accept either as long as the
+    bytes agree with the proof's leaf_hex."""
+    leaves = [_h(f"r{i}".encode()) for i in range(4)]
+    legacy_entries = [
+        {"chain_seq": i + 1, "entry_hash": leaf.hex()}
+        for i, leaf in enumerate(leaves)
+    ]
+    bundles = [("/dev/null", legacy_entries)]
+    proof = _build_proof(leaves, target_index=2)
+    proof_path = tmp_path / "proof.json"
+    proof_path.write_text(json.dumps(proof))
+    assert cli.verify_merkle_proofs([str(proof_path)], bundles) == 1


### PR DESCRIPTION
## Summary

**Stacked on #921** (Phase 2). Closes ADR-037: the offline auditor CLI can now consume the inclusion proof JSON returned by \`/v1/admin/audit/merkle/proof/{chain_seq}\` (Phase 2) and assert that a row in the NDJSON export bundle is provably included in the anchored Merkle root — without any Mastio access.

> ⚠️ **Stacked PR (3rd level)**: merge order is #920 → #921 → #918. Do NOT \`--delete-branch\` on #920 or #921 until this PR is also rebased, or the cascade closes downstream PRs.

The Merkle math is inlined in the script (same bytes as \`mcp_proxy.audit.merkle\`) so the CLI stays a single-file self-contained tool. An auditor can carry it on a USB key and run against a bundle handed to them three years after the audit.

## What ships

- **New CLI flag**: \`--merkle-proof <file>\`. Pass once per proof JSON; multiple flags batch-verify. Refuses to PASS on:
  - File unreadable / malformed JSON / missing required field
  - \`chain_seq\` not present in the loaded bundle(s)
  - bundle \`row_hash\` (or legacy \`entry_hash\`) ≠ proof's \`leaf_hex\`
  - reconstructed root ≠ proof's \`merkle_root\`
- **Exit code 6** carved out for Merkle failure modes, distinct from chain (2) / anchor (3,5) / cross-ref (4) so a CI alarm wires Merkle-only without polluting existing forensic classifiers
- **Verdict integration**: success summary now reads \`N Merkle inclusion proofs verified\` when proofs are passed
- **Helper** \`_merkle_verify_inclusion(leaf, proof, root)\`: same byte-for-byte semantics as \`mcp_proxy.audit.merkle.verify_inclusion\`, plus extra hostile-input rejection (never raises on malformed bundle/proof)

## CLI usage example

\`\`\`bash
# Fetch the bundle + a few proofs from the Mastio
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/audit/export?org_id=acme > acme.ndjson
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/audit/merkle/proof/5 > proof-5.json
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/audit/merkle/proof/12 > proof-12.json

# Verify offline — no Mastio access needed, the math is in the script
python3 cullis-audit-verify.py \\
    --bundle acme.ndjson \\
    --merkle-proof proof-5.json \\
    --merkle-proof proof-12.json \\
    --tsa-trust-store /etc/cullis/tsa-roots.pem
\`\`\`

## Test plan

- [x] **14 unit tests** in \`test/unit/test_cullis_audit_verify_merkle.py\` (~50ms, no I/O beyond \`tmp_path\` proof files):
  - Math: forged leaf, wrong position, malformed inputs
  - Driver: valid path, multi-file batch, unmatched chain_seq, leaf disagreement, wrong root, unreadable file, malformed JSON, missing field, legacy \`entry_hash\` fallback
- [x] **Smoke 00_boot PASS** post-change (no integration surface change — the CLI is exercised via \`91_merkle_anchor\`'s in-process replay using the same math)

## What closes

This is the **last PR in the ADR-037 Merkle anchoring track**:

| Phase | PR | What |
|---|---|---|
| 0 | #918 (merged) | Pure tree math + 40 unit |
| 1 | #920 | Table 0044 + ORM + lifespan watcher + 10 unit |
| 2 | #921 | Admin endpoints + 14 unit + smoke scenario |
| 3 | **this** | CLI \`--merkle-proof\` + 14 unit |

Cumulative: **78 unit tests** (40+10+14+14) + smoke 11/11. Audit chain has three layers of evidence (hash chain → TSA single-row anchoring → Merkle batch + TSA on root), and an auditor with the CLI + a bundle export + a few proof JSONs can independently replay all three without trusting the Mastio.

429 insertions, 2 files changed.