### PR TITLE
feat(audit): cullis-audit-verify.py --archive-* flags (Enterprise audit_archive verifier)

### DIFF
--- a/scripts/cullis-audit-verify.py
+++ b/scripts/cullis-audit-verify.py
@@ -58,6 +58,11 @@ Exit codes:
        malformed, no matching chain_seq entry in bundle, bundle
        row_hash disagrees with proof leaf_hex, or reconstructed root
        does not match anchored root) — ADR-037 Phase 3
+  7  — Enterprise audit_archive verification failure (STH ES256
+       signature invalid, manifest signature invalid, RFC 6962 audit
+       path does not reconstruct the anchored root, bundle row_hash
+       disagrees with proof leaf_hash, or --archive-manifest-pubkey
+       missing when archive flags are set)
 """
 from __future__ import annotations
 
@@ -991,6 +996,397 @@ def verify_merkle_proofs(
     return verified
 
 
+# ── Enterprise archive verification (audit_archive plugin) ──────────
+#
+# Operators on the Enterprise edition run the ``audit_archive`` plugin
+# (cullis-security/cullis-enterprise) which exports the per-epoch
+# audit chain to a WORM-sealed sink (S3 Object Lock COMPLIANCE, file://,
+# Azure Blob immutable on roadmap), computes an RFC 6962 Merkle root
+# over the row_hash leaves, and signs the root with the active Mastio
+# ES256 identity key as a Signed Tree Head (STH).
+#
+# An auditor receiving the NDJSON bundle + STH JSON + inclusion proof
+# JSON + the Mastio's ES256 public key can verify the whole envelope
+# offline with this CLI — no Mastio access, no Cullis vendor trust.
+# That is the open-core line: the WORM sink + STH generation are
+# Enterprise (per-deployment integration), the math + the verifier
+# are public so the auditor's check is vendor-independent.
+#
+# Three artefact shapes (matching the audit_archive plugin output):
+#
+#   STH JSON (per epoch):
+#     {"epoch_utc": "2026-05-24T00:00:00Z",
+#      "mastio_org_id": "acme",
+#      "tree_size": 1234,
+#      "root_hash_hex": "<64 hex>",
+#      "chain_seq_lo": 1, "chain_seq_hi": 1234,
+#      "signature_b64u": "<base64url ECDSA sig over canonical JSON>",
+#      "mastio_kid": "mastio-<id>",
+#      "signed_at": "<RFC 3339>"}
+#
+#   Inclusion proof JSON (per row):
+#     {"epoch_utc": "...",
+#      "leaf_index": 567,
+#      "leaf_hash_hex": "<64 hex>",
+#      "audit_path": ["<64 hex>", ...],     # RFC 6962 sibling list, no positions
+#      "sth": { ... STH inlined for self-contained verify ... }}
+#
+#   Manifest JSON (per bundle export):
+#     {"epoch_utc": "...",
+#      "chain_seq_lo": 1, "chain_seq_hi": 1234, "row_count": 1234,
+#      "sink_url": "s3://.../audit-2026-05-24.ndjson.zst",
+#      "bundle_sha256": "<64 hex>",
+#      "signature_b64u": "<base64url ECDSA sig over canonical JSON>"}
+#
+# The math is inlined here so the CLI stays a single-file
+# self-contained tool, but it follows RFC 6962 §2.1 byte-for-byte
+# (leaf prefix 0x00, internal prefix 0x01) so a third-party CT
+# library would compute the same root.
+
+
+_RFC6962_LEAF_PREFIX = b"\x00"
+_RFC6962_NODE_PREFIX = b"\x01"
+
+
+def _rfc6962_leaf_hash(row_hash_hex: str) -> bytes:
+    """RFC 6962 §2.1: leaf hash = sha256(0x00 || raw_leaf_bytes).
+
+    The Mastio's row_hash is already a SHA-256 hex digest, but RFC 6962
+    treats THAT as the leaf content; we prepend the leaf prefix and
+    rehash, matching what the audit_archive STH builder does
+    server-side.
+    """
+    raw = bytes.fromhex(row_hash_hex)
+    return hashlib.sha256(_RFC6962_LEAF_PREFIX + raw).digest()
+
+
+def _rfc6962_node_hash(left: bytes, right: bytes) -> bytes:
+    """RFC 6962 §2.1: internal node = sha256(0x01 || left || right)."""
+    return hashlib.sha256(_RFC6962_NODE_PREFIX + left + right).digest()
+
+
+def _rfc6962_verify_audit_path(
+    leaf_hash: bytes,
+    audit_path: list[str],
+    leaf_index: int,
+    tree_size: int,
+    expected_root: bytes,
+) -> bool:
+    """Verify an RFC 6962 audit path under the "promote unpaired"
+    construction used by the audit_archive plugin.
+
+    The plugin builds the tree with ``compute_merkle_root``:
+    pairwise hashing within each layer, trailing unpaired nodes are
+    PROMOTED to the next layer unchanged (not duplicated). The
+    matching ``compute_inclusion_proof`` emits an empty string in
+    ``audit_path`` at each level where the current node was promoted
+    unpaired — the verifier MUST skip the sibling combination at
+    that level and only advance the index.
+
+    Position at each level is the LSB of the index folded one bit
+    per step. The audit_path therefore carries no L/R marker, only
+    siblings (or '' for promote-skip).
+    """
+    if not 0 <= leaf_index < tree_size:
+        return False
+    if len(leaf_hash) != 32 or len(expected_root) != 32:
+        return False
+
+    h = leaf_hash
+    idx = leaf_index
+    for sibling_hex in audit_path:
+        if sibling_hex == "":
+            # Promoted unpaired at this level — h passes through.
+            idx >>= 1
+            continue
+        if not isinstance(sibling_hex, str):
+            return False
+        try:
+            sibling = bytes.fromhex(sibling_hex)
+        except (TypeError, ValueError):
+            return False
+        if len(sibling) != 32:
+            return False
+        if idx & 1:
+            # Current node sits on the right of its parent.
+            h = _rfc6962_node_hash(sibling, h)
+        else:
+            h = _rfc6962_node_hash(h, sibling)
+        idx >>= 1
+    return h == expected_root
+
+
+def _canonical_json(obj: dict) -> bytes:
+    """Canonical JSON encoding for signing/verification.
+
+    sorted keys, no whitespace, ensure_ascii=True. Bytes returned ready
+    for ECDSA sign/verify input. Matches what the audit_archive plugin
+    feeds into ``AgentManager.countersign`` server-side.
+    """
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _verify_es256_signature(
+    payload: bytes,
+    signature_b64u: str,
+    pubkey_pem_bytes: bytes,
+) -> bool:
+    """Verify a JOSE ES256 signature (ECDSA P-256 + SHA-256) over
+    ``payload`` against a PEM-encoded EC public key.
+
+    ``signature_b64u`` is the JOSE flat encoding: base64url(r || s)
+    where r and s are each 32 bytes big-endian (RFC 7515 §3.4 / RFC
+    7518 §3.4 ``ES256``). We convert to the DER form ``cryptography``
+    expects before calling ``verify``.
+
+    Returns False on any malformed input or signature mismatch.
+    Never raises — the offline verifier path must stay robust against
+    adversarial bundle content.
+    """
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.hazmat.primitives.asymmetric.utils import (
+            encode_dss_signature,
+        )
+    except ImportError:
+        return False
+
+    try:
+        pad = "=" * (-len(signature_b64u) % 4)
+        raw_sig = base64.urlsafe_b64decode(signature_b64u + pad)
+        if len(raw_sig) != 64:
+            return False
+        r = int.from_bytes(raw_sig[:32], "big")
+        s = int.from_bytes(raw_sig[32:], "big")
+        der_sig = encode_dss_signature(r, s)
+
+        pubkey = serialization.load_pem_public_key(pubkey_pem_bytes)
+        if not isinstance(pubkey, ec.EllipticCurvePublicKey):
+            return False
+        if not isinstance(pubkey.curve, ec.SECP256R1):
+            return False
+        pubkey.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+    except Exception:  # noqa: BLE001 — adversarial input must not crash CLI
+        return False
+
+
+def _sth_canonical_payload(sth: dict) -> bytes:
+    """The exact field set the audit_archive plugin signs over.
+
+    Order is documented in the patch: mastio_org_id, epoch_utc,
+    tree_size, root_hash_hex, chain_seq_lo, chain_seq_hi, mastio_kid,
+    issued_at. ``signature_b64u`` is NOT in the signed payload (it
+    IS the signature). ``signed_at`` is also outside the canonical
+    payload to match the server-side signer.
+    """
+    fields = {
+        "mastio_org_id": sth["mastio_org_id"],
+        "epoch_utc": sth["epoch_utc"],
+        "tree_size": int(sth["tree_size"]),
+        "root_hash_hex": sth["root_hash_hex"],
+        "chain_seq_lo": int(sth["chain_seq_lo"]),
+        "chain_seq_hi": int(sth["chain_seq_hi"]),
+        "mastio_kid": sth["mastio_kid"],
+        "issued_at": sth["signed_at"],
+    }
+    return _canonical_json(fields)
+
+
+def _manifest_canonical_payload(manifest: dict) -> bytes:
+    """Canonical payload the audit_archive plugin signs for each
+    bundle manifest. Fields: epoch_utc, mastio_org_id, chain_seq_lo,
+    chain_seq_hi, row_count, sink_url, bundle_sha256.
+    """
+    fields = {
+        "epoch_utc": manifest["epoch_utc"],
+        "mastio_org_id": manifest.get("mastio_org_id", ""),
+        "chain_seq_lo": int(manifest["chain_seq_lo"]),
+        "chain_seq_hi": int(manifest["chain_seq_hi"]),
+        "row_count": int(manifest["row_count"]),
+        "sink_url": manifest["sink_url"],
+        "bundle_sha256": manifest["bundle_sha256"],
+    }
+    return _canonical_json(fields)
+
+
+def verify_archive_proofs(
+    sth_paths: list[str],
+    proof_paths: list[str],
+    manifest_paths: list[str],
+    pubkey_pem_path: str | None,
+    bundles: list[tuple[str, list[dict]]],
+) -> tuple[int, int, int]:
+    """Verify Enterprise audit_archive artefacts: STH signatures,
+    bundle manifests, and per-row inclusion proofs against the
+    Mastio's ES256 public key.
+
+    Returns ``(sth_verified, manifest_verified, proof_verified)``.
+    Exits 7 on any failure mode so an operator can wire archive
+    verification into a distinct alarm vs chain (2) / anchor (3,5) /
+    cross-ref (4) / Merkle proof (6).
+
+    All three artefact families share the same pubkey: the auditor
+    obtains it out of band (the Mastio's ``/v1/admin/mastio-pubkey``
+    endpoint, or a customer-handover PEM). Trust path is "the
+    auditor trusted this pubkey was the Mastio's at archive time",
+    not "trust whatever kid is in the JSON".
+    """
+    if not (sth_paths or proof_paths or manifest_paths):
+        return 0, 0, 0
+
+    if pubkey_pem_path is None:
+        print(
+            "ARCHIVE VERIFY: --archive-manifest-pubkey is required when "
+            "--archive-sth / --archive-proof / --archive-manifest is set"
+        )
+        sys.exit(7)
+
+    try:
+        with open(pubkey_pem_path, "rb") as f:
+            pubkey_pem = f.read()
+    except OSError as exc:
+        print(f"ARCHIVE PUBKEY UNREADABLE path={pubkey_pem_path}: {exc}")
+        sys.exit(7)
+
+    # ── 1. STH JSONs ────────────────────────────────────────────────
+    sth_verified = 0
+    sth_by_epoch: dict[str, dict] = {}
+    for path in sth_paths:
+        sth = _load_json_file(path, "ARCHIVE STH")
+        try:
+            payload = _sth_canonical_payload(sth)
+            sig = sth["signature_b64u"]
+        except KeyError as exc:
+            print(f"ARCHIVE STH MALFORMED path={path}: missing {exc}")
+            sys.exit(7)
+        if not _verify_es256_signature(payload, sig, pubkey_pem):
+            print(
+                f"ARCHIVE STH SIGNATURE INVALID path={path} "
+                f"epoch={sth.get('epoch_utc', '?')}"
+            )
+            sys.exit(7)
+        sth_by_epoch[str(sth["epoch_utc"])] = sth
+        sth_verified += 1
+
+    # ── 2. Manifests ────────────────────────────────────────────────
+    manifest_verified = 0
+    for path in manifest_paths:
+        manifest = _load_json_file(path, "ARCHIVE MANIFEST")
+        try:
+            payload = _manifest_canonical_payload(manifest)
+            sig = manifest["signature_b64u"]
+        except KeyError as exc:
+            print(f"ARCHIVE MANIFEST MALFORMED path={path}: missing {exc}")
+            sys.exit(7)
+        if not _verify_es256_signature(payload, sig, pubkey_pem):
+            print(
+                f"ARCHIVE MANIFEST SIGNATURE INVALID path={path} "
+                f"epoch={manifest.get('epoch_utc', '?')}"
+            )
+            sys.exit(7)
+        manifest_verified += 1
+
+    # ── 3. Inclusion proofs ─────────────────────────────────────────
+    # Each proof has its STH inlined (self-contained verify). We
+    # re-verify the embedded STH signature even if the same epoch was
+    # already verified standalone — the inlined STH could disagree
+    # with the standalone one and that disagreement is the signal an
+    # operator needs to see.
+    proof_verified = 0
+    by_chain_seq: dict[int, dict] = {}
+    for _path, entries in bundles:
+        for e in entries:
+            seq = e.get("chain_seq")
+            if seq is None:
+                continue
+            try:
+                by_chain_seq[int(seq)] = e
+            except (TypeError, ValueError):
+                continue
+
+    for path in proof_paths:
+        proof = _load_json_file(path, "ARCHIVE PROOF")
+        try:
+            inlined_sth = proof["sth"]
+            leaf_index = int(proof["leaf_index"])
+            leaf_hash_hex = str(proof["leaf_hash_hex"])
+            audit_path_hex = list(proof["audit_path"])
+        except (KeyError, TypeError, ValueError) as exc:
+            print(f"ARCHIVE PROOF MALFORMED path={path}: {exc}")
+            sys.exit(7)
+
+        sth_payload = _sth_canonical_payload(inlined_sth)
+        if not _verify_es256_signature(
+            sth_payload, inlined_sth["signature_b64u"], pubkey_pem,
+        ):
+            print(
+                f"ARCHIVE PROOF STH-SIGNATURE INVALID path={path} "
+                f"epoch={inlined_sth.get('epoch_utc', '?')}"
+            )
+            sys.exit(7)
+
+        try:
+            leaf_hash = bytes.fromhex(leaf_hash_hex)
+            root = bytes.fromhex(inlined_sth["root_hash_hex"])
+            tree_size = int(inlined_sth["tree_size"])
+            chain_seq_lo = int(inlined_sth["chain_seq_lo"])
+            # audit_path_hex stays as list[str] — entries may be ""
+            # to signal a promoted-unpaired level (skip sibling combine).
+        except (KeyError, TypeError, ValueError) as exc:
+            print(f"ARCHIVE PROOF hex parse error: {exc}")
+            sys.exit(7)
+
+        if not _rfc6962_verify_audit_path(
+            leaf_hash, audit_path_hex, leaf_index, tree_size, root,
+        ):
+            print(
+                f"ARCHIVE PROOF INCLUSION FAIL path={path} "
+                f"leaf_index={leaf_index} epoch={inlined_sth.get('epoch_utc', '?')}"
+            )
+            sys.exit(7)
+
+        # Cross-check against the bundle: bundle row at
+        # chain_seq = chain_seq_lo + leaf_index must have row_hash
+        # whose RFC 6962 leaf hash equals the proof's leaf_hash.
+        bundle_chain_seq = chain_seq_lo + leaf_index
+        entry = by_chain_seq.get(bundle_chain_seq)
+        if entry is not None:
+            bundle_row_hash = entry.get("row_hash") or entry.get("entry_hash")
+            if bundle_row_hash is not None:
+                computed = _rfc6962_leaf_hash(str(bundle_row_hash))
+                if computed != leaf_hash:
+                    print(
+                        f"ARCHIVE PROOF BUNDLE MISMATCH path={path} "
+                        f"chain_seq={bundle_chain_seq}: bundle row_hash "
+                        f"leaf-hash != proof leaf_hash_hex — bundle and "
+                        f"proof disagree on the same row"
+                    )
+                    sys.exit(7)
+        proof_verified += 1
+
+    return sth_verified, manifest_verified, proof_verified
+
+
+def _load_json_file(path: str, label: str) -> dict:
+    try:
+        with open(path) as f:
+            obj = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"{label} UNREADABLE path={path}: {exc}")
+        sys.exit(7)
+    if not isinstance(obj, dict):
+        print(f"{label} not a JSON object: path={path}")
+        sys.exit(7)
+    return obj
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument(
@@ -1058,6 +1454,57 @@ def main() -> int:
             "batch of proofs in one run. Exit code 6 on any failure."
         ),
     )
+    ap.add_argument(
+        "--archive-sth", action="append", default=[],
+        metavar="STH_JSON",
+        help=(
+            "Path to a Signed Tree Head JSON emitted by the Enterprise "
+            "audit_archive plugin (GET /v1/admin/audit/sth/{epoch} or "
+            "/sth/latest). The CLI verifies the ES256 signature over "
+            "the canonical STH fields against --archive-manifest-pubkey. "
+            "Pass multiple times to batch-verify a window of epochs."
+        ),
+    )
+    ap.add_argument(
+        "--archive-proof", action="append", default=[],
+        metavar="PROOF_JSON",
+        help=(
+            "Path to an RFC 6962 inclusion proof JSON emitted by "
+            "GET /v1/admin/audit/proof?chain_seq=N (Enterprise "
+            "audit_archive plugin). Each proof carries its STH "
+            "inlined; the CLI re-verifies the STH ES256 signature, "
+            "walks the RFC 6962 audit_path bottom-up against the "
+            "anchored root, and (when the bundle is loaded) confirms "
+            "the proof's leaf_hash matches sha256(0x00 || row_hash) "
+            "of the corresponding chain_seq entry. Exit code 7."
+        ),
+    )
+    ap.add_argument(
+        "--archive-manifest", action="append", default=[],
+        metavar="MANIFEST_JSON",
+        help=(
+            "Path to a per-epoch bundle manifest JSON. The CLI verifies "
+            "the ES256 signature over the manifest's canonical payload "
+            "(epoch, range, row_count, sink_url, bundle_sha256) against "
+            "--archive-manifest-pubkey, proving the operator's named "
+            "bundle URL was authoritatively sealed by the Mastio at "
+            "archive time."
+        ),
+    )
+    ap.add_argument(
+        "--archive-manifest-pubkey",
+        default=None,
+        metavar="PEM",
+        help=(
+            "Path to the Mastio's ES256 public key in PEM format. "
+            "Required when any --archive-sth, --archive-proof, or "
+            "--archive-manifest is set. The auditor obtains this "
+            "pubkey out of band (the Mastio's /v1/admin/mastio-pubkey "
+            "endpoint, or a customer handover); trust is anchored on "
+            "having received this pubkey from a trusted channel, not "
+            "on the kid metadata inside the JSONs."
+        ),
+    )
     args = ap.parse_args()
 
     bundles: list[tuple[str, list[dict]]] = []
@@ -1089,6 +1536,13 @@ def main() -> int:
 
     cross_n = cross_reconcile(bundles)
     merkle_n = verify_merkle_proofs(args.merkle_proof, bundles)
+    sth_n, manifest_n, archive_proof_n = verify_archive_proofs(
+        args.archive_sth,
+        args.archive_proof,
+        args.archive_manifest,
+        args.archive_manifest_pubkey,
+        bundles,
+    )
 
     # CISO-readable PASS summary. The line breaks below are deliberate
     # so the auditor's terminal output reads like a verdict, not a CSV.
@@ -1106,6 +1560,20 @@ def main() -> int:
         print(f"  {cross_n} cross-org peer row{'s' if cross_n != 1 else ''} reconciled")
     if merkle_n:
         print(f"  {merkle_n} Merkle inclusion proof{'s' if merkle_n != 1 else ''} verified")
+    if sth_n or manifest_n or archive_proof_n:
+        parts: list[str] = []
+        if sth_n:
+            parts.append(f"{sth_n} STH{'s' if sth_n != 1 else ''}")
+        if manifest_n:
+            parts.append(
+                f"{manifest_n} bundle manifest{'s' if manifest_n != 1 else ''}"
+            )
+        if archive_proof_n:
+            parts.append(
+                f"{archive_proof_n} archive inclusion proof"
+                f"{'s' if archive_proof_n != 1 else ''}"
+            )
+        print(f"  {' · '.join(parts)} verified against the Mastio pubkey")
     print("")
     print("  Every entry_hash matches the SHA-256 of its canonical row.")
     print("  No previous_hash → next entry_hash break detected.")

--- a/test/unit/test_cullis_audit_verify_archive.py
+++ b/test/unit/test_cullis_audit_verify_archive.py
@@ -1,0 +1,480 @@
+"""Unit tests for ``scripts/cullis-audit-verify.py`` Enterprise
+audit_archive verification flags: ``--archive-sth``,
+``--archive-proof``, ``--archive-manifest``.
+
+The CLI math (RFC 6962 prefix bytes, ES256 over canonical JSON) is
+pure and inlined; we exercise it here by generating valid STH /
+proof / manifest artefacts with a freshly-minted EC P-256 key and
+asserting the verifier accepts them, then perturb each field and
+assert it refuses with exit code 7.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import (
+    decode_dss_signature,
+)
+
+
+# ── Load the dash-named CLI as a module ─────────────────────────────
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts" / "cullis-audit-verify.py"
+)
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "cullis_audit_verify_cli", str(_SCRIPT_PATH),
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cli = _load_cli_module()
+
+
+# ── Crypto helpers (server-side equivalent) ─────────────────────────
+
+
+@pytest.fixture
+def mastio_key(tmp_path) -> tuple[ec.EllipticCurvePrivateKey, Path]:
+    """Mint a fresh ES256 key, write the PEM, return both."""
+    privkey = ec.generate_private_key(ec.SECP256R1())
+    pubkey_pem = privkey.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    path = tmp_path / "mastio.pub.pem"
+    path.write_bytes(pubkey_pem)
+    return privkey, path
+
+
+def _sign_b64u(privkey: ec.EllipticCurvePrivateKey, payload: bytes) -> str:
+    """Sign ``payload`` with ES256 and return JOSE flat b64url(r||s)."""
+    der_sig = privkey.sign(payload, ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der_sig)
+    raw = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _h(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+# ── RFC 6962 tree builder (server-side equivalent) ──────────────────
+
+
+def _build_rfc6962_tree(row_hashes_hex: list[str]) -> tuple[bytes, list[list[bytes]]]:
+    """Build an RFC 6962 binary Merkle tree using the audit_archive
+    plugin's "promote unpaired" construction (matches
+    ``compute_merkle_root`` in the patch):
+
+      * Leaves: sha256(0x00 || row_hash_raw)
+      * Internal: sha256(0x01 || left || right)
+      * Trailing unpaired node at each level is PROMOTED unchanged
+        to the next level (NOT duplicate-last)
+
+    Returns (root, levels_bottom_up).
+    """
+    leaves = [
+        hashlib.sha256(b"\x00" + bytes.fromhex(rh)).digest()
+        for rh in row_hashes_hex
+    ]
+    levels: list[list[bytes]] = [leaves]
+    while len(levels[-1]) > 1:
+        layer = levels[-1]
+        next_layer: list[bytes] = []
+        for i in range(0, len(layer) - 1, 2):
+            next_layer.append(
+                hashlib.sha256(b"\x01" + layer[i] + layer[i + 1]).digest()
+            )
+        if len(layer) % 2 == 1:
+            next_layer.append(layer[-1])  # promote unpaired
+        levels.append(next_layer)
+    return levels[-1][0], levels
+
+
+def _audit_path(levels: list[list[bytes]], index: int) -> list[str]:
+    """Bottom-up audit path. Each level emits the sibling hex string,
+    or "" when the cursor sits on a trailing unpaired (promoted) node
+    and there is no sibling at that level. Matches what
+    ``compute_inclusion_proof`` in the patch produces.
+    """
+    path: list[str] = []
+    cursor = index
+    for level in levels[:-1]:
+        if cursor == len(level) - 1 and len(level) % 2 == 1:
+            path.append("")  # promote-unpaired, no sibling
+        else:
+            sibling_idx = cursor ^ 1
+            path.append(level[sibling_idx].hex())
+        cursor //= 2
+    return path
+
+
+# ── Bundle + artefact builders ──────────────────────────────────────
+
+
+def _make_bundle_entries(start_seq: int, count: int) -> list[dict]:
+    """Generate audit bundle entries with predictable row_hashes."""
+    return [
+        {
+            "kind": "entry",
+            "chain_seq": start_seq + i,
+            "row_hash": _h(f"r{start_seq + i}".encode()),
+        }
+        for i in range(count)
+    ]
+
+
+def _sth_dict(
+    privkey: ec.EllipticCurvePrivateKey,
+    *,
+    epoch_utc: str = "2026-05-24T00:00:00Z",
+    org_id: str = "acme",
+    tree_size: int,
+    root_hash_hex: str,
+    chain_seq_lo: int,
+    chain_seq_hi: int,
+    kid: str = "mastio-test-kid",
+    signed_at: str = "2026-05-24T00:00:01Z",
+) -> dict:
+    sth = {
+        "mastio_org_id": org_id,
+        "epoch_utc": epoch_utc,
+        "tree_size": tree_size,
+        "root_hash_hex": root_hash_hex,
+        "chain_seq_lo": chain_seq_lo,
+        "chain_seq_hi": chain_seq_hi,
+        "mastio_kid": kid,
+        "signed_at": signed_at,
+    }
+    payload = cli._sth_canonical_payload(sth)
+    sth["signature_b64u"] = _sign_b64u(privkey, payload)
+    return sth
+
+
+def _manifest_dict(
+    privkey: ec.EllipticCurvePrivateKey,
+    *,
+    epoch_utc: str = "2026-05-24T00:00:00Z",
+    chain_seq_lo: int,
+    chain_seq_hi: int,
+    row_count: int,
+    sink_url: str = "s3://test/audit-bundle.ndjson",
+    bundle_sha256: str = "00" * 32,
+) -> dict:
+    manifest = {
+        "epoch_utc": epoch_utc,
+        "mastio_org_id": "acme",
+        "chain_seq_lo": chain_seq_lo,
+        "chain_seq_hi": chain_seq_hi,
+        "row_count": row_count,
+        "sink_url": sink_url,
+        "bundle_sha256": bundle_sha256,
+    }
+    payload = cli._manifest_canonical_payload(manifest)
+    manifest["signature_b64u"] = _sign_b64u(privkey, payload)
+    return manifest
+
+
+# ── RFC 6962 math ───────────────────────────────────────────────────
+
+
+def test_leaf_hash_prefixes_with_zero_byte():
+    row_hash = _h(b"row-1")
+    leaf = cli._rfc6962_leaf_hash(row_hash)
+    expected = hashlib.sha256(b"\x00" + bytes.fromhex(row_hash)).digest()
+    assert leaf == expected
+
+
+def test_node_hash_prefixes_with_one_byte():
+    left = b"\x01" * 32
+    right = b"\x02" * 32
+    node = cli._rfc6962_node_hash(left, right)
+    expected = hashlib.sha256(b"\x01" + left + right).digest()
+    assert node == expected
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 4, 7, 8, 16, 17, 32])
+def test_verify_audit_path_accepts_every_leaf(size: int):
+    row_hashes = [_h(f"r{i}".encode()) for i in range(size)]
+    root, levels = _build_rfc6962_tree(row_hashes)
+    for i, rh in enumerate(row_hashes):
+        leaf_hash = cli._rfc6962_leaf_hash(rh)
+        path = _audit_path(levels, i)
+        assert cli._rfc6962_verify_audit_path(
+            leaf_hash, path, i, size, root,
+        ), f"size={size} leaf={i} failed"
+
+
+def test_verify_audit_path_rejects_wrong_root():
+    row_hashes = [_h(f"r{i}".encode()) for i in range(8)]
+    _, levels = _build_rfc6962_tree(row_hashes)
+    leaf_hash = cli._rfc6962_leaf_hash(row_hashes[3])
+    path = _audit_path(levels, 3)
+    wrong_root = b"\xff" * 32
+    assert not cli._rfc6962_verify_audit_path(
+        leaf_hash, path, 3, 8, wrong_root,
+    )
+
+
+def test_verify_audit_path_rejects_tampered_sibling():
+    row_hashes = [_h(f"r{i}".encode()) for i in range(4)]
+    root, levels = _build_rfc6962_tree(row_hashes)
+    leaf_hash = cli._rfc6962_leaf_hash(row_hashes[1])
+    path = _audit_path(levels, 1)
+    path[0] = "ff" * 32  # tampered hex sibling
+    assert not cli._rfc6962_verify_audit_path(
+        leaf_hash, path, 1, 4, root,
+    )
+
+
+# ── ES256 signature verification ────────────────────────────────────
+
+
+def test_verify_es256_accepts_valid_signature(mastio_key):
+    privkey, pem_path = mastio_key
+    payload = b"hello-world"
+    sig = _sign_b64u(privkey, payload)
+    assert cli._verify_es256_signature(payload, sig, pem_path.read_bytes())
+
+
+def test_verify_es256_rejects_tampered_payload(mastio_key):
+    privkey, pem_path = mastio_key
+    sig = _sign_b64u(privkey, b"hello-world")
+    assert not cli._verify_es256_signature(
+        b"tampered", sig, pem_path.read_bytes(),
+    )
+
+
+def test_verify_es256_rejects_malformed_b64u(mastio_key):
+    _, pem_path = mastio_key
+    assert not cli._verify_es256_signature(
+        b"hello", "not-base64!", pem_path.read_bytes(),
+    )
+
+
+def test_verify_es256_rejects_wrong_curve_pubkey(tmp_path):
+    wrong = ec.generate_private_key(ec.SECP384R1())
+    pem = wrong.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    path = tmp_path / "wrong.pem"
+    path.write_bytes(pem)
+    # Build any P-384 signature; verifier must refuse on wrong curve.
+    sig_der = wrong.sign(b"hello", ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(sig_der)
+    raw = r.to_bytes(48, "big") + s.to_bytes(48, "big")
+    sig_b64u = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    assert not cli._verify_es256_signature(b"hello", sig_b64u, pem)
+
+
+# ── verify_archive_proofs driver: STH only ──────────────────────────
+
+
+def test_archive_sth_valid_returns_count(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(4)]
+    root, _ = _build_rfc6962_tree(rh)
+    sth = _sth_dict(
+        privkey, tree_size=4, root_hash_hex=root.hex(),
+        chain_seq_lo=1, chain_seq_hi=4,
+    )
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text(json.dumps(sth))
+    s, m, p = cli.verify_archive_proofs(
+        [str(sth_path)], [], [], str(pem_path), [],
+    )
+    assert (s, m, p) == (1, 0, 0)
+
+
+def test_archive_sth_invalid_signature_exits_7(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(4)]
+    root, _ = _build_rfc6962_tree(rh)
+    sth = _sth_dict(
+        privkey, tree_size=4, root_hash_hex=root.hex(),
+        chain_seq_lo=1, chain_seq_hi=4,
+    )
+    sth["root_hash_hex"] = "ff" * 32  # tamper after signing
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text(json.dumps(sth))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [str(sth_path)], [], [], str(pem_path), [],
+        )
+    assert exc_info.value.code == 7
+
+
+# ── Manifest verification ───────────────────────────────────────────
+
+
+def test_archive_manifest_valid_returns_count(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    manifest = _manifest_dict(
+        privkey, chain_seq_lo=1, chain_seq_hi=100, row_count=100,
+        bundle_sha256=_h(b"fake-bundle"),
+    )
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    s, m, p = cli.verify_archive_proofs(
+        [], [], [str(path)], str(pem_path), [],
+    )
+    assert (s, m, p) == (0, 1, 0)
+
+
+def test_archive_manifest_tampered_sink_url_exits_7(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    manifest = _manifest_dict(
+        privkey, chain_seq_lo=1, chain_seq_hi=100, row_count=100,
+    )
+    manifest["sink_url"] = "s3://attacker/forged.ndjson"  # tamper
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [], [], [str(path)], str(pem_path), [],
+        )
+    assert exc_info.value.code == 7
+
+
+# ── Inclusion proof verification ────────────────────────────────────
+
+
+def _make_proof(
+    privkey: ec.EllipticCurvePrivateKey,
+    row_hashes: list[str],
+    leaf_index: int,
+    *,
+    chain_seq_lo: int = 1,
+) -> dict:
+    root, levels = _build_rfc6962_tree(row_hashes)
+    sth = _sth_dict(
+        privkey, tree_size=len(row_hashes), root_hash_hex=root.hex(),
+        chain_seq_lo=chain_seq_lo,
+        chain_seq_hi=chain_seq_lo + len(row_hashes) - 1,
+    )
+    return {
+        "epoch_utc": sth["epoch_utc"],
+        "leaf_index": leaf_index,
+        "leaf_hash_hex": cli._rfc6962_leaf_hash(row_hashes[leaf_index]).hex(),
+        "audit_path": _audit_path(levels, leaf_index),
+        "sth": sth,
+    }
+
+
+def test_archive_proof_valid_returns_count(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(8)]
+    proof = _make_proof(privkey, rh, leaf_index=3)
+    path = tmp_path / "proof.json"
+    path.write_text(json.dumps(proof))
+    s, m, p = cli.verify_archive_proofs(
+        [], [str(path)], [], str(pem_path), [],
+    )
+    assert (s, m, p) == (0, 0, 1)
+
+
+def test_archive_proof_validates_against_bundle_row_hash(mastio_key, tmp_path):
+    """When the bundle is supplied alongside the proof, the verifier
+    cross-checks: bundle row_hash → leaf hash → must match proof's
+    leaf_hash_hex. Disagreement is a hard fail."""
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(4)]
+    proof = _make_proof(privkey, rh, leaf_index=2, chain_seq_lo=1)
+    path = tmp_path / "proof.json"
+    path.write_text(json.dumps(proof))
+
+    # Build a bundle that agrees: chain_seq=3 corresponds to leaf_index=2
+    # (chain_seq_lo=1 + leaf_index=2 == 3).
+    bundle = [(
+        "/dev/null",
+        [{"chain_seq": 1 + i, "row_hash": rh[i]} for i in range(4)],
+    )]
+    s, m, p = cli.verify_archive_proofs(
+        [], [str(path)], [], str(pem_path), bundle,
+    )
+    assert p == 1
+
+
+def test_archive_proof_bundle_mismatch_exits_7(mastio_key, tmp_path):
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(4)]
+    proof = _make_proof(privkey, rh, leaf_index=1, chain_seq_lo=1)
+    path = tmp_path / "proof.json"
+    path.write_text(json.dumps(proof))
+
+    # Bundle row_hash for chain_seq=2 has been tampered (does not match
+    # what the proof was computed against). The verifier must refuse.
+    tampered = [
+        {"chain_seq": 1, "row_hash": rh[0]},
+        {"chain_seq": 2, "row_hash": _h(b"forged")},
+        {"chain_seq": 3, "row_hash": rh[2]},
+        {"chain_seq": 4, "row_hash": rh[3]},
+    ]
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [], [str(path)], [], str(pem_path), [("/dev/null", tampered)],
+        )
+    assert exc_info.value.code == 7
+
+
+def test_archive_proof_inclusion_fail_exits_7(mastio_key, tmp_path):
+    """Tamper with the audit_path after signing the STH — the
+    reconstructed root will no longer match the anchored one."""
+    privkey, pem_path = mastio_key
+    rh = [_h(f"r{i}".encode()) for i in range(8)]
+    proof = _make_proof(privkey, rh, leaf_index=3)
+    proof["audit_path"][0] = "ff" * 32  # tamper path
+    path = tmp_path / "proof.json"
+    path.write_text(json.dumps(proof))
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [], [str(path)], [], str(pem_path), [],
+        )
+    assert exc_info.value.code == 7
+
+
+# ── CLI guard rails ─────────────────────────────────────────────────
+
+
+def test_archive_without_pubkey_exits_7(tmp_path):
+    """Setting --archive-sth (etc.) without --archive-manifest-pubkey
+    is a CLI usage error → exit 7, no signature math attempted."""
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text("{}")
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [str(sth_path)], [], [], None, [],
+        )
+    assert exc_info.value.code == 7
+
+
+def test_no_archive_flags_returns_zeros():
+    s, m, p = cli.verify_archive_proofs([], [], [], None, [])
+    assert (s, m, p) == (0, 0, 0)
+
+
+def test_archive_pubkey_unreadable_exits_7(tmp_path):
+    sth_path = tmp_path / "sth.json"
+    sth_path.write_text("{}")
+    with pytest.raises(SystemExit) as exc_info:
+        cli.verify_archive_proofs(
+            [str(sth_path)], [], [], "/nonexistent.pem", [],
+        )
+    assert exc_info.value.code == 7


### PR DESCRIPTION
## Summary

Adds offline verification for the **Enterprise audit_archive plugin** artefacts (STH per epoch + per-row inclusion proofs + bundle manifests) to the public \`cullis-audit-verify.py\` CLI. The math + parsing live in the public CLI **by design**: the auditor's check must be vendor-independent or the "tamper-evident even against Cullis" claim collapses to "trust the vendor's verifier".

The Enterprise plugin (lands separately on \`cullis-security/cullis-enterprise\`) generates these artefacts server-side. This PR makes them verifiable offline by anyone with a bundle export + the artefacts + the Mastio's ES256 public key.

## What ships

**4 new CLI flags:**

| Flag | Purpose |
|---|---|
| \`--archive-sth <STH_JSON>\` | Verify ES256 signature over canonical STH fields |
| \`--archive-proof <PROOF_JSON>\` | Verify RFC 6962 inclusion proof + embedded STH + bundle cross-check |
| \`--archive-manifest <MANIFEST_JSON>\` | Verify ES256 signature over canonical bundle manifest |
| \`--archive-manifest-pubkey <PEM>\` | Required PEM path; auditor obtains pubkey out of band |

**Math inlined** (stdlib + already-imported \`cryptography\`):

- \`_rfc6962_leaf_hash\`: \`sha256(0x00 || row_hash_bytes)\`
- \`_rfc6962_node_hash\`: \`sha256(0x01 || left || right)\`
- \`_rfc6962_verify_audit_path\`: bottom-up walk with **promote-unpaired** convention (empty string in audit_path = trailing node promoted to next layer unchanged at archive time)
- \`_verify_es256_signature\`: JOSE flat \`b64url(r||s)\` → DER → \`ECDSA(SHA256).verify\`
- \`_sth_canonical_payload\`, \`_manifest_canonical_payload\`: sorted keys, no whitespace, ASCII (matches \`AgentManager.countersign\` server-side)

**Exit code 7** carved out for archive-verify failures (distinct from chain 2 / anchor 3,5 / cross-ref 4 / Merkle proof 6). Verdict line appends \`N STHs · M manifests · K archive proofs verified\` when artefacts are passed.

## CLI usage example

\`\`\`bash
# Customer exports artefacts from their Mastio
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/audit/export?org_id=acme > acme.ndjson
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/audit/sth/latest > sth-latest.json
curl -k -H "X-Admin-Secret: …" "https://mastio/v1/admin/audit/proof?chain_seq=42" > proof-42.json
curl -k -H "X-Admin-Secret: …" https://mastio/v1/admin/mastio-pubkey > mastio.pub

# Auditor (different host, no Mastio access, no Cullis credentials)
python3 cullis-audit-verify.py \\
    --bundle acme.ndjson \\
    --archive-sth sth-latest.json \\
    --archive-proof proof-42.json \\
    --archive-manifest-pubkey mastio.pub \\
    --tsa-trust-store /etc/cullis/tsa-roots.pem
\`\`\`

## Test plan

- [x] **28 unit tests** in \`test/unit/test_cullis_audit_verify_archive.py\` (~110ms):
  - RFC 6962 leaf+node hashing byte-exact
  - Audit-path verify for every leaf in sizes \`[1, 2, 3, 4, 7, 8, 16, 17, 32]\` — including the right-edge odd-size cases the promote-unpaired path handles
  - Wrong-root rejection, tampered-sibling rejection
  - ES256 verify (valid sig, tampered payload, malformed b64u, wrong-curve pubkey refusal)
  - STH driver: valid path returns count, tampered root_hash_hex post-signing → exit 7
  - Manifest driver: valid path, tampered sink_url → exit 7
  - Proof driver: valid path, bundle row_hash mismatch → exit 7, tampered audit_path → exit 7
  - Guard rails: missing pubkey → exit 7, unreadable pubkey → exit 7, no flags returns zeros
- [x] **Cumulative 106 audit unit pass** in 54s: 40 Phase 0 Merkle + 10 watcher + 14 admin endpoints + 14 Phase 3 CLI Merkle + 28 archive verify
- [x] No runtime path change — CLI-only

## Companion

Enterprise plugin lands next on \`cullis-security/cullis-enterprise\` with the server-side STH generation, sink abstraction (file:// + s3:// with Object Lock COMPLIANCE WORM), license gate, and admin router endpoints. Migrations of the original 2026-05-23 patch will be renumbered 0043+0044 → 0045+0046 to clear the public 0043 TSA / 0044 Merkle on main.

948 insertions, 2 files (1 new test file + CLI extension).