### PR TITLE
feat(nginx): allow /saml /scim/v2 /admin + dockerignore smoke ephemera

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,9 @@ sdk-ts/dist/
 .coverage
 htmlcov/
 tests/connector/__pycache__/
+
+# Smoke harness ephemera — owned by uid 10001 inside containers,
+# unreadable by the host build context loader. Always excluded.
+test/smoke/state/
+test/smoke/.smoke-fail-*/
+**/.smoke-fail-*/

--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,10 @@ tests/connector/__pycache__/
 test/smoke/state/
 test/smoke/.smoke-fail-*/
 **/.smoke-fail-*/
+
+# Bundle runtime bind dirs — also uid-10001-owned after deploy.sh runs,
+# also context-loader-hostile.
+packaging/mastio-bundle/data/
+packaging/mastio-bundle/nginx-certs/
+packaging/mastio-bundle/audit-archive/
+packaging/mastio-bundle/keys/

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -159,6 +159,41 @@ server {
         proxy_read_timeout                 86400;
     }
 
+    # Enterprise plugin surfaces (cullis-enterprise installed) — auth is
+    # plugin-side (Bearer for SCIM, SAML assertion for /saml/acs, session
+    # cookie for /admin/login). The routes are conditionally mounted: a
+    # community deploy with no enterprise package installed simply has
+    # nothing behind these paths and the app returns 404 itself.
+    location ~ ^/saml(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    location ~ ^/scim/v2(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    location ~ ^/admin(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
     # PDP webhook — broker calls this over the docker network.
     location ~ ^/pdp(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;


### PR DESCRIPTION
## Summary

Two-commit prep work to unblock the enterprise smoke harness on
`cullis-security/cullis-enterprise` (companion PR:
[cullis-security/cullis-enterprise#NN](https://github.com/cullis-security/cullis-enterprise) — to be linked
once that PR is filed):

1. `chore(dockerignore)` — exclude `test/smoke/state/` +
   `**/.smoke-fail-*/` from the Docker build context. These dirs
   are written by `mastio` running as uid 10001 inside containers;
   the host-side loader (uid != 10001) cannot read them, so a
   stale snapshot from a previous smoke run aborts every subsequent
   `docker build` with `permission denied`. Same lockout hits
   `packaging/mastio-bundle/data/`. Always-ignored now.

2. `feat(nginx)` — add 3 location blocks to the `mastio-nginx`
   sidecar config so the enterprise plugin surfaces are reachable:
   - `^/saml(/.*)?$` — saml_sso SP endpoints (metadata, login,
     acs, slo)
   - `^/scim/v2(/.*)?$` — scim_2_0 user + group provisioning
   - `^/admin(/.*)?$` — rbac_multi_admin login / logout / users
     CRUD (NB the 4-eyes approval queue lives at
     `/proxy/admin/approvals` which the existing `/proxy(/.*)?$`
     block already covers)

   Each block follows the same proxy_set_header profile as `/proxy/*`:
   terminate TLS at nginx, strip any client-supplied
   `X-SSL-Client-Cert` so anonymous-over-TLS endpoints can't be
   mistaken for authenticated mTLS ones, forward
   `X-Real-IP / X-Forwarded-For / X-Forwarded-Proto`. Auth is
   plugin-side: Bearer for SCIM, SAMLResponse for `/saml/acs`,
   session cookie for `/admin/*`.

   The routes are **conditionally mounted on the app side**: a
   community deploy without cullis-enterprise installed has
   nothing behind these paths and the app returns 404 itself.

## Test plan

- [x] Public smoke (`test/smoke/smoke.sh`) still green — these
      paths aren't exercised, but the nginx config still has to
      parse.
- [x] Enterprise smoke harness (cullis-enterprise
      smoke-enterprise/) runs end-to-end: 9 scenarios, 9 PASS,
      0 SKIP, 0 FAIL on a warm stack. Without these blocks the
      smoke's 220 / 230 / 240 scenarios hit nginx 404 before
      ever reaching the plugin router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)