### PR TITLE
fix(admin): atomic agent enrollment tx, INSERT first to avoid key clobber on duplicate

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -166,17 +166,26 @@ async def create_agent(
         cert_pem, key_pem = mgr._generate_agent_cert(agent_name)
         minted_locally = True
 
-    # Persist the private key. Store in Vault if configured, otherwise
-    # fall back to proxy_config (same pattern as AgentManager.create_agent).
-    try:
-        await mgr._store_key_vault(agent_id, key_pem)
-    except Exception as exc:
-        from mcp_proxy.db import set_config
-        _log.info("Vault unavailable for %s (%s) — stashing key in proxy_config",
-                  agent_id, exc)
-        await set_config(f"agent_key:{agent_id}", key_pem)
-
+    # Bug #6 tactical fix: persist the agent row atomically with the
+    # private-key write so a duplicate ``agent_id`` (typo, demo reset,
+    # multi-worker race on the same name) cannot clobber an existing
+    # agent's signing key before failing.
+    #
+    # Order matters:
+    #   1. INSERT INTO internal_agents FIRST. The PRIMARY KEY on
+    #      ``agent_id`` serialises concurrent attempts at the DB layer
+    #      and raises IntegrityError on duplicates BEFORE any key
+    #      material is exposed. SQLite WAL + Postgres both honour
+    #      this, no application-level lock needed.
+    #   2. Vault store (out-of-DB, idempotent overwrite). Failure here
+    #      falls back to ``set_config`` in the same transaction so the
+    #      INSERT rolls back if neither store succeeds.
+    #   3. ``set_config`` fallback writes into ``proxy_config`` on the
+    #      open ``conn`` so the rollback covers both rows if anything
+    #      after raises.
+    from mcp_proxy.db import set_config
     ts = _now_iso()
+    vault_stored = False
     try:
         async with get_db() as conn:
             await conn.execute(
@@ -208,7 +217,40 @@ async def create_agent(
                     "federated": bool(body.federated),
                 },
             )
+            # Store private key. Vault is the preferred backend; on
+            # failure fall back to proxy_config inside the same DB tx so
+            # the rollback covers the agent row too if anything later
+            # raises.
+            try:
+                await mgr._store_key_vault(agent_id, key_pem)
+                vault_stored = True
+            except Exception as exc:
+                _log.info(
+                    "Vault unavailable for %s (%s), stashing key in proxy_config",
+                    agent_id, exc,
+                )
+                await set_config(
+                    f"agent_key:{agent_id}", key_pem, conn=conn,
+                )
     except IntegrityError as exc:
+        # The agent already existed. The INSERT raised before any key
+        # write touched proxy_config; if Vault was attempted at all on
+        # this code path the call is unreachable here (we get to the
+        # Vault block only after the INSERT succeeded). Leave a warning
+        # so operators noticing a stranded Vault entry from a prior
+        # interrupted run have a breadcrumb; there is no
+        # ``_delete_key_vault`` helper today and inventing one is out of
+        # scope for this tactical fix.
+        if vault_stored:
+            # Defensive: this branch should be unreachable because
+            # Vault store is inside the transaction AFTER the INSERT.
+            # Logged in case of refactor regression.
+            _log.warning(
+                "agent %s INSERT raised IntegrityError after Vault store "
+                "succeeded; Vault entry may be stale (no _delete_key_vault "
+                "helper, manual cleanup required)",
+                agent_id,
+            )
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"agent {agent_id!r} already registered",

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -991,20 +991,37 @@ async def get_config(key: str) -> str | None:
         return row["value"] if row else None
 
 
-async def set_config(key: str, value: str) -> None:
+async def set_config(
+    key: str,
+    value: str,
+    *,
+    conn: AsyncConnection | None = None,
+) -> None:
     """Set a config value (upsert).
 
     SQLite and PostgreSQL both support ON CONFLICT ... DO UPDATE with the
     same syntax, so a raw text() upsert stays portable.
+
+    Bug #6 tactical fix: when ``conn`` is provided, the upsert runs on
+    that connection so the caller can compose it with other writes in a
+    single transaction. With ``conn=None`` (default, every existing
+    caller), the helper opens its own ``get_db()`` context exactly as
+    before. Pinning the key upsert to an already-open transaction is
+    what lets ``admin/agents.py:create_agent`` order the agent INSERT
+    BEFORE the key write, so a duplicate ``agent_id`` is rejected by
+    the UNIQUE constraint before any existing agent's signing key is
+    overwritten in ``proxy_config``.
     """
-    async with get_db() as conn:
-        await conn.execute(
-            text(
-                """INSERT INTO proxy_config (key, value) VALUES (:key, :value)
-                   ON CONFLICT(key) DO UPDATE SET value = excluded.value"""
-            ),
-            {"key": key, "value": value},
-        )
+    stmt = text(
+        """INSERT INTO proxy_config (key, value) VALUES (:key, :value)
+           ON CONFLICT(key) DO UPDATE SET value = excluded.value"""
+    )
+    params = {"key": key, "value": value}
+    if conn is not None:
+        await conn.execute(stmt, params)
+    else:
+        async with get_db() as c:
+            await c.execute(stmt, params)
 
 
 async def set_config_if_absent(key: str, value: str) -> bool:

--- a/test/unit/test_admin_agents_atomic_enroll.py
+++ b/test/unit/test_admin_agents_atomic_enroll.py
@@ -1,0 +1,309 @@
+"""Bug #6 tactical fix tests — atomic agent enrollment transaction.
+
+The pre-fix POST ``/v1/admin/agents`` handler ran the key write
+(``set_config('agent_key:<id>', key_pem)``) BEFORE the
+``INSERT INTO internal_agents``. Two failure modes:
+
+A. Multi-worker race: two workers concurrent on the same ``agent_id``
+   land both ``set_config`` upserts (last write wins on the key) and
+   then race the INSERT. The winner ships back a 201 with a key that
+   already belongs to the loser, the loser hits the UNIQUE constraint
+   and 409s, but proxy_config now holds the wrong key for the
+   surviving row.
+
+B. Single-worker overwrite-on-duplicate: admin tries to enroll an
+   ``agent_id`` that already exists (typo, demo reset, recovery
+   retry). ``set_config`` upserts the NEW key over the EXISTING agent's
+   key. The INSERT then raises ``IntegrityError`` and the handler
+   returns 409, but the existing agent's signing key has already been
+   clobbered. That agent can no longer authenticate (its cert is
+   pinned to the lost key).
+
+The fix wraps INSERT + key-store in a single ``async with get_db()``
+transaction and ORDERS the INSERT FIRST so the UNIQUE constraint
+serialises duplicates BEFORE any key material is exposed. The two
+tests below pin both invariants:
+
+* ``test_duplicate_enrollment_does_not_clobber_existing_key`` covers (B):
+  pre-existing key in ``proxy_config`` survives a failed duplicate
+  enrollment attempt unchanged.
+* ``test_concurrent_enrollment_serializes_on_unique_constraint`` covers
+  (A): two ``asyncio.gather``-ed enrollments on the same agent_id end
+  with exactly one row in ``internal_agents``, exactly one matching
+  ``agent_key:<id>`` in ``proxy_config``, and one 201 / one 409.
+
+A third test pins back-compat for ``set_config(key, value)`` without
+the new ``conn`` kwarg — every existing call site in the codebase
+must keep working.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.admin.agents import router as admin_agents_router
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, get_config, get_db, init_db, set_config
+
+
+_ADMIN_SECRET = "test-admin-secret-atomic-enroll"
+
+
+# ── Stub AgentManager ──────────────────────────────────────────────────
+#
+# The real ``mcp_proxy.egress.agent_manager.AgentManager`` requires the
+# Org CA loaded in memory. For this test we only need three surface
+# members the handler touches:
+#   * ``ca_loaded`` (truthy → request passes the ``_require_agent_mgr``
+#     gate)
+#   * ``org_id`` (used to compose ``agent_id``)
+#   * ``_generate_agent_cert(agent_name)`` (returns a (cert_pem,
+#     key_pem) pair; opaque to the handler, just stored as-is)
+#   * ``_store_key_vault(agent_id, key_pem)`` (raises so the handler
+#     falls through to the ``set_config`` fallback path, which is the
+#     path we want to exercise — Vault success path doesn't touch
+#     ``proxy_config`` at all and is covered by the third test)
+
+
+class _StubAgentManager:
+    ca_loaded = True
+
+    def __init__(self, org_id: str, *, vault_succeeds: bool = False):
+        self.org_id = org_id
+        self._vault_succeeds = vault_succeeds
+        self._mint_counter = 0
+
+    def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
+        # Unique per-mint output so the test can tell a stale key from a
+        # fresh one byte-perfect.
+        self._mint_counter += 1
+        cert = (
+            f"-----BEGIN CERTIFICATE-----\nstub-cert-{agent_name}-"
+            f"{self._mint_counter}\n-----END CERTIFICATE-----\n"
+        )
+        key = (
+            f"-----BEGIN PRIVATE KEY-----\nstub-key-{agent_name}-"
+            f"{self._mint_counter}\n-----END PRIVATE KEY-----\n"
+        )
+        return cert, key
+
+    async def _store_key_vault(self, agent_id: str, key_pem: str) -> None:
+        if not self._vault_succeeds:
+            raise RuntimeError("Vault backend not configured")
+        # Silent success: a real Vault store would write to KV v2 here.
+        # The handler must NOT fall back to proxy_config on success, and
+        # the third test asserts that.
+        return None
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    # NOTE: we run the full alembic chain here (no PROXY_SKIP_MIGRATIONS)
+    # because the ``internal_agents.federated`` column lives only in a
+    # migration, not in ``db_models.metadata``. ``metadata.create_all``
+    # would build a schema missing that column and the INSERT in the
+    # handler would fail with "no such column".
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "atomic_enroll.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _make_app(mgr: _StubAgentManager) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_agents_router)
+    app.state.agent_manager = mgr
+    return app
+
+
+def _post_enroll(client: TestClient, agent_name: str) -> Any:
+    return client.post(
+        "/v1/admin/agents",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+        json={"agent_name": agent_name},
+    )
+
+
+# ── (B) single-worker overwrite-on-duplicate ───────────────────────────
+
+
+def test_duplicate_enrollment_does_not_clobber_existing_key(proxy_db):
+    """First enroll succeeds, second enroll on the same ``agent_id``
+    returns 409 AND leaves the original agent's key in proxy_config
+    unchanged.
+
+    Pre-fix behaviour: the second ``set_config`` upserts the new key
+    over the existing entry BEFORE the INSERT raises IntegrityError.
+    The handler returns 409 but the original agent's authentication is
+    silently broken.
+    """
+    mgr = _StubAgentManager("test-org")
+    app = _make_app(mgr)
+    client = TestClient(app)
+
+    r1 = _post_enroll(client, "alice")
+    assert r1.status_code == 201, r1.text
+    first_key = r1.json()["private_key_pem"]
+    assert first_key  # minted_locally → echoed
+
+    # Snapshot the key stashed in proxy_config (Vault path raises in the
+    # stub so the handler falls back to set_config).
+    async def _read() -> str | None:
+        return await get_config("agent_key:test-org::alice")
+
+    stored_first = asyncio.run(_read())
+    assert stored_first == first_key, (
+        "first enroll must persist the minted key in proxy_config"
+    )
+
+    # Second enrollment with the same agent_name. Pre-fix this would
+    # have minted a NEW keypair, upserted it over the existing
+    # ``agent_key:test-org::alice`` row, then 409'd on the INSERT.
+    r2 = _post_enroll(client, "alice")
+    assert r2.status_code == 409, r2.text
+    assert "already registered" in r2.text
+
+    stored_after = asyncio.run(_read())
+    assert stored_after == first_key, (
+        "duplicate enrollment must NOT overwrite the existing agent's "
+        "private key in proxy_config — pre-fix the upsert clobbered it "
+        "before the INSERT raised IntegrityError"
+    )
+
+
+# ── (A) multi-worker race ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_enrollment_serializes_on_unique_constraint(proxy_db):
+    """Two concurrent enrollments on the same agent_id end with:
+      * exactly one 201 + one 409,
+      * exactly one row in ``internal_agents``,
+      * exactly one ``agent_key:<id>`` row in ``proxy_config``
+        matching the winner's minted key.
+
+    The PRIMARY KEY on ``internal_agents.agent_id`` serialises the
+    INSERT, the IntegrityError rolls back the loser's transaction
+    (including its ``set_config`` fallback in the same tx), and the
+    winner's key is the one that survives.
+    """
+    mgr = _StubAgentManager("test-org")
+    app = _make_app(mgr)
+
+    # Drive the handler concurrently via the ASGI transport — TestClient
+    # is sync so we use httpx ASGITransport instead. Two coroutines
+    # racing on the same agent_name exercise the UNIQUE constraint.
+    from httpx import ASGITransport, AsyncClient
+    transport = ASGITransport(app=app)
+    h = {"X-Admin-Secret": _ADMIN_SECRET}
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        r1, r2 = await asyncio.gather(
+            cli.post("/v1/admin/agents", headers=h, json={"agent_name": "bob"}),
+            cli.post("/v1/admin/agents", headers=h, json={"agent_name": "bob"}),
+        )
+
+    codes = sorted([r1.status_code, r2.status_code])
+    assert codes == [201, 409], (
+        f"expected one winner one loser, got {codes}: "
+        f"{r1.text!r} / {r2.text!r}"
+    )
+
+    winner = r1 if r1.status_code == 201 else r2
+    winning_key = winner.json()["private_key_pem"]
+
+    async with get_db() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id FROM internal_agents "
+                    "WHERE agent_id = :aid"
+                ),
+                {"aid": "test-org::bob"},
+            )
+        ).all()
+    assert len(rows) == 1, (
+        "exactly one internal_agents row expected for the duplicated "
+        f"agent_id; got {len(rows)}"
+    )
+
+    stored_key = await get_config("agent_key:test-org::bob")
+    assert stored_key == winning_key, (
+        "proxy_config must hold the winner's key — the loser's "
+        "set_config write should have rolled back with the failed "
+        "INSERT (it runs on the same conn inside the same transaction)"
+    )
+
+
+# ── Vault-success path: no proxy_config write ────────────────────────
+
+
+def test_vault_success_path_does_not_touch_proxy_config(proxy_db):
+    """When ``_store_key_vault`` succeeds, the handler must NOT write
+    the key into ``proxy_config`` as a fallback. Asserts the
+    Vault-preferred path stays clean.
+    """
+    mgr = _StubAgentManager("test-org", vault_succeeds=True)
+    app = _make_app(mgr)
+    client = TestClient(app)
+
+    r = _post_enroll(client, "carol")
+    assert r.status_code == 201, r.text
+
+    async def _read() -> str | None:
+        return await get_config("agent_key:test-org::carol")
+
+    assert asyncio.run(_read()) is None, (
+        "Vault-success path must not fall back to proxy_config; the "
+        "agent_key entry should be absent"
+    )
+
+
+# ── set_config back-compat ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_set_config_backward_compat_without_conn_kwarg(proxy_db):
+    """The new ``conn`` keyword on ``set_config`` is optional. Every
+    pre-existing call site in the codebase invokes ``set_config(key,
+    value)`` positionally and must keep working. This pins that
+    behaviour explicitly so a future refactor cannot break it.
+    """
+    await set_config("compat-test-key", "value-A")
+    assert await get_config("compat-test-key") == "value-A"
+
+    # Upsert path: same call, different value.
+    await set_config("compat-test-key", "value-B")
+    assert await get_config("compat-test-key") == "value-B"
+
+
+@pytest.mark.asyncio
+async def test_set_config_with_explicit_conn_writes_on_same_tx(proxy_db):
+    """When ``conn`` is provided, the upsert runs on the open
+    connection — verified by ensuring the write is visible inside the
+    same ``get_db()`` block before commit.
+    """
+    async with get_db() as conn:
+        await set_config("tx-test-key", "value-in-tx", conn=conn)
+        # Same connection sees the row inside the open tx.
+        row = (
+            await conn.execute(
+                text("SELECT value FROM proxy_config WHERE key = :k"),
+                {"k": "tx-test-key"},
+            )
+        ).mappings().first()
+        assert row is not None and row["value"] == "value-in-tx"
+
+    # And the value survives commit.
+    assert await get_config("tx-test-key") == "value-in-tx"


### PR DESCRIPTION
## Summary

Bug #6 tactical fix for `POST /v1/admin/agents`. Pre-fix the handler ran two separate transactions:

```python
# Transaction #1 — set_config opens its own get_db() context
await set_config(f"agent_key:{agent_id}", key_pem)
# (commit)

# Transaction #2 — separate get_db()
async with get_db() as conn:
    await conn.execute(text("INSERT INTO internal_agents ..."))
# (commit)
```

This is broken in two failure modes.

### Bug A (multi-worker race)

Two workers concurrent on the same `agent_id` both land their `set_config` upsert (last write wins on the key), then race the INSERT. One worker 409s on the UNIQUE constraint, but `proxy_config` may now hold the loser's minted key for the surviving `internal_agents` row. The cert in the DB no longer matches the key in `proxy_config`. The surviving agent cannot authenticate.

### Bug B (single-worker overwrite-on-duplicate)

Hits even with `MASTIO_WORKERS=1`. Admin re-enrolls an `agent_id` that already exists (typo, demo reset, recovery retry). `set_config` upserts the NEW key over the EXISTING agent's `agent_key:<id>` row. INSERT then raises `IntegrityError`, handler returns 409, but the existing agent's signing key is already gone. Pre-existing certificate no longer pairs with any private key in storage. Silent break of the existing agent's authentication.

### Fix

Wrap INSERT + key-store in a SINGLE `async with get_db() as conn:` transaction, and REVERSE the order so INSERT is FIRST:

```python
async with get_db() as conn:
    # 1. INSERT INTO internal_agents (PRIMARY KEY on agent_id serialises duplicates)
    # 2. Try Vault store (out-of-DB, idempotent overwrite)
    # 3. On Vault failure, fall back to set_config(conn=conn) inside the same tx
```

`set_config` gains an optional `*, conn: AsyncConnection | None = None` parameter. With `conn=None` (default, every existing call site), it opens its own `get_db()` context exactly as before. With `conn` provided, the upsert runs on that connection so the caller can compose it into an open transaction.

### Why INSERT-first + UNIQUE-constraint is sufficient

`internal_agents.agent_id` is the PRIMARY KEY. Both SQLite (with WAL) and Postgres serialise concurrent INSERTs at the DB layer and raise `IntegrityError` on duplicates. We do not need an application-level lock (no leader-election, no Redis advisory lock, no alembic migration). The DB constraint is the race protection, and it fires BEFORE any key material is touched in `proxy_config`.

### Scope boundaries (deliberately NOT crossed)

- No alembic migration (UNIQUE PRIMARY KEY already in place).
- No leader-election advisory lock (UNIQUE serialises for free).
- No refactor of `egress/agent_manager.py:create_agent` or `admin/enroll.py` (BYOCA / SPIFFE flows — different audit lineage, separate PR).
- No new Vault delete helper (`_delete_key_vault` doesn't exist, kept as a defensive `_log.warning` breadcrumb in the unreachable case).

## Files

- `mcp_proxy/db.py` — `set_config` signature gains `*, conn=None`. 32 existing call sites all use positional invocation, none break.
- `mcp_proxy/admin/agents.py` — `create_agent` handler refactor (single tx, INSERT-first, Vault attempt inside tx, `set_config` fallback inside tx).
- `test/unit/test_admin_agents_atomic_enroll.py` — 5 new tests (see Test plan).

## Test plan

- [x] `test_duplicate_enrollment_does_not_clobber_existing_key` — first enroll succeeds + persists key; second enroll on the same `agent_name` returns 409; pre-existing key in `proxy_config` is byte-identical to the first enroll's minted key (pins Bug B).
- [x] `test_concurrent_enrollment_serializes_on_unique_constraint` — `asyncio.gather` of two enroll requests on the same agent_name via ASGI transport; one 201, one 409; exactly one `internal_agents` row; exactly one `proxy_config` key matching the winner's minted key (pins Bug A).
- [x] `test_vault_success_path_does_not_touch_proxy_config` — when `_store_key_vault` succeeds, no fallback `agent_key:<id>` row appears in `proxy_config`.
- [x] `test_set_config_backward_compat_without_conn_kwarg` — positional `set_config(key, value)` keeps working (pins every existing call site).
- [x] `test_set_config_with_explicit_conn_writes_on_same_tx` — when `conn` is provided, the upsert is visible on that connection before commit.
- [x] All 5 new tests FAIL on the pre-fix code (verified via `git stash`).
- [x] Full `test/unit/` suite (205 tests) green after fix.
- [x] No `ruff` regressions (no unused imports, no orphan vars, no F-string-no-braces).