### PR TITLE
fix(admin+sdk): emit cert_chain_pem on enroll + auto-discover ca-chain.pem in SDK

### DIFF
--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -254,10 +254,60 @@ class _EnrollmentMixin:
         instance = cls.__new__(cls)
         instance.base = mastio_url.rstrip("/")
         instance._verify_tls = verify_tls
+
+        # Bug #1 follow-up #3: under ADR-033 three-tier PKI hardening
+        # the leaf in ``cert.pem`` is signed by the Mastio Intermediate
+        # CA, not the Org Root that nginx's ``ssl_client_certificate``
+        # points at. Strict TLS clients (Python ssl, OpenSSL, Go) need
+        # the Intermediate on the wire to build the path
+        # ``leaf -> Intermediate -> Org Root``.
+        #
+        # Convention discovery: if a sibling ``ca-chain.pem`` exists
+        # next to ``cert_path``, assemble a fullchain file (leaf ||
+        # Intermediate, PEM concatenated) and hand THAT to the httpx
+        # mTLS context. Customers who pre-assemble fullchain into
+        # ``cert.pem`` themselves keep working — they just have no
+        # sibling ``ca-chain.pem`` and we use the original
+        # ``cert_path`` unchanged. Connector enrollment writes the
+        # split layout (cert.pem leaf + ca-chain.pem) so this auto-
+        # discovery covers the "30-min-to-agent" customer scenario.
+        cert_path_obj = Path(cert_path)
+        chain_sibling = cert_path_obj.parent / "ca-chain.pem"
+        effective_cert_path: "str | Path" = cert_path
+        if chain_sibling.is_file():
+            fullchain_path = cert_path_obj.parent / "fullchain.pem"
+            try:
+                leaf_pem = cert_path_obj.read_text()
+                chain_pem = chain_sibling.read_text()
+                # Idempotent rewrite: if fullchain.pem is stale (older
+                # mtime than either source), regenerate. Otherwise reuse.
+                regenerate = (
+                    not fullchain_path.is_file()
+                    or fullchain_path.stat().st_mtime
+                    < max(
+                        cert_path_obj.stat().st_mtime,
+                        chain_sibling.stat().st_mtime,
+                    )
+                )
+                if regenerate:
+                    fullchain_path.write_text(leaf_pem.rstrip() + "\n" + chain_pem)
+                effective_cert_path = fullchain_path
+                log(
+                    "sdk",
+                    f"discovered ca-chain.pem sibling → using fullchain="
+                    f"{fullchain_path} for mTLS handshake",
+                )
+            except OSError as exc:
+                log(
+                    "sdk",
+                    f"warning: ca-chain.pem sibling present but unreadable "
+                    f"({exc}) — falling back to cert_path leaf only",
+                )
+
         instance._http = _build_proxy_http_client(
             verify_tls=verify_tls,
             timeout=timeout,
-            cert_path=cert_path,
+            cert_path=effective_cert_path,
             key_path=key_path,
             ca_chain_path=ca_chain_path,
         )
@@ -292,6 +342,69 @@ class _EnrollmentMixin:
         instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+        # Bug #1 follow-up #2: ``login_via_proxy_with_local_key`` also
+        # needs ``_cert_pem`` AND ``_proxy_agent_id`` /
+        # ``_proxy_org_id``. ``from_identity_dir`` previously left
+        # them unset for callers who didn't pass ``agent_id=`` /
+        # ``org_id=`` explicitly, which broke the local-key
+        # auto-login dispatch. Fill them in from the cert content on
+        # disk so the cohort that holds cert+key locally can mint a
+        # LOCAL_TOKEN without a separate enrolment round-trip.
+        try:
+            instance._cert_pem = Path(cert_path).read_text()
+            # Same chain-sibling discovery as the mTLS handshake above:
+            # if ``ca-chain.pem`` is present, include the Intermediate
+            # in ``_cert_pem`` too so ``/v1/auth/sign-challenged-
+            # assertion`` can verify the path against the Org Root.
+            if chain_sibling.is_file():
+                try:
+                    instance._cert_pem = (
+                        instance._cert_pem.rstrip() + "\n"
+                        + chain_sibling.read_text()
+                    )
+                except OSError:
+                    # Already logged above; mTLS path may still work
+                    # if the server is lenient about chain verification.
+                    pass
+        except OSError as exc:
+            raise RuntimeError(
+                f"from_identity_dir: cannot read cert_path={cert_path!r} "
+                f"({exc}). The same file is required for TLS mTLS handshake."
+            ) from exc
+
+        if instance._proxy_agent_id is None or instance._proxy_org_id is None:
+            try:
+                from cryptography import x509 as _x509
+                from cryptography.hazmat.backends import default_backend as _be
+                _cert_obj = _x509.load_pem_x509_certificate(
+                    instance._cert_pem.encode(), _be(),
+                )
+                _san_ext = _cert_obj.extensions.get_extension_for_class(
+                    _x509.SubjectAlternativeName,
+                )
+                for _uri in _san_ext.value.get_values_for_type(
+                    _x509.UniformResourceIdentifier,
+                ):
+                    # SPIFFE ID shape: spiffe://<trust_domain>/<org_id>/<agent_name>
+                    if not _uri.startswith("spiffe://"):
+                        continue
+                    _parts = _uri.split("/", 4)
+                    if len(_parts) >= 5 and _parts[3] and _parts[4]:
+                        _parsed_org = _parts[3]
+                        _parsed_name = _parts[4]
+                        if instance._proxy_org_id is None:
+                            instance._proxy_org_id = _parsed_org
+                        if instance._proxy_agent_id is None:
+                            instance._proxy_agent_id = (
+                                f"{_parsed_org}::{_parsed_name}"
+                            )
+                        instance._label = instance._proxy_agent_id
+                        break
+            except Exception as _exc:  # noqa: BLE001 best-effort
+                log(
+                    "sdk",
+                    f"warning: could not extract agent_id from cert SAN: {_exc}",
+                )
         # Dogfood Finding #9 — proxy-bound: see __init__.
         instance._use_egress_for_sessions = True
         # ``_update_nonce`` reads ``self.server_role`` on every response;

--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -86,6 +86,14 @@ class AgentCreateResponse(BaseModel):
     capabilities: list[str]
     federated: bool
     cert_pem: str
+    # Three-tier PKI hardening (ADR-033): leaf certs are signed by the
+    # Mastio Intermediate CA, NOT directly by the Org Root. Clients that
+    # do mTLS against ``ssl_client_certificate = org-ca.crt`` need the
+    # Intermediate on the wire to build the chain. ``cert_chain_pem``
+    # carries ``leaf || Intermediate`` (PEM concatenated, leaf first).
+    # ``cert_pem`` stays leaf-only for backward compat with existing
+    # consumers (BYOCA enrolment tooling, audit log emit, etc.).
+    cert_chain_pem: str | None = None
     private_key_pem: str | None = None  # echoed when the Mastio minted the keypair
 
 
@@ -263,12 +271,26 @@ async def create_agent(
         detail=f"agent_id={agent_id} federated={body.federated}",
     )
 
+    # ADR-033 full chain: concatenate the Mastio Intermediate CA cert
+    # so mTLS clients have everything they need to build
+    # ``leaf -> Intermediate -> Org Root`` (root lives in the client
+    # trust store). Legacy Org-Root-only deploys keep ``cert_chain_pem
+    # = None``.
+    cert_chain_pem: str | None = None
+    mastio_ca_cert = getattr(mgr, "_mastio_ca_cert", None)
+    if mastio_ca_cert is not None:
+        from cryptography.hazmat.primitives import serialization as _ser
+        cert_chain_pem = cert_pem + mastio_ca_cert.public_bytes(
+            _ser.Encoding.PEM
+        ).decode()
+
     return AgentCreateResponse(
         agent_id=agent_id,
         display_name=body.display_name or agent_name,
         capabilities=body.capabilities,
         federated=body.federated,
         cert_pem=cert_pem,
+        cert_chain_pem=cert_chain_pem,
         # Echo the freshly-minted private key only when the Mastio
         # generated the keypair itself — otherwise the caller already
         # has it (BYOCA / volume-shared sandbox bootstrap).


### PR DESCRIPTION
## Summary

Closes the dogfood-discovered gap that broke the "30-min-to-agent"
pitch for the `from_identity_dir + key_path + MCP` cohort. ADR-033
three-tier PKI hardening makes leaf certs Intermediate-signed; strict
TLS clients (Python ssl, OpenSSL, Go) need the Intermediate on the
wire. Pre-this-PR, `POST /v1/admin/agents` returned only the leaf and
`CullisClient.from_identity_dir` fed the leaf to httpx — every
subsequent `client.call_mcp_tool(...)` died at `/v1/auth/sign-
challenged-assertion` with `401 x509 chain verification failed`.

## What lands

**1. `AgentCreateResponse.cert_chain_pem`** (new field, optional)

Carries `leaf || Intermediate` PEM concatenated. Populated when
`agent_manager._mastio_ca_cert` is loaded (ADR-033 deploys).
`cert_pem` stays leaf-only — backward compat with BYOCA enrolment
tooling, audit emitters, and any client that pinned on the
pre-existing shape.

**2. `CullisClient.from_identity_dir` convention auto-discovery**

Public signature unchanged. New behaviour when a sibling `ca-chain.pem`
exists next to `cert_path`:
- Assembles `fullchain.pem` (idempotent rewrite on stale mtime) and
  hands THAT to httpx for the mTLS handshake.
- Lifts the chain into `_cert_pem` so `/v1/auth/sign-challenged-
  assertion` can verify the full path.
- Parses cert SAN to populate `_proxy_agent_id` / `_proxy_org_id` if
  the caller didn't pass them explicitly (`spiffe://trust_domain/
  <org>/<agent>` shape).
- Reads `_signing_key_pem` from `key_path` so the lazy auto-login
  (#927) dispatches to `login_via_proxy_with_local_key` (the correct
  path under ADR-014 "TLS cert is the credential").

Callers who pre-assemble fullchain into `cert.pem` keep working — no
sibling `ca-chain.pem` to discover, original `cert_path` is used as-is.

## Why this PR exists

Dogfood of #927 found that `from_identity_dir + call_mcp_tool` still
failed after the lazy-auto-login fix, because the wire chain was
incomplete. This PR closes the remaining gap end-to-end. Companion PR
on cullis-enterprise adds the regression scenarios (260+270) that
exercise both Bug #6 (already fixed by #928) and Bug #1 (this PR).

## Test plan

- [x] Companion smoke harness on cullis-enterprise — **11/11 PASS,
      0 SKIP, 0 FAIL** on a fresh stack
- [x] Scenario `270_sdk_auto_login`: from_identity_dir + immediate
      list_mcp_tools end-to-end without `RuntimeError("Not
      authenticated")` and without `401 x509 chain verification failed`
- [x] Scenario `260_admin_enroll_duplicate_clobber`: confirms Bug #6
      atomic-tx fix (#928) still holds with the new response field
- [x] Backward compat: existing callers of `from_identity_dir` that
      pre-assemble fullchain into `cert.pem` still work (no sibling
      `ca-chain.pem` discovered, original path used)
- [x] `cert_pem` shape unchanged for non-`from_identity_dir` callers

## Refs

- cullis#927 (SDK lazy auto-login) — this PR finishes the job for the
  local-key-holder cohort
- cullis#928 (admin enroll atomic-tx) — orthogonal, already merged
- ADR-033 three-tier PKI hardening (Org Root + Mastio Intermediate + leaf)
- ADR-014 "TLS cert is the credential"

🤖 Generated with [Claude Code](https://claude.com/claude-code)