### PR TITLE
fix(bundle): repair v0.5.2 quickstart + reproducible staging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Banks, insurers, and other regulated organizations are starting to put AI agents
 
 Cullis sits underneath any agent stack (Claude Agent SDK, OpenAI Agents SDK, custom loops) and provides the three primitives a regulated deployment is missing: per-agent cryptographic identity bound to whoever or whatever authorized the agent, a policy decision point that runs before the LLM call lands, and a hash-chained append-only audit log that an external auditor can verify without trusting Cullis or your IT team.
 
-Cullis is LLM-agnostic by design. The embedded gateway routes to Anthropic, OpenAI, Gemini, or Ollama via LiteLLM, and an alternative AI gateway can be wired in as a sidecar. The identity, policy, and audit primitives stay the same.
+Cullis is LLM-agnostic by design. The embedded gateway is wired to Anthropic today; OpenAI, Gemini, and Ollama route through LiteLLM and are rolling out. An alternative AI gateway can be configured as a sidecar. The identity, policy, and audit primitives stay the same regardless of the provider.
 
 ---
 
@@ -34,7 +34,7 @@ Mastio is the gateway. One container, one organization, one source of truth for 
 
 **Audit.** Every accepted action lands as a row in an append-only audit log, hash-chained per organization, optionally anchored to RFC 3161 TSA on a configurable cadence. The chain replays deterministically: an external auditor can verify it offline without holding any Cullis credentials.
 
-**Embedded AI gateway.** LiteLLM is bundled. Anthropic, OpenAI, Gemini, and Ollama work out of the box, and per-agent identity is propagated into every upstream call as part of the audit trail. The provider can be switched by env var without touching agent code.
+**Embedded AI gateway.** LiteLLM is bundled. Anthropic is wired out of the box (set `MCP_PROXY_ANTHROPIC_API_KEY` in `proxy.env`); OpenAI, Gemini, and Ollama are on the roadmap and currently return HTTP 501. Per-agent identity is propagated into every upstream call as part of the audit trail. The provider can be switched by env var without touching agent code.
 
 **MCP reverse proxy.** Mastio terminates MCP traffic from agents, applies the capability gate, propagates the agent identity into the tool call, and logs the result. Both stdio and HTTP transports are supported. Resources are declared per tool with explicit allowed-domain lists.
 
@@ -46,7 +46,10 @@ Mastio is the gateway. One container, one organization, one source of truth for 
 
 `cullis-sdk` is the Python client an autonomous agent uses to talk to Mastio. It handles mTLS client cert presentation, DPoP signing, token refresh, and request retries, exposing a small surface that maps onto what an agent actually does: ask the LLM something, list the MCP tools it is allowed to call, call one, and let the audit trail accumulate underneath.
 
-The canonical entry point is `CullisClient.from_identity_dir(...)`, which takes the path to the leaf cert, the matching private key, and an optional DPoP private JWK that the SDK uses to sign each egress request. The cert and key are the credential. There is no shared API key to leak.
+Two entry points, depending on how the identity gets to the agent:
+
+- `CullisClient.from_enrollment(enroll_url)` is the quickstart path. The dashboard issues a one-shot enrollment URL; the SDK calls it, persists the credentials locally, generates a DPoP keypair, and returns a ready-to-use client. No file paths to wire up.
+- `CullisClient.from_identity_dir(mastio_url, cert_path=..., key_path=..., dpop_key_path=...)` is the production path. Cert + key are delivered out-of-band (BYOCA, KMS, systemd LoadCredential) and the SDK loads them from disk. The cert and key are the credential. There is no shared API key to leak.
 
 `chat_completion` and `chat_completion_stream` route through Mastio's `/v1/llm/chat` endpoint. The provider, the model, and the upstream API key are configured org-side, in the Mastio dashboard. The agent never sees the upstream key, and every prompt and response is audit-logged with the agent identity attached.
 
@@ -55,13 +58,10 @@ The canonical entry point is `CullisClient.from_identity_dir(...)`, which takes 
 ```python
 from cullis_sdk import CullisClient
 
-client = CullisClient.from_identity_dir(
-    "https://mastio.example.com:9443",
-    cert_path="./identity/agent.crt",
-    key_path="./identity/agent.key",
-    dpop_key_path="./identity/dpop.jwk",
-    agent_id="kyc-screener",
-    org_id="acme",
+# Paste the enrollment URL the dashboard showed you after "Enroll new agent".
+client = CullisClient.from_enrollment(
+    "https://localhost:9443/v1/enroll/enroll_kyc_screener_abc123",
+    verify_tls=False,  # self-signed Org CA on a laptop; pin ca_chain_path in prod
 )
 
 response = client.chat_completion({
@@ -82,22 +82,28 @@ result = client.call_mcp_tool(
 
 ## Quickstart
 
-Pull the Mastio bundle, deploy it, enroll an agent identity, install the SDK, run an agent loop. The Mastio bundle is a self-contained `docker compose` stack with first-boot Org CA minting, an admin account, and a dashboard.
+Pull the Mastio bundle, set an Anthropic key, enroll an agent, install the SDK, run an agent loop. The Mastio bundle is a self-contained `docker compose` stack with first-boot Org CA minting, an admin account, and a dashboard.
 
 ```bash
-# 1. Mastio
+# 1. Pull and deploy the Mastio bundle.
 curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
-# 2. Open https://localhost:9443/proxy/login, accept the self-signed TLS warning,
-#    create the admin account, mint an agent identity bundle from the dashboard,
-#    download the zip and unpack it into ./identity/.
+# 2. Enable chat by setting an Anthropic key in proxy.env, then restart.
+#    Chat returns HTTP 503 'provider_key_missing' until this is set;
+#    registry, MCP, and audit work regardless.
+echo 'MCP_PROXY_ANTHROPIC_API_KEY=sk-ant-...' >> proxy.env
+./deploy.sh --pull
 
-# 3. SDK
+# 3. Open https://localhost:9443/proxy/login, accept the self-signed TLS warning,
+#    create the admin account, go to Agents > Enroll new, and copy the one-shot
+#    enrollment URL the dashboard displays.
+
+# 4. Install the SDK.
 pip install cullis-sdk
 ```
 
-Then point your agent at the identity dir using the code example above. The first request lands as an audit row visible in the dashboard under `Audit`.
+Then run the agent loop with the enrollment URL you copied — see the code example above. The first request lands as an audit row visible in the dashboard under `Audit`.
 
 **Policies.** Open the dashboard's `Policies → Rego` tab and paste a Rego rule, or stay on the legacy `Built-in Rules` + `Tool Rules` tabs for simple allowlists. The Mastio compiles Rego on Save (~25 ms) and evaluates the WebAssembly bundle in-process on every decision (~0.2 ms p50). Two worked examples in [cullis.io/docs/operate/rego-policies](https://cullis.io/docs/operate/rego-policies).
 

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -1003,11 +1003,23 @@ fi
 PUBLIC_URL="$(grep -E '^MCP_PROXY_PROXY_PUBLIC_URL=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
 PUBLIC_URL="${PUBLIC_URL:-https://localhost:${PROXY_PORT}}"
 
+# Browser-friendly URL. On Linux hosts without Docker Desktop, host.docker.internal
+# is not resolvable from the host itself (browser/curl/wget fail with DNS error);
+# rewrite to localhost so the URL the operator clicks actually works. macOS/Windows
+# Docker Desktop, and Linux with Docker Desktop installed, both pin
+# host.docker.internal in /etc/hosts, so the rewrite is a no-op there.
+BROWSER_URL="$PUBLIC_URL"
+if [[ "$BROWSER_URL" == *"host.docker.internal"* ]] \
+   && [[ "$(uname -s)" == "Linux" ]] \
+   && ! grep -q "host.docker.internal" /etc/hosts 2>/dev/null; then
+    BROWSER_URL="${BROWSER_URL/host.docker.internal/localhost}"
+fi
+
 echo ""
 echo -e "${GREEN}${BOLD}Cullis Mastio deployed (${MODE}).${RESET}"
 echo ""
-echo -e "  ${BOLD}Dashboard${RESET}        ${GRAY}${PUBLIC_URL}/proxy/login${RESET}"
-echo -e "  ${BOLD}Health${RESET}           ${GRAY}${PUBLIC_URL}/health${RESET}"
+echo -e "  ${BOLD}Dashboard${RESET}        ${GRAY}${BROWSER_URL}/proxy/login${RESET}"
+echo -e "  ${BOLD}Health${RESET}           ${GRAY}${BROWSER_URL}/health${RESET}"
 if [[ -f "$ORG_CA_HOST" ]]; then
     echo -e "  ${BOLD}Org CA${RESET}           ${GRAY}./certs/org-ca.pem${RESET}"
     echo -e "                   ${GRAY}use as CULLIS_FRONTDESK_CA_BUNDLE_HOST when bringing up the Frontdesk bundle${RESET}"
@@ -1017,7 +1029,7 @@ SEED_PWD="$(grep -E '^MCP_PROXY_INITIAL_ADMIN_PASSWORD=' "$SCRIPT_DIR/proxy.env"
 
 if [[ "$MODE" == "development" ]]; then
     echo "  Next steps (development):"
-    echo "    1. Open ${PUBLIC_URL}/proxy/login"
+    echo "    1. Open ${BROWSER_URL}/proxy/login"
     echo "       (browser will warn — TLS is signed by your local Org CA,"
     echo "        not a public CA. Accept the self-signed warning.)"
     if [[ -n "$SEED_PWD" ]]; then
@@ -1028,7 +1040,7 @@ if [[ "$MODE" == "development" ]]; then
         echo "    3. Enroll agents via the Connector or paste an invite token"
     else
         echo "    2. First-boot setup: the dashboard will redirect to"
-        echo "         ${PUBLIC_URL}/proxy/register"
+        echo "         ${BROWSER_URL}/proxy/register"
         echo "       Pick the admin password there (typed once, never stored"
         echo "        on disk in plaintext or surfaced on stdout)."
         echo "    3. Enroll agents via the Connector or paste an invite token"

--- a/scripts/stage-mastio-bundle.sh
+++ b/scripts/stage-mastio-bundle.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Stage cullis-mastio-bundle.tar.gz for release with strict allowlist.
+#
+# Why this exists: the manual `tar czf ... mastio-bundle/` we used for
+# v0.5.2 (2026-05-22) skipped the sibling _common-deploy-helpers.sh
+# (it lives in packaging/, one level above mastio-bundle/), shipping a
+# tarball that crashes at deploy.sh line 106 on cold install. v0.5.1
+# happened to include it because the dir was named with the version
+# and staged differently. This script removes the foot-gun by codifying
+# the allowlist and running a post-stage cold-reader sanity check.
+#
+# Usage:
+#   ./scripts/stage-mastio-bundle.sh <version> [out-dir]
+#
+# Example:
+#   ./scripts/stage-mastio-bundle.sh 0.5.2 ./dist/
+#
+# Produces:
+#   <out-dir>/cullis-mastio-bundle.tar.gz             (unversioned, for README quickstart curl)
+#   <out-dir>/cullis-mastio-bundle-<version>.tar.gz   (versioned, for archive)
+#
+# Both tarballs have identical content; only the asset name differs so
+# the GitHub release can publish both URLs without sha mismatch.
+#
+# Exit code: 0 on success, non-zero if any allowlist file is missing
+# or the post-stage cold-reader check fails.
+
+set -euo pipefail
+
+VERSION="${1:?usage: $0 <version> [out-dir]}"
+OUT_DIR="${2:-./dist}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_BUNDLE="$REPO_ROOT/packaging/mastio-bundle"
+SRC_HELPER="$REPO_ROOT/packaging/_common-deploy-helpers.sh"
+
+C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_NEU=$'\033[36m'
+C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+
+err()  { echo "${C_ERR}${C_BOLD}error:${C_RST} $*" >&2; }
+ok()   { echo "${C_OK}$*${C_RST}" >&2; }
+info() { echo "${C_NEU}$*${C_RST}" >&2; }
+
+banner() {
+  echo "" >&2
+  echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+  echo "${C_NEU}${C_BOLD}  $*${C_RST}" >&2
+  echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+}
+
+# Allowlist: files copied INTO the tarball's cullis-mastio-bundle/ dir.
+# Order: matches v0.5.1 layout + post-v0.5.1 additions (postgres compose).
+# Runtime artifacts (data/, nginx-certs/, certs/ with operator org id,
+# proxy.env without .example) are intentionally excluded.
+BUNDLE_ALLOWLIST=(
+  "deploy.sh"
+  "generate-proxy-env.sh"
+  "docker-compose.yml"
+  "docker-compose.prod.yml"
+  "docker-compose.shared-broker.yml"
+  "docker-compose.postgres.yml"
+  "proxy.env.example"
+  "README.md"
+  "nginx"
+)
+
+banner "Stage cullis-mastio-bundle $VERSION"
+
+# Preflight: source-of-truth files all present.
+for f in "${BUNDLE_ALLOWLIST[@]}"; do
+  if [[ ! -e "$SRC_BUNDLE/$f" ]]; then
+    err "missing source: packaging/mastio-bundle/$f"
+    exit 1
+  fi
+done
+if [[ ! -e "$SRC_HELPER" ]]; then
+  err "missing source: packaging/_common-deploy-helpers.sh"
+  exit 1
+fi
+ok "  preflight: all ${#BUNDLE_ALLOWLIST[@]} bundle files + sibling helper present"
+
+# Stage in a temp dir so the tar metadata is clean (no .gitignored
+# runtime crud, no operator-specific certs/).
+STAGE_DIR="$(mktemp -d /tmp/cullis-mastio-stage-XXXXXX)"
+trap 'rm -rf "$STAGE_DIR"' EXIT
+TAR_ROOT="$STAGE_DIR/cullis-mastio-bundle"
+mkdir -p "$TAR_ROOT"
+
+for f in "${BUNDLE_ALLOWLIST[@]}"; do
+  cp -r "$SRC_BUNDLE/$f" "$TAR_ROOT/$f"
+done
+cp "$SRC_HELPER" "$TAR_ROOT/_common-deploy-helpers.sh"
+ok "  staged $(find "$TAR_ROOT" -mindepth 1 -maxdepth 1 | wc -l) entries in $TAR_ROOT"
+
+# Tar.
+mkdir -p "$OUT_DIR"
+OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
+
+TAR_UNVER="$OUT_DIR_ABS/cullis-mastio-bundle.tar.gz"
+TAR_VER="$OUT_DIR_ABS/cullis-mastio-bundle-$VERSION.tar.gz"
+
+(cd "$STAGE_DIR" && tar czf "$TAR_UNVER" cullis-mastio-bundle/)
+cp "$TAR_UNVER" "$TAR_VER"
+ok "  $TAR_UNVER ($(stat -c%s "$TAR_UNVER") bytes)"
+ok "  $TAR_VER  (identical sha)"
+
+# Sanity check post-stage: extract elsewhere, replay cold reader.
+banner "Cold-reader sanity check"
+
+CHECK_DIR="$(mktemp -d /tmp/cullis-mastio-check-XXXXXX)"
+trap 'rm -rf "$STAGE_DIR" "$CHECK_DIR"' EXIT
+
+(cd "$CHECK_DIR" && tar xzf "$TAR_UNVER")
+cd "$CHECK_DIR/cullis-mastio-bundle"
+
+# 1. deploy.sh syntactically valid.
+if ! bash -n deploy.sh; then
+  err "deploy.sh has bash syntax errors"
+  exit 1
+fi
+ok "  bash -n deploy.sh"
+
+# 2. helper sibling present (the v0.5.2 regression).
+if [[ ! -f _common-deploy-helpers.sh ]]; then
+  err "_common-deploy-helpers.sh missing from tarball (the v0.5.2 bug)"
+  exit 1
+fi
+ok "  _common-deploy-helpers.sh present"
+
+# 3. helper source line resolves: dry-run the if/else in deploy.sh.
+if ! grep -q '_common-deploy-helpers.sh' deploy.sh; then
+  err "deploy.sh no longer references _common-deploy-helpers.sh"
+  exit 1
+fi
+ok "  deploy.sh sources the helper"
+
+# 4. no runtime crud leaked.
+for forbidden in data nginx-certs certs proxy.env; do
+  if [[ -e "$forbidden" ]]; then
+    err "forbidden runtime artifact in tarball: $forbidden"
+    exit 1
+  fi
+done
+ok "  no runtime artifacts (data/, nginx-certs/, certs/, proxy.env)"
+
+# 5. helper is sourceable in isolation (catches future helper bugs early).
+if ! ( source _common-deploy-helpers.sh 2>/dev/null ); then
+  err "_common-deploy-helpers.sh cannot be sourced standalone"
+  exit 1
+fi
+ok "  _common-deploy-helpers.sh sources cleanly"
+
+cd "$REPO_ROOT"
+
+SHA="$(sha256sum "$TAR_UNVER" | awk '{print $1}')"
+
+banner "${C_OK}Stage OK"
+echo "  Version:     $VERSION" >&2
+echo "  Output:      $TAR_UNVER" >&2
+echo "               $TAR_VER" >&2
+echo "  SHA-256:     $SHA" >&2
+echo "" >&2
+echo "  Next:        gh release upload mastio-v$VERSION \\" >&2
+echo "                 $TAR_UNVER \\" >&2
+echo "                 $TAR_VER \\" >&2
+echo "                 --clobber" >&2


### PR DESCRIPTION
## Summary

- **v0.5.2 tarball asset (already fixed in-place on the GH release)**: `./deploy.sh` failed at line 106 because `packaging/_common-deploy-helpers.sh` was missing from the bundle tarball. Both v0.5.2 assets (alias + versioned) re-uploaded to 46410 bytes including the helper. No version bump.
- **README quickstart**: rewrote on top of `CullisClient.from_enrollment(enroll_url)` so cold readers don't paste file paths the dashboard never produces. Added explicit `MCP_PROXY_ANTHROPIC_API_KEY` step.
- **Provider claim**: corrected "Anthropic, OpenAI, Gemini, and Ollama work out of the box" — only Anthropic is wired today.
- **`scripts/stage-mastio-bundle.sh`**: reproducible staging with allowlist + 5 post-stage sanity checks, so this regression can't ship silently again.

## Test plan

- [x] Cold-reader test: `curl ... | tar xz && ./deploy.sh` passes past line 106 and reaches first-boot prompt
- [x] Staging script: all 5 sanity checks green on `0.5.2` re-stage
- [x] Tarball uploaded to GH release verified (46410 B, helper present, postgres compose present)
- [x] `bash -n scripts/stage-mastio-bundle.sh` clean