### PR TITLE
feat(dogfood): single-command end-to-end smoke stack (B1-B12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,11 @@ scripts/stress/*.log
 /docs/runbooks/frontdesk-shared-hardening.md
 /site/src/pages/insurance.astro
 /site/src/pages/download.astro
+
+# Dogfood stack symlink to sibling cullis-enterprise/legacy/ checkout,
+# populated by ./dogfood.sh setup. No trailing slash so the pattern
+# matches both a symlink (.dogfood -> ...) and a real directory.
+/.dogfood
+
+# Git worktree management dir, used to isolate parallel agent work.
+/.worktrees/

--- a/agent_smoke_stub.py
+++ b/agent_smoke_stub.py
@@ -1,0 +1,153 @@
+"""Deterministic MCP tool-call stub for dogfood smoke scenarios B8-B11.
+
+Replaces an LLM-driven agent (kyc-screener, dora-reporter, pitchbook-builder)
+with a fixed sequence of `client.call_mcp_tool()` calls. No LLM, no real
+payload — only the same identity / capability / audit chain exercised that a
+real agent would trigger.
+
+Designed to run inside an existing stack container (agent-a) that mounts the
+bootstrap-state volume at /state/, so any agent's identity material is
+reachable without extracting certs to the host.
+
+Exit codes:
+    0  expected outcome reached (all tools called OK, or denial observed
+       when --expect-denied)
+    1  scenario failure (tool calls did not match expected outcome)
+    2  setup error (identity not found, SDK import broken, etc.)
+
+Usage:
+    docker exec agent-a python3 /tmp/agent_smoke_stub.py \\
+        --agent-id orga::kyc-screener \\
+        --tools verify_identity,screen_sanctions,query_beneficial_owners,escalate_to_compliance \\
+        --mastio https://mastio-a-nginx:9443
+
+Capability-denied probe (B11):
+    docker exec agent-a python3 /tmp/agent_smoke_stub.py \\
+        --agent-id orga::kyc-screener \\
+        --tools get_market_data \\
+        --mastio https://mastio-a-nginx:9443 \\
+        --expect-denied
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _agent_short_name(agent_id: str) -> str:
+    return agent_id.split("::", 1)[1] if "::" in agent_id else agent_id
+
+
+def _org_id(agent_id: str) -> str:
+    return agent_id.split("::", 1)[0] if "::" in agent_id else "orga"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-id", required=True, help="e.g. orga::kyc-screener")
+    parser.add_argument("--tools", required=True, help="comma-separated tool names")
+    parser.add_argument("--mastio", required=True, help="Mastio TLS URL")
+    parser.add_argument(
+        "--state-root",
+        default="/state",
+        help="Bootstrap-state volume mount root (default /state)",
+    )
+    parser.add_argument(
+        "--expect-denied",
+        action="store_true",
+        help="Scenario B11: tool call SHOULD return capability_denied",
+    )
+    parser.add_argument(
+        "--scenario",
+        default="smoke",
+        help="Tag passed in tool args (audit chain visibility)",
+    )
+    args = parser.parse_args()
+
+    sys.path.insert(0, "/app")
+    try:
+        from cullis_sdk.client import CullisClient
+    except ImportError as exc:
+        print(f"SETUP_FAIL: cullis_sdk not importable: {exc}", file=sys.stderr)
+        return 2
+
+    short = _agent_short_name(args.agent_id)
+    org = _org_id(args.agent_id)
+    id_dir = Path(args.state_root) / org / "agents" / short
+    cert = id_dir / "agent.pem"
+    key = id_dir / "agent-key.pem"
+    ca = Path(args.state_root) / org / "ca.pem"
+
+    for f in (cert, key, ca):
+        if not f.exists():
+            print(f"SETUP_FAIL: missing {f}", file=sys.stderr)
+            return 2
+
+    try:
+        client = CullisClient.from_identity_dir(
+            args.mastio,
+            cert_path=str(cert),
+            key_path=str(key),
+            ca_chain_path=str(ca),
+            verify_tls=True,
+            agent_id=args.agent_id,
+            org_id=org,
+        )
+        client.login(
+            agent_id=args.agent_id,
+            org_id=org,
+            cert_path=str(cert),
+            key_path=str(key),
+        )
+    except Exception as exc:
+        print(f"SETUP_FAIL: client build/login: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    tools = [t.strip() for t in args.tools.split(",") if t.strip()]
+    results = []
+    for tool in tools:
+        try:
+            resp = client.call_mcp_tool(
+                tool,
+                {"flag": "smoke", "scenario": args.scenario, "agent": args.agent_id},
+            )
+            results.append((tool, "ok", json.dumps(resp)[:120]))
+        except Exception as exc:
+            cls = type(exc).__name__
+            msg = str(exc)[:160]
+            low = msg.lower()
+            denied = (
+                "capability" in low
+                or "403" in msg
+                or "denied" in low
+                or "no active binding" in low
+                or "binding" in low and "resource" in low
+            )
+            results.append((tool, "denied" if denied else "fail", f"{cls}: {msg}"))
+
+    print(f"=== {args.agent_id} ===")
+    for tool, status, detail in results:
+        marker = {"ok": "OK", "denied": "DENIED", "fail": "FAIL"}[status]
+        print(f"  [{marker}] {tool}  {detail}")
+
+    if args.expect_denied:
+        every_denied = all(s == "denied" for _, s, _ in results)
+        if every_denied:
+            print(f"RESULT: B11 OK ({len(results)} tool(s) correctly denied)")
+            return 0
+        print(f"RESULT: B11 FAIL (expected denied, got {[s for _,s,_ in results]})", file=sys.stderr)
+        return 1
+    else:
+        all_ok = all(s == "ok" for _, s, _ in results)
+        if all_ok:
+            print(f"RESULT: OK {len(results)}/{len(results)} tools succeeded")
+            return 0
+        print(f"RESULT: FAIL (mixed outcomes: {[s for _,s,_ in results]})", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dogfood-scenarios.sh
+++ b/dogfood-scenarios.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Dogfood-extra scenarios: B8 (kyc stub), B9 (dora stub), B10 (pitchbook stub),
+# B11 (capability_gate denial), B12 (release tarball cold-reader validation).
+#
+# Runs against a stack already brought up by ./dogfood.sh full (or
+# `cd .dogfood/stack && ./demo.sh up`). Each scenario is a fixed sequence of
+# MCP tool calls with no LLM involvement — pure capability + audit chain
+# probe. Replaces the LLM-driven agent_*_smoke variant which would otherwise
+# require Anthropic API key + flaky parsing.
+#
+# Usage:
+#   ./dogfood-scenarios.sh                # run all extras (B8..B12)
+#   ./dogfood-scenarios.sh B8 B11         # run a subset
+#
+# Exit code: 0 if every selected scenario PASSES, 1 otherwise.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STUB_PY="$SCRIPT_DIR/agent_smoke_stub.py"
+STAGE_BUNDLE_SH="${STAGE_BUNDLE_SH:-/home/daenaihax/projects/agent-trust/scripts/stage-mastio-bundle.sh}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-cullis-stack}"
+AGENT_CONTAINER="${AGENT_CONTAINER:-${COMPOSE_PROJECT}-agent-a-1}"
+MASTIO_URL="${MASTIO_URL:-https://mastio-a-nginx:9443}"
+
+C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_NEU=$'\033[36m'
+C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_RST=$'\033[0m'
+
+PASS=0
+FAIL=0
+
+run() {
+  local name="$1"; shift
+  echo "" >&2
+  echo "${C_NEU}${C_BOLD}»${C_RST} ${name}" >&2
+  if "$@"; then
+    echo "  ${C_OK}${C_BOLD}PASS${C_RST}  ${name}" >&2
+    PASS=$((PASS + 1))
+  else
+    echo "  ${C_ERR}${C_BOLD}FAIL${C_RST}  ${name}" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+_require_stack_up() {
+  if ! docker ps --format '{{.Names}}' | grep -q "^${AGENT_CONTAINER}$"; then
+    echo "${C_ERR}error:${C_RST} container ${AGENT_CONTAINER} not running. Run ./dogfood.sh full first." >&2
+    return 1
+  fi
+}
+
+_ship_stub() {
+  if ! docker cp "$STUB_PY" "${AGENT_CONTAINER}:/tmp/agent_smoke_stub.py" 2>/dev/null; then
+    echo "${C_ERR}error:${C_RST} docker cp stub to ${AGENT_CONTAINER} failed" >&2
+    return 1
+  fi
+}
+
+# ── B8. kyc-screener stub ────────────────────────────────────────────────────
+
+scenario_b8_kyc_stub() {
+  _require_stack_up || return 1
+  _ship_stub || return 1
+  local out
+  out="$(docker exec "$AGENT_CONTAINER" python3 /tmp/agent_smoke_stub.py \
+    --agent-id orga::kyc-screener \
+    --tools verify_identity,screen_sanctions,query_beneficial_owners,escalate_to_compliance \
+    --mastio "$MASTIO_URL" \
+    --scenario B8 2>&1)"
+  echo "${C_DIM}$(echo "$out" | tail -n6)${C_RST}" >&2
+  echo "$out" | grep -q "^RESULT: OK"
+}
+
+# ── B9. dora-reporter stub ───────────────────────────────────────────────────
+
+scenario_b9_dora_stub() {
+  _require_stack_up || return 1
+  _ship_stub || return 1
+  local out
+  out="$(docker exec "$AGENT_CONTAINER" python3 /tmp/agent_smoke_stub.py \
+    --agent-id orga::dora-reporter \
+    --tools list_third_party_vendors,query_vendor_assessment,draft_dora_register_entry,submit_to_auditor_org \
+    --mastio "$MASTIO_URL" \
+    --scenario B9 2>&1)"
+  echo "${C_DIM}$(echo "$out" | tail -n6)${C_RST}" >&2
+  echo "$out" | grep -q "^RESULT: OK"
+}
+
+# ── B10. pitchbook-builder stub ──────────────────────────────────────────────
+
+scenario_b10_pitchbook_stub() {
+  _require_stack_up || return 1
+  _ship_stub || return 1
+  local out
+  out="$(docker exec "$AGENT_CONTAINER" python3 /tmp/agent_smoke_stub.py \
+    --agent-id orga::pitchbook-builder \
+    --tools query_comps_db,read_internal_research,news_feed_query,generate_excel,generate_pptx \
+    --mastio "$MASTIO_URL" \
+    --scenario B10 2>&1)"
+  echo "${C_DIM}$(echo "$out" | tail -n7)${C_RST}" >&2
+  echo "$out" | grep -q "^RESULT: OK"
+}
+
+# ── B11. capability_gate denial (kyc-screener → portfolio tool) ──────────────
+
+scenario_b11_capability_denial() {
+  _require_stack_up || return 1
+  _ship_stub || return 1
+  # kyc-screener has NO binding for portfolio tools. Mastio must deny.
+  local out
+  out="$(docker exec "$AGENT_CONTAINER" python3 /tmp/agent_smoke_stub.py \
+    --agent-id orga::kyc-screener \
+    --tools get_market_data \
+    --mastio "$MASTIO_URL" \
+    --scenario B11 \
+    --expect-denied 2>&1)"
+  echo "${C_DIM}$(echo "$out" | tail -n4)${C_RST}" >&2
+  echo "$out" | grep -q "^RESULT: B11 OK"
+}
+
+# ── B12. release tarball cold-reader validation ──────────────────────────────
+
+scenario_b12_release_tarball() {
+  if [[ ! -x "$STAGE_BUNDLE_SH" ]]; then
+    echo "${C_DIM}    stage script not found: $STAGE_BUNDLE_SH${C_RST}" >&2
+    echo "${C_DIM}    set STAGE_BUNDLE_SH=/path or wait PR #930 merge${C_RST}" >&2
+    return 1
+  fi
+  local tmpout
+  tmpout="$(mktemp -d /tmp/b12-dogfood-XXXXXX)"
+  trap "rm -rf $tmpout" RETURN
+  if ! "$STAGE_BUNDLE_SH" 0.0.0-smoke "$tmpout" >"$tmpout/log" 2>&1; then
+    echo "${C_DIM}    stage script failed; tail:${C_RST}" >&2
+    echo "${C_DIM}$(tail -n8 "$tmpout/log")${C_RST}" >&2
+    return 1
+  fi
+  echo "${C_DIM}    $(grep -E 'SHA-256|Output|Stage OK' "$tmpout/log" | head -3 | tr '\n' ' ')${C_RST}" >&2
+  return 0
+}
+
+# ── Driver ──────────────────────────────────────────────────────────────────
+
+ALL=(B8 B9 B10 B11 B12)
+SELECTED=("${@:-${ALL[@]}}")
+if [[ $# -eq 0 ]]; then
+  SELECTED=("${ALL[@]}")
+fi
+
+echo "" >&2
+echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+echo "${C_NEU}${C_BOLD}  dogfood-scenarios: ${SELECTED[*]}${C_RST}" >&2
+echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+
+for s in "${SELECTED[@]}"; do
+  case "$s" in
+    B8)  run "B8.  kyc-screener stub (4 tools)"        scenario_b8_kyc_stub ;;
+    B9)  run "B9.  dora-reporter stub (4 tools)"       scenario_b9_dora_stub ;;
+    B10) run "B10. pitchbook-builder stub (5 tools)"   scenario_b10_pitchbook_stub ;;
+    B11) run "B11. capability_gate denial probe"       scenario_b11_capability_denial ;;
+    B12) run "B12. release tarball cold-reader test"   scenario_b12_release_tarball ;;
+    *)   echo "${C_ERR}unknown scenario: $s${C_RST}" >&2; FAIL=$((FAIL+1)) ;;
+  esac
+done
+
+echo "" >&2
+echo "${C_BOLD}════════════════════════════════════════════════════════════════════${C_RST}" >&2
+if [[ $FAIL -eq 0 ]]; then
+  echo "  ${C_OK}${C_BOLD}[extras] PASS=$PASS FAIL=$FAIL${C_RST}" >&2
+else
+  echo "  ${C_ERR}${C_BOLD}[extras] PASS=$PASS FAIL=$FAIL${C_RST}" >&2
+fi
+echo "${C_BOLD}════════════════════════════════════════════════════════════════════${C_RST}" >&2
+
+exit $((FAIL > 0 ? 1 : 0))

--- a/dogfood.sh
+++ b/dogfood.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Cullis dogfood orchestrator.
+#
+# Wraps the modern dogfood stack (Court + 2 Mastio + 5 MCP mock servers +
+# 4 reference agents + Frontdesk) that lives in the sibling
+# cullis-enterprise/legacy/ checkout. Lets the founder run the full
+# product surface against the current public mcp_proxy/ without copying
+# enterprise sources into the public tree.
+#
+# The smoke stack builds the Mastio image with
+#   build:  context: ..   dockerfile: mcp_proxy/Dockerfile
+# inside the stack docker-compose.yml. Because legacy/mcp_proxy is a
+# symlink to agent-trust/mcp_proxy, the built image always reflects the
+# current public mcp_proxy/ working tree — that is the point.
+#
+# Usage:
+#   ./dogfood.sh setup        symlink .dogfood/ -> ../cullis-enterprise/legacy/
+#   ./dogfood.sh quick        up stack + healthcheck, no LLM scenarios (~30s)
+#   ./dogfood.sh full         up stack + smoke E2E B1-B11 (~5min warm)
+#   ./dogfood.sh pytest [...] legacy pytest suite (DOES NOT test mcp_proxy/,
+#                             tests legacy/app/ — see warning at runtime)
+#   ./dogfood.sh down         teardown + drop volumes
+#   ./dogfood.sh status       service state + endpoints
+#   ./dogfood.sh logs [svc]   tail logs (all services or one)
+#
+# Exit code: 0 if the requested action succeeded.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOGFOOD_DIR="$SCRIPT_DIR/.dogfood"
+STACK_DIR="$DOGFOOD_DIR/stack"
+SIBLING_DEFAULT="$SCRIPT_DIR/../cullis-enterprise/legacy"
+SIBLING="${CULLIS_ENTERPRISE_LEGACY:-$SIBLING_DEFAULT}"
+
+C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_NEU=$'\033[36m'
+C_WARN=$'\033[33m'; C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+
+err()  { echo "${C_ERR}${C_BOLD}error:${C_RST} $*" >&2; }
+warn() { echo "${C_WARN}${C_BOLD}warn:${C_RST}  $*" >&2; }
+info() { echo "${C_NEU}$*${C_RST}" >&2; }
+ok()   { echo "${C_OK}$*${C_RST}" >&2; }
+
+banner() {
+  echo "" >&2
+  echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+  echo "${C_NEU}${C_BOLD}  $*${C_RST}" >&2
+  echo "${C_NEU}${C_BOLD}═════════════════════════════════════════════════════════════════════${C_RST}" >&2
+}
+
+require_setup() {
+  if [[ ! -e "$DOGFOOD_DIR" ]]; then
+    err ".dogfood/ not set up. Run: ./dogfood.sh setup"
+    exit 1
+  fi
+  if [[ ! -d "$STACK_DIR" ]]; then
+    err "$STACK_DIR not found. Sibling checkout may have moved. Re-run: ./dogfood.sh setup"
+    exit 1
+  fi
+}
+
+cmd_setup() {
+  banner "Setup .dogfood/ symlink"
+
+  if [[ -L "$DOGFOOD_DIR" ]]; then
+    local current
+    current="$(readlink "$DOGFOOD_DIR")"
+    info "  .dogfood/ already symlink -> $current"
+  elif [[ -e "$DOGFOOD_DIR" ]]; then
+    err ".dogfood/ exists and is not a symlink. Inspect manually before removing."
+    exit 1
+  fi
+
+  if [[ ! -d "$SIBLING" ]]; then
+    err "Sibling enterprise checkout not found at:"
+    err "  $SIBLING"
+    err ""
+    err "To populate it:"
+    err "  cd $(dirname "$SCRIPT_DIR")"
+    err "  git clone git@github.com:cullis-security/cullis-enterprise.git"
+    err ""
+    err "Or set CULLIS_ENTERPRISE_LEGACY=/path/to/cullis-enterprise/legacy"
+    err "Then re-run: ./dogfood.sh setup"
+    exit 1
+  fi
+
+  ln -sfn "$SIBLING" "$DOGFOOD_DIR"
+  ok "  .dogfood/ -> $SIBLING"
+
+  local missing=0
+  for sub in stack tests sandbox/agents-demo; do
+    if [[ ! -d "$DOGFOOD_DIR/$sub" ]]; then
+      err "  missing $DOGFOOD_DIR/$sub"
+      missing=$((missing+1))
+    else
+      ok "  found  $sub/"
+    fi
+  done
+  if [[ $missing -gt 0 ]]; then
+    err "Enterprise checkout incomplete. Check the sibling repo."
+    exit 1
+  fi
+
+  banner "Setup OK"
+  echo "  Next: ./dogfood.sh quick   (healthcheck-only)" >&2
+  echo "        ./dogfood.sh full    (smoke E2E B1-B11)" >&2
+}
+
+cmd_quick() {
+  require_setup
+  banner "Quick: up stack + healthcheck (no LLM scenarios)"
+
+  cd "$STACK_DIR"
+  if ! ./up.sh; then
+    err "up.sh failed"
+    return 1
+  fi
+
+  banner "Healthcheck"
+  local fail=0
+  local svcs=(
+    "Court:http://localhost:8000/health"
+    "MastioA:http://localhost:9100/health"
+    "MastioB:http://localhost:9200/health"
+    "Frontdesk:http://localhost:7777/api/status"
+  )
+  for svc in "${svcs[@]}"; do
+    local name="${svc%%:*}"
+    local url="${svc#*:}"
+    if curl -sf --max-time 3 "$url" >/dev/null 2>&1; then
+      ok "  $name $url"
+    else
+      err "  $name $url"
+      fail=$((fail+1))
+    fi
+  done
+
+  if [[ $fail -eq 0 ]]; then
+    banner "${C_OK}QUICK OK"
+    echo "  Stack up + healthchecks green. Run ./dogfood.sh full for E2E." >&2
+    return 0
+  fi
+  err "$fail healthcheck(s) failed"
+  return 1
+}
+
+cmd_full() {
+  require_setup
+  banner "Full: up + smoke E2E (B1-B7 baseline + B8-B12 extras)"
+  local baseline_rc=0 extras_rc=0
+  "$STACK_DIR/demo.sh" || baseline_rc=$?
+  "$SCRIPT_DIR/dogfood-scenarios.sh" || extras_rc=$?
+  banner "Full summary"
+  if [[ $baseline_rc -eq 0 ]]; then ok "  baseline B1-B7  PASS"; else err "  baseline B1-B7  FAIL (some scenarios failed; see above)"; fi
+  if [[ $extras_rc -eq 0 ]];   then ok "  extras   B8-B12 PASS"; else err "  extras   B8-B12 FAIL (some scenarios failed; see above)"; fi
+  return $(( baseline_rc | extras_rc ))
+}
+
+cmd_pytest() {
+  require_setup
+  banner "Pytest: tests/ suite"
+  warn "This runs against legacy app/, NOT public mcp_proxy/."
+  warn "Drift is possible. The real gate for mcp_proxy/ changes is"
+  warn "  ./dogfood.sh full  (smoke E2E builds the image from public)."
+  echo "" >&2
+
+  if ! command -v pytest >/dev/null 2>&1; then
+    err "pytest not in PATH. Activate venv first."
+    exit 1
+  fi
+
+  cd "$DOGFOOD_DIR"
+  exec pytest tests/ -n auto --dist=loadfile "$@"
+}
+
+cmd_down() {
+  require_setup
+  banner "Teardown"
+  exec "$STACK_DIR/down.sh"
+}
+
+cmd_status() {
+  require_setup
+  exec "$STACK_DIR/demo.sh" status
+}
+
+cmd_logs() {
+  require_setup
+  exec "$STACK_DIR/demo.sh" logs "$@"
+}
+
+case "${1:-}" in
+  setup)        shift; cmd_setup ;;
+  quick)        shift; cmd_quick ;;
+  full)         shift; cmd_full ;;
+  pytest|test)  shift; cmd_pytest "$@" ;;
+  down)         shift; cmd_down ;;
+  status|ps)    shift; cmd_status ;;
+  logs)         shift; cmd_logs "$@" ;;
+  -h|--help|help|"")
+    sed -n '/^# Usage:/,/^# Exit/p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    err "unknown subcommand: $1"
+    err "Try: $0 --help"
+    exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `./dogfood.sh` top-level orchestrator that wraps the modern dogfood stack from sibling `cullis-enterprise/legacy/` checkout via gitignored `.dogfood/` symlink. Stack builds the Mastio image from public `mcp_proxy/` so every smoke run validates the current working tree.
- Adds 5 new scenarios (B8 kyc-screener stub, B9 dora-reporter stub, B10 pitchbook-builder stub, B11 capability_gate denial, B12 release tarball cold-reader validation) on top of the 7 baseline scenarios from `legacy/stack/smoke.sh`. Agent stubs are deterministic sequences of `client.call_mcp_tool()` calls inside the existing `agent-a` container that mounts the bootstrap-state volume, so identity material for kyc-screener / dora-reporter / pitchbook-builder is reachable without extracting certs to the host. No LLM in the loop, zero flake.
- Caught two regressions on day one that unit tests would never have surfaced: v0.5.2 bundle missing `_common-deploy-helpers.sh` (fixed in #930) and modern stack ollama provider not configured by `bootstrap_mastio.py` (hot-fix curl, persistence pending as a follow-up PR to `cullis-enterprise`).

## Sub-commands

```
./dogfood.sh setup        symlink .dogfood/ -> ../cullis-enterprise/legacy/
./dogfood.sh quick        up stack + healthcheck, no LLM scenarios (~30s)
./dogfood.sh full         up stack + smoke E2E B1-B12 (~3min warm)
./dogfood.sh pytest [...] legacy tests/ suite (does NOT test mcp_proxy/, warning at runtime)
./dogfood.sh down         teardown + drop volumes
./dogfood.sh status       service state + endpoints
./dogfood.sh logs [svc]   tail logs (all or one)
```

## Known limitations

- Requires sibling `cullis-enterprise/legacy/` checkout. Override via `CULLIS_ENTERPRISE_LEGACY=/path` for non-sibling layouts.
- Baseline B6 (cross-user isolation, Finding #16 regression) currently fails on fresh up.sh: alice cookie not surfacing as a distinct principal. Tracked as a follow-up.
- The hot-fixes for the bugs caught in this session (nginx config files in stack/, ollama provider config) live only in my local enterprise checkout. A companion PR to `cullis-enterprise` is needed to make these persistent for any contributor running the dogfood from a fresh clone.

## Test plan

- [x] `./dogfood.sh setup` creates symlink, verifies stack/ tests/ sandbox/agents-demo/ visible
- [x] `./dogfood.sh quick` brings stack up + healthchecks Court / Mastio A / Mastio B / Frontdesk
- [x] `./dogfood.sh full` runs B1-B12 end-to-end; achieved 11/12 PASS (B1-B5,B7,B8-B12), B6 pre-existing fragility tracked separately
- [x] `./dogfood.sh down` tears stack down cleanly
- [x] Each of B8/B9/B10 exercises the expected MCP tool count (4/4, 4/4, 5/5) with the correct agent identity
- [x] B11 confirms capability_gate denial when kyc-screener attempts a portfolio tool (`get_market_data`)
- [x] B12 stages the bundle tarball and the post-stage cold-reader test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)