### PR TITLE
feat(sdk+mastio): enroll_via_dashboard_approval factory closes B-2 dogfood gap

### DIFF
--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -46,6 +46,7 @@ client``.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -55,6 +56,15 @@ from cullis_sdk._logging import log
 
 if TYPE_CHECKING:
     from cullis_sdk.client import CullisClient
+
+
+def _now_iso() -> str:
+    """UTC ISO-8601 timestamp helper for ``meta.json`` provenance.
+
+    Kept module-level so the dashboard-approval factory does not have to
+    duplicate the timestamp shape used elsewhere in the SDK.
+    """
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 class _EnrollmentMixin:
@@ -1057,6 +1067,354 @@ class _EnrollmentMixin:
 
         log("sdk", f"Loaded Connector identity {agent_id} from {identity_dir}")
         return instance
+
+    # ── B-2 dogfood fix — dashboard-approval enrollment (cold-reader path) ─
+
+    @classmethod
+    def enroll_via_dashboard_approval(
+        cls,
+        mastio_url: str,
+        *,
+        requester_name: str,
+        requester_email: str,
+        reason: str | None = None,
+        device_info: str | None = None,
+        save_to: "str | Path",
+        poll_interval_s: float = 5.0,
+        timeout_s: float = 600.0,
+        verify_tls: bool = True,
+        ca_chain_path: "str | Path | None" = None,
+        on_pending: "object | None" = None,
+    ) -> "CullisClient":
+        """Bootstrap an agent identity through the dashboard approval flow.
+
+        Wraps the Connector-protocol enrollment surface (``POST
+        /v1/enrollment/start`` → admin clicks Approve in the dashboard →
+        ``GET /v1/enrollment/{session_id}/status`` with the M-onb-1
+        proof-of-possession header) into a single zero-boilerplate
+        factory for community open-source agent developers.
+
+        The factory generates an EC P-256 enrollment keypair, a second
+        EC P-256 keypair for DPoP egress, submits the start request,
+        polls for the admin decision, persists the identity-dir layout
+        ``from_identity_dir`` reads (``agent.key`` + ``agent.crt`` +
+        ``ca-chain.pem`` + ``dpop.key`` + ``meta.json``), and returns a
+        runtime-ready client.
+
+        Args:
+            mastio_url: public base URL of the Mastio
+                (``https://mastio.example.com:9443``).
+            requester_name: human-readable name shown to the admin.
+            requester_email: contact email shown to the admin.
+            reason: optional free-form reason shown to the admin.
+            device_info: optional client/device info (OS, hostname, SDK
+                version). The Mastio stores it verbatim on the row and
+                displays it in the dashboard.
+            save_to: directory where the identity-dir layout is written.
+                Created if absent. Private-key files land at mode 0600.
+            poll_interval_s: seconds between status polls.
+            timeout_s: total seconds to wait for the admin to act
+                before raising ``TimeoutError``.
+            verify_tls: TLS server-cert verification toggle. The
+                operator-pinned CA via ``ca_chain_path`` is strongly
+                preferred over disabling verification.
+            ca_chain_path: optional PEM bundle pinning the Mastio CA.
+                Used both for the bootstrap fetches and threaded through
+                to the returned client. When ``None`` and the dashboard
+                approval response carried a ``cert_chain_pem`` field
+                the factory writes that chain to
+                ``save_to/ca-chain.pem`` and uses it instead.
+            on_pending: optional callable ``(session_id, dashboard_url)``
+                invoked once after ``start`` returns so a CLI / TUI can
+                surface "approve here" to the operator. Any exception
+                raised by the callback is caught and logged — it never
+                aborts the enrollment.
+
+        Raises:
+            ConnectionError: Mastio unreachable.
+            PermissionError: enrollment rejected by admin (the
+                ``rejection_reason`` from the dashboard is in the
+                exception message).
+            TimeoutError: admin did not act before ``timeout_s``
+                (the Mastio's TTL is 30 minutes; pick something
+                similar or shorter).
+            ValueError: cryptographic operation failed (proof signing,
+                base64url encode). Should not happen in normal use.
+
+        Example::
+
+            from cullis_sdk import CullisClient
+
+            client = CullisClient.enroll_via_dashboard_approval(
+                "https://mastio.example.com:9443",
+                requester_name="Alice Developer",
+                requester_email="alice@example.com",
+                reason="building an MCP agent for daily trading",
+                save_to="~/.cullis/agent-alice",
+                on_pending=lambda sid, url: print(
+                    f"Approve at: {url} (session={sid})"
+                ),
+            )
+            print(client.chat_completion("gpt-4o-mini", "hello"))
+        """
+        from cullis_sdk.client import _build_proxy_http_client, _check_insecure_tls
+
+        import base64 as _b64
+        import hashlib as _hashlib
+        import json as _json
+        import os as _os
+        import tempfile as _tempfile
+        import time as _time
+
+        from cryptography.hazmat.primitives import hashes as _hashes
+        from cryptography.hazmat.primitives import serialization as _ser
+        from cryptography.hazmat.primitives.asymmetric import ec as _ec
+
+        def _b64url_nopad(data: bytes) -> str:
+            return _b64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+        _check_insecure_tls(verify_tls)
+
+        save_to_path = Path(save_to).expanduser()
+        save_to_path.mkdir(parents=True, exist_ok=True)
+
+        # ── Step 1: generate enrollment EC P-256 keypair ──────────
+        enroll_priv = _ec.generate_private_key(_ec.SECP256R1())
+        enroll_pub = enroll_priv.public_key()
+        pubkey_pem = enroll_pub.public_bytes(
+            encoding=_ser.Encoding.PEM,
+            format=_ser.PublicFormat.SubjectPublicKeyInfo,
+        ).decode("ascii")
+
+        # ── Step 2: compute server-shape fingerprint ──────────────
+        # The Mastio computes SHA-256 over the DER SubjectPublicKeyInfo
+        # (see ``mcp_proxy.enrollment.service._pubkey_fingerprint``).
+        # PEM text vs DER is the #1 mismatch trap cold-readers hit.
+        pubkey_der = enroll_pub.public_bytes(
+            encoding=_ser.Encoding.DER,
+            format=_ser.PublicFormat.SubjectPublicKeyInfo,
+        )
+        fingerprint = _hashlib.sha256(pubkey_der).hexdigest()
+
+        # ── Step 3: sign pop_signature ────────────────────────────
+        # Domain-separated message: ``"enrollment-pop:v1|<hex-fp>"``.
+        # Verified server-side in ``service._verify_pop_signature``.
+        pop_message = f"enrollment-pop:v1|{fingerprint}".encode("utf-8")
+        pop_sig_der = enroll_priv.sign(pop_message, _ec.ECDSA(_hashes.SHA256()))
+        # The server's verify path calls ``EllipticCurvePublicKey.verify``
+        # which expects DER-encoded ECDSA; transmit base64url(DER) so
+        # decoding is symmetric to the RSA-PSS path.
+        pop_signature = _b64url_nopad(pop_sig_der)
+
+        # ── Step 4: DPoP keypair (egress JWK) ─────────────────────
+        dpop_priv = _ec.generate_private_key(_ec.SECP256R1())
+        dpop_nums = dpop_priv.public_key().public_numbers()
+        dpop_jwk = {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": _b64url_nopad(dpop_nums.x.to_bytes(32, "big")),
+            "y": _b64url_nopad(dpop_nums.y.to_bytes(32, "big")),
+        }
+
+        # ── Step 5: POST /v1/enrollment/start ─────────────────────
+        base = mastio_url.rstrip("/")
+        http = _build_proxy_http_client(
+            verify_tls=verify_tls, timeout=30.0,
+            ca_chain_path=ca_chain_path,
+        )
+        try:
+            try:
+                resp = http.post(
+                    f"{base}/v1/enrollment/start",
+                    json={
+                        "pubkey_pem": pubkey_pem,
+                        "requester_name": requester_name,
+                        "requester_email": requester_email,
+                        "reason": reason,
+                        "device_info": device_info,
+                        "dpop_jwk": dpop_jwk,
+                        "pop_signature": pop_signature,
+                        "principal_type": "agent",
+                    },
+                )
+            except httpx.ConnectError as exc:
+                raise ConnectionError(
+                    f"Mastio unreachable at {base}: {exc}",
+                ) from exc
+            except httpx.TimeoutException as exc:
+                raise ConnectionError(
+                    f"Mastio timed out during enrollment start: {exc}",
+                ) from exc
+            if resp.status_code != 201:
+                raise PermissionError(
+                    f"enrollment start failed (HTTP {resp.status_code}): "
+                    f"{resp.text[:500]}",
+                )
+            started = resp.json()
+            session_id = started["session_id"]
+
+            # ── Step 6: notify operator ───────────────────────────
+            if on_pending is not None:
+                try:
+                    on_pending(session_id, f"{base}/proxy/enrollments")
+                except Exception as exc:  # noqa: BLE001 — callback errors must not abort
+                    log("sdk", f"on_pending callback raised (ignored): {exc}")
+
+            # ── Step 7: pre-sign the proof header once ────────────
+            # The proof binds the session_id (non-replayable across
+            # sessions). We sign once and reuse for every poll.
+            proof_message = (
+                f"enrollment-status:v1|{session_id}".encode("utf-8")
+            )
+            proof_sig_der = enroll_priv.sign(
+                proof_message, _ec.ECDSA(_hashes.SHA256()),
+            )
+            proof_header = _b64url_nopad(proof_sig_der)
+
+            # ── Step 8: poll for admin decision ───────────────────
+            deadline = _time.monotonic() + timeout_s
+            status_url = f"{base}/v1/enrollment/{session_id}/status"
+            headers = {"X-Enrollment-Proof": proof_header}
+            approved: dict | None = None
+            while True:
+                if _time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"enrollment {session_id} not approved within "
+                        f"{timeout_s}s (Mastio TTL is 30 minutes; ask the "
+                        f"admin to approve at {base}/proxy/enrollments)",
+                    )
+                try:
+                    poll = http.get(status_url, headers=headers)
+                except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                    # Transient network — keep polling until the
+                    # deadline kicks in.
+                    log("sdk", f"poll transient error (will retry): {exc}")
+                    _time.sleep(poll_interval_s)
+                    continue
+                if poll.status_code == 429:
+                    # Rate-limited; respect the budget by widening the
+                    # interval for this iteration only.
+                    _time.sleep(max(poll_interval_s, 5.0))
+                    continue
+                if poll.status_code != 200:
+                    raise PermissionError(
+                        f"enrollment status poll failed "
+                        f"(HTTP {poll.status_code}): {poll.text[:500]}",
+                    )
+                body = poll.json()
+                status_value = body.get("status")
+                if status_value == "approved":
+                    if not body.get("cert_pem"):
+                        # Server accepted the proof header but the row
+                        # is half-populated — either an upgrade in
+                        # flight (cert_chain_pem retrofit) or the
+                        # ``detail`` hint path fired without our
+                        # awareness. Surface the server-side detail
+                        # so the failure mode is debuggable.
+                        raise ValueError(
+                            "enrollment approved but server returned "
+                            f"no cert_pem. detail={body.get('detail')!r}",
+                        )
+                    approved = body
+                    break
+                if status_value == "rejected":
+                    reject_msg = body.get("rejection_reason") or "(no reason)"
+                    raise PermissionError(
+                        f"enrollment {session_id} rejected by admin: "
+                        f"{reject_msg}",
+                    )
+                if status_value == "expired":
+                    raise TimeoutError(
+                        f"enrollment {session_id} expired before approval",
+                    )
+                # ``pending`` — keep polling.
+                _time.sleep(poll_interval_s)
+        finally:
+            http.close()
+
+        assert approved is not None  # narrow for type-checkers
+        agent_id = approved.get("agent_id") or ""
+        cert_pem = approved["cert_pem"]
+        cert_chain_pem = approved.get("cert_chain_pem")
+        capabilities = approved.get("capabilities") or []
+
+        # ── Step 9: persist identity-dir layout (atomic 0600) ────
+        # Pattern: ``tempfile.NamedTemporaryFile`` + ``os.replace``
+        # so a crash mid-write leaves either the old file or the
+        # fully-written new one, never a half-written secret. Mirrors
+        # the Connector's atomic 0600 helper.
+        def _atomic_write(target: Path, content: str, *, mode: int) -> None:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with _tempfile.NamedTemporaryFile(
+                mode="w", dir=str(target.parent),
+                prefix=f".{target.name}.tmp-", delete=False,
+            ) as tmp:
+                tmp_path = Path(tmp.name)
+                tmp.write(content)
+                tmp.flush()
+                _os.fsync(tmp.fileno())
+            _os.chmod(tmp_path, mode)
+            _os.replace(tmp_path, target)
+
+        agent_key_path = save_to_path / "agent.key"
+        agent_crt_path = save_to_path / "agent.crt"
+        dpop_key_path = save_to_path / "dpop.key"
+        ca_chain_dst_path = save_to_path / "ca-chain.pem"
+        meta_path = save_to_path / "meta.json"
+
+        enroll_key_pem = enroll_priv.private_bytes(
+            encoding=_ser.Encoding.PEM,
+            format=_ser.PrivateFormat.PKCS8,
+            encryption_algorithm=_ser.NoEncryption(),
+        ).decode("ascii")
+        dpop_key_pem = dpop_priv.private_bytes(
+            encoding=_ser.Encoding.PEM,
+            format=_ser.PrivateFormat.PKCS8,
+            encryption_algorithm=_ser.NoEncryption(),
+        ).decode("ascii")
+
+        _atomic_write(agent_key_path, enroll_key_pem, mode=0o600)
+        _atomic_write(agent_crt_path, cert_pem, mode=0o644)
+        _atomic_write(dpop_key_path, dpop_key_pem, mode=0o600)
+        if cert_chain_pem:
+            # Server-supplied ADR-033 chain (PR #929 sister-pattern).
+            # ``from_identity_dir`` auto-discovers this sibling and
+            # uses it for both the mTLS handshake and for the
+            # ``_cert_pem`` blob the local-key login path verifies.
+            _atomic_write(ca_chain_dst_path, cert_chain_pem, mode=0o644)
+        _atomic_write(
+            meta_path,
+            _json.dumps(
+                {
+                    "agent_id": agent_id,
+                    "capabilities": capabilities,
+                    "enrolled_at": _now_iso(),
+                    "mastio_url": mastio_url,
+                },
+                indent=2,
+            ),
+            mode=0o644,
+        )
+
+        log(
+            "sdk",
+            f"dashboard-approval enrollment complete: agent_id={agent_id} "
+            f"saved to {save_to_path}",
+        )
+
+        # ── Step 10: hand off to from_identity_dir ────────────────
+        # The factory auto-discovers ``ca-chain.pem`` and auto-populates
+        # the signing key + agent_id from the cert SAN, so the returned
+        # client is immediately ready for chat_completion /
+        # list_mcp_tools without additional setup.
+        return cls.from_identity_dir(
+            mastio_url,
+            cert_path=agent_crt_path,
+            key_path=agent_key_path,
+            dpop_key_path=None,  # dpop.key here is a PKCS8 PEM, not a JWK
+            ca_chain_path=ca_chain_path,
+            verify_tls=verify_tls,
+        )
 
     # ── ADR-021 PR4c — user-principal client (in-memory cert+key) ───
 

--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -1098,8 +1098,10 @@ class _EnrollmentMixin:
         EC P-256 keypair for DPoP egress, submits the start request,
         polls for the admin decision, persists the identity-dir layout
         ``from_identity_dir`` reads (``agent.key`` + ``agent.crt`` +
-        ``ca-chain.pem`` + ``dpop.key`` + ``meta.json``), and returns a
-        runtime-ready client.
+        ``dpop.key`` + ``meta.json``), and returns a runtime-ready
+        client. ``agent.crt`` carries the ADR-034 chain
+        ``leaf || Mastio Intermediate`` server-side, so no separate
+        ``ca-chain.pem`` is written by this factory.
 
         Args:
             mastio_url: public base URL of the Mastio
@@ -1120,10 +1122,11 @@ class _EnrollmentMixin:
                 preferred over disabling verification.
             ca_chain_path: optional PEM bundle pinning the Mastio CA.
                 Used both for the bootstrap fetches and threaded through
-                to the returned client. When ``None`` and the dashboard
-                approval response carried a ``cert_chain_pem`` field
-                the factory writes that chain to
-                ``save_to/ca-chain.pem`` and uses it instead.
+                to the returned client. Independent from the server-side
+                cert chain in ``agent.crt`` (the latter is the agent's
+                own leaf+intermediate for client-cert auth; this is the
+                operator-pinned Org Root used for verifying the Mastio's
+                server cert).
             on_pending: optional callable ``(session_id, dashboard_url)``
                 invoked once after ``start`` returns so a CLI / TUI can
                 surface "approve here" to the operator. Any exception
@@ -1306,11 +1309,10 @@ class _EnrollmentMixin:
                 if status_value == "approved":
                     if not body.get("cert_pem"):
                         # Server accepted the proof header but the row
-                        # is half-populated — either an upgrade in
-                        # flight (cert_chain_pem retrofit) or the
-                        # ``detail`` hint path fired without our
-                        # awareness. Surface the server-side detail
-                        # so the failure mode is debuggable.
+                        # is half-populated, or the ``detail`` hint
+                        # path fired without our awareness. Surface
+                        # the server-side detail so the failure mode
+                        # is debuggable.
                         raise ValueError(
                             "enrollment approved but server returned "
                             f"no cert_pem. detail={body.get('detail')!r}",
@@ -1334,8 +1336,17 @@ class _EnrollmentMixin:
 
         assert approved is not None  # narrow for type-checkers
         agent_id = approved.get("agent_id") or ""
+        # B-4 follow-up (2026-05-25): ``cert_pem`` already contains
+        # ``leaf || Mastio Intermediate`` because
+        # ``mcp_proxy/egress/agent_manager.py:sign_external_pubkey``
+        # (PR #816) concatenates the chain server-side before
+        # persisting the row. The server returns the chained PEM as
+        # ``cert_pem``, so the factory writes that verbatim to
+        # ``agent.crt`` without a separate ``ca-chain.pem`` companion.
+        # Writing a fabricated ``ca-chain.pem`` here used to trigger
+        # the ``from_identity_dir`` sibling auto-discovery and inflate
+        # the JWT x5c chain to 5 certs with a duplicated Intermediate.
         cert_pem = approved["cert_pem"]
-        cert_chain_pem = approved.get("cert_chain_pem")
         capabilities = approved.get("capabilities") or []
 
         # ── Step 9: persist identity-dir layout (atomic 0600) ────
@@ -1359,7 +1370,6 @@ class _EnrollmentMixin:
         agent_key_path = save_to_path / "agent.key"
         agent_crt_path = save_to_path / "agent.crt"
         dpop_key_path = save_to_path / "dpop.key"
-        ca_chain_dst_path = save_to_path / "ca-chain.pem"
         meta_path = save_to_path / "meta.json"
 
         enroll_key_pem = enroll_priv.private_bytes(
@@ -1376,12 +1386,6 @@ class _EnrollmentMixin:
         _atomic_write(agent_key_path, enroll_key_pem, mode=0o600)
         _atomic_write(agent_crt_path, cert_pem, mode=0o644)
         _atomic_write(dpop_key_path, dpop_key_pem, mode=0o600)
-        if cert_chain_pem:
-            # Server-supplied ADR-033 chain (PR #929 sister-pattern).
-            # ``from_identity_dir`` auto-discovers this sibling and
-            # uses it for both the mTLS handshake and for the
-            # ``_cert_pem`` blob the local-key login path verifies.
-            _atomic_write(ca_chain_dst_path, cert_chain_pem, mode=0o644)
         _atomic_write(
             meta_path,
             _json.dumps(
@@ -1403,10 +1407,13 @@ class _EnrollmentMixin:
         )
 
         # ── Step 10: hand off to from_identity_dir ────────────────
-        # The factory auto-discovers ``ca-chain.pem`` and auto-populates
-        # the signing key + agent_id from the cert SAN, so the returned
-        # client is immediately ready for chat_completion /
-        # list_mcp_tools without additional setup.
+        # ``from_identity_dir`` auto-populates the signing key + agent_id
+        # from the cert SAN, so the returned client is immediately ready
+        # for chat_completion / list_mcp_tools without additional setup.
+        # ``agent.crt`` already carries ``leaf || Intermediate`` (the
+        # server concatenated them in ``sign_external_pubkey``) so no
+        # sibling ``ca-chain.pem`` is needed for the local-key login
+        # path to walk the chain back to the Org Root.
         return cls.from_identity_dir(
             mastio_url,
             cert_path=agent_crt_path,

--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -1098,7 +1098,7 @@ class _EnrollmentMixin:
         EC P-256 keypair for DPoP egress, submits the start request,
         polls for the admin decision, persists the identity-dir layout
         ``from_identity_dir`` reads (``agent.key`` + ``agent.crt`` +
-        ``dpop.key`` + ``meta.json``), and returns a runtime-ready
+        ``dpop.jwk`` + ``meta.json``), and returns a runtime-ready
         client. ``agent.crt`` carries the ADR-034 chain
         ``leaf || Mastio Intermediate`` server-side, so no separate
         ``ca-chain.pem`` is written by this factory.
@@ -1369,7 +1369,7 @@ class _EnrollmentMixin:
 
         agent_key_path = save_to_path / "agent.key"
         agent_crt_path = save_to_path / "agent.crt"
-        dpop_key_path = save_to_path / "dpop.key"
+        dpop_jwk_path = save_to_path / "dpop.jwk"
         meta_path = save_to_path / "meta.json"
 
         enroll_key_pem = enroll_priv.private_bytes(
@@ -1377,15 +1377,18 @@ class _EnrollmentMixin:
             format=_ser.PrivateFormat.PKCS8,
             encryption_algorithm=_ser.NoEncryption(),
         ).decode("ascii")
-        dpop_key_pem = dpop_priv.private_bytes(
-            encoding=_ser.Encoding.PEM,
-            format=_ser.PrivateFormat.PKCS8,
-            encryption_algorithm=_ser.NoEncryption(),
-        ).decode("ascii")
 
         _atomic_write(agent_key_path, enroll_key_pem, mode=0o600)
         _atomic_write(agent_crt_path, cert_pem, mode=0o644)
-        _atomic_write(dpop_key_path, dpop_key_pem, mode=0o600)
+        # B-7 follow-up (2026-05-25): persist DPoP material as the JSON
+        # JWK shape the rest of the SDK consumes (``DpopKey.load`` calls
+        # ``json.loads`` on this path; PKCS8 PEM here crashed
+        # ``from_identity_dir`` with a JSONDecodeError on the first
+        # egress call). ``DpopKey.save`` already does atomic-write +
+        # chmod 0600, so we reuse it instead of the local helper.
+        from cullis_sdk.dpop import DpopKey
+        dpop_key = DpopKey(dpop_priv, dpop_jwk, path=dpop_jwk_path)
+        dpop_key.save(dpop_jwk_path)
         _atomic_write(
             meta_path,
             _json.dumps(
@@ -1403,7 +1406,8 @@ class _EnrollmentMixin:
         log(
             "sdk",
             f"dashboard-approval enrollment complete: agent_id={agent_id} "
-            f"saved to {save_to_path}",
+            f"saved to {save_to_path} "
+            f"(agent.key, agent.crt, dpop.jwk, meta.json)",
         )
 
         # ── Step 10: hand off to from_identity_dir ────────────────
@@ -1413,12 +1417,13 @@ class _EnrollmentMixin:
         # ``agent.crt`` already carries ``leaf || Intermediate`` (the
         # server concatenated them in ``sign_external_pubkey``) so no
         # sibling ``ca-chain.pem`` is needed for the local-key login
-        # path to walk the chain back to the Org Root.
+        # path to walk the chain back to the Org Root. The DPoP key on
+        # disk is the JSON JWK shape ``DpopKey.load`` consumes.
         return cls.from_identity_dir(
             mastio_url,
             cert_path=agent_crt_path,
             key_path=agent_key_path,
-            dpop_key_path=None,  # dpop.key here is a PKCS8 PEM, not a JWK
+            dpop_key_path=dpop_jwk_path,
             ca_chain_path=ca_chain_path,
             verify_tls=verify_tls,
         )

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -94,6 +94,34 @@ def _require_agent_manager(request: Request):
     return mgr
 
 
+def _build_cert_chain_pem(request: Request, leaf_cert_pem: str | None) -> str | None:
+    """Best-effort construct ``cert_chain_pem`` = leaf || Intermediate CA.
+
+    ADR-033 three-tier PKI hardening: strict mTLS clients need the
+    Mastio Intermediate on the wire to build
+    ``leaf -> Intermediate -> Org Root``. Mirrors the
+    ``cert_chain_pem`` field emitted by ``POST /v1/admin/agents``
+    (PR #929) so the dashboard-approval path is at parity.
+
+    Returns ``None`` when the leaf is missing or the Mastio
+    Intermediate is not loaded (legacy two-tier deploys). Never raises
+    — the caller treats ``None`` as "use cert_pem alone".
+    """
+    if not leaf_cert_pem:
+        return None
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None:
+        return None
+    mastio_ca_cert = getattr(mgr, "_mastio_ca_cert", None)
+    if mastio_ca_cert is None:
+        return None
+    try:
+        from cryptography.hazmat.primitives import serialization as _ser
+        return leaf_cert_pem + mastio_ca_cert.public_bytes(_ser.Encoding.PEM).decode()
+    except Exception:  # noqa: BLE001 — never break the status endpoint on chain build
+        return None
+
+
 # ── Connector-facing (unauthenticated, keyed by session_id) ──────────────
 
 
@@ -288,6 +316,14 @@ async def enrollment_status(
     if record["status"] == "approved" and has_valid_proof:
         response.agent_id = record["agent_id_assigned"]
         response.cert_pem = record["cert_pem"]
+        # PR #929 sister-pattern: emit the ADR-033 full chain
+        # (leaf || Mastio Intermediate) so strict mTLS stacks build
+        # ``leaf -> Intermediate -> Org Root`` without an OOB fetch.
+        # Computed on-the-fly from the agent_manager's loaded
+        # Intermediate CA cert rather than persisted on
+        # ``pending_enrollments`` (no schema bump needed). Legacy
+        # two-tier deploys without an Intermediate keep this NULL.
+        response.cert_chain_pem = _build_cert_chain_pem(request, record["cert_pem"])
         caps_raw = record.get("capabilities_assigned") or "[]"
         try:
             response.capabilities = json.loads(caps_raw)
@@ -295,6 +331,19 @@ async def enrollment_status(
             response.capabilities = []
     elif record["status"] == "rejected" and has_valid_proof:
         response.rejection_reason = record["rejection_reason"]
+    elif record["status"] == "approved" and not has_valid_proof:
+        # B-2 dogfood fix: surface the proof-header requirement so a
+        # cold-reader SDK / curl user has a clue what to send next.
+        # The sensitive fields stay nulled out — this only adds a hint
+        # text, no PoP gate weakening (M-onb-1 audit).
+        response.detail = (
+            "Proof header X-Enrollment-Proof required. Sign "
+            f"'{_ENROLLMENT_STATUS_PROOF_DOMAIN}|{session_id}' "
+            "(ECDSA-SHA256 or RSA-PSS depending on enrollment key type), "
+            "base64url-encode without padding, and pass as "
+            "X-Enrollment-Proof header. See "
+            "docs/operate/enrollment-protocol.md."
+        )
     return response
 
 

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -94,34 +94,6 @@ def _require_agent_manager(request: Request):
     return mgr
 
 
-def _build_cert_chain_pem(request: Request, leaf_cert_pem: str | None) -> str | None:
-    """Best-effort construct ``cert_chain_pem`` = leaf || Intermediate CA.
-
-    ADR-033 three-tier PKI hardening: strict mTLS clients need the
-    Mastio Intermediate on the wire to build
-    ``leaf -> Intermediate -> Org Root``. Mirrors the
-    ``cert_chain_pem`` field emitted by ``POST /v1/admin/agents``
-    (PR #929) so the dashboard-approval path is at parity.
-
-    Returns ``None`` when the leaf is missing or the Mastio
-    Intermediate is not loaded (legacy two-tier deploys). Never raises
-    — the caller treats ``None`` as "use cert_pem alone".
-    """
-    if not leaf_cert_pem:
-        return None
-    mgr = getattr(request.app.state, "agent_manager", None)
-    if mgr is None:
-        return None
-    mastio_ca_cert = getattr(mgr, "_mastio_ca_cert", None)
-    if mastio_ca_cert is None:
-        return None
-    try:
-        from cryptography.hazmat.primitives import serialization as _ser
-        return leaf_cert_pem + mastio_ca_cert.public_bytes(_ser.Encoding.PEM).decode()
-    except Exception:  # noqa: BLE001 — never break the status endpoint on chain build
-        return None
-
-
 # ── Connector-facing (unauthenticated, keyed by session_id) ──────────────
 
 
@@ -315,15 +287,17 @@ async def enrollment_status(
 
     if record["status"] == "approved" and has_valid_proof:
         response.agent_id = record["agent_id_assigned"]
+        # B-4 follow-up (2026-05-25): ``cert_pem`` already carries the
+        # full chain ``leaf || Mastio Intermediate``. Under ADR-034 the
+        # AgentManager's ``sign_external_pubkey`` (PR #816,
+        # ``mcp_proxy/egress/agent_manager.py``) concatenates the
+        # Intermediate onto the leaf before persisting the row, so
+        # the cert_pem read here is already the ADR-033 chain. Emitting
+        # a separate ``cert_chain_pem`` field that re-appended the
+        # Intermediate produced ``leaf || Intermediate || Intermediate``
+        # which the SDK then fanned out into the JWT x5c header and the
+        # server rejected with ``x509 chain verification failed``.
         response.cert_pem = record["cert_pem"]
-        # PR #929 sister-pattern: emit the ADR-033 full chain
-        # (leaf || Mastio Intermediate) so strict mTLS stacks build
-        # ``leaf -> Intermediate -> Org Root`` without an OOB fetch.
-        # Computed on-the-fly from the agent_manager's loaded
-        # Intermediate CA cert rather than persisted on
-        # ``pending_enrollments`` (no schema bump needed). Legacy
-        # two-tier deploys without an Intermediate keep this NULL.
-        response.cert_chain_pem = _build_cert_chain_pem(request, record["cert_pem"])
         caps_raw = record.get("capabilities_assigned") or "[]"
         try:
             response.capabilities = json.loads(caps_raw)
@@ -334,7 +308,7 @@ async def enrollment_status(
     elif record["status"] == "approved" and not has_valid_proof:
         # B-2 dogfood fix: surface the proof-header requirement so a
         # cold-reader SDK / curl user has a clue what to send next.
-        # The sensitive fields stay nulled out — this only adds a hint
+        # The sensitive fields stay nulled out; this only adds a hint
         # text, no PoP gate weakening (M-onb-1 audit).
         response.detail = (
             "Proof header X-Enrollment-Proof required. Sign "

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -142,9 +142,25 @@ class EnrollmentStatusResponse(BaseModel):
     # Populated only when status == "approved"
     agent_id: str | None = None
     cert_pem: str | None = None
+    # ADR-033 full chain — leaf || Mastio Intermediate CA so strict mTLS
+    # clients (httpx, Python ssl, Go) can build ``leaf -> Intermediate ->
+    # Org Root`` without an out-of-band fetch. Mirrors the
+    # ``cert_chain_pem`` field shipped by ``POST /v1/admin/agents``
+    # (PR #929). Populated only when ``status == "approved"`` AND a valid
+    # ``X-Enrollment-Proof`` header was supplied.
+    cert_chain_pem: str | None = None
     capabilities: list[str] | None = None
     # Populated only when status == "rejected"
     rejection_reason: str | None = None
+    # B-2 dogfood fix (2026-05-25): when the caller polls after the
+    # admin has approved but did NOT pass the ``X-Enrollment-Proof``
+    # header, the sensitive fields (cert_pem, cert_chain_pem,
+    # agent_id, capabilities) stay nulled out, so a cold-reader SDK
+    # has nothing to hint at the proof-of-possession gate. ``detail``
+    # carries a human-readable instruction in that exact case. Always
+    # ``None`` outside the "approved-but-no-proof" combination so the
+    # field is invisible to the happy path.
+    detail: str | None = None
 
 
 class EnrollmentApproveRequest(BaseModel):

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -139,27 +139,31 @@ class EnrollmentStartResponse(BaseModel):
 class EnrollmentStatusResponse(BaseModel):
     session_id: str
     status: Literal["pending", "approved", "rejected", "expired"]
-    # Populated only when status == "approved"
+    # Populated only when status == "approved". Under ADR-034 three-tier
+    # PKI hardening, ``cert_pem`` already concatenates
+    # ``leaf || Mastio Intermediate`` server-side (see
+    # ``mcp_proxy/egress/agent_manager.py:sign_external_pubkey``), so
+    # strict mTLS clients (httpx, Python ssl, Go) can build
+    # ``leaf -> Intermediate -> Org Root`` from this single field
+    # without an extra round-trip. No separate ``cert_chain_pem`` is
+    # emitted; B-4 dogfood (2026-05-25) showed that surfacing one
+    # produced ``leaf || Intermediate || Intermediate`` once the SDK
+    # auto-discovery layered the duplicate into the JWT x5c header,
+    # which the broker then rejected as ``x509 chain verification
+    # failed``.
     agent_id: str | None = None
     cert_pem: str | None = None
-    # ADR-033 full chain — leaf || Mastio Intermediate CA so strict mTLS
-    # clients (httpx, Python ssl, Go) can build ``leaf -> Intermediate ->
-    # Org Root`` without an out-of-band fetch. Mirrors the
-    # ``cert_chain_pem`` field shipped by ``POST /v1/admin/agents``
-    # (PR #929). Populated only when ``status == "approved"`` AND a valid
-    # ``X-Enrollment-Proof`` header was supplied.
-    cert_chain_pem: str | None = None
     capabilities: list[str] | None = None
     # Populated only when status == "rejected"
     rejection_reason: str | None = None
     # B-2 dogfood fix (2026-05-25): when the caller polls after the
     # admin has approved but did NOT pass the ``X-Enrollment-Proof``
-    # header, the sensitive fields (cert_pem, cert_chain_pem,
-    # agent_id, capabilities) stay nulled out, so a cold-reader SDK
-    # has nothing to hint at the proof-of-possession gate. ``detail``
-    # carries a human-readable instruction in that exact case. Always
-    # ``None`` outside the "approved-but-no-proof" combination so the
-    # field is invisible to the happy path.
+    # header, the sensitive fields (cert_pem, agent_id, capabilities)
+    # stay nulled out, so a cold-reader SDK has nothing to hint at the
+    # proof-of-possession gate. ``detail`` carries a human-readable
+    # instruction in that exact case. Always ``None`` outside the
+    # "approved-but-no-proof" combination so the field is invisible to
+    # the happy path.
     detail: str | None = None
 
 

--- a/site/src/content/docs/operate/enrollment-protocol.md
+++ b/site/src/content/docs/operate/enrollment-protocol.md
@@ -8,7 +8,7 @@ updated: "2026-05-25"
 
 # Enrollment protocol (dashboard approval)
 
-**Who this is for**: a developer (or operator) bootstrapping a fresh agent identity into a community Mastio bundle without enterprise Connector tooling. The result is a local identity directory (`agent.key`, `agent.crt`, `dpop.key`, `meta.json`) that the SDK reads on every subsequent run. `agent.crt` carries the full ADR-034 chain (leaf + Mastio Intermediate) inline, so no separate chain file is needed.
+**Who this is for**: a developer (or operator) bootstrapping a fresh agent identity into a community Mastio bundle without enterprise Connector tooling. The result is a local identity directory (`agent.key`, `agent.crt`, `dpop.jwk`, `meta.json`) that the SDK reads on every subsequent run. `agent.crt` carries the full ADR-034 chain (leaf + Mastio Intermediate) inline, so no separate chain file is needed.
 
 ## 30-second TL;DR
 
@@ -60,9 +60,9 @@ After enrollment completes the identity directory looks like:
 
 ```
 ~/.cullis/agent-alice/
-├── agent.key       # PKCS8 PEM, 0600 — enrollment private key + signing key
-├── agent.crt       # PEM — leaf + Mastio Intermediate, ADR-034 chain inline
-├── dpop.key        # PKCS8 PEM, 0600 — runtime DPoP egress key
+├── agent.key       # PKCS8 PEM, 0600: enrollment private key + signing key
+├── agent.crt       # PEM: leaf + Mastio Intermediate, ADR-034 chain inline
+├── dpop.jwk        # JSON JWK, 0600: runtime DPoP egress key
 └── meta.json       # {agent_id, capabilities, enrolled_at, mastio_url}
 ```
 

--- a/site/src/content/docs/operate/enrollment-protocol.md
+++ b/site/src/content/docs/operate/enrollment-protocol.md
@@ -1,0 +1,183 @@
+---
+title: "Enrollment protocol (dashboard approval)"
+description: "Bootstrap an agent identity through the Mastio dashboard approval flow: start → admin approves → poll-with-proof. Includes the Python SDK factory, curl + openssl recipe, and the M-onb-1 proof-of-possession rationale."
+category: "Operate"
+order: 5
+updated: "2026-05-25"
+---
+
+# Enrollment protocol (dashboard approval)
+
+**Who this is for**: a developer (or operator) bootstrapping a fresh agent identity into a community Mastio bundle without enterprise Connector tooling. The result is a local identity directory (`agent.key`, `agent.crt`, `ca-chain.pem`, `dpop.key`, `meta.json`) that the SDK reads on every subsequent run.
+
+## 30-second TL;DR
+
+1. Agent dev calls `POST /v1/enrollment/start` with a freshly-generated public key, a proof of possession over that key, and a public DPoP JWK. The server returns a `session_id`.
+2. Admin opens `https://<mastio>/proxy/enrollments` and clicks **Approve**. The server signs a leaf cert against the Org CA and pins the DPoP JKT to the row.
+3. Agent dev polls `GET /v1/enrollment/{session_id}/status` with an `X-Enrollment-Proof` header (signed over `enrollment-status:v1|<session_id>` using the original enrollment private key). The server releases `cert_pem` + `cert_chain_pem` + `agent_id` + `capabilities`.
+4. Agent dev writes the identity directory and starts calling `chat_completion`, `list_mcp_tools`, etc.
+
+The **proof header** is the M-onb-1 audit gate: without it, an attacker who guesses or steals a `session_id` cannot exfiltrate the issued cert. The gate is non-negotiable, but as of v0.5.4 the server returns a `detail` hint in the status response when the proof header is missing, so the path is discoverable from the wire.
+
+## Python (SDK factory)
+
+The `cullis-sdk` Python package ships a single-call factory that handles all five steps: keypair generation, fingerprint computation (SHA-256 of DER `SubjectPublicKeyInfo`, the trap that costs cold-readers half a day), pop signature, polling with the proof header, and atomic 0600 writes.
+
+```python
+from cullis_sdk import CullisClient
+
+client = CullisClient.enroll_via_dashboard_approval(
+    "https://mastio.example.com:9443",
+    requester_name="Alice Developer",
+    requester_email="alice@example.com",
+    reason="building an MCP agent for daily trading",
+    device_info="macOS 15.4 / cullis-sdk 0.5.4",
+    save_to="~/.cullis/agent-alice",
+    poll_interval_s=5.0,
+    timeout_s=600.0,
+    verify_tls=True,
+    ca_chain_path=None,  # or path to a pinned org-ca.pem
+    on_pending=lambda sid, url: print(
+        f"Pending session {sid}. Ask the admin to approve at {url}"
+    ),
+)
+
+# The returned client is fully wired: TLS client cert (the credential
+# under ADR-014), persistent DPoP key, auto-login on first authed call.
+print(client.chat_completion(model="gpt-4o-mini", messages=[{
+    "role": "user", "content": "hello",
+}]))
+```
+
+The factory raises:
+
+- `ConnectionError` — Mastio unreachable (TLS / DNS / refused).
+- `PermissionError` — start rejected (bad pop signature, rate limited) OR admin clicked **Reject** (the `rejection_reason` is in the message).
+- `TimeoutError` — admin did not act before `timeout_s` (the server-side TTL is 30 minutes; pick something similar or shorter).
+- `ValueError` — cryptographic failure (should not happen in normal use).
+
+After enrollment completes the identity directory looks like:
+
+```
+~/.cullis/agent-alice/
+├── agent.key       # PKCS8 PEM, 0600 — enrollment private key + signing key
+├── agent.crt       # PEM — leaf cert signed by the Mastio Intermediate CA
+├── ca-chain.pem    # PEM — leaf || Intermediate, ADR-033 full chain
+├── dpop.key        # PKCS8 PEM, 0600 — runtime DPoP egress key
+└── meta.json       # {agent_id, capabilities, enrolled_at, mastio_url}
+```
+
+Subsequent runs skip the dashboard dance entirely:
+
+```python
+client = CullisClient.from_identity_dir(
+    "https://mastio.example.com:9443",
+    cert_path="~/.cullis/agent-alice/agent.crt",
+    key_path="~/.cullis/agent-alice/agent.key",
+)
+```
+
+`from_identity_dir` auto-discovers the `ca-chain.pem` sibling and assembles `fullchain.pem` automatically.
+
+## Curl + openssl (non-Python clients)
+
+The same flow without the SDK, suitable for Go / Rust / shell agents.
+
+### Step 1: generate the enrollment keypair (EC P-256)
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out agent.key
+openssl ec -in agent.key -pubout -out agent.pub
+```
+
+### Step 2: compute the server-shape fingerprint
+
+The Mastio computes SHA-256 over the **DER** `SubjectPublicKeyInfo`. PEM text does not work.
+
+```bash
+openssl pkey -in agent.pub -pubin -outform DER -out agent.pub.der
+FP=$(openssl dgst -sha256 -binary agent.pub.der | xxd -p -c 64)
+echo "fingerprint: $FP"
+```
+
+### Step 3: sign the pop_signature
+
+Domain-separated message `enrollment-pop:v1|<fingerprint>`:
+
+```bash
+printf 'enrollment-pop:v1|%s' "$FP" > pop.msg
+openssl dgst -sha256 -sign agent.key -out pop.sig pop.msg
+POP_B64URL=$(base64 -w0 pop.sig \
+  | tr '+/' '-_' \
+  | tr -d '=')
+```
+
+### Step 4: POST start
+
+```bash
+PUBKEY_PEM=$(awk '{printf "%s\\n",$0}' agent.pub)
+RESPONSE=$(curl -sS -X POST \
+  "https://mastio.example.com:9443/v1/enrollment/start" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"pubkey_pem\": \"$PUBKEY_PEM\",
+    \"requester_name\": \"Alice\",
+    \"requester_email\": \"alice@example.com\",
+    \"reason\": \"shell-bootstrapped agent\",
+    \"device_info\": \"curl/openssl recipe\",
+    \"pop_signature\": \"$POP_B64URL\",
+    \"principal_type\": \"agent\"
+  }")
+SESSION_ID=$(echo "$RESPONSE" | jq -r .session_id)
+echo "session_id: $SESSION_ID"
+echo "Ask the admin to approve at https://mastio.example.com:9443/proxy/enrollments"
+```
+
+(In production agents you would also generate a DPoP JWK and include it under `dpop_jwk`. Omitting it leaves the agent on the `egress_dpop_mode=optional` grace path; the admin endpoint can populate it post-hoc.)
+
+### Step 5: sign the proof header ONCE
+
+Bind it to the session_id — non-replayable across sessions.
+
+```bash
+printf 'enrollment-status:v1|%s' "$SESSION_ID" > proof.msg
+openssl dgst -sha256 -sign agent.key -out proof.sig proof.msg
+PROOF=$(base64 -w0 proof.sig \
+  | tr '+/' '-_' \
+  | tr -d '=')
+```
+
+### Step 6: poll for the admin decision
+
+```bash
+while true; do
+  BODY=$(curl -sS -H "X-Enrollment-Proof: $PROOF" \
+    "https://mastio.example.com:9443/v1/enrollment/$SESSION_ID/status")
+  STATUS=$(echo "$BODY" | jq -r .status)
+  case "$STATUS" in
+    approved) echo "$BODY" | jq -r .cert_pem > agent.crt
+              echo "$BODY" | jq -r .cert_chain_pem > ca-chain.pem
+              break ;;
+    rejected) echo "rejected: $(echo "$BODY" | jq -r .rejection_reason)"
+              exit 1 ;;
+    expired)  echo "expired"; exit 1 ;;
+    *)        sleep 5 ;;
+  esac
+done
+```
+
+If you **forget** the `X-Enrollment-Proof` header on the poll, the server returns `status: "approved"` with `cert_pem: null` AND a `detail` field describing the missing header. This is the v0.5.4 cold-reader fix: the wire now hints at the proof-of-possession gate instead of silently nulling everything out.
+
+## Why the proof header exists (M-onb-1 audit)
+
+The `session_id` is a 128-bit URL-safe random token, but it travels through logs, CI pipelines, browser histories, and admin dashboards. Without an additional gate, anyone who shoulder-surfed or grepped a log could pull a freshly-approved cert just by knowing the `session_id`.
+
+The proof header binds the `/status` poll to the original enrollment keypair: the server holds the public key on the pending row, the caller signs a domain-separated message (`enrollment-status:v1|<session_id>`) with the private half, and the server verifies before releasing `cert_pem`. The signature is non-replayable across sessions (binds to `session_id`) and across keys (binds via verification against the row's `pubkey_pem`).
+
+The gate is **not optional** and never will be. The v0.5.4 fix only adds discoverability: the `detail` field tells a caller who forgot the header what to send next, and links here.
+
+## See also
+
+- [Rotate keys](rotate-keys) — once enrolled, the cert is rotated via `POST /v1/registry/agents/{id}/rotate-cert`.
+- [Vault as Org CA private key store](vault-org-ca) — how the Mastio loads the CA that signs the leaf during approve.
+- [Rego policies](rego-policies) — the `capabilities` granted at approval drive policy evaluation on every call.

--- a/site/src/content/docs/operate/enrollment-protocol.md
+++ b/site/src/content/docs/operate/enrollment-protocol.md
@@ -8,13 +8,13 @@ updated: "2026-05-25"
 
 # Enrollment protocol (dashboard approval)
 
-**Who this is for**: a developer (or operator) bootstrapping a fresh agent identity into a community Mastio bundle without enterprise Connector tooling. The result is a local identity directory (`agent.key`, `agent.crt`, `ca-chain.pem`, `dpop.key`, `meta.json`) that the SDK reads on every subsequent run.
+**Who this is for**: a developer (or operator) bootstrapping a fresh agent identity into a community Mastio bundle without enterprise Connector tooling. The result is a local identity directory (`agent.key`, `agent.crt`, `dpop.key`, `meta.json`) that the SDK reads on every subsequent run. `agent.crt` carries the full ADR-034 chain (leaf + Mastio Intermediate) inline, so no separate chain file is needed.
 
 ## 30-second TL;DR
 
 1. Agent dev calls `POST /v1/enrollment/start` with a freshly-generated public key, a proof of possession over that key, and a public DPoP JWK. The server returns a `session_id`.
-2. Admin opens `https://<mastio>/proxy/enrollments` and clicks **Approve**. The server signs a leaf cert against the Org CA and pins the DPoP JKT to the row.
-3. Agent dev polls `GET /v1/enrollment/{session_id}/status` with an `X-Enrollment-Proof` header (signed over `enrollment-status:v1|<session_id>` using the original enrollment private key). The server releases `cert_pem` + `cert_chain_pem` + `agent_id` + `capabilities`.
+2. Admin opens `https://<mastio>/proxy/enrollments` and clicks **Approve**. The server signs a leaf cert against the Mastio Intermediate CA and pins the DPoP JKT to the row.
+3. Agent dev polls `GET /v1/enrollment/{session_id}/status` with an `X-Enrollment-Proof` header (signed over `enrollment-status:v1|<session_id>` using the original enrollment private key). The server releases `cert_pem` (already concatenated as leaf + Mastio Intermediate), `agent_id`, and `capabilities`.
 4. Agent dev writes the identity directory and starts calling `chat_completion`, `list_mcp_tools`, etc.
 
 The **proof header** is the M-onb-1 audit gate: without it, an attacker who guesses or steals a `session_id` cannot exfiltrate the issued cert. The gate is non-negotiable, but as of v0.5.4 the server returns a `detail` hint in the status response when the proof header is missing, so the path is discoverable from the wire.
@@ -61,11 +61,12 @@ After enrollment completes the identity directory looks like:
 ```
 ~/.cullis/agent-alice/
 ├── agent.key       # PKCS8 PEM, 0600 — enrollment private key + signing key
-├── agent.crt       # PEM — leaf cert signed by the Mastio Intermediate CA
-├── ca-chain.pem    # PEM — leaf || Intermediate, ADR-033 full chain
+├── agent.crt       # PEM — leaf + Mastio Intermediate, ADR-034 chain inline
 ├── dpop.key        # PKCS8 PEM, 0600 — runtime DPoP egress key
 └── meta.json       # {agent_id, capabilities, enrolled_at, mastio_url}
 ```
+
+The server-side `cert_pem` already concatenates `leaf || Mastio Intermediate` (see `sign_external_pubkey` in `mcp_proxy/egress/agent_manager.py`), so the factory writes that single blob to `agent.crt` and the local-key login path walks the chain back to the Org Root without a sibling file.
 
 Subsequent runs skip the dashboard dance entirely:
 
@@ -77,7 +78,7 @@ client = CullisClient.from_identity_dir(
 )
 ```
 
-`from_identity_dir` auto-discovers the `ca-chain.pem` sibling and assembles `fullchain.pem` automatically.
+`from_identity_dir` reads the chained `agent.crt`, signs JWT assertions whose `x5c` header carries both certs, and the broker validates the path to the Org Root.
 
 ## Curl + openssl (non-Python clients)
 
@@ -155,8 +156,8 @@ while true; do
     "https://mastio.example.com:9443/v1/enrollment/$SESSION_ID/status")
   STATUS=$(echo "$BODY" | jq -r .status)
   case "$STATUS" in
-    approved) echo "$BODY" | jq -r .cert_pem > agent.crt
-              echo "$BODY" | jq -r .cert_chain_pem > ca-chain.pem
+    approved) # cert_pem already carries leaf || Mastio Intermediate
+              echo "$BODY" | jq -r .cert_pem > agent.crt
               break ;;
     rejected) echo "rejected: $(echo "$BODY" | jq -r .rejection_reason)"
               exit 1 ;;

--- a/test/unit/test_enrollment_status_hint_on_missing_proof.py
+++ b/test/unit/test_enrollment_status_hint_on_missing_proof.py
@@ -1,0 +1,288 @@
+"""B-2 dogfood fix tests — ``EnrollmentStatusResponse.detail`` hint.
+
+When a cold-reader agent dev polls ``GET /v1/enrollment/{sid}/status``
+after the admin has approved BUT did not pass the
+``X-Enrollment-Proof`` header, the server used to return a bare
+``{"status": "approved"}`` with every sensitive field nulled out and
+no human-readable hint why. Result: every open-source dev who hadn't
+read the router source bounced silently.
+
+The fix populates an optional ``detail`` field in that exact
+"approved-but-no-proof" combination, pointing the caller at the proof
+header mechanism + the doc page. The M-onb-1 audit gate stays intact:
+``cert_pem`` / ``cert_chain_pem`` / ``agent_id`` / ``capabilities`` are
+still nulled out without a valid proof.
+
+These tests verify both halves on a live FastAPI app — the route
+behaviour AND the schema field declaration.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment.router import router as enrollment_router
+from mcp_proxy.enrollment.schemas import EnrollmentStatusResponse
+
+
+# ── Schema declaration: detail field present + optional ───────────────
+
+
+def test_status_response_carries_optional_detail_field() -> None:
+    """The schema must expose ``detail: str | None``. Pinning this stops
+    a future schema sweep from accidentally dropping it (the field is
+    invisible on the happy path so the absence would not surface in
+    other tests)."""
+    fields = EnrollmentStatusResponse.model_fields
+    assert "detail" in fields
+    # Same shape as the other null-by-default fields on the response.
+    assert fields["detail"].default is None
+
+
+def test_status_response_includes_cert_chain_pem() -> None:
+    """PR #929 sister-pattern: the dashboard-approval path must also
+    surface ``cert_chain_pem`` so strict mTLS clients (httpx, Go) can
+    build ``leaf -> Intermediate -> Org Root``."""
+    fields = EnrollmentStatusResponse.model_fields
+    assert "cert_chain_pem" in fields
+    assert fields["cert_chain_pem"].default is None
+
+
+# ── Route behaviour: detail fires only in the "approved-no-proof" combo ─
+
+
+_ADMIN_SECRET = "test-admin-secret-enrollment-hint"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite + full alembic chain.
+
+    Same shape as ``test_admin_agents_atomic_enroll.proxy_db`` so the
+    enrollment table is created via migrations (the column list on
+    ``pending_enrollments`` is large enough that ``metadata.create_all``
+    drifts from migrations 0003 + 0006 + later updates).
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "enrollment_hint.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _make_app() -> FastAPI:
+    """Bare app with only the enrollment router mounted. The status
+    route doesn't depend on ``agent_manager`` so no stub is required
+    (``_build_cert_chain_pem`` tolerates a missing manager by returning
+    ``None``)."""
+    app = FastAPI()
+    app.include_router(enrollment_router)
+    return app
+
+
+async def _seed_approved_enrollment(
+    *,
+    session_id: str,
+    pubkey_pem: str,
+    cert_pem: str,
+    agent_id: str = "acme::dashboard-agent",
+    capabilities: list[str] | None = None,
+) -> None:
+    """Insert a pending → approved row directly. Simulates the state
+    after the admin clicks Approve in the dashboard, without exercising
+    the full ``approve()`` machinery (which needs an AgentManager + CA
+    + binding publisher)."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    expires = (
+        datetime.now(timezone.utc) + timedelta(minutes=30)
+    ).isoformat(timespec="seconds")
+    caps_json = json.dumps(capabilities or ["llm.chat"])
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO pending_enrollments (
+                    session_id, pubkey_pem, pubkey_fingerprint,
+                    requester_name, requester_email, reason, device_info,
+                    status, created_at, expires_at,
+                    decided_at, decided_by,
+                    agent_id_assigned, capabilities_assigned, cert_pem
+                ) VALUES (
+                    :sid, :pk, 'deadbeef',
+                    :name, :email, NULL, NULL,
+                    'approved', :created, :expires,
+                    :decided, 'admin',
+                    :agent_id, :caps, :cert
+                )"""
+            ),
+            {
+                "sid": session_id,
+                "pk": pubkey_pem,
+                "name": "alice",
+                "email": "alice@example.com",
+                "created": now,
+                "expires": expires,
+                "decided": now,
+                "agent_id": agent_id,
+                "caps": caps_json,
+                "cert": cert_pem,
+            },
+        )
+
+
+def _b64url_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_approved_without_proof_returns_detail_hint(proxy_db):
+    """Approved row + missing ``X-Enrollment-Proof`` header → response
+    carries the human-readable hint AND keeps the sensitive fields
+    nulled out (PoP gate unchanged)."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pubkey_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    session_id = "sid-approved-noproof"
+    await _seed_approved_enrollment(
+        session_id=session_id,
+        pubkey_pem=pubkey_pem,
+        cert_pem="-----BEGIN CERTIFICATE-----\nFAKE-LEAF\n-----END CERTIFICATE-----\n",
+    )
+
+    client = TestClient(_make_app())
+    r = client.get(f"/v1/enrollment/{session_id}/status")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "approved"
+    # Sensitive fields stay nulled — PoP gate unchanged.
+    assert body["cert_pem"] is None
+    assert body["cert_chain_pem"] is None
+    assert body["agent_id"] is None
+    assert body["capabilities"] is None
+    # Hint is populated and includes the canonical message string + the
+    # session_id so the caller knows exactly what to sign.
+    assert body["detail"] is not None
+    assert "X-Enrollment-Proof" in body["detail"]
+    assert f"enrollment-status:v1|{session_id}" in body["detail"]
+    assert "docs/operate/enrollment-protocol.md" in body["detail"]
+
+
+@pytest.mark.asyncio
+async def test_approved_with_valid_proof_releases_cert_and_no_detail(proxy_db):
+    """Same row, this time WITH a valid proof header → cert_pem +
+    agent_id + capabilities populated, detail stays None."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pubkey_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    session_id = "sid-approved-withproof"
+    cert_pem = "-----BEGIN CERTIFICATE-----\nFAKE-LEAF\n-----END CERTIFICATE-----\n"
+    await _seed_approved_enrollment(
+        session_id=session_id,
+        pubkey_pem=pubkey_pem,
+        cert_pem=cert_pem,
+    )
+
+    # Sign the canonical message exactly as the SDK does.
+    canonical = f"enrollment-status:v1|{session_id}".encode()
+    proof = _b64url_nopad(priv.sign(canonical, ec.ECDSA(hashes.SHA256())))
+
+    client = TestClient(_make_app())
+    r = client.get(
+        f"/v1/enrollment/{session_id}/status",
+        headers={"X-Enrollment-Proof": proof},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "approved"
+    assert body["cert_pem"] == cert_pem
+    assert body["agent_id"] == "acme::dashboard-agent"
+    assert body["capabilities"] == ["llm.chat"]
+    # Detail must be absent on the happy path so existing SDK callers
+    # don't surface confusing hint text.
+    assert body["detail"] is None
+
+
+@pytest.mark.asyncio
+async def test_pending_status_has_no_detail(proxy_db):
+    """A still-pending row → no detail, no hint. The hint is scoped
+    strictly to the approved-but-no-proof combination to avoid noise."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    expires = (
+        datetime.now(timezone.utc) + timedelta(minutes=30)
+    ).isoformat(timespec="seconds")
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO pending_enrollments (
+                    session_id, pubkey_pem, pubkey_fingerprint,
+                    requester_name, requester_email, reason, device_info,
+                    status, created_at, expires_at
+                ) VALUES (
+                    'sid-pending', 'fake', 'fp',
+                    'alice', 'alice@example.com', NULL, NULL,
+                    'pending', :created, :expires
+                )"""
+            ),
+            {"created": now, "expires": expires},
+        )
+
+    client = TestClient(_make_app())
+    r = client.get("/v1/enrollment/sid-pending/status")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "pending"
+    assert body["detail"] is None
+    assert body["cert_pem"] is None
+
+
+@pytest.mark.asyncio
+async def test_approved_with_invalid_proof_returns_detail_hint(proxy_db):
+    """Garbage proof header (wrong key, malformed sig) → treated as
+    missing → detail hint fires, no cert leak."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pubkey_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+    session_id = "sid-approved-badproof"
+    await _seed_approved_enrollment(
+        session_id=session_id,
+        pubkey_pem=pubkey_pem,
+        cert_pem="-----BEGIN CERTIFICATE-----\nFAKE-LEAF\n-----END CERTIFICATE-----\n",
+    )
+
+    # Random bytes that won't verify against the keypair on the row.
+    bogus_proof = _b64url_nopad(b"\x00" * 70)
+
+    client = TestClient(_make_app())
+    r = client.get(
+        f"/v1/enrollment/{session_id}/status",
+        headers={"X-Enrollment-Proof": bogus_proof},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "approved"
+    assert body["cert_pem"] is None
+    assert body["detail"] is not None
+    assert "X-Enrollment-Proof" in body["detail"]

--- a/test/unit/test_enrollment_status_hint_on_missing_proof.py
+++ b/test/unit/test_enrollment_status_hint_on_missing_proof.py
@@ -10,10 +10,10 @@ read the router source bounced silently.
 The fix populates an optional ``detail`` field in that exact
 "approved-but-no-proof" combination, pointing the caller at the proof
 header mechanism + the doc page. The M-onb-1 audit gate stays intact:
-``cert_pem`` / ``cert_chain_pem`` / ``agent_id`` / ``capabilities`` are
-still nulled out without a valid proof.
+``cert_pem`` / ``agent_id`` / ``capabilities`` are still nulled out
+without a valid proof.
 
-These tests verify both halves on a live FastAPI app — the route
+These tests verify both halves on a live FastAPI app: the route
 behaviour AND the schema field declaration.
 """
 from __future__ import annotations
@@ -50,13 +50,15 @@ def test_status_response_carries_optional_detail_field() -> None:
     assert fields["detail"].default is None
 
 
-def test_status_response_includes_cert_chain_pem() -> None:
-    """PR #929 sister-pattern: the dashboard-approval path must also
-    surface ``cert_chain_pem`` so strict mTLS clients (httpx, Go) can
-    build ``leaf -> Intermediate -> Org Root``."""
+def test_status_response_does_not_carry_cert_chain_pem() -> None:
+    """B-4 follow-up (2026-05-25): ``cert_pem`` already concatenates
+    ``leaf || Mastio Intermediate`` server-side, so there is no
+    separate ``cert_chain_pem`` field on the status response. Pinning
+    the absence keeps a future schema sweep from re-introducing the
+    duplicated-intermediate bug that broke ``from_identity_dir``
+    sibling auto-discovery."""
     fields = EnrollmentStatusResponse.model_fields
-    assert "cert_chain_pem" in fields
-    assert fields["cert_chain_pem"].default is None
+    assert "cert_chain_pem" not in fields
 
 
 # ── Route behaviour: detail fires only in the "approved-no-proof" combo ─
@@ -87,9 +89,9 @@ async def proxy_db(tmp_path, monkeypatch):
 
 def _make_app() -> FastAPI:
     """Bare app with only the enrollment router mounted. The status
-    route doesn't depend on ``agent_manager`` so no stub is required
-    (``_build_cert_chain_pem`` tolerates a missing manager by returning
-    ``None``)."""
+    route doesn't depend on ``agent_manager`` after the B-4 cleanup,
+    so no stub is required: ``cert_pem`` is read straight off the
+    pending_enrollments row."""
     app = FastAPI()
     app.include_router(enrollment_router)
     return app
@@ -171,9 +173,11 @@ async def test_approved_without_proof_returns_detail_hint(proxy_db):
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["status"] == "approved"
-    # Sensitive fields stay nulled — PoP gate unchanged.
+    # Sensitive fields stay nulled — PoP gate unchanged. B-4 follow-up:
+    # ``cert_chain_pem`` field is removed entirely; verify it's absent
+    # so the schema sweep doesn't drift back.
     assert body["cert_pem"] is None
-    assert body["cert_chain_pem"] is None
+    assert "cert_chain_pem" not in body
     assert body["agent_id"] is None
     assert body["capabilities"] is None
     # Hint is populated and includes the canonical message string + the

--- a/test/unit/test_sdk_enroll_via_dashboard_approval.py
+++ b/test/unit/test_sdk_enroll_via_dashboard_approval.py
@@ -20,16 +20,27 @@ for ``httpx.Client`` — no real network, no real CA, no real admin.
 ``CullisClient.from_identity_dir`` is also stubbed so we don't have to
 parse a real cert SAN; the test only cares about the on-disk layout and
 the kwargs forwarded to the runtime constructor.
+
+B-4 follow-up (2026-05-25): the fake Mastio returns ``cert_pem`` as a
+2-cert PEM (``leaf || Intermediate``) mirroring the real server, where
+``mcp_proxy/egress/agent_manager.py:sign_external_pubkey`` already
+concatenates the chain before persisting the row. The factory writes
+that to ``agent.crt`` verbatim; no separate ``ca-chain.pem`` is written
+because doing so used to duplicate the Intermediate via the
+``from_identity_dir`` sibling auto-discovery and break x5c verification.
 """
 from __future__ import annotations
 
 import base64
+import datetime as _dt
 import hashlib
 import json
 
 import pytest
+from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -39,28 +50,83 @@ def _b64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
-def _mint_fake_leaf_cert() -> str:
-    """Build a syntactically valid PEM certificate the factory persists.
+def _mint_fake_chained_cert() -> str:
+    """Build a 2-cert PEM mirroring the real server's ``cert_pem``.
 
-    The factory just writes ``cert_pem`` to ``agent.crt`` verbatim; no
-    parsing happens inside the factory itself (``from_identity_dir`` is
-    stubbed). A blob recognisable as ``-----BEGIN CERTIFICATE-----`` is
-    enough for the layout assertions below.
+    ``mcp_proxy/egress/agent_manager.py:sign_external_pubkey`` (PR #816,
+    ADR-034 three-tier hardening) concatenates the leaf with the Mastio
+    Intermediate before persisting the row, so what the SDK reads off
+    the wire is always ``leaf || Intermediate``. The B-4 fix is that
+    the factory writes this verbatim to ``agent.crt`` without
+    duplicating the Intermediate into a separate ``ca-chain.pem``.
+
+    Generates Org Root → Mastio Intermediate (signed by Root) → Leaf
+    (signed by Intermediate) so the resulting blob can stand in for the
+    real server output for layout + count assertions.
     """
-    return (
-        "-----BEGIN CERTIFICATE-----\n"
-        "FAKE-LEAF-FOR-DASHBOARD-APPROVAL-TEST\n"
-        "-----END CERTIFICATE-----\n"
+    now = _dt.datetime.now(_dt.timezone.utc)
+
+    org_root_key = ec.generate_private_key(ec.SECP256R1())
+    org_root_name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "Test Org Root CA")],
+    )
+    org_root_cert = (
+        x509.CertificateBuilder()
+        .subject_name(org_root_name)
+        .issuer_name(org_root_name)
+        .public_key(org_root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(days=1))
+        .not_valid_after(now + _dt.timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=1), critical=True,
+        )
+        .sign(org_root_key, hashes.SHA256())
     )
 
-
-def _mint_fake_chain_cert() -> str:
-    """Concatenated leaf || Intermediate, as PR #929's admin path emits."""
-    return _mint_fake_leaf_cert() + (
-        "-----BEGIN CERTIFICATE-----\n"
-        "FAKE-INTERMEDIATE-MASTIO-CA\n"
-        "-----END CERTIFICATE-----\n"
+    mastio_int_key = ec.generate_private_key(ec.SECP256R1())
+    mastio_int_name = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "Test Mastio Intermediate CA")],
     )
+    mastio_int_cert = (
+        x509.CertificateBuilder()
+        .subject_name(mastio_int_name)
+        .issuer_name(org_root_name)
+        .public_key(mastio_int_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(days=1))
+        .not_valid_after(now + _dt.timedelta(days=180))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=0), critical=True,
+        )
+        .sign(org_root_key, hashes.SHA256())
+    )
+
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(
+            x509.Name(
+                [x509.NameAttribute(NameOID.COMMON_NAME, "acme::test-agent")],
+            ),
+        )
+        .issuer_name(mastio_int_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(days=1))
+        .not_valid_after(now + _dt.timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None), critical=True,
+        )
+        .sign(mastio_int_key, hashes.SHA256())
+    )
+
+    leaf_pem = leaf_cert.public_bytes(serialization.Encoding.PEM).decode()
+    int_pem = mastio_int_cert.public_bytes(serialization.Encoding.PEM).decode()
+    # The server emits leaf || Intermediate. Org Root is the trust
+    # anchor and stays off the wire.
+    _ = org_root_cert  # silence linter; kept for documentation
+    return leaf_pem + int_pem
 
 
 class _FakeResponse:
@@ -87,8 +153,9 @@ class _FakeMastio:
         self.posts: list[tuple[str, dict, dict]] = []
         self.gets: list[tuple[str, dict]] = []
         self.approved: bool = False
-        self.cert_pem = _mint_fake_leaf_cert()
-        self.cert_chain_pem = _mint_fake_chain_cert()
+        # B-4 follow-up: ``cert_pem`` is the 2-cert chain
+        # ``leaf || Intermediate`` server-side, mirrored here.
+        self.cert_pem = _mint_fake_chained_cert()
         self.agent_id = "acme::test-agent"
         self.last_pubkey_pem: str | None = None
 
@@ -137,8 +204,10 @@ class _FakeMastio:
                     "session_id": self.session_id,
                     "status": "approved",
                     "agent_id": self.agent_id,
+                    # B-4 follow-up: cert_pem already carries the
+                    # full ``leaf || Intermediate`` chain. The server
+                    # no longer emits a separate ``cert_chain_pem``.
                     "cert_pem": self.cert_pem,
-                    "cert_chain_pem": self.cert_chain_pem,
                     "capabilities": ["llm.chat"],
                 },
             )
@@ -228,8 +297,17 @@ def test_happy_path_writes_identity_dir(
     ]
 
     # Identity-dir layout — exactly what from_identity_dir reads.
-    for name in ("agent.key", "agent.crt", "ca-chain.pem", "dpop.key", "meta.json"):
+    # B-4 follow-up: no ``ca-chain.pem`` here. The chain is inline in
+    # ``agent.crt`` because the server's ``cert_pem`` already carries
+    # ``leaf || Intermediate``.
+    for name in ("agent.key", "agent.crt", "dpop.key", "meta.json"):
         assert (save_to / name).is_file(), f"missing {name}"
+    assert not (save_to / "ca-chain.pem").exists(), (
+        "ca-chain.pem must NOT be written by the factory; cert_pem "
+        "already carries the chain and writing the same intermediate "
+        "again triggers the from_identity_dir sibling auto-discovery "
+        "which inflates the JWT x5c header and breaks chain verify."
+    )
 
     # Private-key files are 0600 (umask-resistant via os.chmod).
     assert (save_to / "agent.key").stat().st_mode & 0o777 == 0o600
@@ -242,9 +320,14 @@ def test_happy_path_writes_identity_dir(
     assert meta["mastio_url"] == "https://fake-mastio:9443"
     assert "enrolled_at" in meta
 
-    # cert.crt is the leaf-only cert; ca-chain.pem is the full chain.
-    assert (save_to / "agent.crt").read_text() == fake_mastio.cert_pem
-    assert (save_to / "ca-chain.pem").read_text() == fake_mastio.cert_chain_pem
+    # agent.crt is the server-side chain verbatim, exactly two PEM
+    # blocks (leaf + intermediate). B-4 regression pin: if the SDK
+    # ever re-introduces a separate ca-chain.pem write or
+    # ``from_identity_dir`` starts duplicating the chain into _cert_pem
+    # again, this count will jump and surface the bug at test time.
+    agent_crt = (save_to / "agent.crt").read_text()
+    assert agent_crt == fake_mastio.cert_pem
+    assert agent_crt.count("-----BEGIN CERTIFICATE-----") == 2
 
     # from_identity_dir was called with the persisted paths.
     call = patched_http_and_runtime[0]
@@ -501,30 +584,36 @@ def test_on_pending_callback_exception_does_not_abort(
     assert (tmp_path / "agent-id" / "agent.crt").is_file()
 
 
-# ── cert_chain_pem fallback ───────────────────────────────────────────
+# ── B-4 regression: stray cert_chain_pem from older Mastio is ignored ─
 
 
-def test_missing_cert_chain_pem_skips_ca_chain_file(
+def test_stray_cert_chain_pem_field_is_ignored(
     tmp_path, fake_mastio, patched_http_and_runtime,
 ):
-    """Legacy two-tier Mastio (no Intermediate loaded) → no
-    cert_chain_pem in the response. The factory must NOT write a
-    half-baked ca-chain.pem or crash."""
+    """If an older Mastio still emits a separate ``cert_chain_pem``
+    field (pre-B-4 servers), the SDK must ignore it and never write a
+    ``ca-chain.pem`` file. Writing one would re-trigger the duplicate-
+    intermediate bug via the ``from_identity_dir`` sibling auto-
+    discovery."""
     from cullis_sdk import CullisClient
 
     fake_mastio.approved = True
-    fake_mastio.cert_chain_pem = None
-    # Re-wire .get to drop the field entirely (mirror what the server
-    # does when ``_build_cert_chain_pem`` returns None).
     original_get = fake_mastio.get
 
-    def _no_chain_get(url, *, headers=None, **_):
+    def _legacy_get(url, *, headers=None, **_):
         resp = original_get(url, headers=headers, **_)
         body = dict(resp.json())
-        body.pop("cert_chain_pem", None)
+        if body.get("status") == "approved" and body.get("cert_pem"):
+            # Simulate a pre-B-4 Mastio still emitting the dead field.
+            body["cert_chain_pem"] = (
+                body["cert_pem"]
+                + "-----BEGIN CERTIFICATE-----\n"
+                  "EXTRA-INTERMEDIATE-IF-FACTORY-WERE-DUMB\n"
+                  "-----END CERTIFICATE-----\n"
+            )
         return _FakeResponse(resp.status_code, body)
 
-    fake_mastio.get = _no_chain_get  # type: ignore[assignment]
+    fake_mastio.get = _legacy_get  # type: ignore[assignment]
 
     CullisClient.enroll_via_dashboard_approval(
         "https://fake-mastio:9443",
@@ -537,3 +626,6 @@ def test_missing_cert_chain_pem_skips_ca_chain_file(
 
     assert (tmp_path / "agent-id" / "agent.crt").is_file()
     assert not (tmp_path / "agent-id" / "ca-chain.pem").exists()
+    # The 2-cert chain stays intact in agent.crt; nothing is appended.
+    agent_crt = (tmp_path / "agent-id" / "agent.crt").read_text()
+    assert agent_crt.count("-----BEGIN CERTIFICATE-----") == 2

--- a/test/unit/test_sdk_enroll_via_dashboard_approval.py
+++ b/test/unit/test_sdk_enroll_via_dashboard_approval.py
@@ -12,8 +12,11 @@ Three invariants the tests pin:
 2. The poll path carries the ``X-Enrollment-Proof`` header signed with
    the original enrollment key over ``"enrollment-status:v1|<sid>"``.
 3. The identity-dir layout written under ``save_to/`` is exactly what
-   ``from_identity_dir`` expects (agent.key + agent.crt + ca-chain.pem +
-   dpop.key + meta.json), with 0600 perms on the two private-key files.
+   ``from_identity_dir`` expects (agent.key + agent.crt + dpop.jwk +
+   meta.json), with 0600 perms on the two private-key files. ``dpop.jwk``
+   is a JSON ``{"private_jwk": {...}}`` blob (B-7 regression pin),
+   not PKCS8 PEM, so ``DpopKey.load`` can decode it on the first
+   egress call.
 
 The Mastio side is faked via a small ``RequestRecorder`` that subs in
 for ``httpx.Client`` — no real network, no real CA, no real admin.
@@ -296,11 +299,11 @@ def test_happy_path_writes_identity_dir(
         (fake_mastio.session_id, "https://fake-mastio:9443/proxy/enrollments"),
     ]
 
-    # Identity-dir layout — exactly what from_identity_dir reads.
+    # Identity-dir layout, exactly what from_identity_dir reads.
     # B-4 follow-up: no ``ca-chain.pem`` here. The chain is inline in
     # ``agent.crt`` because the server's ``cert_pem`` already carries
     # ``leaf || Intermediate``.
-    for name in ("agent.key", "agent.crt", "dpop.key", "meta.json"):
+    for name in ("agent.key", "agent.crt", "dpop.jwk", "meta.json"):
         assert (save_to / name).is_file(), f"missing {name}"
     assert not (save_to / "ca-chain.pem").exists(), (
         "ca-chain.pem must NOT be written by the factory; cert_pem "
@@ -308,10 +311,31 @@ def test_happy_path_writes_identity_dir(
         "again triggers the from_identity_dir sibling auto-discovery "
         "which inflates the JWT x5c header and breaks chain verify."
     )
+    # B-7 regression pin: ``dpop.key`` (PKCS8 PEM) used to land here and
+    # crash ``DpopKey.load`` with JSONDecodeError on the first egress
+    # call. The factory now writes only ``dpop.jwk``.
+    assert not (save_to / "dpop.key").exists(), (
+        "dpop.key (PKCS8 PEM) must NOT be written; the SDK loader "
+        "expects the JSON JWK shape at dpop.jwk (B-7)."
+    )
 
     # Private-key files are 0600 (umask-resistant via os.chmod).
     assert (save_to / "agent.key").stat().st_mode & 0o777 == 0o600
-    assert (save_to / "dpop.key").stat().st_mode & 0o777 == 0o600
+    assert (save_to / "dpop.jwk").stat().st_mode & 0o777 == 0o600
+
+    # B-7 regression pin: ``dpop.jwk`` is the JSON shape ``DpopKey.load``
+    # consumes, namely ``{"private_jwk": {kty, crv, x, y, d}}``.
+    dpop_blob = json.loads((save_to / "dpop.jwk").read_text())
+    assert "private_jwk" in dpop_blob, (
+        "dpop.jwk must wrap the private JWK under the 'private_jwk' key"
+    )
+    priv_jwk = dpop_blob["private_jwk"]
+    assert priv_jwk["kty"] == "EC"
+    assert priv_jwk["crv"] == "P-256"
+    for field in ("x", "y", "d"):
+        assert field in priv_jwk and priv_jwk[field], (
+            f"private_jwk is missing the {field!r} member"
+        )
 
     # meta.json carries the fields the SDK expects.
     meta = json.loads((save_to / "meta.json").read_text())
@@ -333,6 +357,9 @@ def test_happy_path_writes_identity_dir(
     call = patched_http_and_runtime[0]
     assert call["cert_path"] == save_to / "agent.crt"
     assert call["key_path"] == save_to / "agent.key"
+    # B-7: the factory now hands the JSON JWK path down so DpopKey.load
+    # can actually decode it on the first egress call.
+    assert call["dpop_key_path"] == save_to / "dpop.jwk"
     assert call["mastio_url"] == "https://fake-mastio:9443"
 
 

--- a/test/unit/test_sdk_enroll_via_dashboard_approval.py
+++ b/test/unit/test_sdk_enroll_via_dashboard_approval.py
@@ -1,0 +1,539 @@
+"""Tests for ``CullisClient.enroll_via_dashboard_approval`` — the cold-reader
+enrollment factory (B-2 dogfood fix, 2026-05-25).
+
+The factory wraps the Connector-protocol enrollment surface so a
+community open-source agent developer can bootstrap an identity without
+hand-rolling the start → admin approve → poll-with-proof-header dance.
+Three invariants the tests pin:
+
+1. The start request payload matches the server contract: server-shape
+   fingerprint (SHA-256 of DER SubjectPublicKeyInfo), domain-separated
+   pop_signature, EC P-256 DPoP JWK.
+2. The poll path carries the ``X-Enrollment-Proof`` header signed with
+   the original enrollment key over ``"enrollment-status:v1|<sid>"``.
+3. The identity-dir layout written under ``save_to/`` is exactly what
+   ``from_identity_dir`` expects (agent.key + agent.crt + ca-chain.pem +
+   dpop.key + meta.json), with 0600 perms on the two private-key files.
+
+The Mastio side is faked via a small ``RequestRecorder`` that subs in
+for ``httpx.Client`` — no real network, no real CA, no real admin.
+``CullisClient.from_identity_dir`` is also stubbed so we don't have to
+parse a real cert SAN; the test only cares about the on-disk layout and
+the kwargs forwarded to the runtime constructor.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _b64url_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def _mint_fake_leaf_cert() -> str:
+    """Build a syntactically valid PEM certificate the factory persists.
+
+    The factory just writes ``cert_pem`` to ``agent.crt`` verbatim; no
+    parsing happens inside the factory itself (``from_identity_dir`` is
+    stubbed). A blob recognisable as ``-----BEGIN CERTIFICATE-----`` is
+    enough for the layout assertions below.
+    """
+    return (
+        "-----BEGIN CERTIFICATE-----\n"
+        "FAKE-LEAF-FOR-DASHBOARD-APPROVAL-TEST\n"
+        "-----END CERTIFICATE-----\n"
+    )
+
+
+def _mint_fake_chain_cert() -> str:
+    """Concatenated leaf || Intermediate, as PR #929's admin path emits."""
+    return _mint_fake_leaf_cert() + (
+        "-----BEGIN CERTIFICATE-----\n"
+        "FAKE-INTERMEDIATE-MASTIO-CA\n"
+        "-----END CERTIFICATE-----\n"
+    )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, json_body: dict | None = None,
+                 text: str = "") -> None:
+        self.status_code = status_code
+        self._json = json_body or {}
+        self.text = text or json.dumps(self._json)
+
+    def json(self) -> dict:
+        return self._json
+
+
+class _FakeMastio:
+    """Tiny in-memory simulation of the Mastio enrollment endpoints.
+
+    Records every request so the test can assert on shape; advances a
+    simple state machine so polling sees ``pending`` first, then
+    ``approved`` once the test flips the flag.
+    """
+
+    def __init__(self) -> None:
+        self.session_id = "test-session-deadbeef"
+        self.posts: list[tuple[str, dict, dict]] = []
+        self.gets: list[tuple[str, dict]] = []
+        self.approved: bool = False
+        self.cert_pem = _mint_fake_leaf_cert()
+        self.cert_chain_pem = _mint_fake_chain_cert()
+        self.agent_id = "acme::test-agent"
+        self.last_pubkey_pem: str | None = None
+
+    def post(self, url: str, *, json: dict, **_) -> _FakeResponse:  # noqa: A002 — match httpx kwarg name
+        self.posts.append((url, json, _))
+        if url.endswith("/v1/enrollment/start"):
+            self.last_pubkey_pem = json["pubkey_pem"]
+            return _FakeResponse(
+                201,
+                {
+                    "session_id": self.session_id,
+                    "status": "pending",
+                    "poll_url": f"https://fake-mastio/v1/enrollment/{self.session_id}/status",
+                    "enroll_url": f"https://fake-mastio/enroll?session={self.session_id}",
+                    "poll_interval_s": 1,
+                    "expires_at": "2099-01-01T00:00:00+00:00",
+                },
+            )
+        return _FakeResponse(404, {"detail": "unknown post"})
+
+    def get(self, url: str, *, headers: dict | None = None, **_) -> _FakeResponse:
+        self.gets.append((url, headers or {}))
+        if "/status" in url:
+            if not self.approved:
+                return _FakeResponse(
+                    200, {"session_id": self.session_id, "status": "pending"},
+                )
+            # Approved branch — only emit sensitive fields when the
+            # proof header is present (mirror the server contract so
+            # the factory's missing-proof handling fires if it
+            # accidentally drops the header).
+            if not (headers or {}).get("X-Enrollment-Proof"):
+                return _FakeResponse(
+                    200,
+                    {
+                        "session_id": self.session_id,
+                        "status": "approved",
+                        "detail": (
+                            "Proof header X-Enrollment-Proof required. ..."
+                        ),
+                    },
+                )
+            return _FakeResponse(
+                200,
+                {
+                    "session_id": self.session_id,
+                    "status": "approved",
+                    "agent_id": self.agent_id,
+                    "cert_pem": self.cert_pem,
+                    "cert_chain_pem": self.cert_chain_pem,
+                    "capabilities": ["llm.chat"],
+                },
+            )
+        return _FakeResponse(404, {"detail": "unknown get"})
+
+    def close(self) -> None:  # match httpx.Client API
+        pass
+
+
+@pytest.fixture
+def fake_mastio() -> _FakeMastio:
+    return _FakeMastio()
+
+
+@pytest.fixture
+def patched_http_and_runtime(monkeypatch, fake_mastio):
+    """Patch the SDK's network + runtime-constructor seams.
+
+    Returns the captured kwargs forwarded to ``from_identity_dir`` for
+    layout assertions in the happy-path test.
+    """
+    # 1) Network: every ``_build_proxy_http_client`` call returns the
+    #    same fake. Closing it is a no-op so the factory's
+    #    ``finally http.close()`` is safe.
+    def _fake_builder(**kwargs):  # noqa: ARG001 — signature-compatible
+        return fake_mastio
+
+    monkeypatch.setattr(
+        "cullis_sdk.client._build_proxy_http_client", _fake_builder,
+    )
+
+    # 2) Runtime constructor: capture the kwargs so the test asserts on
+    #    the identity-dir layout, and return an opaque sentinel as the
+    #    "client".
+    calls: list[dict] = []
+
+    def _fake_from_identity_dir(cls, mastio_url, **kwargs):  # noqa: ARG001
+        calls.append({"mastio_url": mastio_url, **kwargs})
+        return object()
+
+    from cullis_sdk._client._enrollment import _EnrollmentMixin
+    monkeypatch.setattr(
+        _EnrollmentMixin, "from_identity_dir",
+        classmethod(_fake_from_identity_dir),
+    )
+
+    # 3) Hide the insecure-tls audit prompt for verify_tls=True.
+    monkeypatch.setattr(
+        "cullis_sdk.client._check_insecure_tls", lambda _x: None,
+    )
+
+    return calls
+
+
+# ── Happy path ───────────────────────────────────────────────────────
+
+
+def test_happy_path_writes_identity_dir(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Approved before first poll → cert + key + chain written, factory
+    hands off to ``from_identity_dir``."""
+    from cullis_sdk import CullisClient
+
+    fake_mastio.approved = True  # admin already clicked Approve
+
+    save_to = tmp_path / "agent-id"
+    pending_calls: list[tuple[str, str]] = []
+
+    client = CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        reason="dogfood",
+        device_info="pytest",
+        save_to=save_to,
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+        on_pending=lambda sid, url: pending_calls.append((sid, url)),
+    )
+
+    # The factory returned the sentinel from the patched from_identity_dir.
+    assert client is not None
+    # on_pending fired exactly once with (session_id, dashboard_url).
+    assert pending_calls == [
+        (fake_mastio.session_id, "https://fake-mastio:9443/proxy/enrollments"),
+    ]
+
+    # Identity-dir layout — exactly what from_identity_dir reads.
+    for name in ("agent.key", "agent.crt", "ca-chain.pem", "dpop.key", "meta.json"):
+        assert (save_to / name).is_file(), f"missing {name}"
+
+    # Private-key files are 0600 (umask-resistant via os.chmod).
+    assert (save_to / "agent.key").stat().st_mode & 0o777 == 0o600
+    assert (save_to / "dpop.key").stat().st_mode & 0o777 == 0o600
+
+    # meta.json carries the fields the SDK expects.
+    meta = json.loads((save_to / "meta.json").read_text())
+    assert meta["agent_id"] == fake_mastio.agent_id
+    assert meta["capabilities"] == ["llm.chat"]
+    assert meta["mastio_url"] == "https://fake-mastio:9443"
+    assert "enrolled_at" in meta
+
+    # cert.crt is the leaf-only cert; ca-chain.pem is the full chain.
+    assert (save_to / "agent.crt").read_text() == fake_mastio.cert_pem
+    assert (save_to / "ca-chain.pem").read_text() == fake_mastio.cert_chain_pem
+
+    # from_identity_dir was called with the persisted paths.
+    call = patched_http_and_runtime[0]
+    assert call["cert_path"] == save_to / "agent.crt"
+    assert call["key_path"] == save_to / "agent.key"
+    assert call["mastio_url"] == "https://fake-mastio:9443"
+
+
+# ── Server contract: start payload shape ─────────────────────────────
+
+
+def test_start_payload_matches_server_contract(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """The pop_signature must verify against the server's fingerprint
+    formula (SHA-256 over DER SubjectPublicKeyInfo) AND the canonical
+    domain-separated message. This is the #1 trap cold-readers hit.
+    """
+    from cullis_sdk import CullisClient
+
+    fake_mastio.approved = True
+    CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        save_to=tmp_path / "agent-id",
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+    )
+
+    assert len(fake_mastio.posts) == 1
+    _, body, _ = fake_mastio.posts[0]
+    assert body["requester_name"] == "Alice"
+    assert body["requester_email"] == "alice@example.com"
+    assert body["principal_type"] == "agent"
+    assert body["dpop_jwk"]["kty"] == "EC"
+    assert body["dpop_jwk"]["crv"] == "P-256"
+    assert "x" in body["dpop_jwk"]
+    assert "y" in body["dpop_jwk"]
+    # PEM is a single SubjectPublicKeyInfo (EC P-256).
+    pub_key = serialization.load_pem_public_key(body["pubkey_pem"].encode())
+    assert isinstance(pub_key, ec.EllipticCurvePublicKey)
+
+    # Recompute fingerprint exactly as the server does.
+    der = pub_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fingerprint = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fingerprint}".encode()
+
+    # Verify pop_signature using the same code path the server uses.
+    sig = _b64url_decode(body["pop_signature"])
+    # No exception → valid signature.
+    pub_key.verify(sig, canonical, ec.ECDSA(hashes.SHA256()))
+
+
+def test_poll_carries_proof_header_signed_over_session_id(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Every status GET MUST send ``X-Enrollment-Proof`` signed over
+    ``"enrollment-status:v1|<session_id>"`` with the original enrollment
+    key. Without it the server stonewalls the cert exfiltration."""
+    from cullis_sdk import CullisClient
+
+    fake_mastio.approved = True
+    CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        save_to=tmp_path / "agent-id",
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+    )
+
+    assert fake_mastio.gets, "expected at least one /status poll"
+    url, headers = fake_mastio.gets[0]
+    assert "X-Enrollment-Proof" in headers
+    proof = headers["X-Enrollment-Proof"]
+
+    # Reconstruct the public key the start POST carried and verify the
+    # proof signature: same algorithm the server uses on the receive
+    # side (_verify_enrollment_proof).
+    pub_key = serialization.load_pem_public_key(
+        fake_mastio.last_pubkey_pem.encode(),
+    )
+    canonical = (
+        f"enrollment-status:v1|{fake_mastio.session_id}".encode()
+    )
+    sig = _b64url_decode(proof)
+    pub_key.verify(sig, canonical, ec.ECDSA(hashes.SHA256()))
+
+
+# ── Pending → approved transition ────────────────────────────────────
+
+
+def test_polls_until_approved(
+    tmp_path, fake_mastio, patched_http_and_runtime, monkeypatch,
+):
+    """Two pending polls, then approved. Factory keeps polling without
+    raising and writes the identity-dir on success."""
+    from cullis_sdk import CullisClient
+
+    poll_count = {"n": 0}
+    original_get = fake_mastio.get
+
+    def _staged_get(url, *, headers=None, **_):
+        poll_count["n"] += 1
+        if poll_count["n"] >= 3:
+            fake_mastio.approved = True
+        return original_get(url, headers=headers, **_)
+
+    fake_mastio.get = _staged_get  # type: ignore[assignment]
+
+    CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        save_to=tmp_path / "agent-id",
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+    )
+
+    assert poll_count["n"] >= 3
+    assert (tmp_path / "agent-id" / "agent.crt").is_file()
+
+
+# ── Rejected / expired / timeout / connection ───────────────────────
+
+
+def test_rejected_raises_permission_error(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Admin clicks Reject → PermissionError carrying the reason."""
+    from cullis_sdk import CullisClient
+
+    def _reject_get(url, *, headers=None, **_):  # noqa: ARG001
+        return _FakeResponse(
+            200,
+            {
+                "session_id": fake_mastio.session_id,
+                "status": "rejected",
+                "rejection_reason": "not on the approved list",
+            },
+        )
+
+    fake_mastio.get = _reject_get  # type: ignore[assignment]
+
+    with pytest.raises(PermissionError, match="not on the approved list"):
+        CullisClient.enroll_via_dashboard_approval(
+            "https://fake-mastio:9443",
+            requester_name="Alice",
+            requester_email="alice@example.com",
+            save_to=tmp_path / "agent-id",
+            poll_interval_s=0.0,
+            timeout_s=5.0,
+        )
+
+
+def test_expired_raises_timeout_error(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Server returns expired → TimeoutError so the caller can retry."""
+    from cullis_sdk import CullisClient
+
+    def _expired_get(url, *, headers=None, **_):  # noqa: ARG001
+        return _FakeResponse(
+            200,
+            {
+                "session_id": fake_mastio.session_id,
+                "status": "expired",
+            },
+        )
+
+    fake_mastio.get = _expired_get  # type: ignore[assignment]
+
+    with pytest.raises(TimeoutError, match="expired"):
+        CullisClient.enroll_via_dashboard_approval(
+            "https://fake-mastio:9443",
+            requester_name="Alice",
+            requester_email="alice@example.com",
+            save_to=tmp_path / "agent-id",
+            poll_interval_s=0.0,
+            timeout_s=5.0,
+        )
+
+
+def test_client_side_timeout_raises_after_deadline(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """No state change at all → TimeoutError once timeout_s elapses."""
+    from cullis_sdk import CullisClient
+
+    # fake_mastio.approved stays False → always pending.
+    with pytest.raises(TimeoutError, match="not approved within"):
+        CullisClient.enroll_via_dashboard_approval(
+            "https://fake-mastio:9443",
+            requester_name="Alice",
+            requester_email="alice@example.com",
+            save_to=tmp_path / "agent-id",
+            poll_interval_s=0.0,
+            timeout_s=0.1,
+        )
+
+
+def test_start_failure_raises_permission_error(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Server rejects the start request (e.g. rate-limited / bad pop)
+    → PermissionError surfaces the body so the dev can debug."""
+    from cullis_sdk import CullisClient
+
+    def _bad_post(url, *, json, **_):  # noqa: ARG001, A002
+        return _FakeResponse(400, text="pop_signature does not verify")
+
+    fake_mastio.post = _bad_post  # type: ignore[assignment]
+
+    with pytest.raises(PermissionError, match="HTTP 400"):
+        CullisClient.enroll_via_dashboard_approval(
+            "https://fake-mastio:9443",
+            requester_name="Alice",
+            requester_email="alice@example.com",
+            save_to=tmp_path / "agent-id",
+            poll_interval_s=0.0,
+            timeout_s=5.0,
+        )
+
+
+# ── on_pending callback errors are swallowed ─────────────────────────
+
+
+def test_on_pending_callback_exception_does_not_abort(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """A crashing on_pending must not abort enrollment. The factory
+    logs and continues so a malformed CLI prompt cannot orphan a
+    pending session."""
+    from cullis_sdk import CullisClient
+
+    def _boom(sid: str, url: str) -> None:
+        raise RuntimeError("operator UI exploded")
+
+    fake_mastio.approved = True
+    CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        save_to=tmp_path / "agent-id",
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+        on_pending=_boom,
+    )
+
+    assert (tmp_path / "agent-id" / "agent.crt").is_file()
+
+
+# ── cert_chain_pem fallback ───────────────────────────────────────────
+
+
+def test_missing_cert_chain_pem_skips_ca_chain_file(
+    tmp_path, fake_mastio, patched_http_and_runtime,
+):
+    """Legacy two-tier Mastio (no Intermediate loaded) → no
+    cert_chain_pem in the response. The factory must NOT write a
+    half-baked ca-chain.pem or crash."""
+    from cullis_sdk import CullisClient
+
+    fake_mastio.approved = True
+    fake_mastio.cert_chain_pem = None
+    # Re-wire .get to drop the field entirely (mirror what the server
+    # does when ``_build_cert_chain_pem`` returns None).
+    original_get = fake_mastio.get
+
+    def _no_chain_get(url, *, headers=None, **_):
+        resp = original_get(url, headers=headers, **_)
+        body = dict(resp.json())
+        body.pop("cert_chain_pem", None)
+        return _FakeResponse(resp.status_code, body)
+
+    fake_mastio.get = _no_chain_get  # type: ignore[assignment]
+
+    CullisClient.enroll_via_dashboard_approval(
+        "https://fake-mastio:9443",
+        requester_name="Alice",
+        requester_email="alice@example.com",
+        save_to=tmp_path / "agent-id",
+        poll_interval_s=0.0,
+        timeout_s=5.0,
+    )
+
+    assert (tmp_path / "agent-id" / "agent.crt").is_file()
+    assert not (tmp_path / "agent-id" / "ca-chain.pem").exists()


### PR DESCRIPTION
## Summary

Adds a 9th `CullisClient` factory that wraps the dashboard-approval enrollment flow into a single zero-boilerplate call, so a community open-source agent developer (the audience the public repo is supposed to serve) can bootstrap a fresh identity without enterprise Connector tooling. Closes B-2, surfaced during the 2026-05-25 dogfood of Mastio v0.5.3.

The dogfood revealed a silent failure: the existing BYOCA / SPIFFE / identity-dir factories all assume the agent already has a cert from somewhere out-of-band, and the one path a cold-reader can discover (`POST /v1/enrollment/start` → admin Approve → `GET /status`) returns `{"status":"approved", "cert_pem":null, ...}` with no hint why, because the M-onb-1 audit gate requires an `X-Enrollment-Proof` header documented only inside the router source. Every open-source dev who tries to enroll without Connector bounces.

## Deliverables (single PR, all three in scope)

**F1 — SDK factory** `CullisClient.enroll_via_dashboard_approval`. Generates EC P-256 enrollment + DPoP keypairs, computes the server-shape fingerprint (SHA-256 of DER `SubjectPublicKeyInfo`), signs the domain-separated pop_signature, calls `start`, signs the proof header once over `enrollment-status:v1|<sid>`, polls with the proof header, raises `PermissionError` / `TimeoutError` / `ConnectionError` on the corresponding terminal states, and persists the identity-dir layout (`agent.key` + `agent.crt` + `ca-chain.pem` + `dpop.key` + `meta.json`) with atomic 0600 writes. Returns a runtime-ready client via `from_identity_dir`.

**F2 — Server-side hint** `EnrollmentStatusResponse.detail` is populated when `status=approved` and `X-Enrollment-Proof` is missing or invalid, pointing the caller at the proof-header mechanism and the docs page. The M-onb-1 audit gate stays intact: `cert_pem` / `cert_chain_pem` / `agent_id` / `capabilities` stay nulled out without a valid proof. Also adds `cert_chain_pem` to the status response (computed on-the-fly from the Mastio Intermediate CA, no schema bump), mirroring the admin/agents pattern from PR #929 so strict mTLS clients can build `leaf -> Intermediate -> Org Root`.

**F3 — Docs page** `site/src/content/docs/operate/enrollment-protocol.md` with 30-second TL;DR, Python SDK example, curl + openssl recipe for non-Python clients, M-onb-1 rationale, and cross-links to rotate-keys / vault-org-ca / rego-policies.

## Test plan

- [x] `python -m compileall -q mcp_proxy cullis_sdk` returns 0
- [x] `pytest test/unit/test_sdk_enroll_via_dashboard_approval.py test/unit/test_enrollment_status_hint_on_missing_proof.py -v` — 16/16 pass
  - 10 SDK tests: happy path identity-dir layout + 0600 perms, server contract (fingerprint formula, pop signature verifies, proof header binds to session_id), pending→approved transition, rejected → `PermissionError`, expired → `TimeoutError`, client-side timeout, start failure surfaces HTTP code, `on_pending` callback exception swallowed, legacy two-tier no-chain fallback
  - 6 router tests: schema declares `detail` + `cert_chain_pem` as optional, approved-no-proof returns hint with nulled-out sensitive fields, approved-with-valid-proof releases cert + no hint, pending status carries no hint, invalid proof treated as missing
- [x] Existing `test_sdk_auto_login_mcp.py` + `test_sdk_systemd_credentials.py` still green (23/23)
- [x] No `Co-Authored-By Claude` line, DCO `Signed-off-by` present
- [x] Branch `feat/sdk-enroll-via-dashboard-approval`, conventional commit
- [ ] Bundle dogfood after merge: build image from this branch, run `./deploy.sh`, exercise the new factory against `:9443` end-to-end (the unit tests stub `_build_proxy_http_client` so this is the real-network gate)