### PR TITLE
fix(packaging): drop cullis_connector from public wheel post-Portkey pivot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "cullis-agent-sdk"
+name = "cullis-sdk"
 version = "0.1.0"
-description = "Python SDK for Cullis — federated agent trust broker"
+description = "Python SDK for Cullis, federated agent trust broker"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.24.0",
@@ -73,20 +73,7 @@ webauthn = [
 ]
 
 [project.scripts]
-cullis-connector = "cullis_connector.cli:main"
-# Thin agent-targeted alias for send/inbox/health. Talks HTTP to the
-# loopback Ambassador on the Connector daemon — no SDK or crypto here.
-cullis = "cullis_connector.cli:cullis_main"
 cullis-proxy = "mcp_proxy.cli:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["cullis_sdk", "cullis_connector"]
-
-[tool.hatch.build.targets.wheel.shared-data]
-# Ship the dashboard templates + static assets alongside the Python code.
-# Without this the PyInstaller bundle (Day 3) misses Jinja templates and
-# the pip install misses the stylesheet.
-
-[tool.hatch.build.targets.wheel.force-include]
-"cullis_connector/templates" = "cullis_connector/templates"
-"cullis_connector/static" = "cullis_connector/static"
+packages = ["cullis_sdk"]


### PR DESCRIPTION
## Summary

Fixes B-3 from 2026-05-25 dogfood: `pip install -e .` fails on a fresh public checkout because `pyproject.toml` still references `cullis_connector/`, which the 2026-05-21 Portkey-style pivot (PR #884) moved to the private `cullis-enterprise` repo.

Reproducer on `origin/main` before this PR:

```
git clone https://github.com/cullis-security/cullis.git
cd cullis && python3 -m venv venv && venv/bin/pip install -e .
# FileNotFoundError: Forced include not found: cullis_connector/static
```

## Changes (pyproject.toml only, +3 / -16)

- `packages = ["cullis_sdk"]` (drop `"cullis_connector"`).
- Remove `[tool.hatch.build.targets.wheel.force-include]` block (only `cullis_connector/*` entries lived there).
- Remove the empty `[tool.hatch.build.targets.wheel.shared-data]` block (comment-only, no actual mappings).
- Drop `cullis-connector` and `cullis` console scripts (cli is in the enterprise repo now). Keep `cullis-proxy = mcp_proxy.cli:main`.
- Rename project name from `cullis-agent-sdk` to `cullis-sdk` to match what the README quickstart says (`pip install cullis-sdk`) and what is already published on PyPI (`cullis-sdk` 0.1.3). `cullis-agent-sdk` was never on PyPI.

Verified no other public code or docs reference `cullis_connector`:

```
$ grep -nE "cullis_connector" pyproject.toml MANIFEST.in setup.py setup.cfg
(empty)
$ grep -rEn "import cullis_connector|from cullis_connector" cullis_sdk/ mcp_proxy/ test/
(empty)
$ grep -rEn "cullis_connector" docs/ site/
(empty)
```

## Test plan

- [x] `python -m compileall -q cullis_sdk mcp_proxy` exits 0
- [x] Fresh venv install succeeds:
      `python3 -m venv /tmp/b3 && /tmp/b3/bin/pip install -e .`
- [x] SDK import works:
      `/tmp/b3/bin/python -c "from cullis_sdk import CullisClient"`
- [x] `grep cullis_connector` returns empty across packaging, code, docs, site.

## Why this matters

The B-2 fix landing in PR #934 adds a new `enroll_via_dashboard_approval` SDK factory that an open-source cold-reader cannot exercise because `pip install -e .` fails before they can import anything. B-3 is the prerequisite. Small fix, large effect.