### PR TITLE
fix(dashboard): surface SSRF escape knobs in backend-save 400 (C-3)

### DIFF
--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -57,6 +57,12 @@ services:
       MCP_PROXY_AUDIT_ANCHOR_TSA_URL: ${MCP_PROXY_AUDIT_ANCHOR_TSA_URL:-http://timestamp.digicert.com}
       MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:-3600}
       MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS:-10}
+      # See packaging/mastio-bundle/docker-compose.yml for the rationale
+      # (C-3 dogfood 2026-05-25): docker compose does not auto-inject
+      # env vars into the container, so the SSRF guard escape knobs must
+      # be forwarded explicitly here too.
+      MCP_PROXY_INTERNAL_HOST_ALLOWLIST:        ${MCP_PROXY_INTERNAL_HOST_ALLOWLIST:-}
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-0}
       # Broker uplink — empty by default in standalone. The shared-broker
       # override fills these with the in-compose service name; production
       # federated deploys set them via proxy.env.

--- a/deploy/proxy/proxy.env.example
+++ b/deploy/proxy/proxy.env.example
@@ -106,6 +106,42 @@ MCP_PROXY_NGINX_SAN=mastio.local,localhost
 # a Court on the same host via a shared-broker compose overlay).
 MCP_PROXY_STANDALONE=true
 
+# ─── SSRF guard escape (internal MCP backends) ──────────────────────────────
+
+# The Mastio refuses by default any MCP backend whose endpoint URL
+# resolves to a private (RFC 1918), loopback, link-local, or cloud-
+# metadata address — that is the F-A-301 SSRF defence.
+#
+# Legitimate internal backends (an MCP server on the same Docker
+# bridge as the Mastio, an on-prem ``internal-mcp.corp.example``)
+# need an explicit escape. Two knobs, choose by posture:
+#
+# (1) FQDN-scoped allowlist — RECOMMENDED for production / CISO posture.
+#     Trust *specific* internal hostnames, leave the rest blocked. The
+#     value is a comma-separated FQDN list. Matched against the URL
+#     hostname before DNS resolution, so it is independent of which
+#     internal IP the name happens to resolve to.
+#
+#     Example: a Docker-Compose deploy where the Mastio talks to a
+#     sibling ``mcp-pitchbook`` and ``mcp-pricing`` container:
+#
+#       MCP_PROXY_INTERNAL_HOST_ALLOWLIST=mcp-pitchbook,mcp-pricing
+#
+#     Cloud-metadata (169.254/16) and CGNAT (100.64/10) remain
+#     blocked even for allowlisted FQDNs.
+MCP_PROXY_INTERNAL_HOST_ALLOWLIST=
+
+# (2) Global private-range escape — dev / sandbox sledgehammer.
+#     Set to ``1`` to allow ANY RFC 1918 / loopback address. Use only
+#     for single-tenant dev stacks where you control every backend on
+#     the bridge; never set in production. Cloud-metadata + CGNAT stay
+#     blocked even when this is on.
+#
+#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
+MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+
+# Runbook: https://cullis.io/docs/operate/internal-mcp-backends
+
 # ─── Vault (optional) ────────────────────────────────────────────────────────
 
 # If the proxy should store agent-signing secrets in Vault instead of disk.

--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -106,6 +106,8 @@ def _validate_endpoint_url(url: str) -> str:
     sandbox stacks reaching MCP servers on the docker bridge keep
     working.
     """
+    from urllib.parse import urlparse
+
     from mcp_proxy.utils.url_safety import (
         UnsafeUrlError,
         assert_safe_outbound_url,
@@ -119,7 +121,27 @@ def _validate_endpoint_url(url: str) -> str:
     try:
         assert_safe_outbound_url(url, allow_private=allow_private)
     except UnsafeUrlError as exc:
-        raise HTTPException(status_code=400, detail=f"endpoint_url: {exc}") from exc
+        # C-3 dogfood 2026-05-25: the bare ``400: endpoint_url: …`` left
+        # operators grepping the source for the two escape knobs. Surface
+        # both legitimate escape paths inline (FQDN-scoped allowlist
+        # preferred for CISO posture, global allow_private_ips as the
+        # dev/sandbox sledgehammer). Default-deny is preserved — this
+        # only changes the error message.
+        suggested_fqdn = (urlparse(url).hostname or "").strip() or "<your-mcp-fqdn>"
+        detail = (
+            f"endpoint_url is blocked by the SSRF guard: {exc}.\n"
+            "\n"
+            "If this backend is an internal MCP server you trust, allow it explicitly:\n"
+            f"  - Recommended (FQDN-scoped): add '{suggested_fqdn}' to "
+            "MCP_PROXY_INTERNAL_HOST_ALLOWLIST\n"
+            "    (comma-separated FQDNs), then restart the Mastio.\n"
+            "  - Or (dev/sandbox, opens all RFC 1918): set "
+            "MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1,\n"
+            "    then restart the Mastio.\n"
+            "\n"
+            "Docs: https://cullis.io/docs/operate/internal-mcp-backends"
+        )
+        raise HTTPException(status_code=400, detail=detail) from exc
     return url
 
 

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -123,6 +123,18 @@ services:
       MCP_PROXY_AUDIT_ANCHOR_TSA_URL: ${MCP_PROXY_AUDIT_ANCHOR_TSA_URL:-http://timestamp.digicert.com}
       MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_INTERVAL_SECONDS:-3600}
       MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS: ${MCP_PROXY_AUDIT_ANCHOR_TSA_TIMEOUT_SECONDS:-10}
+      # F-A-301 SSRF guard escape (C-3 dogfood 2026-05-25). Default-deny
+      # at the dashboard backend-save boundary refuses any URL that
+      # resolves into RFC 1918 / loopback / cloud-metadata. Two
+      # documented escapes live in proxy.env.example: a FQDN-scoped
+      # allowlist (recommended) and a global private-range opt-in
+      # (dev/sandbox). They MUST be forwarded explicitly here because
+      # docker compose --env-file only substitutes ${...} in this file;
+      # it does NOT auto-inject vars into the container. See
+      # site/src/content/docs/operate/internal-mcp-backends.md for the
+      # operator runbook + posture matrix.
+      MCP_PROXY_INTERNAL_HOST_ALLOWLIST:        ${MCP_PROXY_INTERNAL_HOST_ALLOWLIST:-}
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-0}
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -315,3 +315,33 @@ MCP_PROXY_ANTHROPIC_API_KEY=
 # emergency access when SSO is misconfigured.
 #MCP_PROXY_LOCAL_AUTH_ENABLED=true
 #MCP_PROXY_FORCE_LOCAL_PASSWORD=
+
+# ── SSRF guard escape (internal MCP backends) ──────────────────────
+#
+# The Mastio refuses by default any MCP backend whose endpoint URL
+# resolves to a private (RFC 1918), loopback, link-local, or cloud-
+# metadata address — that is the F-A-301 SSRF defence. Legitimate
+# internal backends (a sibling ``mcp-pitchbook`` container on the
+# same compose network, an on-prem ``internal-mcp.corp.example``)
+# need an explicit escape. Two knobs, choose by posture.
+#
+# (1) FQDN-scoped allowlist — RECOMMENDED for production / CISO posture.
+#     Trust *specific* internal hostnames, leave the rest blocked.
+#     Comma-separated FQDN list, matched against the URL hostname
+#     before DNS resolution. Cloud-metadata (169.254/16) and CGNAT
+#     (100.64/10) stay blocked even for allowlisted FQDNs.
+#
+#       MCP_PROXY_INTERNAL_HOST_ALLOWLIST=mcp-pitchbook,mcp-pricing
+#
+MCP_PROXY_INTERNAL_HOST_ALLOWLIST=
+
+# (2) Global private-range escape — dev / sandbox sledgehammer.
+#     Set to ``1`` to allow ANY RFC 1918 / loopback address. Use only
+#     for single-tenant dev stacks where you control every backend on
+#     the bridge; never set in production. Cloud-metadata + CGNAT stay
+#     blocked even when this is on.
+#
+#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
+MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+
+# Runbook: https://cullis.io/docs/operate/internal-mcp-backends

--- a/site/src/content/docs/operate/internal-mcp-backends.md
+++ b/site/src/content/docs/operate/internal-mcp-backends.md
@@ -1,0 +1,101 @@
+---
+title: "Internal MCP backends (SSRF guard escape)"
+description: "Allow the Mastio to register MCP backends on a private network (Docker bridge, on-prem) without disabling the SSRF defence. FQDN-scoped allowlist preferred; global private-range escape as a dev/sandbox fallback."
+category: "Operate"
+order: 6
+updated: "2026-05-25"
+---
+
+# Internal MCP backends (SSRF guard escape)
+
+**Who this is for**: an operator registering an MCP backend whose endpoint URL points at a private (RFC 1918), loopback, or Docker-bridge address — for example, a sibling `mcp-pitchbook` container on the same compose network, or an on-prem `internal-mcp.corp.example` that resolves to `10.20.30.40`. By default the Mastio refuses these, by design.
+
+## The error you hit
+
+In the dashboard, **Backends → Save**, you see HTTP 400 with a message like:
+
+```
+endpoint_url is blocked by the SSRF guard: hostname 'mcp-pitchbook' resolves to
+172.18.0.3 which is blocked: private (RFC 1918, RFC 4193).
+
+If this backend is an internal MCP server you trust, allow it explicitly:
+  - Recommended (FQDN-scoped): add 'mcp-pitchbook' to MCP_PROXY_INTERNAL_HOST_ALLOWLIST
+    (comma-separated FQDNs), then restart the Mastio.
+  - Or (dev/sandbox, opens all RFC 1918): set MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1,
+    then restart the Mastio.
+
+Docs: https://cullis.io/docs/operate/internal-mcp-backends
+```
+
+This is not a bug. It is the F-A-301 SSRF defence (audit 2026-05-20): without it, an admin (or a compromised admin role) could register an MCP resource pointing at `169.254.169.254` and have the Mastio fire a POST against the cloud IMDS endpoint on every tool invocation. The default-deny posture is non-negotiable.
+
+What you choose next depends on the trust posture you can defend to your CISO.
+
+## Option A — FQDN-scoped allowlist (recommended)
+
+`MCP_PROXY_INTERNAL_HOST_ALLOWLIST` is a comma-separated list of hostnames that bypass the IP-block check. The Mastio matches the URL hostname against this list **before** DNS resolution, so the entry is independent of which internal IP the name happens to resolve to today.
+
+Trade-offs:
+
+- **Pros**: only the hostnames you name are trusted; everything else (including future internal containers an operator forgets to audit) remains blocked. Cloud-metadata (`169.254/16`) and CGNAT (`100.64/10`) stay blocked even for allowlisted FQDNs.
+- **Cons**: every new internal backend needs an env edit + Mastio restart.
+
+Compose snippet (community bundle, `proxy.env`):
+
+```bash
+# Trust two sibling MCP containers on the same docker network.
+MCP_PROXY_INTERNAL_HOST_ALLOWLIST=mcp-pitchbook,mcp-pricing
+```
+
+Then:
+
+```bash
+./deploy.sh --upgrade   # or: docker compose -p cullis-mastio up -d --force-recreate --wait
+```
+
+Re-open the dashboard, **Backends → Save** the same `http://mcp-pitchbook:8080` URL — green.
+
+## Option B — Global private-range escape (dev / sandbox only)
+
+`MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1` opens up the entire RFC 1918 + loopback range. Any URL the admin types is accepted as long as it is not in the cloud-metadata or CGNAT family.
+
+Trade-offs:
+
+- **Pros**: zero per-backend config; a single-tenant dev stack where you control every container on the bridge just works.
+- **Cons**: an admin (or a leaked admin session) can register **any** internal address as an MCP backend. Not defensible in a regulated production deploy.
+
+Compose snippet:
+
+```bash
+MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
+```
+
+Restart the same way (`./deploy.sh --upgrade`).
+
+## Which one to pick
+
+| Deployment | Recommendation |
+|---|---|
+| Single-tenant dev / hack day / laptop demo | **B** is fine. |
+| Pilot with a CISO in the room | **A**. Name every backend you trust; let the dashboard reject the rest. |
+| Production on-prem / cloud | **A**, full stop. The audit trail of which hostnames were added (and when) lives in your config management; `B` leaves no per-backend record. |
+| Mixed (dev compose + real internal backend) | **A** for the real backend; spin a separate dev compose stack with `B` for sandbox experimentation. |
+
+## What stays blocked either way
+
+Both escapes leave the following families **always refused**, by design:
+
+- Cloud metadata: `169.254.0.0/16` (AWS IMDS, GCP metadata), `fe80::/10` (IPv6 link-local).
+- CGNAT: `100.64.0.0/10` (AWS internal NAT range; used by IMDSv2 in some configs).
+- Non-HTTP schemes: `file://`, `gopher://`, etc. — only `http://` and `https://` are accepted at the dashboard boundary.
+
+If your legitimate backend uses one of these ranges, the answer is **not** to bypass the guard. Put it behind a hostname that resolves to a routable address, or front it with a reverse proxy you trust.
+
+## Where the knobs are read
+
+Both env vars are read at Mastio startup. Editing `proxy.env` without restarting the container has no effect. The `proxy.env.example` template ships with both knobs documented and commented out at sensible defaults; copy it to `proxy.env` and edit there.
+
+## Related
+
+- Threat model: SSRF section (`docs/security/threat-model.md`, F-A-301).
+- ADR-030: Mastio bundle upgrade + data layout — explains why `proxy.env` is the single source of truth for the bundled deploy.

--- a/test/unit/test_dashboard_backend_save_unsafe_url_hint.py
+++ b/test/unit/test_dashboard_backend_save_unsafe_url_hint.py
@@ -1,0 +1,138 @@
+"""C-3 dogfood fix tests — ``_validate_endpoint_url`` operator hint.
+
+When an operator saved an MCP backend whose endpoint URL pointed at a
+private (RFC 1918) / loopback / cloud-metadata address, the dashboard
+returned HTTP 400 with a bare ``endpoint_url: hostname '…' resolves to
+… which is blocked: …`` detail. The two legitimate escape knobs
+(``MCP_PROXY_INTERNAL_HOST_ALLOWLIST`` — FQDN-scoped, recommended;
+``MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS`` — global dev/sandbox)
+existed only in the source: every cold-reader operator hit the wall
+silently. The bundle dogfood on 2026-05-25 (`mcp-pitchbook` on
+172.18.0.3) surfaced this as finding C-3.
+
+The fix preserves the default-deny posture (no change in *which* URLs
+are accepted) and only stylises the 400 detail so the two escape paths
++ runbook are inline. These tests pin that contract.
+
+The sister test pinning the same hint contract in the SDK enrollment
+flow lives in ``test_enrollment_status_hint_on_missing_proof.py``
+(PR #934). Keep them in sync if the hint copy ever changes.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard.mcp_resources import _validate_endpoint_url
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    """Provide ``MCP_PROXY_ADMIN_SECRET`` so the lazy ``get_settings()``
+    call inside ``_validate_endpoint_url`` can instantiate
+    ``ProxySettings`` without tripping the F-A-507 boot gate. The hint
+    logic itself does not depend on the secret value; we only need
+    Pydantic settings to construct."""
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-c3-hint-secret-do-not-use")
+    monkeypatch.delenv("MCP_PROXY_INTERNAL_HOST_ALLOWLIST", raising=False)
+    monkeypatch.delenv("MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", raising=False)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    yield
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+# Stable strings the dashboard error must surface. Lifted as constants
+# so a copy edit in mcp_resources.py shows up here as a single failing
+# assertion instead of five.
+_HINT_ALLOWLIST_ENV = "MCP_PROXY_INTERNAL_HOST_ALLOWLIST"
+_HINT_GLOBAL_ENV = "MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS"
+_HINT_DOCS_PATH = "/docs/operate/internal-mcp-backends"
+
+
+def _detail_of(exc: HTTPException) -> str:
+    """Detail is built as a single multi-line string by the fix."""
+    assert isinstance(exc.detail, str), (
+        "detail must stay a plain str (HTMX dashboard renders it as-is); "
+        f"got {type(exc.detail).__name__}"
+    )
+    return exc.detail
+
+
+def test_blocked_rfc1918_ip_literal_surfaces_full_hint() -> None:
+    """The bundle-dogfood path: an IP literal in the RFC 1918 range
+    (e.g. a docker-bridge sibling) must return 400 with both escape
+    knobs + the runbook URL inline."""
+    with pytest.raises(HTTPException) as ei:
+        _validate_endpoint_url("http://172.18.0.3:8080")
+
+    assert ei.value.status_code == 400
+    detail = _detail_of(ei.value)
+
+    # Root cause from the SSRF guard is preserved verbatim.
+    assert "172.18.0.3" in detail
+    assert "private" in detail.lower() or "blocked" in detail.lower()
+
+    # Both escape knobs are named with their exact env var spellings —
+    # an operator must be able to grep --color the detail and copy the
+    # variable name straight into proxy.env.
+    assert _HINT_ALLOWLIST_ENV in detail
+    assert _HINT_GLOBAL_ENV in detail
+
+    # The runbook URL is linkable. Match the path (not the full URL)
+    # so a docs hostname change does not break the test.
+    assert _HINT_DOCS_PATH in detail
+
+
+def test_blocked_hostname_quotes_the_fqdn_in_allowlist_suggestion() -> None:
+    """When the URL has a resolvable hostname, the allowlist hint must
+    quote the exact FQDN so the operator can paste it directly into
+    ``MCP_PROXY_INTERNAL_HOST_ALLOWLIST=...``. The hostname must be
+    one the platform resolves to an RFC 1918 address; we use a literal
+    inside the loopback range (``127.0.0.1``) via the ``localhost``
+    alias to keep the test offline."""
+    with pytest.raises(HTTPException) as ei:
+        _validate_endpoint_url("http://localhost:8080")
+
+    detail = _detail_of(ei.value)
+    # The hostname appears in single-quotes inside the hint.
+    assert "'localhost'" in detail
+    assert _HINT_ALLOWLIST_ENV in detail
+
+
+def test_blocked_invalid_scheme_still_surfaces_hint() -> None:
+    """A non-http(s) scheme (``file://``) is also rejected by the
+    guard. The hint must still surface — an operator who fat-fingered
+    the scheme deserves the same actionable detail."""
+    with pytest.raises(HTTPException) as ei:
+        _validate_endpoint_url("file:///etc/passwd")
+
+    assert ei.value.status_code == 400
+    detail = _detail_of(ei.value)
+    # The original UnsafeUrlError message is preserved.
+    assert "scheme" in detail.lower()
+    # Hint stays attached even on non-private-IP rejections.
+    assert _HINT_ALLOWLIST_ENV in detail
+    assert _HINT_DOCS_PATH in detail
+
+
+def test_blocked_empty_url_uses_placeholder_fqdn() -> None:
+    """An empty URL triggers the guard early and has no hostname to
+    suggest. The hint must still be coherent — a placeholder FQDN
+    keeps the allowlist sentence readable instead of leaking a stray
+    empty-quote ``''``."""
+    with pytest.raises(HTTPException) as ei:
+        _validate_endpoint_url("")
+
+    detail = _detail_of(ei.value)
+    assert "<your-mcp-fqdn>" in detail
+    assert _HINT_ALLOWLIST_ENV in detail
+
+
+def test_public_ip_literal_passes_without_exception() -> None:
+    """Sanity: a globally-routable IP literal (1.1.1.1) bypasses the
+    block path cleanly. Without this, a regression that always raises
+    (e.g. someone moves the hint *outside* the except branch) would go
+    unnoticed."""
+    out = _validate_endpoint_url("http://1.1.1.1:8080")
+    assert out == "http://1.1.1.1:8080"


### PR DESCRIPTION
## Summary

- Closes finding **C-3** from the 2026-05-25 dogfood (Scenario C interrupted): the dashboard refused legit internal MCP backends (`mcp-pitchbook` on 172.18.0.3) with a bare `400 endpoint_url: ...` and the two legitimate escape knobs (`MCP_PROXY_INTERNAL_HOST_ALLOWLIST` FQDN-scoped, `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS` global) were undiscoverable without reading the source.
- The fix is **universal scope** (Option A from the plan): default-deny posture preserved (no change in which URLs are accepted), only the 400 detail is restyled. CISO-friendly because the FQDN-scoped allowlist is presented as the recommended path; the global escape stays a documented dev/sandbox fallback.
- Both knobs are now documented in `deploy/proxy/proxy.env.example` (community) and `packaging/mastio-bundle/proxy.env.example` (bundle), plus a new runbook at `site/src/content/docs/operate/internal-mcp-backends.md`.

## Why this shape (not tier-aware default change)

Default-deny is a non-negotiable Cullis principle (CLAUDE.md `Security, regole non negoziabili`). The community bundle is the first touchpoint a pilot CISO sees (cold-reader path) — flipping it permissive-by-default would be a confidence-killer. The strategic Q1/Q2/Q3 decisions on community ↔ enterprise tier scoping stay open for a separate /office-hours session (tracked in `project_tier_scope_open_questions`).

## What changed

| File | Change |
|---|---|
| `mcp_proxy/dashboard/mcp_resources.py` | `_validate_endpoint_url()` 400 detail rewrites: multi-line message naming both env knobs + runbook URL, allowlist suggestion auto-fills the offending FQDN |
| `deploy/proxy/proxy.env.example` | New `SSRF guard escape` section documenting both env knobs |
| `packaging/mastio-bundle/proxy.env.example` | Same section, matched verbiage (bundle cold-reader parity) |
| `site/src/content/docs/operate/internal-mcp-backends.md` | New runbook: error message anatomy, two strategies, trade-offs, posture matrix |
| `test/unit/test_dashboard_backend_save_unsafe_url_hint.py` | 5 tests pinning the hint contract |

## Test plan

- [x] `pytest test/unit/test_dashboard_backend_save_unsafe_url_hint.py -v` → 5/5 green
- [x] `pytest test/unit/ -n auto --dist=loadfile` → 236/236 green (no regression)
- [ ] Bundle dogfood on VM `mastio-demo`: rebuild image v0.5.4-rc3 from this branch, `./deploy.sh --upgrade`, dashboard Save backend `mcp-pitchbook` → verify hint visible (not bare 400). Then set `MCP_PROXY_INTERNAL_HOST_ALLOWLIST=mcp-pitchbook` → Save green.
- [ ] `/security-review` pre-merge (touches admin endpoint + error response shape)

## Out of scope

- Strategic Q1 (conversion UX community ↔ enterprise), Q2 (Merkle community-or-enterprise), Q3 (Rego community-or-enterprise), C-1 LLM gating gap — separate /office-hours
- Caller paths beyond the dashboard CRUD (`federation.py`, `http_whitelist.py`, `provider_catalog.py`, `resource_loader.py`) — runtime paths with their own error semantics, not operator-facing forms
- Audit row `mcp_resource.create.refused` on SSRF block (today the 400 raise short-circuits before `log_audit`) — separately tracked, not a regression