### PR TITLE
fix(pki): close multi-worker race in Org CA bootstrap (D-9 cold-reader blocker)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -477,9 +477,30 @@ class AgentManager:
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
             derived = hashlib.sha256(pubkey_der).hexdigest()[:16]
-            self._org_id = derived
-            await set_config("org_id", derived)
-            logger.info("Derived deterministic org_id=%s from Org CA public key", derived)
+            # D-9 multi-worker race: every uvicorn worker runs lifespan
+            # in parallel and would otherwise upsert its own derived
+            # org_id (one per candidate key), then sign an intermediate
+            # whose CN says one thing while a sibling worker exports a
+            # cert with a different CN. Atomically claim the org_id row
+            # — winner stamps it, losers adopt the winning value before
+            # building the cert subject. Mirrors the Intermediate CA
+            # winner-election pattern in ``_mint_mastio_ca``.
+            from mcp_proxy.db import set_config_if_absent
+            wrote_org_id = await set_config_if_absent("org_id", derived)
+            if wrote_org_id:
+                self._org_id = derived
+                logger.info(
+                    "Derived deterministic org_id=%s from Org CA public key",
+                    derived,
+                )
+            else:
+                winner_org_id = await get_config("org_id")
+                self._org_id = winner_org_id or self._org_id
+                logger.info(
+                    "Org CA derive race lost — adopted winner org_id=%s "
+                    "(this worker's candidate=%s discarded)",
+                    self._org_id, derived,
+                )
 
         subject = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} CA"),
@@ -527,34 +548,56 @@ class AgentManager:
         ).decode()
         ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
 
-        # Route through the KMS provider so enterprise backends (cloud
-        # KMS / Key Vault / Secrets Manager) get to persist this without
-        # touching agent_manager. The LocalKMSProvider default writes
-        # the encrypted PEM into ``pki_key_store`` under the Fernet
-        # at-rest envelope (three-tier PKI hardening, audit 2026-05-18).
+        # D-9 multi-worker race: at boot, every uvicorn worker runs
+        # lifespan in parallel. Without atomic persistence each worker
+        # would upsert its own ``org_ca_{key,cert}`` pair, leaving the
+        # nginx trust bundle pointing at one worker's root while a
+        # sibling worker signs the Mastio Intermediate (and therefore
+        # every agent leaf) with a different root — ECDSA verification
+        # of the leaf chain fails at the nginx mTLS boundary. The
+        # persist helper now uses ``set_config_if_absent`` on the dev
+        # fallback path (and provider-level atomicity on the encrypted
+        # KMS path); only the first writer's pair lands. Losers adopt
+        # the winning pair before any code signs leaves off the root.
+        # Mirrors the Intermediate CA pattern in ``_mint_mastio_ca``.
+        won = await self._persist_org_ca(ca_key_pem, ca_cert_pem)
+
         from mcp_proxy.kms import get_kms_provider
         from mcp_proxy.kms.pki_at_rest import pki_master_key_configured
-
         provider = get_kms_provider()
-        if provider.name == "local" and not pki_master_key_configured():
-            # Legacy dev/test path: keep the plaintext
-            # ``proxy_config.org_ca_key`` / ``org_ca_cert`` rows so
-            # ``/pki/ca.crt`` + bootstrap endpoints still serve. Validate
-            # _config refuses this in production.
-            logger.warning(
-                "MCP_PROXY_DB_ENCRYPTION_KEY not set, falling back to "
-                "legacy plaintext org_ca_{key,cert} rows in proxy_config. "
-                "Dev/test only.",
-            )
-            await set_config("org_ca_key", ca_key_pem)
-            await set_config("org_ca_cert", ca_cert_pem)
-        else:
-            await provider.store_org_ca(ca_key_pem, ca_cert_pem)
-            # The /pki/ca.crt endpoint still reads org_ca_cert from
-            # proxy_config for back-compat; write the cert (public
-            # material, no privacy concern) so legacy callers keep
-            # working. The private key NEVER lands in proxy_config.
-            await set_config("org_ca_cert", ca_cert_pem)
+        dev_fallback = provider.name == "local" and not pki_master_key_configured()
+
+        if not won:
+            # Another worker won the race. Re-read the persisted pair
+            # and adopt it as our in-memory state (the candidate we
+            # generated above is discarded, including its private key).
+            persisted_key_pem: str | None = None
+            persisted_cert_pem: str | None = None
+            try:
+                loaded = await provider.load_org_ca()
+                if loaded is not None:
+                    persisted_key_pem, persisted_cert_pem = loaded
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.warning(
+                    "post-mint Org CA KMS reload failed: %s — falling back "
+                    "to legacy proxy_config rows", exc,
+                )
+            if not persisted_key_pem or not persisted_cert_pem:
+                persisted_key_pem = await get_config("org_ca_key")
+                persisted_cert_pem = await get_config("org_ca_cert")
+            if persisted_key_pem and persisted_cert_pem:
+                ca_key = serialization.load_pem_private_key(
+                    persisted_key_pem.encode(), password=None,
+                )
+                ca_cert = x509.load_pem_x509_certificate(
+                    persisted_cert_pem.encode(),
+                )
+                ca_key_pem = persisted_key_pem
+                ca_cert_pem = persisted_cert_pem
+                logger.info(
+                    "Org CA generate race lost — adopted winning pair (CN=%s)",
+                    ca_cert.subject.rfc4514_string(),
+                )
 
         # Three-tier PKI hardening — cache only the cert at steady state
         # when the encrypted KMS path is active (the unseal helper can
@@ -563,7 +606,7 @@ class AgentManager:
         # private key cached so the immediate next call to
         # ``_mint_mastio_ca`` doesn't have to scaffold a fake unseal.
         self._org_ca_cert = ca_cert
-        if provider.name == "local" and not pki_master_key_configured():
+        if dev_fallback:
             # Dev fallback: keep the key in memory (matches pre-fix
             # behavior so existing tests + dev sandbox keep booting).
             self._org_ca_key = ca_key
@@ -1824,6 +1867,73 @@ class AgentManager:
         # winner signal we assume win-on-success and leave the
         # race-safe behaviour to the provider plugin.
         await provider.store_intermediate_ca(key_pem, cert_pem)
+        return True
+
+    async def _persist_org_ca(
+        self, key_pem: str, cert_pem: str,
+    ) -> bool:
+        """Race-safe persistence for the self-signed Org CA (D-9 cold-
+        reader dogfood 2026-05-25).
+
+        Returns ``True`` when this worker won the persistence race,
+        ``False`` when another worker had already persisted a pair
+        first and the caller should adopt the existing pair instead.
+
+        Dev-only fallback (no PKI at-rest master key, KMS=local): the
+        key+cert pair is bundled into a single JSON payload and
+        persisted atomically via ``set_config_if_absent`` on a sentinel
+        row ``org_ca_pair``. Coupling the pair into one INSERT closes
+        a race that two-separate-set_config_if_absent calls leave open
+        (worker A wins on the key row while worker B wins on the cert
+        row → split-brain pair on disk → ECDSA chain verification
+        failure at the nginx mTLS boundary). After the atomic claim,
+        both winners and losers write the *winner's* values back into
+        the legacy ``org_ca_key`` / ``org_ca_cert`` back-compat rows
+        (which the ``/pki/ca.crt`` endpoint + offline tooling still
+        read) — every worker converges on the same pair regardless of
+        race outcome. Production validate_config refuses to start
+        without the at-rest passphrase so this path is dev/test only.
+        """
+        from mcp_proxy.kms import get_kms_provider
+        from mcp_proxy.kms.pki_at_rest import pki_master_key_configured
+
+        provider = get_kms_provider()
+        if provider.name == "local" and not pki_master_key_configured():
+            logger.warning(
+                "MCP_PROXY_DB_ENCRYPTION_KEY not set, falling back to "
+                "legacy plaintext org_ca_{key,cert} rows in proxy_config. "
+                "Dev/test only.",
+            )
+            import json
+            from mcp_proxy.db import set_config, set_config_if_absent
+            pair_payload = json.dumps({"key": key_pem, "cert": cert_pem})
+            wrote = await set_config_if_absent("org_ca_pair", pair_payload)
+            if wrote:
+                # Winner — propagate to back-compat rows for the
+                # /pki/ca.crt reader and any offline tooling.
+                await set_config("org_ca_key", key_pem)
+                await set_config("org_ca_cert", cert_pem)
+                return True
+            # Loser — read the winner's pair and overwrite the back-
+            # compat rows with the canonical values. set_config is an
+            # upsert; multiple losers writing the same winning values
+            # idempotently converge.
+            winning_pair_json = await get_config("org_ca_pair")
+            if winning_pair_json:
+                winning = json.loads(winning_pair_json)
+                await set_config("org_ca_key", winning["key"])
+                await set_config("org_ca_cert", winning["cert"])
+            return False
+
+        # KMS providers (Vault / AWS-KMS / Azure-KV / etc) implement
+        # their own atomic-insert semantics under ``store_org_ca``;
+        # we assume win-on-success for the encrypted path and leave
+        # the race-safe behaviour to the provider plugin. The cert is
+        # still written race-safe to proxy_config for the back-compat
+        # readers.
+        await provider.store_org_ca(key_pem, cert_pem)
+        from mcp_proxy.db import set_config_if_absent
+        await set_config_if_absent("org_ca_cert", cert_pem)
         return True
 
     async def _mint_mastio_leaf(self, now: datetime) -> None:

--- a/test/unit/test_pki_bootstrap_concurrent.py
+++ b/test/unit/test_pki_bootstrap_concurrent.py
@@ -1,0 +1,226 @@
+"""D-9 cold-reader dogfood (2026-05-25) tests — PKI bootstrap multi-worker
+race-free guarantee.
+
+Pre-fix ``AgentManager.generate_org_ca`` had no atomic-persistence
+gate. Under ``MASTIO_WORKERS=4`` (Mastio bundle default) every uvicorn
+worker ran the lifespan in parallel and called this function
+independently, each generating a fresh EC P-256 keypair + a self-
+signed Org CA cert from it. The legacy plaintext path (``set_config``)
+upserted whichever worker landed last; the resulting on-disk
+``proxy_config.org_ca_{key,cert}`` rows came from one worker while
+the ``derive_org_id`` value came from yet another, and the in-memory
+``self._org_ca_key`` of each worker pointed at its own candidate key
+— diverging from the persisted pair the nginx sidecar exported as
+the trust bundle.
+
+Downstream effect: the Mastio Intermediate CA gets minted by a worker
+signing with key A; the nginx ``org-ca.crt`` is from worker B's key.
+Any agent leaf signed by the Intermediate (chain leaf || intermediate)
+fails ``openssl verify -CAfile org-ca.crt agent.crt`` with::
+
+    error 7 at 1 depth lookup: certificate signature failure
+    ECDSA digest_verify_final:provider signature failure
+
+The cold-reader chat smoke fails at the mTLS handshake: nginx returns
+``400 Bad Request — The SSL certificate error`` before the request
+ever reaches uvicorn.
+
+The fix mirrors the pre-existing ``_mint_mastio_ca`` winner-election
+pattern (see ``_persist_intermediate_ca`` line 1770+): persist the
+new pair via ``set_config_if_absent`` (the dev fallback) or via the
+provider-level ``store_org_ca`` (encrypted path); on a lost race
+re-read the winning pair from the source-of-truth and adopt it into
+the worker's in-memory state before any signing happens. These tests
+pin the invariants.
+
+Sister atomic-enrollment tests live in
+``test_admin_agents_atomic_enroll.py`` (PR #928 pattern). Keep the
+fixture shape aligned so the two test files exercise the same race-
+serialization primitive.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, get_config, init_db
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+_ADMIN_SECRET = "test-pki-bootstrap-concurrent-secret"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite + audit chain disabled. Skipping migrations is
+    safe here — ``generate_org_ca`` only touches ``proxy_config`` (the
+    metadata-defined rows ``org_id`` / ``org_ca_key`` / ``org_ca_cert``)
+    and the legacy fallback path that ``set_config_if_absent`` operates
+    on, so the migration chain that adds ``internal_agents.federated``
+    is not needed for this test.
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
+    # Force the dev fallback path: no PKI master key → set_config_if_absent
+    # branch. The encrypted KMS path (provider.store_org_ca + atomic
+    # insert under pki_key_store) is provider-level and tested
+    # separately when the provider plugin is exercised.
+    monkeypatch.delenv("MCP_PROXY_DB_ENCRYPTION_KEY", raising=False)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "pki_bootstrap.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _pubkey_der(key_or_cert) -> bytes:
+    return key_or_cert.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ) if hasattr(key_or_cert, "public_key") else key_or_cert.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_org_ca_converges_single_persisted_pair(proxy_db):
+    """N parallel workers calling ``generate_org_ca(derive_org_id=True)``
+    must converge on exactly one persisted Org CA pair, and every
+    worker's in-memory state must point at that same pair after the
+    gather completes. The placeholder org_id passed to each manager
+    is replaced by the winner-derived value during the call."""
+    placeholder_org_id = "placeholder-pre-derive"
+    managers = [AgentManager(placeholder_org_id) for _ in range(5)]
+
+    # Race the lifespan-equivalent boot path: every "worker" enters
+    # generate_org_ca concurrently with the same DB underneath.
+    await asyncio.gather(*(
+        m.generate_org_ca(derive_org_id=True) for m in managers
+    ))
+
+    # Exactly one org_id row persisted (the winner's derivation; losers
+    # must NOT have stamped over it).
+    persisted_org_id = await get_config("org_id")
+    assert persisted_org_id is not None
+    assert persisted_org_id != placeholder_org_id
+
+    # Every worker converged on the persisted org_id (no split-brain
+    # where some workers keep their own derivation).
+    in_memory_ids = [m._org_id for m in managers]
+    assert all(oid == persisted_org_id for oid in in_memory_ids), (
+        f"divergent org_ids across workers: {in_memory_ids}"
+    )
+
+    # Exactly one cert + one key pair persisted.
+    persisted_cert_pem = await get_config("org_ca_cert")
+    persisted_key_pem = await get_config("org_ca_key")
+    assert persisted_cert_pem is not None
+    assert persisted_key_pem is not None
+
+    # Every worker's in-memory cert is byte-identical to the persisted
+    # cert (the SHA-256 fingerprint roundtrips). This is the
+    # invariant that, when violated, causes the nginx mTLS chain
+    # failure observed in the dogfood.
+    persisted_cert = x509.load_pem_x509_certificate(persisted_cert_pem.encode())
+    persisted_fp = persisted_cert.fingerprint(hashes.SHA256()).hex()
+    in_memory_fps = [
+        m._org_ca_cert.fingerprint(hashes.SHA256()).hex()
+        for m in managers
+    ]
+    assert all(fp == persisted_fp for fp in in_memory_fps), (
+        f"divergent cert fingerprints across workers — D-9 race not "
+        f"closed. persisted={persisted_fp[:16]}…, workers="
+        f"{[fp[:16] + '…' for fp in in_memory_fps]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_org_ca_persisted_key_matches_cert(proxy_db):
+    """The winning persisted pair must be internally consistent: the
+    private key's public component matches the cert's subject pubkey.
+    A split-brain (key from worker A, cert from worker B) would let
+    nginx mTLS accept the chain on file but fail the actual signing
+    check — exactly the D-9 dogfood symptom. Eight workers, more
+    racy than the four-worker production default."""
+    placeholder_org_id = "ph"
+    managers = [AgentManager(placeholder_org_id) for _ in range(8)]
+    await asyncio.gather(*(
+        m.generate_org_ca(derive_org_id=True) for m in managers
+    ))
+
+    persisted_key_pem = await get_config("org_ca_key")
+    persisted_cert_pem = await get_config("org_ca_cert")
+    assert persisted_key_pem and persisted_cert_pem
+
+    key = serialization.load_pem_private_key(
+        persisted_key_pem.encode(), password=None,
+    )
+    cert = x509.load_pem_x509_certificate(persisted_cert_pem.encode())
+
+    key_pub_der = key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    cert_pub_der = cert.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert key_pub_der == cert_pub_der, (
+        "split-brain: persisted private key does NOT match persisted "
+        "cert pubkey. The on-disk pair would fail any chain that signs "
+        "off it (D-9 dogfood symptom)."
+    )
+
+    # Persisted org_id must derive from the persisted cert pubkey
+    # (closes the loop: org_id, key, cert all from the same winning
+    # worker, no straddling).
+    derived = hashlib.sha256(cert_pub_der).hexdigest()[:16]
+    persisted_org_id = await get_config("org_id")
+    assert derived == persisted_org_id, (
+        f"persisted org_id={persisted_org_id} does NOT derive from "
+        f"persisted cert pubkey={derived} — split-brain between the "
+        f"derivation step and the cert persistence step."
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_generate_org_ca_every_worker_can_sign(proxy_db):
+    """After the race, every worker must be able to use its
+    ``self._org_ca_key`` to sign material that verifies against the
+    persisted ``org_ca_cert``. Without the winner-adoption step a
+    losing worker would still hold its discarded candidate key and
+    produce signatures the nginx trust bundle rejects."""
+    placeholder_org_id = "ph"
+    managers = [AgentManager(placeholder_org_id) for _ in range(4)]
+    await asyncio.gather(*(
+        m.generate_org_ca(derive_org_id=True) for m in managers
+    ))
+
+    persisted_cert_pem = await get_config("org_ca_cert")
+    persisted_cert = x509.load_pem_x509_certificate(persisted_cert_pem.encode())
+    cert_pub_der = persisted_cert.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    for i, m in enumerate(managers):
+        worker_pub_der = m._org_ca_key.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        assert worker_pub_der == cert_pub_der, (
+            f"worker {i} holds a private key whose pubkey does not "
+            f"match the persisted cert pubkey. Any leaf signed by "
+            f"this worker would fail ``openssl verify`` against the "
+            f"nginx-exported org-ca.crt — exactly the D-9 symptom."
+        )


### PR DESCRIPTION
## Summary

- **Closes D-9 from the cold-reader dogfood (2026-05-25)** — critical PKI bootstrap race that made every fresh-install Mastio v0.5.3+ unable to serve a chat after enroll. Multi-worker uvicorn (`MASTIO_WORKERS=4`) raced on Org CA generation/persistence; the on-disk pair came from one worker while the in-memory CA in another worker signed the Mastio Intermediate, causing ECDSA chain verification to fail at the nginx mTLS boundary (`400 The SSL certificate error`).
- Fix mirrors the pre-existing winner-election pattern from `_mint_mastio_ca` / `_persist_intermediate_ca`, with one improvement: couple the key+cert pair into a single JSON payload persisted atomically via `set_config_if_absent("org_ca_pair", …)`. The two-separate-set_config_if_absent approach (one per row) leaves a split-brain window in scope where worker A wins the key INSERT while worker B wins the cert INSERT.
- Adds 3 unit tests that fail without the fix.

## What changed

| File | Change |
|---|---|
| `mcp_proxy/egress/agent_manager.py` | `generate_org_ca`: atomic `set_config_if_absent` on `org_id` + `_persist_org_ca` helper with winner/loser pair-payload semantics; loser path re-reads the winning pair and adopts it before any signing happens |
| `test/unit/test_pki_bootstrap_concurrent.py` (new) | 3 tests pin: single persisted pair across N workers; persisted key.pub == cert.pub (no split-brain); every worker's `_org_ca_key.pub` matches the canonical cert pubkey |

## Verification

- [x] `pytest test/unit/test_pki_bootstrap_concurrent.py -v` → 3/3 green
- [x] `pytest test/unit/ -n auto --dist=loadfile` → 239/239 green (no regression)
- [x] **Cold-reader dogfood VM v0.5.4-rc4** (fresh wipe, new org_id `9a89119cb49e00b3`):
  - Mastio logs show exactly one `"Self-signed Org CA generated"` event (winner) + exactly one `"Mastio Intermediate CA minted"` — race converged ✓
  - `openssl verify -CAfile ./certs/org-ca.pem agent.crt` → **OK** (pre-fix: `ECDSA signature failure`)
  - SDK `enroll_via_dashboard_approval` end-to-end: 3.1s wall, agent.crt + agent.key + dpop.jwk + meta.json all written
  - Cold-reader chain verification chain green end-to-end

## Out of scope

- **Encrypted KMS path** (`LocalKMSProvider.store_org_ca` with `MCP_PROXY_DB_ENCRYPTION_KEY` set) is still race-vulnerable at the provider level — `kms/local.py` uses an unconditional INSERT into `pki_key_store` + `activate_staged_pki_and_deprecate_old` swap. Tracked separately; cold-reader path hits this only when validate_config-rejected (production refuses without the at-rest passphrase). Same treatment in a follow-up PR.
- **D-10**: `deploy.sh --down --wipe-data` does NOT remove `data/mcp_proxy.db` on the dogfood VM (observed: file `Birth` survives the wipe). Separate finding, separate PR.
- **D-11**: `chat_completion` fails with HTTP 401 (not the D-9 mTLS 400). Mastio middleware gate refuses before reaching the handler, no visible log. Separate finding.

## Related findings

This PR fixes D-9. The dogfood that uncovered it also surfaced:
- D-1, D-2 (env template + LAN banner gaps — low UX)
- D-3 (cullis-sdk pyproject 0.1.0 vs `__init__.py` 0.1.3 drift)
- D-6 (session cookie JSON+escaped-quotes break python-requests)
- D-7 (approve endpoint requires `agent_id` field, undocumented for scripted admins)
- D-8 (`chat_completion(model=…)` kwargs-style fails — docs example wrong)
- D-10, D-11 (above)

All open for v0.5.4 release triage.