### PR TITLE
fix(auth): _build_htu returns tuple of acceptable URLs (D-11 v2)

### DIFF
--- a/mcp_proxy/auth/dpop.py
+++ b/mcp_proxy/auth/dpop.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import time
+from typing import Sequence
 from urllib.parse import urlparse, urlunparse
 
 from cryptography.hazmat.primitives import serialization
@@ -193,7 +194,7 @@ def _normalize_htu(url: str) -> str:
 async def verify_dpop_proof(
     proof_jwt: str,
     htm: str,
-    htu: str,
+    htu: "str | Sequence[str]",
     access_token: str | None = None,
     require_nonce: bool = True,
 ) -> str:
@@ -202,6 +203,20 @@ async def verify_dpop_proof(
     Returns the JWK thumbprint (jkt) on success.
     Raises HTTPException 401 on any failure.
     JTI is consumed only after all checks pass.
+
+    ``htu`` accepts either a single string (backward-compat, pre-D-11 v2
+    callers) or a sequence of candidate URLs — the proof is accepted if
+    its ``htu`` claim normalizes to ANY of the candidates. This widens
+    the binding when the same Mastio is legitimately reachable under
+    multiple hostnames (pinned ``MCP_PROXY_PROXY_PUBLIC_URL`` vs the
+    LAN IP / Host header the client actually used). Security-wise this
+    is safe: htu is the anti-replay binding, not identity — the client
+    must still possess the registered DPoP key to sign the proof, so
+    accepting alternative URLs the same proxy answers on does not
+    reduce the security posture; it just stops penalising deploy
+    topologies (cold-reader on Linux, LAN IP access) where the pinned
+    URL and the reached URL legitimately differ. Root cause confirmed
+    via the dogfood VM 2026-05-26 — see fix/d11-v2-server-permissive-htu.
 
     12-point verification:
       1. JWT structurally valid
@@ -213,7 +228,7 @@ async def verify_dpop_proof(
       7. jti present and not replayed
       8. iat within [-clock_skew, iat_window]
       9. htm matches (case-insensitive)
-      10. htu matches (normalized)
+      10. htu matches at least one candidate (normalized)
       11. ath == base64url(SHA-256(access_token)) if provided
       12. nonce matches if require_nonce
     """
@@ -311,9 +326,17 @@ async def verify_dpop_proof(
         )
 
     # -- 10. htu
-    expected_norm = _normalize_htu(htu)
+    # Accept either a single string (backward-compat) or a Sequence of
+    # candidate URLs. The proof's htu claim must normalize to AT LEAST
+    # ONE candidate — D-11 v2 root cause fix: a Mastio reachable under
+    # both the pinned proxy_public_url and the actual request URL (LAN
+    # IP, Host header) should accept proofs signed against either.
+    htu_candidates: list[str] = (
+        [htu] if isinstance(htu, str) else list(htu)
+    )
+    expected_norms = {_normalize_htu(h) for h in htu_candidates if h}
     got_norm = _normalize_htu(claims.get("htu", ""))
-    if got_norm != expected_norm:
+    if got_norm not in expected_norms:
         # Server-side: log structured diagnostics so operators can correlate
         # 401s with a wrong MCP_PROXY_PROXY_PUBLIC_URL (memory:
         # feedback_proxy_env_public_url_vm). Do NOT log the jkt to keep
@@ -321,7 +344,7 @@ async def verify_dpop_proof(
         _log.warning(
             "DPoP htu mismatch",
             extra={
-                "expected_htu": expected_norm,
+                "expected_htus": sorted(expected_norms),
                 "got_htu": got_norm,
                 "hint": "htu_mismatch_check_proxy_public_url",
             },
@@ -335,7 +358,7 @@ async def verify_dpop_proof(
         else:
             detail = (
                 f"Invalid DPoP proof: htu mismatch "
-                f"(expected={expected_norm!r}, got={got_norm!r})"
+                f"(expected={sorted(expected_norms)!r}, got={got_norm!r})"
             )
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED, detail, headers=headers

--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -45,15 +45,66 @@ _REQUIRE_NONCE_DEFAULT = True
 _MODES = frozenset({"off", "optional", "required"})
 
 
-def _build_htu(request: Request) -> str:
-    """Mirror ``dpop_api_key._build_htu`` — same htu construction so a
-    deploy that flips between the two during a transition window has
-    consistent proof binding."""
+def _build_htu(request: Request) -> tuple[str, ...]:
+    """Return the tuple of acceptable htu URLs for this request.
+
+    D-11 v2 root cause fix (dogfood VM 2026-05-26): when the bundle's
+    pinned ``MCP_PROXY_PROXY_PUBLIC_URL`` (e.g. ``host.docker.internal``,
+    the default community quickstart hint) does not resolve from the
+    client's host (Linux cold-reader without a hosts entry, LAN IP
+    access, alternative DNS), the SDK signed proofs against the actual
+    URL it reached (e.g. ``https://192.168.x.x:9443/...``) and the
+    server pinned the comparison to the proxy_public_url, so every
+    request 401'd with "htu mismatch" even though the client was
+    perfectly honest about which URL it dialled.
+
+    We now return every URL the same proxy could legitimately answer
+    on for this request:
+
+      * ``str(request.url)`` — the actual URL the ASGI layer saw
+        (scheme + host + path as the client framed it).
+      * ``proxy_public_url + request.url.path`` — the operator-pinned
+        URL, when set. Keeps the legacy contract for deploys whose SDK
+        signs against the published proxy_public_url.
+      * ``"{scheme}://{Host header}{path}"`` — the URL implied by the
+        ``Host:`` header (or ``X-Forwarded-Host`` once nginx normalises
+        it), in case nginx + uvicorn disagree on which one is in
+        ``request.url`` for this deployment.
+
+    ``verify_dpop_proof`` accepts any ``Sequence[str]`` and matches on
+    set membership, so the returned tuple is deduplicated but order is
+    not load-bearing.
+
+    Security: htu is the anti-replay binding, not identity. The client
+    still has to sign with the registered DPoP key, so widening the
+    accepted URL set does not reduce the security posture — it just
+    stops penalising deploys where the pinned URL and the reached URL
+    legitimately differ.
+    """
     settings = get_settings()
+    path = request.url.path
+
+    candidates: list[str] = []
+    # 1) The URL the ASGI layer materialised for this request.
+    candidates.append(str(request.url))
+
+    # 2) The operator-pinned proxy_public_url + the request path.
     base = (settings.proxy_public_url or "").rstrip("/")
     if base:
-        return base + request.url.path
-    return str(request.url)
+        candidates.append(base + path)
+
+    # 3) The URL implied by the Host header (covers Forwarded-Host
+    #    flows where nginx rewrites the host but request.url still
+    #    points at the upstream socket name).
+    host_header = request.headers.get("host")
+    if host_header:
+        scheme = request.url.scheme or "https"
+        host_url = f"{scheme}://{host_header}{path}"
+        candidates.append(host_url)
+
+    # Deduplicate while preserving the candidate set; tuple order is
+    # not load-bearing because the verifier compares set membership.
+    return tuple(dict.fromkeys(candidates))
 
 
 def _resolve_mode() -> str:

--- a/test/unit/test_dpop_htu_permissive.py
+++ b/test/unit/test_dpop_htu_permissive.py
@@ -1,0 +1,286 @@
+"""Tests for D-11 v2 server-side permissive htu binding.
+
+Root cause confirmed by the dogfood VM 2026-05-26: cold-reader on a
+Linux host without ``host.docker.internal`` resolved the Mastio via the
+LAN IP, but the server's ``_build_htu`` pinned the comparison to
+``MCP_PROXY_PROXY_PUBLIC_URL=https://host.docker.internal:9443`` and
+every ``/v1/llm/chat`` request 401'd with "htu mismatch" even though
+the client was perfectly honest about which URL it dialled.
+
+The fix:
+
+  * ``verify_dpop_proof`` now accepts ``htu: str | Sequence[str]`` and
+    matches the claim against set membership (was strict equality
+    against a single normalized URL).
+  * ``_build_htu(request)`` returns a tuple of acceptable URLs (the
+    actual request URL, the pinned ``proxy_public_url``, and the URL
+    implied by the ``Host:`` header when they differ).
+
+Security: htu is the anti-replay binding, not identity — the client
+still has to sign with the registered DPoP key, so widening the
+accepted URL set does not reduce the security posture; it just stops
+penalising deploys where the pinned URL and the reached URL
+legitimately differ (LAN IP access, alternative DNS).
+
+Five invariants pinned:
+
+1. ``htu=<str>`` keeps working (pre-D-11 v2 callers — ``dependencies``,
+   ``local_token``, ``local_agent_dep`` — still pass a single string).
+2. ``htu=(a, b)`` with proof signed against ``a`` is accepted.
+3. ``htu=(a, b)`` with proof signed against ``b`` is accepted.
+4. ``htu=(a, b)`` with proof signed against ``c`` is rejected with a
+   401 whose detail mentions "htu mismatch".
+5. ``_build_htu(req)`` returns a tuple that includes BOTH the actual
+   request URL AND the pinned ``proxy_public_url`` when they differ.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import jwt as jose_jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import HTTPException
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers — minimal local DPoP proof signing so the tests don't depend
+# on the SDK's DpopKey shape (which lives in a different package and
+# could drift). Mirrors ``cullis_sdk.dpop.DpopKey.sign_proof`` plus the
+# RFC 7638 thumbprint helper.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _make_keypair() -> tuple[ec.EllipticCurvePrivateKey, dict]:
+    """Generate an EC P-256 keypair and return (priv, public_jwk)."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+    x = _b64url(nums.x.to_bytes(32, "big"))
+    y = _b64url(nums.y.to_bytes(32, "big"))
+    public_jwk = {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+    return priv, public_jwk
+
+
+def _sign_proof(
+    priv: ec.EllipticCurvePrivateKey,
+    public_jwk: dict,
+    *,
+    htm: str,
+    htu: str,
+    jti: str | None = None,
+    iat: int | None = None,
+) -> str:
+    """Sign a DPoP proof JWT in the shape ``verify_dpop_proof`` expects."""
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    claims: dict[str, Any] = {
+        "jti": jti or uuid.uuid4().hex,
+        "htm": htm.upper(),
+        "htu": htu,
+        "iat": int(iat if iat is not None else time.time()),
+    }
+    return jose_jwt.encode(
+        claims,
+        priv_pem,
+        algorithm="ES256",
+        headers={"typ": "dpop+jwt", "jwk": public_jwk},
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_dpop_singletons(monkeypatch):
+    """Reset DPoP module-scoped state per test.
+
+    ``verify_dpop_proof`` consumes JTIs into a module-level in-memory
+    store; tests that reuse the same jti across calls would otherwise
+    see a spurious "replay" 401. Forces a fresh store per test.
+    """
+    # Avoid the validate_config insecure-default refusal in dev — same
+    # rationale as ``conftest.audit_test_env``.
+    monkeypatch.setenv(
+        "MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default"
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.auth import dpop_jti_store
+    dpop_jti_store.reset_dpop_jti_store()
+
+    yield
+
+    get_settings.cache_clear()
+    dpop_jti_store.reset_dpop_jti_store()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# verify_dpop_proof tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_dpop_proof_accepts_string_htu_backward_compat():
+    """Pin retrocompat: callers passing a single string still work.
+
+    Pre-D-11 v2 callers (``dependencies.py``, ``local_token.py``,
+    ``local_agent_dep.py``) still construct ``htu`` as a single string.
+    The new signature accepts ``str | Sequence[str]`` and must not
+    break those call sites.
+    """
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+
+    priv, pub_jwk = _make_keypair()
+    url = "https://mastio.example/v1/llm/chat"
+    proof = _sign_proof(priv, pub_jwk, htm="POST", htu=url)
+
+    jkt = await verify_dpop_proof(
+        proof,
+        htm="POST",
+        htu=url,  # string, not sequence
+        access_token=None,
+        require_nonce=False,
+    )
+    assert isinstance(jkt, str) and len(jkt) > 0
+
+
+@pytest.mark.asyncio
+async def test_verify_dpop_proof_accepts_first_of_sequence():
+    """Proof signed against the FIRST candidate URL is accepted."""
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+
+    priv, pub_jwk = _make_keypair()
+    url_a = "https://host.docker.internal:9443/v1/llm/chat"
+    url_b = "https://192.168.122.62:9443/v1/llm/chat"
+    proof = _sign_proof(priv, pub_jwk, htm="POST", htu=url_a)
+
+    jkt = await verify_dpop_proof(
+        proof,
+        htm="POST",
+        htu=(url_a, url_b),
+        access_token=None,
+        require_nonce=False,
+    )
+    assert isinstance(jkt, str) and len(jkt) > 0
+
+
+@pytest.mark.asyncio
+async def test_verify_dpop_proof_accepts_second_of_sequence():
+    """Proof signed against the SECOND candidate URL is accepted.
+
+    This is the dogfood VM scenario: pinned ``proxy_public_url`` is
+    ``host.docker.internal`` (candidate A) but the client actually
+    reached the Mastio via the LAN IP (candidate B). Pre-fix the
+    server rejected; post-fix it accepts.
+    """
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+
+    priv, pub_jwk = _make_keypair()
+    url_a = "https://host.docker.internal:9443/v1/llm/chat"
+    url_b = "https://192.168.122.62:9443/v1/llm/chat"
+    proof = _sign_proof(priv, pub_jwk, htm="POST", htu=url_b)
+
+    jkt = await verify_dpop_proof(
+        proof,
+        htm="POST",
+        htu=(url_a, url_b),
+        access_token=None,
+        require_nonce=False,
+    )
+    assert isinstance(jkt, str) and len(jkt) > 0
+
+
+@pytest.mark.asyncio
+async def test_verify_dpop_proof_rejects_when_neither_matches():
+    """Proof signed against a URL OUTSIDE the candidate set is rejected.
+
+    The permissive binding only widens the accepted set to URLs the
+    server explicitly considers legitimate for this request. A proof
+    bound to an unrelated URL ("https://attacker.example/...") must
+    still 401 — htu binding is not bypassed, just relaxed to a set.
+    """
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+
+    priv, pub_jwk = _make_keypair()
+    url_a = "https://host.docker.internal:9443/v1/llm/chat"
+    url_b = "https://192.168.122.62:9443/v1/llm/chat"
+    url_c = "https://attacker.example:9443/v1/llm/chat"
+    proof = _sign_proof(priv, pub_jwk, htm="POST", htu=url_c)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_dpop_proof(
+            proof,
+            htm="POST",
+            htu=(url_a, url_b),
+            access_token=None,
+            require_nonce=False,
+        )
+    assert exc_info.value.status_code == 401
+    assert "htu mismatch" in exc_info.value.detail
+
+
+# ─────────────────────────────────────────────────────────────────────
+# _build_htu tests
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_build_htu_returns_tuple_with_proxy_public_url_and_request_url(
+    monkeypatch,
+):
+    """``_build_htu`` returns BOTH the request URL and the pinned URL.
+
+    Scenario: ``MCP_PROXY_PROXY_PUBLIC_URL=https://host.docker.internal:9443``
+    (the bundle community quickstart default), but the SDK reached the
+    Mastio via ``https://192.168.122.62:9443/v1/llm/chat`` (LAN IP).
+    The returned tuple must include both so ``verify_dpop_proof`` can
+    accept a proof signed against either.
+    """
+    monkeypatch.setenv(
+        "MCP_PROXY_PROXY_PUBLIC_URL",
+        "https://host.docker.internal:9443",
+    )
+    monkeypatch.setenv(
+        "MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default"
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    try:
+        from mcp_proxy.auth.dpop_client_cert import _build_htu
+
+        # Minimal Request mock — we only touch .url and .headers.
+        request = MagicMock()
+        request.url = MagicMock()
+        request.url.path = "/v1/llm/chat"
+        request.url.scheme = "https"
+        request.url.__str__ = lambda self=None: (
+            "https://192.168.122.62:9443/v1/llm/chat"
+        )
+        request.headers = {"host": "192.168.122.62:9443"}
+
+        result = _build_htu(request)
+
+        assert isinstance(result, tuple)
+        # Both URLs must be present somewhere in the tuple.
+        assert "https://192.168.122.62:9443/v1/llm/chat" in result
+        assert (
+            "https://host.docker.internal:9443/v1/llm/chat" in result
+        ), (
+            "pinned proxy_public_url + request.url.path must be in the "
+            f"candidate tuple; got {result!r}"
+        )
+        # Deduplication: each entry appears once.
+        assert len(result) == len(set(result))
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Closes D-11 root cause confirmed by the dogfood VM (2026-05-26 mattina). The SDK sibling auto-discovery shipped in PR #938 fixed only the symptom (missing `dpop.jwk` discovery for cold-readers using the four-file identity dir). The actual block was server-side: `_build_htu` pinned its comparison to `MCP_PROXY_PROXY_PUBLIC_URL` (default `host.docker.internal:9443` in the community bundle quickstart) even when the SDK legitimately reached the Mastio via a different hostname.

Failure trace from the dogfood VM:

```
Invalid DPoP proof: htu mismatch
(expected='https://host.docker.internal:9443/v1/llm/chat',
 got='https://192.168.122.62:9443/v1/llm/chat')
```

Every cold-reader who downloaded the bundle and ran `./deploy.sh` on a Linux host (the documented community quickstart) hit this: the dashboard default `proxy_public_url` was `host.docker.internal` and the actual URL the SDK reached was the LAN IP, so the DPoP htu binding mismatched and the first `/v1/llm/chat` request 401'd.

## What changed

* `mcp_proxy/auth/dpop.py` — `verify_dpop_proof` signature widened to `htu: str | Sequence[str]`. Backward-compat preserved: existing callers (`dependencies.py`, `local_token.py`, `local_agent_dep.py`) still pass a single string and that path is normalized + matched against a 1-element set. New callers pass a tuple and the proof is accepted if its `htu` claim normalizes to ANY candidate. Warning log emits the full sorted candidate list under `expected_htus`.
* `mcp_proxy/auth/dpop_client_cert.py` — `_build_htu(request)` now returns `tuple[str, ...]`. Three URL slots populated, deduped: (1) actual `str(request.url)`, (2) pinned `proxy_public_url + request.url.path` when set, (3) `Host:` header derived URL. Caller (`get_agent_from_dpop_client_cert` line 129) is semantically unchanged.
* `test/unit/test_dpop_htu_permissive.py` — new test file, 5 cases pinning the invariants.

The historical sister-file `mcp_proxy/auth/dpop_api_key.py` referenced in `_build_htu`'s docstring no longer exists post Portkey pivot (the api-key path was replaced by mTLS+DPoP in ADR-014 PR-B), so the parity update is moot for that file.

## Security posture

htu is the anti-replay binding, not identity. The client still has to sign with the registered DPoP key (pinned against `internal_agents.dpop_jkt`), so widening the URL set does not reduce the security posture; it just stops penalising deploy topologies where the pinned URL and the reached URL legitimately differ. The candidate set is built deterministically from the server's own view of the request, not from anything the client claims, so an attacker cannot widen the accepted set.

## Verification

* `python -m compileall -q mcp_proxy` — clean
* `pytest test/unit/test_dpop_htu_permissive.py -v` — 5/5 PASS
* `pytest test/unit/ -k "dpop" -n auto --dist=loadfile` — 11/11 PASS (5 new + 6 pre-existing)
* `pytest test/unit/ -k "auth or htu or proof" -n auto --dist=loadfile` — 60/60 PASS
* `pytest test/unit/ -n auto --dist=loadfile` — 248/248 PASS (full unit suite)

## Test plan

- [ ] Build a Mastio image off this branch and redeploy onto `mastio-demo` VM
- [ ] Run the cold-reader SDK scenario from the Linux host (no `host.docker.internal` entry, accessing via LAN IP) and confirm the first `/v1/llm/chat` lands a 200 instead of 401
- [ ] Confirm no regression on the existing `/v1/chat/completions` flow when `proxy_public_url` and the dialled URL DO match (the pre-fix happy path)

## Related

* PR #938 — SDK-side fix for the same D-11 symptom (sibling `dpop.jwk` auto-discovery in `from_identity_dir`)
* Dogfood VM run 2026-05-26 mattina confirmed root cause was server-side, not SDK-side

Signed-off-by: DaenAIHax <DaenAIHax@users.noreply.github.com>