### PR TITLE
fix(bundle+auth): propagate X-Forwarded-* + uvicorn proxy-headers (D-12)

### DIFF
--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -58,18 +58,37 @@ def _build_htu(request: Request) -> tuple[str, ...]:
     request 401'd with "htu mismatch" even though the client was
     perfectly honest about which URL it dialled.
 
+    D-12 follow-up (post-#939): the dogfood VM showed that even with
+    the v2 permissive set, ``str(request.url)`` itself was wrong —
+    nginx forwarded ``Host: 192.168.122.62`` (with the ``$host``
+    variable stripping the ``:9443`` port the client actually dialled),
+    so uvicorn reconstructed ``request.url`` without the port and none
+    of the v2 candidates matched the client-signed htu (which carries
+    ``:9443``). The nginx config now forwards ``Host: $http_host``
+    (port preserved) and publishes the explicit ``X-Forwarded-{Host,
+    Port,Proto}`` triplet. We add a candidate assembled from that
+    triplet directly so the htu set still matches even if a future
+    middleware ordering regression leaves ``request.url`` pointed at
+    the upstream socket again.
+
     We now return every URL the same proxy could legitimately answer
     on for this request:
 
       * ``str(request.url)`` — the actual URL the ASGI layer saw
-        (scheme + host + path as the client framed it).
+        (scheme + host + path as the client framed it). With the
+        D-12 nginx ``Host: $http_host`` change this carries the port
+        the client dialled.
       * ``proxy_public_url + request.url.path`` — the operator-pinned
         URL, when set. Keeps the legacy contract for deploys whose SDK
         signs against the published proxy_public_url.
       * ``"{scheme}://{Host header}{path}"`` — the URL implied by the
-        ``Host:`` header (or ``X-Forwarded-Host`` once nginx normalises
-        it), in case nginx + uvicorn disagree on which one is in
-        ``request.url`` for this deployment.
+        ``Host:`` header.
+      * ``"{X-Forwarded-Proto}://{X-Forwarded-Host}:{X-Forwarded-Port}
+        {path}"`` — the URL implied by the explicit forwarded triplet
+        nginx publishes (D-12). Belt-and-suspenders: if the
+        ProxyHeadersMiddleware ordering or a future Host-header rewrite
+        ever drops the port from ``request.url`` again, this candidate
+        still carries it.
 
     ``verify_dpop_proof`` accepts any ``Sequence[str]`` and matches on
     set membership, so the returned tuple is deduplicated but order is
@@ -101,6 +120,36 @@ def _build_htu(request: Request) -> tuple[str, ...]:
         scheme = request.url.scheme or "https"
         host_url = f"{scheme}://{host_header}{path}"
         candidates.append(host_url)
+
+    # 4) (D-12) The URL implied by the explicit X-Forwarded-{Proto,
+    #    Host,Port} triplet nginx now publishes. Combines the host
+    #    (which may or may not already carry a port) with the port the
+    #    client reached the edge on. Only emit when we have at least a
+    #    forwarded-host to anchor on; otherwise we'd just rebuild the
+    #    Host-header URL with weaker defaults.
+    fwd_host = request.headers.get("x-forwarded-host")
+    if fwd_host:
+        fwd_proto = (
+            request.headers.get("x-forwarded-proto")
+            or request.url.scheme
+            or "https"
+        )
+        fwd_port = request.headers.get("x-forwarded-port") or ""
+        # If the forwarded-host already carries a port don't append a
+        # second one ("host:9443:9443" would be a parse error). The
+        # check excludes IPv6 colons inside ``[::1]`` style literals
+        # because the port (if any) sits OUTSIDE the brackets in that
+        # form, so a closing-bracket-then-colon is the only "has port"
+        # signal we trust.
+        if fwd_host.startswith("["):
+            has_port = "]:" in fwd_host
+        else:
+            has_port = ":" in fwd_host
+        if fwd_port and not has_port:
+            netloc = f"{fwd_host}:{fwd_port}"
+        else:
+            netloc = fwd_host
+        candidates.append(f"{fwd_proto}://{netloc}{path}")
 
     # Deduplicate while preserving the candidate set; tuple order is
     # not load-bearing because the verifier compares set membership.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1787,6 +1787,42 @@ else:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Uvicorn ProxyHeadersMiddleware (D-12)
+#
+# The deployed image runs uvicorn with ``--proxy-headers
+# --forwarded-allow-ips '*'`` (see ``mcp_proxy/Dockerfile`` CMD), which
+# wraps the ASGI app with the same middleware externally. Registering
+# it here too is harmless (idempotent — re-applies the same
+# scheme/client rewrite from the X-Forwarded-Proto / X-Forwarded-For
+# headers) and gives the in-process test suite, ``uvicorn.run``
+# call sites without the CLI flag, and any future ASGI server choice
+# the same scheme/client rewrite the deployed shape relies on. Without
+# this registration, ``request.url.scheme`` would fall back to the
+# upstream socket's scheme (``http`` on the docker network) and every
+# DPoP htu candidate that anchors on ``str(request.url)`` would emit
+# ``http://...`` while the client signs ``https://...``.
+#
+# Registered LAST so Starlette's LIFO order runs it FIRST on every
+# inbound request — the X-Forwarded-* rewrite has to happen before
+# downstream middleware / dep observes ``request.url``. ``trusted_hosts
+# ="*"`` matches the CLI ``--forwarded-allow-ips '*'`` posture; the
+# backend listener (9100) is never published to the host or LAN per the
+# Dockerfile contract, so any inbound request necessarily traversed the
+# nginx sidecar and the X-Forwarded headers are trusted by network
+# topology.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from uvicorn.middleware.proxy_headers import (
+    ProxyHeadersMiddleware as _ProxyHeadersMiddleware,
+)
+
+app.add_middleware(_ProxyHeadersMiddleware, trusted_hosts="*")
+_log.info(
+    "Uvicorn ProxyHeadersMiddleware registered in-app (D-12 belt-and-suspenders)"
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Routers
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/packaging/mastio-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-bundle/nginx/mastio/mastio.conf
@@ -73,6 +73,33 @@ server {
     client_max_body_size 4m;
 
     # ──────────────────────────────────────────────────────────────────
+    # Forwarded-Host / Forwarded-Port propagation (D-12)
+    # ──────────────────────────────────────────────────────────────────
+    # ``$host`` in nginx is ``server_name`` or the bare Host header with
+    # the port stripped. Forwarding that to uvicorn made
+    # ``request.url.netloc`` lose the port the client actually contacted
+    # (e.g. ``localhost:9443`` arrived as ``localhost``), and the
+    # SDK-signed DPoP htu carried ``:9443`` so every egress request
+    # 401'd with "htu mismatch" unless ``MCP_PROXY_PROXY_PUBLIC_URL``
+    # was hand-tuned to exactly the URL the client reached. Two changes
+    # close that systemically:
+    #
+    #   * ``proxy_set_header Host $http_host`` forwards the raw Host
+    #     header (port included). uvicorn reconstructs ``request.url``
+    #     from this so ``str(request.url)`` matches what the client
+    #     dialled.
+    #   * ``proxy_set_header X-Forwarded-Host/Port/Proto`` published
+    #     explicit forwarded triplet for ``_build_htu`` to assemble a
+    #     belt-and-suspenders htu candidate even if the middleware
+    #     ordering ever regresses.
+    #
+    # ``$server_port`` resolves to the port nginx itself is listening on
+    # for this request (9443 in the bundle), so it always reflects the
+    # port the client reached us at, including when nginx is fronting
+    # multiple ``listen`` directives.
+    # ──────────────────────────────────────────────────────────────────
+
+    # ──────────────────────────────────────────────────────────────────
     # mTLS-required (TLS-layer agent identity)
     # ──────────────────────────────────────────────────────────────────
     # /v1/egress + /v1/agents + /v1/audit are the surfaces where the
@@ -93,10 +120,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         # Always overwrite: never trust a client-supplied value.
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
@@ -109,10 +138,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
     }
@@ -133,10 +164,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
         # SSE streaming on /v1/llm/chat: disable buffering + bump the
@@ -161,10 +194,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         # Strip any client-supplied cert header: anonymous endpoints
         # must not be confusable with authenticated ones.
         proxy_set_header X-SSL-Client-Cert "";
@@ -181,10 +216,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
     }
 
@@ -193,10 +230,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
         proxy_set_header Upgrade           $http_upgrade;
         proxy_read_timeout                 86400;
@@ -207,10 +246,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
     }
 
@@ -219,10 +260,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
     }
 
@@ -232,10 +275,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
     }
 
@@ -247,10 +292,12 @@ server {
         proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
         proxy_set_header Connection        $connection_upgrade;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $http_host;
+        proxy_set_header X-Forwarded-Port  $server_port;
         proxy_set_header X-SSL-Client-Cert "";
     }
 

--- a/test/unit/test_dpop_htu_xforwarded.py
+++ b/test/unit/test_dpop_htu_xforwarded.py
@@ -1,0 +1,229 @@
+"""Tests for D-12 X-Forwarded-* candidate assembly in ``_build_htu``.
+
+Root cause: D-11 v2 (PR #939) widened the server-side htu acceptable
+set to include ``str(request.url)``, the pinned proxy_public_url, and
+the Host-header URL. The dogfood VM 2026-05-26 then revealed that
+``str(request.url)`` itself was wrong: nginx forwarded ``Host:
+192.168.122.62`` (with the ``$host`` variable stripping the ``:9443``
+port the client actually dialled), so uvicorn reconstructed
+``request.url`` without the port and none of the v2 candidates matched
+the client-signed htu (which carries ``:9443``).
+
+D-12 ships two coordinated changes:
+
+  * nginx now forwards ``Host: $http_host`` (port preserved) and
+    publishes the explicit ``X-Forwarded-{Host,Port,Proto}`` triplet.
+  * ``_build_htu`` assembles an additional candidate URL from the
+    triplet directly — belt-and-suspenders so the htu set still
+    matches even if a future middleware ordering regression leaves
+    ``request.url`` pointed at the upstream socket again.
+
+This file pins the Python half (the candidate-assembly logic). The
+nginx half lives in ``packaging/mastio-bundle/nginx/mastio/mastio.conf``
+and is exercised via the bundle dogfood smoke; nginx config tests in
+pytest would require booting the container which is the smoke gate's
+job, not unit-test scope.
+
+Invariants pinned:
+
+1. ``_build_htu`` includes the URL implied by the X-Forwarded-* triplet
+   when both ``X-Forwarded-Host`` (carrying port) and
+   ``X-Forwarded-Proto`` are present.
+2. When ``X-Forwarded-Host`` lacks a port and ``X-Forwarded-Port`` is
+   set, the two are combined into ``host:port``.
+3. When the X-Forwarded-* triplet is absent the candidate set still
+   contains the Host-header URL (backward-compat with D-11 v2).
+4. Bracketed IPv6 forwarded-host values keep their brackets and only
+   combine with ``X-Forwarded-Port`` when the port is outside the
+   brackets (``[::1]`` has no port, ``[::1]:9443`` already does).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _config_env(monkeypatch):
+    """Reset settings + provide an admin secret so ``get_settings`` succeeds.
+
+    ``_build_htu`` reads ``settings.proxy_public_url`` and the dev
+    insecure-default refusal in ``validate_config`` would otherwise
+    raise on the very first cache miss.
+    """
+    monkeypatch.setenv(
+        "MCP_PROXY_ADMIN_SECRET",
+        "test-admin-secret-not-the-default",
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_request(
+    *,
+    path: str = "/v1/llm/chat",
+    request_url: str = "https://192.168.122.62/v1/llm/chat",
+    request_scheme: str = "https",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a minimal ``Request`` mock for ``_build_htu``.
+
+    The function only touches ``request.url.path``, ``request.url.scheme``,
+    ``str(request.url)``, and ``request.headers.get(<name>)`` — no need
+    to spin a real starlette Request.
+    """
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.path = path
+    request.url.scheme = request_scheme
+    request.url.__str__ = lambda self=None, _u=request_url: _u
+    request.headers = headers or {}
+    return request
+
+
+def test_build_htu_includes_xforwarded_host_with_port(monkeypatch):
+    """Forwarded-Host carrying its own port: candidate uses it verbatim.
+
+    Scenario: nginx publishes ``X-Forwarded-Host: localhost:9443`` (the
+    client-supplied Host with the port intact, courtesy of the D-12
+    ``$http_host`` substitution), plus ``X-Forwarded-Port: 9443`` and
+    ``X-Forwarded-Proto: https``. The assembled candidate must be
+    ``https://localhost:9443/v1/llm/chat`` (no double-port).
+    """
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.auth.dpop_client_cert import _build_htu
+
+    request = _make_request(
+        request_url="https://localhost/v1/llm/chat",  # uvicorn dropped port
+        headers={
+            "host": "localhost",
+            "x-forwarded-host": "localhost:9443",
+            "x-forwarded-port": "9443",
+            "x-forwarded-proto": "https",
+        },
+    )
+
+    result = _build_htu(request)
+
+    assert isinstance(result, tuple)
+    assert "https://localhost:9443/v1/llm/chat" in result, (
+        "X-Forwarded triplet candidate missing; got "
+        f"{result!r}"
+    )
+    # No double-port; the triplet candidate was assembled from the
+    # already-portful Forwarded-Host and not appended with Port again.
+    assert "https://localhost:9443:9443/v1/llm/chat" not in result
+
+
+def test_build_htu_combines_host_and_port_when_host_lacks_port(monkeypatch):
+    """Forwarded-Host has no port: combine with X-Forwarded-Port.
+
+    Scenario: a proxy further upstream propagated ``X-Forwarded-Host:
+    192.168.122.62`` (port stripped) but kept ``X-Forwarded-Port:
+    9443``. The candidate must combine the two into
+    ``https://192.168.122.62:9443/v1/llm/chat`` so the client-signed
+    htu (which carries :9443) matches.
+    """
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.auth.dpop_client_cert import _build_htu
+
+    request = _make_request(
+        request_url="https://192.168.122.62/v1/llm/chat",
+        headers={
+            "host": "192.168.122.62",
+            "x-forwarded-host": "192.168.122.62",
+            "x-forwarded-port": "9443",
+            "x-forwarded-proto": "https",
+        },
+    )
+
+    result = _build_htu(request)
+
+    assert isinstance(result, tuple)
+    assert "https://192.168.122.62:9443/v1/llm/chat" in result, (
+        "combined Forwarded-Host + Forwarded-Port candidate missing; "
+        f"got {result!r}"
+    )
+
+
+def test_build_htu_fallback_to_host_header_when_xforwarded_missing(monkeypatch):
+    """No X-Forwarded-* headers: fall back to Host header (D-11 v2 path).
+
+    Pure backward-compat pin: D-11 v2 already includes the Host-header
+    URL in the candidate set, and the D-12 patch must not regress that
+    behaviour for deploys where nginx hasn't been re-rolled yet.
+    """
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.auth.dpop_client_cert import _build_htu
+
+    request = _make_request(
+        request_url="https://localhost:9443/v1/llm/chat",
+        headers={"host": "localhost:9443"},
+    )
+
+    result = _build_htu(request)
+
+    assert isinstance(result, tuple)
+    # Host-header URL must still be reconstructed even without a
+    # forwarded-host (the D-11 v2 candidate).
+    assert "https://localhost:9443/v1/llm/chat" in result
+    # And no X-Forwarded-* candidate is emitted when the headers are
+    # absent (we don't fabricate one out of the Host header alone — the
+    # Host-header branch already covers that shape).
+    assert len(result) == len(set(result))
+
+
+def test_build_htu_ipv6_forwarded_host_preserves_brackets(monkeypatch):
+    """Bracketed IPv6 X-Forwarded-Host keeps brackets, port appends OUTSIDE.
+
+    ``[::1]`` carries no port; combine with ``X-Forwarded-Port`` to
+    yield ``https://[::1]:9443/...``. ``[::1]:9443`` already has the
+    port outside the brackets so it must pass through verbatim.
+    """
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.auth.dpop_client_cert import _build_htu
+
+    # No port outside brackets → append Forwarded-Port.
+    request_a = _make_request(
+        request_url="https://[::1]/v1/llm/chat",
+        headers={
+            "host": "[::1]",
+            "x-forwarded-host": "[::1]",
+            "x-forwarded-port": "9443",
+            "x-forwarded-proto": "https",
+        },
+    )
+    result_a = _build_htu(request_a)
+    assert "https://[::1]:9443/v1/llm/chat" in result_a, (
+        f"bracketed-IPv6 + port-append missing; got {result_a!r}"
+    )
+
+    # Already has port outside brackets → pass through, do NOT append.
+    request_b = _make_request(
+        request_url="https://[::1]:9443/v1/llm/chat",
+        headers={
+            "host": "[::1]:9443",
+            "x-forwarded-host": "[::1]:9443",
+            "x-forwarded-port": "9443",
+            "x-forwarded-proto": "https",
+        },
+    )
+    result_b = _build_htu(request_b)
+    assert "https://[::1]:9443/v1/llm/chat" in result_b
+    # No double-port appended.
+    assert "https://[::1]:9443:9443/v1/llm/chat" not in result_b


### PR DESCRIPTION
## Summary

Closes the D-12 cold-reader 401 surfaced on the 2026-05-26 dogfood VM. D-11 v2 ([PR #939](https://github.com/cullis-security/cullis/pull/939)) widened the server-side htu acceptable set, but ``str(request.url)`` itself was wrong: nginx forwarded ``Host: 192.168.122.62`` (with ``$host`` stripping the ``:9443`` port the client dialled), so uvicorn reconstructed ``request.url`` without the port and none of the v2 candidates matched the client-signed htu (which carries ``:9443``). Customers who did not override the bundle ``MCP_PROXY_PROXY_PUBLIC_URL`` still hit the 401.

## What changed

Three-pronged fix:

1. **nginx (`packaging/mastio-bundle/nginx/mastio/mastio.conf`)** — every ``location`` that proxies to ``mcp-proxy:9100`` now sets:
   - ``Host $http_host`` (was ``$host``), so the port the client reached us at survives the hop.
   - ``X-Forwarded-Proto $scheme`` (was hard-coded ``https``), so the value follows the actual ``listen`` directive.
   - ``X-Forwarded-Host $http_host`` and ``X-Forwarded-Port $server_port`` — explicit triplet published for ``_build_htu`` to assemble a candidate from directly.
2. **Mastio FastAPI (`mcp_proxy/main.py`)** — registers ``uvicorn.middleware.proxy_headers.ProxyHeadersMiddleware`` in-app with ``trusted_hosts="*"``. The Dockerfile CMD already passes ``--proxy-headers --forwarded-allow-ips '*'`` so the deployed shape was covered; the in-app registration is belt-and-suspenders for the in-process test suite and any future ASGI server choice. Registered LAST so Starlette's LIFO order runs it FIRST on every inbound request, rewriting ``scheme`` + ``client`` from the X-Forwarded-* triplet before any downstream middleware/dep observes ``request.url``.
3. **`mcp_proxy/auth/dpop_client_cert.py`** — ``_build_htu`` adds a fourth candidate URL assembled directly from ``X-Forwarded-{Proto,Host,Port}``. Belt-and-suspenders: if the middleware ordering ever regresses, the candidate is still in the set. Handles bracketed IPv6 hosts and avoids the double-port trap when the Forwarded-Host already carries a port.

Security posture: htu is the anti-replay binding, not identity. The client still has to sign with the registered DPoP key, so widening the accepted URL set does not reduce the security posture — it just stops penalising deploys where the pinned URL and the reached URL legitimately differ.

## Verification

- ``python -m compileall -q mcp_proxy`` clean.
- ``pytest test/unit/test_dpop_htu_xforwarded.py -v`` → 4/4 pass (new file).
- ``pytest test/unit/ -k "dpop or htu" -n auto --dist=loadfile`` → 15/15 pass (11 existing D-11 v2 tests + 4 new).
- ``pytest test/unit/ -n auto --dist=loadfile`` → 252/252 pass.

nginx config syntax not exercised in pytest (booting the container is the smoke gate's job); the bundle dogfood smoke will exercise it via the ``./deploy.sh`` cold-reader path before the next release tag.

## Test plan

- [ ] Cold-reader on a vanilla Linux laptop hitting ``https://localhost:9443`` without editing ``MCP_PROXY_PROXY_PUBLIC_URL`` no longer 401s on ``/v1/llm/chat``.
- [ ] Same with LAN-reachable VM at ``https://192.168.x.x:9443``.
- [ ] Regression: deploys that already set ``MCP_PROXY_PROXY_PUBLIC_URL`` continue to work (legacy candidate still in the set).
- [ ] Bundle smoke ``./test/smoke/run.sh`` green.

## Related

- D-11 v2: PR #939 (server-side permissive htu)
- D-11 v1: PR #938 (SDK auto-discover dpop.jwk sibling)
- D-9: PR #937 (PKI multi-worker race)