### PR TITLE
fix(sdk): chat_completion accepts kwargs-style call (D-8 OpenAI-compat)

### DIFF
--- a/cullis_sdk/_client/_ai_gateway.py
+++ b/cullis_sdk/_client/_ai_gateway.py
@@ -27,14 +27,56 @@ from typing import Iterator
 import httpx
 
 
+def _coerce_chat_request(request: dict | None, kwargs: dict) -> dict:
+    """Normalise the dict-or-kwargs call shape used by
+    :meth:`_AiGatewayMixin.chat_completion` and
+    :meth:`_AiGatewayMixin.chat_completion_stream`.
+
+    The historical signature accepted a single positional dict
+    (matching the audit-pinned request envelope). Cold-readers
+    familiar with the OpenAI / Anthropic SDK pattern naturally write
+    ``client.chat_completion(model="...", messages=[...])`` and got a
+    ``TypeError`` from the unexpected kwargs. This helper accepts
+    either form, rejects ambiguous "both at once" calls so a typo
+    cannot silently drop one half, and defends against non-dict
+    positional args (e.g. someone passing a string model name).
+    """
+    if request is not None and kwargs:
+        raise TypeError(
+            "chat_completion accepts either a request dict or kwargs, "
+            "not both. Pick one style."
+        )
+    if request is None:
+        request = kwargs
+    if not isinstance(request, dict):
+        raise TypeError(
+            f"chat_completion request must be a dict (or kwargs); "
+            f"got {type(request).__name__}"
+        )
+    return request
+
+
 class _AiGatewayMixin:
     """AI gateway egress, MCP aggregator and tool-call PDP on
     ``CullisClient``."""
 
     # ── ADR-017 — AI gateway egress ────────────────────────────────
-    def chat_completion(self, request: dict) -> dict:
+    def chat_completion(
+        self, request: dict | None = None, **kwargs
+    ) -> dict:
         """Forward an OpenAI-compatible chat completion to Mastio's
         ``/v1/llm/chat`` endpoint.
+
+        Accepts two equivalent calling conventions, the historical
+        dict-only form and the OpenAI / Anthropic SDK kwargs form::
+
+            client.chat_completion({"model": "...", "messages": [...]})
+            client.chat_completion(model="...", messages=[...])
+
+        Both shapes resolve to the same downstream request envelope.
+        Mixing them in a single call (passing ``request`` AND extra
+        kwargs) is rejected with ``TypeError`` so an ambiguous call
+        site does not silently drop one half.
 
         ``request`` is the OpenAI ChatCompletion body (model, messages,
         max_tokens, temperature). Returns the parsed response dict
@@ -54,12 +96,18 @@ class _AiGatewayMixin:
         body intact so callers can distinguish 401 (unauth), 502
         (gateway upstream), 504 (timeout), 501 (not implemented).
         """
+        request = _coerce_chat_request(request, kwargs)
         resp = self._egress_http("post", "/v1/llm/chat", json=request)
         resp.raise_for_status()
         return resp.json()
 
-    def chat_completion_stream(self, request: dict) -> Iterator[str]:
+    def chat_completion_stream(
+        self, request: dict | None = None, **kwargs
+    ) -> Iterator[str]:
         """Streaming variant of :meth:`chat_completion`.
+
+        Accepts the same dict-or-kwargs calling convention as
+        :meth:`chat_completion` (see that docstring for the rationale).
 
         Forces ``stream=True`` on the request and yields SSE frame
         strings exactly as they arrive from the Mastio, including
@@ -75,6 +123,7 @@ class _AiGatewayMixin:
         the marker can re-open the stream once with the fresh nonce.
         On any other status we surface immediately.
         """
+        request = _coerce_chat_request(request, kwargs)
         body = dict(request)
         body["stream"] = True
         path = "/v1/llm/chat"

--- a/test/unit/test_chat_completion_kwargs.py
+++ b/test/unit/test_chat_completion_kwargs.py
@@ -1,0 +1,123 @@
+"""Tests for the dict-or-kwargs calling convention on ``chat_completion``
+(D-8 OpenAI-compat fix).
+
+Pre-fix, ``CullisClient.chat_completion`` only accepted a single dict
+argument matching the audit-pinned request envelope::
+
+    client.chat_completion({"model": "...", "messages": [...]})
+
+Cold-readers used to the OpenAI / Anthropic / agent-SDK pattern copy
+snippets like ``client.chat_completion(model="...", messages=[...])``
+and hit ``TypeError: chat_completion() got an unexpected keyword
+argument 'model'`` on the first call. The dict-only signature is fine
+for the audit envelope but blocking the kwargs convention is needless
+friction.
+
+The fix accepts either shape, raises on ambiguous "both at once"
+calls, and routes both forms to the same ``_egress_http`` call so the
+downstream wire payload is unchanged. The tests below construct a
+minimal ``_AiGatewayMixin`` subclass with a recording stub for
+``_egress_http`` so we can assert payload equivalence without standing
+up TLS, DPoP or a live Mastio.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cullis_sdk._client._ai_gateway import _AiGatewayMixin
+
+
+class _StubClient(_AiGatewayMixin):
+    """Bare _AiGatewayMixin host that records ``_egress_http`` calls.
+
+    ``chat_completion`` is the only method exercised here, and it only
+    touches ``_egress_http`` on ``self`` (no DPoP / cert / nonce
+    plumbing required for the request-shape coercion path under test).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def _egress_http(self, method: str, path: str, **kwargs: Any):
+        self.calls.append((method, path, kwargs))
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"id": "chatcmpl-stub", "choices": []}
+        return resp
+
+
+def test_chat_completion_dict_style_works():
+    """The historical dict-positional form still produces the exact
+    same egress call as before the D-8 fix.
+    """
+    client = _StubClient()
+    request = {
+        "model": "claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    out = client.chat_completion(request)
+
+    assert out == {"id": "chatcmpl-stub", "choices": []}
+    assert len(client.calls) == 1
+    method, path, kwargs = client.calls[0]
+    assert method == "post"
+    assert path == "/v1/llm/chat"
+    assert kwargs["json"] == request
+
+
+def test_chat_completion_kwargs_style_works():
+    """The new OpenAI / Anthropic-style kwargs form produces an
+    identical wire payload to the dict form — same egress method,
+    path, and ``json`` body — so customers can pick either style.
+    """
+    client = _StubClient()
+
+    out = client.chat_completion(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert out == {"id": "chatcmpl-stub", "choices": []}
+    assert len(client.calls) == 1
+    method, path, kwargs = client.calls[0]
+    assert method == "post"
+    assert path == "/v1/llm/chat"
+    # Wire payload identical to the dict-style call above so the
+    # audit envelope, signing inputs and Mastio-side handling do not
+    # depend on which calling convention the customer picked.
+    assert kwargs["json"] == {
+        "model": "claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_chat_completion_both_dict_and_kwargs_raises():
+    """Mixing a positional dict with extra kwargs is ambiguous (which
+    half wins?) so the SDK refuses up front rather than silently
+    dropping one side. This catches typos like passing a dict and then
+    also overriding ``model="..."`` thinking it merges.
+    """
+    client = _StubClient()
+    with pytest.raises(TypeError, match="either a request dict or kwargs"):
+        client.chat_completion(
+            {"model": "claude-sonnet-4-6", "messages": []},
+            model="gpt-4o-mini",
+        )
+    assert client.calls == [], "no egress call should fire on ambiguous input"
+
+
+def test_chat_completion_non_dict_request_raises():
+    """Defensive: a non-dict positional (e.g. someone passing the
+    model name as a string, mirroring some quickstart copy-paste)
+    fails fast with a clear TypeError rather than blowing up later
+    inside the egress JSON serialiser with an opaque message.
+    """
+    client = _StubClient()
+    with pytest.raises(TypeError, match="must be a dict"):
+        client.chat_completion("claude-sonnet-4-6")  # type: ignore[arg-type]
+    assert client.calls == [], "no egress call should fire on non-dict input"


### PR DESCRIPTION
## Summary

Cold-reader dogfood finding D-8: `CullisClient.chat_completion` only accepted a single positional dict, so anyone copying the OpenAI / Anthropic / agent-SDK `model="...", messages=[...]` convention hit `TypeError: chat_completion() got an unexpected keyword argument 'model'` on the first call.

The dict-only signature is intentional for the audit-pinned request envelope, but rejecting the kwargs convention is needless friction for a confidence-killer first call.

- `chat_completion` and `chat_completion_stream` now accept either form via a shared `_coerce_chat_request` helper
- Mixing positional dict + kwargs in one call raises `TypeError` (ambiguous, refuses up front rather than silently dropping one half)
- Non-dict positional raises `TypeError` with a clear message instead of failing deep in the egress JSON serialiser
- 4 new unit tests pin both shapes, the ambiguous combo, and the non-dict defensive branch, asserting the wire payload is byte-identical across the two calling conventions

## Files

- `cullis_sdk/_client/_ai_gateway.py` (modified)
- `test/unit/test_chat_completion_kwargs.py` (new)

## Test plan

- [x] `python -m compileall -q cullis_sdk`
- [x] `pytest test/unit/test_chat_completion_kwargs.py -n auto --dist=loadfile` (4 passed)
- [x] `pytest test/unit/ -k chat_completion -n auto --dist=loadfile` (4 passed, no pre-existing test was matching the filter so no regression possible there)
- [x] `pytest test/unit/test_sdk_auto_login_mcp.py test/unit/test_from_identity_dir_dpop_autodiscovery.py test/unit/test_sdk_enroll_via_dashboard_approval.py -n auto --dist=loadfile` (24 passed, SDK auth + factory path still green)

Out of scope: bundle dogfood deferred (pure SDK Python change, no new HTTP route surface).