### PR TITLE
fix(dashboard): correct cert display in PKI + agent detail (A-1, A-9)

### DIFF
--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -227,6 +227,52 @@ async def agents_create(request: Request):
     ))
 
 
+def _summarise_agent_cert(cert_pem: str | None) -> dict | None:
+    """Parse the agent's stored cert PEM into a small dashboard summary.
+
+    Returns ``None`` when ``cert_pem`` is missing or the cert cannot be
+    parsed — callers treat that as "no cert" and render the empty
+    state. When the cert parses, the returned dict carries enough for
+    the operator to confirm at a glance which cert is bound to the
+    agent: SHA-256 thumbprint hex, CN, SHA-256 fingerprint colon-form,
+    not-after timestamp (UTC, ISO-8601 truncated to seconds).
+
+    A-9 root cause: ``_agent_row_to_dict`` never populated
+    ``cert_thumbprint`` (no column for it on ``internal_agents``), so
+    the template's ``{% if agent.cert_thumbprint %}`` was always
+    falsy and the page rendered "No cert" even for agents whose
+    handshake worked. We derive the thumbprint on-the-fly from the
+    ``cert_pem`` column instead.
+    """
+    if not cert_pem:
+        return None
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.x509.oid import NameOID
+
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        cn = cn_attrs[0].value if cn_attrs else ""
+        # SHA-256 fingerprint in colon-separated upper-hex (the form
+        # ``openssl x509 -fingerprint -sha256`` prints) so an operator
+        # can grep it against a CA-side audit line.
+        fp_bytes = cert.fingerprint(hashes.SHA256())
+        fingerprint = ":".join(f"{b:02X}" for b in fp_bytes)
+        # Plain SHA-256 hex for the existing template title= attribute
+        # and the "short" 24-char preview the page already renders.
+        thumbprint = fp_bytes.hex()
+        not_after = cert.not_valid_after_utc.isoformat()[:19]
+        return {
+            "thumbprint": thumbprint,
+            "fingerprint_sha256": fingerprint,
+            "subject_cn": cn,
+            "not_after": not_after,
+        }
+    except Exception:
+        return None
+
+
 @router.get("/agents/{agent_id:path}", response_class=HTMLResponse)
 async def agent_detail_page(request: Request, agent_id: str):
     session = require_login(request)
@@ -239,6 +285,17 @@ async def agent_detail_page(request: Request, agent_id: str):
     agent = await get_agent(agent_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+
+    # A-9: derive the cert summary from the stored PEM so the template
+    # can switch on a real signal instead of the never-populated
+    # ``cert_thumbprint`` field. Expose it under
+    # ``agent['cert_thumbprint']`` for back-compat with the existing
+    # template + a new ``agent['cert_summary']`` dict for the
+    # parsed-cert detail panel.
+    cert_summary = _summarise_agent_cert(agent.get("cert_pem"))
+    if cert_summary is not None:
+        agent["cert_thumbprint"] = cert_summary["thumbprint"]
+        agent["cert_summary"] = cert_summary
 
     # Fetch recent audit entries for this agent
     from sqlalchemy import text

--- a/mcp_proxy/dashboard/pki_routes.py
+++ b/mcp_proxy/dashboard/pki_routes.py
@@ -26,6 +26,7 @@ import pathlib
 from datetime import datetime, timezone
 
 from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509.oid import NameOID
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
@@ -52,6 +53,43 @@ templates = build_templates(_TEMPLATE_DIR)
 router = APIRouter(tags=["dashboard-pki"])
 
 
+# Map the OpenSSL/cryptography curve names to the user-friendly labels
+# that operators actually recognise on a CA cert ("P-256" instead of
+# "SECP256R1"). Unknown curves fall back to the uppercased curve name so
+# we never render an empty string.
+_EC_CURVE_LABELS: dict[str, str] = {
+    "secp256r1": "P-256",
+    "secp384r1": "P-384",
+    "secp521r1": "P-521",
+}
+
+
+def _format_key_algorithm(cert: x509.Certificate) -> str:
+    """Render the cert's public-key family + size for the PKI page.
+
+    The Org CA is EC P-256 since ADR-031, but the page used to
+    concatenate ``RSA-{key_size}`` unconditionally, producing the
+    nonsense label ``RSA-256`` on an EC cert. Branch on the actual
+    public-key object so EC and RSA each render correctly, and keep
+    a permissive fallback for anything else (DSA, Ed25519, …) so we
+    never blow up the dashboard over a label.
+    """
+    pubkey = cert.public_key()
+    # ``cert.public_key()`` always returns a *public* key, but accept
+    # the private-key types too so the helper stays useful if a caller
+    # ever passes the key directly (e.g. fresh ``generate_org_ca``
+    # output before the cert is written back to config).
+    if isinstance(pubkey, (ec.EllipticCurvePublicKey, ec.EllipticCurvePrivateKey)):
+        curve_name = pubkey.curve.name.lower()
+        label = _EC_CURVE_LABELS.get(curve_name, curve_name.upper())
+        return f"EC {label}"
+    if isinstance(pubkey, (rsa.RSAPublicKey, rsa.RSAPrivateKey)):
+        return f"RSA-{pubkey.key_size}"
+    # Unknown family — surface the class name so the operator at least
+    # sees something deterministic instead of "RSA-N/A".
+    return type(pubkey).__name__
+
+
 @router.get("/pki", response_class=HTMLResponse)
 async def pki_page(request: Request):
     session = require_login(request)
@@ -74,7 +112,6 @@ async def pki_page(request: Request):
                 is_ca = bc.value.ca
             except x509.ExtensionNotFound:
                 is_ca = False
-            key_size = cert.public_key().key_size if hasattr(cert.public_key(), "key_size") else "N/A"
             ca = {
                 "subject_cn": cn_attrs[0].value if cn_attrs else "N/A",
                 "organization": org_attrs[0].value if org_attrs else "N/A",
@@ -82,7 +119,7 @@ async def pki_page(request: Request):
                 "valid_from": cert.not_valid_before_utc.isoformat()[:19],
                 "valid_until": cert.not_valid_after_utc.isoformat()[:19],
                 "is_ca": is_ca,
-                "key_size": f"RSA-{key_size}" if isinstance(key_size, int) else key_size,
+                "key_size": _format_key_algorithm(cert),
                 "cert_pem": ca_cert_pem,
             }
         except Exception as exc:
@@ -189,11 +226,20 @@ async def pki_rotate_ca(request: Request):
     await set_config("org_ca_cert", cert_pem)
     await set_config("org_ca_key", key_pem)
 
+    # Render the new CA's algorithm label from the freshly minted cert so
+    # the audit trail tracks whatever ``generate_org_ca`` actually
+    # produced (ADR-031 = EC P-256). The legacy ``RSA-4096`` literal
+    # here was already wrong post-ADR-031 even before A-1 surfaced it.
+    try:
+        _new_ca_cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        _new_ca_algo = _format_key_algorithm(_new_ca_cert)
+    except Exception:
+        _new_ca_algo = "unknown"
     await log_audit(
         agent_id="admin",
         action="ca.rotate",
         status="success",
-        detail=f"org_id={org_id}, new self-signed RSA-4096. All agent certs need re-issue.",
+        detail=f"org_id={org_id}, new self-signed {_new_ca_algo}. All agent certs need re-issue.",
     )
 
     # Store in Vault if configured

--- a/mcp_proxy/dashboard/templates/agent_detail.html
+++ b/mcp_proxy/dashboard/templates/agent_detail.html
@@ -90,13 +90,27 @@
         <!-- Certificate status -->
         <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
             <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">Certificate</h3>
-            {% if agent.cert_thumbprint %}
-            <div class="flex items-center gap-3">
+            {% if agent.cert_summary %}
+            <div class="flex items-center gap-3 mb-4">
                 <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
                     Issued
                 </span>
                 <span class="text-xs text-gray-500 font-mono" title="{{ agent.cert_thumbprint }}">{{ agent.cert_thumbprint[:24] }}...</span>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Subject CN</p>
+                    <p class="text-xs text-gray-300 font-mono break-all">{{ agent.cert_summary.subject_cn or '—' }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">SHA-256 Fingerprint</p>
+                    <p class="text-xs text-gray-400 font-mono truncate" title="{{ agent.cert_summary.fingerprint_sha256 }}">{{ agent.cert_summary.fingerprint_sha256[:35] }}…</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Not After</p>
+                    <p class="text-xs text-gray-300 font-mono">{{ agent.cert_summary.not_after }}</p>
+                </div>
             </div>
             {% else %}
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Two confidence-killer UI bugs surfaced by the 2026-05-25 cold-reader dogfood (session 3).

- **A-1 PKI page rendered "RSA-256" on an EC P-256 Org CA.** `pki_routes.py` concatenated `RSA-{key_size}` unconditionally; `key_size` from `cert.public_key()` returns the bit-size of *whatever* key family it is, so an EC P-256 cert came out as `RSA-256`. Now branches on the public-key family via a new `_format_key_algorithm` helper, mapping `secp{256,384,521}r1` to the operator-friendly `P-256 / P-384 / P-521` labels and keeping the historical `RSA-{key_size}` shape for RSA. The stale `RSA-4096` literal in the `ca.rotate` audit detail is also derived from the new cert now (was wrong post-ADR-031 too).
- **A-9 agent detail page rendered "No cert" on agents with valid certs.** Template checked `agent.cert_thumbprint`, but `_agent_row_to_dict` in `db.py` never populates that key (there is no `cert_thumbprint` column on `internal_agents`; the comment on `cert_thumbprint_from_pem` notes callers derive it on-the-fly). Added `_summarise_agent_cert(cert_pem)` in `agents_routes.py` that parses the stored PEM and returns `thumbprint`, colon-separated `fingerprint_sha256`, `subject_cn`, and `not_after`. The route now populates `agent['cert_thumbprint']` for back-compat with the existing template and adds a small `agent['cert_summary']` panel (CN, fingerprint short, not-after) so the operator can confirm at a glance which cert is bound.

## Files changed

- `mcp_proxy/dashboard/pki_routes.py` — `_format_key_algorithm` helper, EC/RSA branch, `ca.rotate` audit detail derived from cert.
- `mcp_proxy/dashboard/agents_routes.py` — `_summarise_agent_cert` helper, populate `cert_thumbprint` + `cert_summary` on the route ctx.
- `mcp_proxy/dashboard/templates/agent_detail.html` — switch the `{% if %}` to `agent.cert_summary` and render the parsed-cert panel.

Scope kept tight to `mcp_proxy/dashboard/` (sub_routers + templates) per task brief. No touch to `cullis_sdk/`, `packaging/`, `mcp_proxy/auth/`, `mcp_proxy/egress/`, README, CHANGELOG.

## Test plan

- [x] `python -m compileall -q mcp_proxy` — clean
- [x] `pytest test/unit/ -k "dashboard or pki or agent" -n auto --dist=loadfile` — 23 passed
- [x] Jinja parse of `pki.html` + `agent_detail.html` — OK
- [x] Inline smoke of `_format_key_algorithm` on EC P-256 / EC P-384 / RSA-2048 certs — labels correct
- [x] Inline smoke of `_summarise_agent_cert` on None / empty / garbage / valid EC PEM — None for invalid, full dict for valid
- [ ] Visual verify on the dogfood VM post-merge (operator will confirm the screenshots flip from "RSA-256" → "EC P-256" and "No cert" → cert summary panel)

## Out of scope

- Persisting `cert_thumbprint` to the `internal_agents` schema (ADR-010 Phase 6b explicitly decided to keep it derived; we follow that decision).
- Backfilling parsed cert details into the `list_agents` table view — only the detail page was reported broken.