### PR TITLE
chore(release): bump mastio v0.5.4.1 cold-reader polish patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ flow until the next `## ` heading.
 
 ## [Unreleased]
 
+## [v0.5.4.1] — Cold-reader polish patch — 2026-05-26
+
+Three confidence-killer bug fixes between v0.5.4 release this morning and the public Show HN announce this evening:
+
+- **A-1** dashboard PKI page rendered `Key Size: RSA-256` on the Org CA which is EC P-256 (#944). The `f"RSA-{key_size}"` formatter was wrong for any non-RSA key; `key.key_size` returns the bit-size for every key family (256 for P-256, 4096 for RSA-4096). The new `_format_key_algorithm()` helper inspects the public-key class and renders `EC P-256` (or P-384, P-521) for EC keys and `RSA-{bits}` for RSA keys. Same helper used by the `ca.rotate` audit detail (was hard-coded `RSA-4096`).
+- **A-9** dashboard agent detail rendered `CERTIFICATE: No cert` for agents whose cert was valid and verifiable via mTLS (#944). The template was checking `agent.cert_thumbprint` but `_agent_row_to_dict()` never populated that key (no DB column, derive-from-PEM only). The route now passes a parsed `cert_summary` dict (CN, SHA-256 fingerprint, not-after) and the template renders a 3-column grid under the `Issued` badge.
+- **D-8** `client.chat_completion(model=..., messages=...)` raised `TypeError` because the SDK accepted only a dict argument (#943). Cold-readers familiar with the OpenAI / Anthropic SDK pattern hit this on the first call. Signature now accepts either form (dict OR kwargs), routes both to the same downstream egress call, raises on the ambiguous "both at once" combo. 4 new unit tests pin the behaviour.
+
+No other changes from v0.5.4.
 ## [v0.5.4] — Cold-reader dogfood cascade (PKI race + SDK enrol factory + DPoP htu binding) — 2026-05-26
 
 The 2026-05-25 cold-reader dogfood on a fresh-install Mastio bundle exposed six blocking gaps between the operator handing the bundle to a developer and the developer's first chat reply. Five close in v0.5.4 so the open-source path is green end-to-end: `tar xz | ./deploy.sh | SDK enrol | chat reply` on a vanilla Linux laptop, without manually editing `proxy.env`.
@@ -329,6 +338,7 @@ The 2026-05-25 cold-reader dogfood on a fresh-install Mastio bundle exposed six 
   and the operator-side troubleshooting matrix (`POSTGRES_PASSWORD`
   missing, orphan SQLite guard, stuck Alembic advisory lock).
 
+[v0.5.4.1]: https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.4.1
 [v0.5.4]: https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.4
 [v0.5.3]: https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.3
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pull the Mastio bundle, set an Anthropic key, enroll an agent, install the SDK, 
 
 ```bash
 # 1. Pull and deploy the Mastio bundle.
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.4/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.5.4.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Enable chat by setting an Anthropic key in proxy.env, then restart.
@@ -160,7 +160,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 
 | Component | Latest | What it is |
 |---|---|---|
-| **Cullis Mastio** | [`mastio-v0.5.4`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.4) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
+| **Cullis Mastio** | [`mastio-v0.5.4.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.4.1) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
 | **Cullis SDK** | [`cullis-sdk 0.1.3`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file) and `from_systemd_credentials` (Linux production tmpfs delivery) |
 
 Use Cullis in evaluation, integration, and internal deploys. Talk to us before putting it in front of regulated production traffic.


### PR DESCRIPTION
## Summary

Three confidence-killer bug fixes between v0.5.4 release this morning and the public Show HN announce this evening:

- **A-1** dashboard PKI key algorithm display (#944)
- **A-9** dashboard agent detail cert summary (#944)
- **D-8** SDK `chat_completion` kwargs-style support (#943)

No other changes from v0.5.4. Same bundle layout, same image schema; rolling forward is a `docker pull` plus a `deploy.sh` restart.

## Test plan

- [x] CI syntax + repo metadata sanity (auto)
- [ ] Cold-reader dogfood VM re-test post-merge (admin signup → enroll → chat) with screenshots showing the fixed dashboard
- [ ] Asciinema re-record with the cleaner dashboard