### PR TITLE
fix(dashboard+bundle): batch 5 cosmetic dogfood findings (D-10, A-2, A-4, A-5, B-1)

### DIFF
--- a/mcp_proxy/dashboard/badges_routes.py
+++ b/mcp_proxy/dashboard/badges_routes.py
@@ -147,8 +147,15 @@ async def badge_audit(request: Request):
         count = row["cnt"] if row else 0
 
     if count:
+        # A-2 dogfood fix: explicit ``title`` so the operator knows the
+        # sidebar badge is a 1-hour rolling count, not the lifetime row
+        # count on /proxy/audit or the chain-verify "N entries"
+        # output. Different slices of the same table; the tooltip pins
+        # which one this number measures.
         return HTMLResponse(
-            f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-teal-500/20 text-teal-400">{count}</span>'
+            f'<span class="px-1.5 py-0.5 rounded-full text-xs '
+            f'bg-teal-500/20 text-teal-400" '
+            f'title="Audit events in the last hour">{count}</span>'
         )
     return HTMLResponse("")
 

--- a/mcp_proxy/dashboard/core_routes.py
+++ b/mcp_proxy/dashboard/core_routes.py
@@ -357,6 +357,28 @@ async def overview_page(request: Request):
         for a in (local_agents or [])[:3]
     ]
 
+    # A-5 dogfood fix: server-rendered update-available banner.
+    # ``base.html`` already mounts the HTMX banner at
+    # ``/proxy/api/update-status``, but a slow link / disabled JS / HTMX
+    # endpoint failure swallows the advisory silently. The overview
+    # landing page is the operator's first stop after login, so render
+    # a lightweight banner inline from the same cached values. Safe:
+    # ``get_update_status`` is a DB read with no GitHub call when the
+    # cache is fresh (24h window), and the helper already nulls the
+    # latest tag if it fails the safe-character class.
+    update_available = False
+    current_version = ""
+    latest_version = ""
+    try:
+        from mcp_proxy.dashboard.update_check import get_update_status
+        _status = await get_update_status()
+        update_available = bool(_status.available)
+        current_version = _status.current or ""
+        latest_version = _status.latest or ""
+    except Exception:
+        # Never block overview render on the advisory subsystem.
+        pass
+
     return templates.TemplateResponse("overview.html", _ctx(
         request, session,
         active="overview",
@@ -377,4 +399,7 @@ async def overview_page(request: Request):
         binding_active=binding_active,
         recent_agents=recent_agents,
         recent_backends=recent_backends,
+        update_available=update_available,
+        current_version=current_version,
+        latest_version=latest_version,
     ))

--- a/mcp_proxy/dashboard/templates/audit.html
+++ b/mcp_proxy/dashboard/templates/audit.html
@@ -17,19 +17,27 @@
             </p>
         </div>
 
-        <!-- Counter chip: Total · Admin · Traffic -->
+        <!-- Counter chip: Total · Admin · Traffic
+             A-2 dogfood fix: explicit ``title=...`` tooltips so the operator
+             can hover any number and learn what it measures. Pre-fix the
+             three counters (sidebar /badge/audit, header total, chain-verify
+             "N entries") looked like the same metric drifting; they are
+             distinct slices of the audit table and the tooltip says which. -->
         <div class="flex items-center gap-0 flex-shrink-0 border border-gray-800/60 rounded-md overflow-hidden bg-surface-900/60 backdrop-blur-sm">
-            <div class="px-3 py-1.5 flex items-center gap-2">
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="{% if view_mode == 'grouped' %}Grouped tool-call cards on this page (one card = one policy decision + executor + egress).{% else %}Raw audit-log rows after the current filter; matches the SELECT COUNT(*) of the table you are viewing.{% endif %}">
                 <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">{% if view_mode == 'grouped' %}Tool calls{% else %}Events{% endif %}</span>
                 <span class="text-sm font-mono text-white">{{ total }}</span>
             </div>
             <div class="w-px h-5 bg-gray-800/80 self-center"></div>
-            <div class="px-3 py-1.5 flex items-center gap-2">
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="Admin-source events in the current filter (dashboard actions, agent lifecycle, policy edits, enrollment approvals).">
                 <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-blue-400/80">Admin</span>
                 <span class="text-sm font-mono text-blue-400">{{ admin_total }}</span>
             </div>
             <div class="w-px h-5 bg-gray-800/80 self-center"></div>
-            <div class="px-3 py-1.5 flex items-center gap-2">
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="Traffic-source events in the current filter (oneshot deliveries, MCP tool calls, agent egress, session activity).">
                 <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-accent-400/80">Traffic</span>
                 <span class="text-sm font-mono text-accent-400">{{ traffic_total }}</span>
             </div>
@@ -459,8 +467,12 @@
                   '<svg class="w-5 h-5 text-emerald-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>' +
                   '<div class="flex-1 min-w-0">' +
                     '<p class="text-sm font-semibold text-emerald-400 uppercase tracking-wider">Chain verified</p>' +
-                    '<p class="text-[12px] text-gray-300 mt-1 font-mono">' +
-                      escapeHtml(data.entries) + ' entries · ' +
+                    '<p class="text-[12px] text-gray-300 mt-1 font-mono" ' +
+                      'title="Hash-chained rows actually verified end-to-end. ' +
+                      'Smaller than the header Events counter because admin-only rows ' +
+                      'with no chain participation are excluded, and the badge in the ' +
+                      'sidebar is a rolling 1-hour count.">' +
+                      escapeHtml(data.entries) + ' chained entries verified · ' +
                       escapeHtml(data.agents) + ' agent' + (data.agents === 1 ? '' : 's') + ' · ' +
                       escapeHtml(data.orgs) + ' org' + (data.orgs === 1 ? '' : 's') + ' · ' +
                       escapeHtml(data.legacy_chain_rows) + ' legacy · ' +

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -61,6 +61,25 @@
 
 <div class="max-w-6xl space-y-6">
 
+    {# A-5 dogfood fix: server-rendered update-available banner.
+       The HTMX banner in base.html (#update-status-banner) still fires
+       and provides the rich expandable instructions, but it depends on
+       JS + an extra round-trip. This server-rendered banner appears
+       immediately on overview page-load so an operator on a slow link
+       or with HTMX failing for any reason still sees the advisory. #}
+    {% if update_available %}
+    <div class="p-3 bg-amber-500/10 border border-amber-500/40 rounded text-sm text-amber-300 flex items-center gap-2">
+        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        <span>
+            Mastio update available:
+            <code class="font-mono text-amber-200">{{ current_version }}</code>
+            &rarr;
+            <code class="font-mono text-amber-200">{{ latest_version }}</code>
+            (<a href="/proxy/updates" class="underline hover:text-amber-200">view changelog</a>)
+        </span>
+    </div>
+    {% endif %}
+
     <!-- Org identity card -->
     <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
         <div class="flex items-start justify-between mb-4">

--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -73,6 +73,32 @@ _log = logging.getLogger("mcp_proxy.dashboard.updates")
 router = APIRouter(prefix="/proxy/updates", tags=["dashboard", "updates"])
 
 
+# A-4 dogfood fix: a customer mistypes the URL as ``/proxy/update``
+# (singular) and gets FastAPI's bare ``{"detail":"Not Found"}`` JSON
+# instead of the dashboard 404. The alias router below catches the
+# singular form and 301-redirects to the canonical plural path so the
+# typo lands on the right page rather than a confusing JSON blob.
+# Kept on a dedicated APIRouter (no prefix) so it sits next to the
+# canonical ``/proxy/updates`` tree in ``main.py`` ``include_router``
+# but does not inherit the plural prefix.
+alias_router = APIRouter(tags=["dashboard", "updates"])
+
+
+@alias_router.get("/proxy/update", include_in_schema=False)
+async def _redirect_singular_to_plural(request: Request) -> RedirectResponse:
+    """Permanent redirect ``/proxy/update`` → ``/proxy/updates``.
+
+    Preserves any query string so a hand-crafted link with filters or
+    flash params survives the redirect. ``301`` (vs ``308``) so naive
+    HTTP clients that downgrade POST → GET on redirect still land
+    correctly; the singular form is never a legitimate mutation
+    target.
+    """
+    qs = request.url.query
+    target = "/proxy/updates" + (f"?{qs}" if qs else "")
+    return RedirectResponse(target, status_code=301)
+
+
 _APPLY_CONFIRM = "APPLY"
 _ROLLBACK_CONFIRM = "ROLLBACK"
 

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -138,7 +138,19 @@ async def start_enrollment(
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
 
-    base = str(request.base_url).rstrip("/")
+    # B-1 dogfood fix: prefer ``settings.proxy_public_url`` (which
+    # carries the operator-visible ``:9443`` of the nginx sidecar) over
+    # ``request.base_url`` (which, inside the uvicorn container behind
+    # nginx, resolves to ``http://mcp-proxy:8080/`` — missing scheme,
+    # missing port, missing public hostname). The Connector polls the
+    # ``poll_url`` literally; an internal URL would either fail DNS or
+    # land on a port the host machine cannot reach.
+    from mcp_proxy.config import get_settings as _get_settings_for_base
+    _public = (_get_settings_for_base().proxy_public_url or "").rstrip("/")
+    if _public:
+        base = _public
+    else:
+        base = str(request.base_url).rstrip("/")
     logger.info(
         "enrollment_started",
         extra={

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -2393,8 +2393,15 @@ app.include_router(downloads_router)
 
 # Federation update framework (PR 4 of imp/federation_hardening_plan.md
 # Parte 1) — admin list / apply / rollback under /proxy/updates.
-from mcp_proxy.dashboard.updates_router import router as updates_router
+from mcp_proxy.dashboard.updates_router import (
+    alias_router as updates_alias_router,
+    router as updates_router,
+)
 app.include_router(updates_router)
+# A-4 dogfood fix: ``/proxy/update`` (singular) 301 → ``/proxy/updates``
+# so a customer typo lands on the dashboard page instead of FastAPI's
+# bare ``{"detail":"Not Found"}`` JSON response.
+app.include_router(updates_alias_router)
 
 # Enterprise plugin routers. Mounted after every core router so a
 # plugin can never shadow a core endpoint by registering a conflicting

--- a/packaging/_common-deploy-helpers.sh
+++ b/packaging/_common-deploy-helpers.sh
@@ -120,17 +120,22 @@ _wipe_bind_dirs() {
     # Build the docker mount list + the in-container paths to wipe.
     # Each host dir is mounted at /wipe<N>; we only wipe contents
     # (``/wipe<N>/.`` glob) so the dir itself survives.
+    #
+    # D-10 dogfood fix: we do NOT use a host-side ``compgen`` empty
+    # check anymore. After init-permissions runs, ``data/`` is owned by
+    # uid 10001 mode 0700; a host operator with a different uid sees an
+    # empty listing even when ``mcp_proxy.db`` is sitting inside, and
+    # the old short-circuit silently skipped the docker wipe. The
+    # busybox ``find ... -delete`` call below is already idempotent on
+    # an empty mount, so we just always mount + always run it. The two
+    # extra docker argv args on a fresh-install ``--down --wipe-data``
+    # are cheaper than the failure mode (operator runs ``--wipe-data``,
+    # gets ``OK``, ``mcp_proxy.db`` survives, next ``./deploy.sh up``
+    # boots into the stale DB instead of a fresh Org CA).
     local idx=0
     for dir in "$@"; do
         [[ -n "$dir" ]] || continue
         [[ -d "$dir" ]] || continue
-        # Empty dir → skip both the mount and the rm to keep the
-        # docker argv short on a fresh-install down.
-        if ! compgen -G "$dir/*" >/dev/null 2>&1 \
-                && ! compgen -G "$dir/.[!.]*" >/dev/null 2>&1 \
-                && ! compgen -G "$dir/..?*" >/dev/null 2>&1; then
-            continue
-        fi
         mount_args+=( -v "$dir:/wipe$idx" )
         rm_paths+=( "/wipe$idx" )
         any_wiped=1

--- a/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
+++ b/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
@@ -1,0 +1,450 @@
+"""Cosmetic-batch dogfood fixes from session 3 + session current.
+
+Five low-impact findings batched into one PR because each is a few
+lines and shares the same risk profile (template / view-context
+tweaks, plus one bundle shell helper):
+
+* D-10 — ``deploy.sh --down --wipe-data`` skipped the busybox wipe
+  when the host operator could not list the bind-dir contents (mode
+  0700 owned by uid 10001 post init-permissions). Fix: drop the
+  host-side ``compgen`` empty check, always mount + always run the
+  idempotent ``find -delete``.
+* A-2 — audit counters across sidebar badge, header chip, chain-verify
+  banner, and DB row count looked like the same metric drifting. Fix:
+  add explicit ``title`` tooltips on every counter so each says what
+  it measures.
+* A-4 — typo ``/proxy/update`` (singular) returned
+  ``{"detail":"Not Found"}`` JSON instead of the dashboard page. Fix:
+  301 redirect to ``/proxy/updates``.
+* A-5 — overview landing page did not surface an update-available
+  advisory when the cached ``update_check_latest_tag`` was newer than
+  the running version. The HTMX banner in ``base.html`` already fires,
+  but a server-rendered inline banner gives the operator the advisory
+  even with HTMX failing. Fix: populate ``update_available`` +
+  ``current_version`` + ``latest_version`` on the overview view ctx
+  and add a conditional banner near the top of ``overview.html``.
+* B-1 — enrollment start response ``poll_url`` stripped the operator
+  ``:9443`` port because it was derived from ``request.base_url``
+  (which inside the uvicorn container resolves to the internal
+  ``http://mcp-proxy:8080/``). Fix: prefer
+  ``settings.proxy_public_url`` over ``request.base_url``.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment.router import router as enrollment_router
+
+
+# ────────────────────────────────────────────────────────────────────
+# D-10 — ``_wipe_bind_dirs`` always mounts + runs busybox find -delete
+# ────────────────────────────────────────────────────────────────────
+
+
+_HELPERS_SH = (
+    Path(__file__).resolve().parents[2]
+    / "packaging"
+    / "_common-deploy-helpers.sh"
+)
+
+
+def test_d10_wipe_bind_dirs_no_compgen_short_circuit() -> None:
+    """The ``_wipe_bind_dirs`` body must NOT short-circuit on a host
+    ``compgen`` listing.
+
+    Pre-fix the function used ``compgen -G "$dir/*"`` (plus dotfile
+    variants) to skip the docker mount + wipe on "empty" dirs. On a
+    bundle deployed via ``./deploy.sh`` the data dir gets chowned to
+    uid 10001 mode 0700 by the init-permissions service; an operator
+    invoking ``./deploy.sh --down --wipe-data`` from their own uid
+    sees an empty listing through ``compgen`` even when
+    ``mcp_proxy.db`` is sitting inside, and the wipe never ran.
+
+    The fix removes the compgen probe entirely (busybox
+    ``find -mindepth 1 -delete`` is already idempotent on an empty
+    mount, so the short-circuit was an unnecessary optimisation that
+    hid a permissions footgun). Pinning the absence so a future
+    cleanup does not re-introduce it.
+    """
+    body = _HELPERS_SH.read_text()
+    # ``_wipe_bind_dirs`` is the function we care about; bound the
+    # inspection to its body so the unrelated comment in
+    # ``_wipe_orphan_sqlite`` does not poison the assertion.
+    m = re.search(
+        r"_wipe_bind_dirs\(\)\s*\{(.*?)\n\}\n",
+        body,
+        re.DOTALL,
+    )
+    assert m, "_wipe_bind_dirs() not found in _common-deploy-helpers.sh"
+    fn = m.group(1)
+    # Strip ``# ...`` shell comments so the rationale comment that
+    # MENTIONS compgen (to explain why it was removed) does not trip
+    # the assertion. We care about live code, not prose.
+    fn_no_comments = "\n".join(
+        re.sub(r"#.*$", "", line) for line in fn.splitlines()
+    )
+    assert "compgen" not in fn_no_comments, (
+        "_wipe_bind_dirs must not call compgen on host dirs (D-10): "
+        "permission-bound listing silently skips the wipe."
+    )
+    # Sanity: the function still uses busybox + find -delete to do the
+    # actual work. If a future refactor swaps it out we want this test
+    # to fail loudly so the replacement is considered consciously.
+    assert "busybox" in fn
+    assert "find" in fn and "-delete" in fn
+
+
+def test_d10_wipe_bind_dirs_documents_d10() -> None:
+    """The fix carries an inline ``D-10`` reference so the next reader
+    sees why the old optimisation was removed and does not "restore"
+    it during a cleanup sweep. The comment is the most reliable
+    forward-looking guard for this category of regression.
+    """
+    body = _HELPERS_SH.read_text()
+    m = re.search(
+        r"_wipe_bind_dirs\(\)\s*\{(.*?)\n\}\n",
+        body,
+        re.DOTALL,
+    )
+    assert m
+    fn = m.group(1)
+    assert "D-10" in fn, "Inline D-10 marker missing in _wipe_bind_dirs body"
+
+
+# ────────────────────────────────────────────────────────────────────
+# A-2 — audit counter tooltips
+# ────────────────────────────────────────────────────────────────────
+
+
+_AUDIT_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "mcp_proxy" / "dashboard" / "templates" / "audit.html"
+)
+_BADGES_PY = (
+    Path(__file__).resolve().parents[2]
+    / "mcp_proxy" / "dashboard" / "badges_routes.py"
+)
+
+
+def test_a2_audit_template_counters_have_titles() -> None:
+    """Each of the three header counters (Events/Tool calls, Admin,
+    Traffic) carries an explicit ``title=...`` tooltip explaining what
+    it measures. Pre-fix the three numbers looked like the same metric
+    drifting; the tooltips pin which slice of ``audit_log`` each one
+    counts.
+    """
+    body = _AUDIT_TEMPLATE.read_text()
+    # The labels live in three sibling ``<div>`` blocks; assert each
+    # neighbouring label sits next to a title attribute that mentions
+    # the expected scope keyword.
+    assert 'title="Admin-source events' in body
+    assert 'title="Traffic-source events' in body
+    # The first counter swaps between "Tool calls" (grouped view) and
+    # "Events" (raw view); the tooltip must cover both via a Jinja
+    # conditional. Match on the umbrella phrasing.
+    assert 'Grouped tool-call cards on this page' in body
+    assert 'Raw audit-log rows after the current filter' in body
+
+
+def test_a2_audit_template_verify_banner_clarifies_entries() -> None:
+    """The chain-verify success banner used to say "N entries"
+    ambiguously — operators read it as the lifetime row count of
+    ``audit_log`` and were confused when it differed from the header
+    Events counter (filter-scoped) and the sidebar badge (1-hour
+    rolling). The clarified copy + tooltip explains why these three
+    numbers are different.
+    """
+    body = _AUDIT_TEMPLATE.read_text()
+    assert "chained entries verified" in body
+    assert "Hash-chained rows actually verified end-to-end" in body
+    assert "rolling 1-hour count" in body
+
+
+def test_a2_badge_audit_has_tooltip() -> None:
+    """The sidebar ``/proxy/badge/audit`` HTMX fragment renders a small
+    pill with the count; pre-fix it had no tooltip and looked
+    indistinguishable from the header counter. The fix adds
+    ``title="Audit events in the last hour"`` so a hover answers the
+    "what does this number mean" question without crossing to
+    ``/proxy/audit``.
+    """
+    body = _BADGES_PY.read_text()
+    # Bound the inspection to the ``badge_audit`` handler so we do not
+    # accidentally match an unrelated title attribute elsewhere.
+    m = re.search(
+        r"async def badge_audit\([^)]*\):(.*?)(?=\n@router\.|\nasync def |\Z)",
+        body,
+        re.DOTALL,
+    )
+    assert m, "badge_audit handler not found"
+    fn = m.group(1)
+    assert 'title="Audit events in the last hour"' in fn
+
+
+# ────────────────────────────────────────────────────────────────────
+# A-4 — ``/proxy/update`` (singular) 301 → ``/proxy/updates``
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_a4_singular_update_path_redirects_to_plural() -> None:
+    """GET ``/proxy/update`` returns ``301`` with
+    ``Location: /proxy/updates``. The redirect lives on a sibling
+    APIRouter (``alias_router``) so it can be mounted without
+    inheriting the canonical ``/proxy/updates`` prefix.
+    """
+    from mcp_proxy.dashboard.updates_router import alias_router
+
+    app = FastAPI()
+    app.include_router(alias_router)
+    client = TestClient(app, follow_redirects=False)
+    r = client.get("/proxy/update")
+    assert r.status_code == 301, r.text
+    assert r.headers.get("location") == "/proxy/updates"
+
+
+def test_a4_singular_update_path_preserves_query_string() -> None:
+    """A hand-crafted link like ``/proxy/update?flash=ok`` should
+    survive the redirect with the query string attached so the
+    plural-form page can read its flash params normally. Pinning the
+    query-preserve behaviour because dropping it would break operator
+    bookmarks silently.
+    """
+    from mcp_proxy.dashboard.updates_router import alias_router
+
+    app = FastAPI()
+    app.include_router(alias_router)
+    client = TestClient(app, follow_redirects=False)
+    r = client.get("/proxy/update?flash=applied&x=1")
+    assert r.status_code == 301
+    assert r.headers.get("location") == "/proxy/updates?flash=applied&x=1"
+
+
+# ────────────────────────────────────────────────────────────────────
+# A-5 — overview server-rendered update banner
+# ────────────────────────────────────────────────────────────────────
+
+
+_OVERVIEW_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "mcp_proxy" / "dashboard" / "templates" / "overview.html"
+)
+_CORE_ROUTES_PY = (
+    Path(__file__).resolve().parents[2]
+    / "mcp_proxy" / "dashboard" / "core_routes.py"
+)
+
+
+def test_a5_overview_template_carries_conditional_banner() -> None:
+    """``overview.html`` renders an inline update-available banner when
+    ``update_available`` is truthy. The banner is the server-rendered
+    fallback for the HTMX advisory in ``base.html``; both fire on the
+    same cached values but the inline one is visible even when JS /
+    HTMX is failing.
+    """
+    body = _OVERVIEW_TEMPLATE.read_text()
+    assert "{% if update_available %}" in body
+    assert "Mastio update available" in body
+    assert "{{ current_version }}" in body
+    assert "{{ latest_version }}" in body
+    # The "view changelog" link must land on the canonical plural form;
+    # the singular ``/proxy/update`` would 301 and add an extra round
+    # trip for no reason.
+    assert 'href="/proxy/updates"' in body
+
+
+def test_a5_overview_view_passes_update_context_vars() -> None:
+    """The ``overview_page`` handler in ``core_routes.py`` must pass
+    ``update_available`` + ``current_version`` + ``latest_version``
+    into the template context, derived from
+    ``mcp_proxy.dashboard.update_check.get_update_status``. Without
+    these three keys the template's conditional renders nothing even
+    when the cache says an update is available.
+    """
+    body = _CORE_ROUTES_PY.read_text()
+    # The handler must import get_update_status (lazily is fine — we
+    # match the function name appearing somewhere in the file body).
+    assert "get_update_status" in body
+    assert "update_available=update_available" in body
+    assert "current_version=current_version" in body
+    assert "latest_version=latest_version" in body
+
+
+# ────────────────────────────────────────────────────────────────────
+# B-1 — enrollment poll_url honours settings.proxy_public_url
+# ────────────────────────────────────────────────────────────────────
+
+
+_TEST_PUBLIC_URL = "https://mastio.acme.example.com:9443"
+
+
+@pytest_asyncio.fixture
+async def enrollment_proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite + the full alembic chain via ``init_db``.
+
+    Same shape as
+    ``test_enrollment_status_hint_on_missing_proof.proxy_db`` — the
+    enrollment table needs the migration-driven schema (its column
+    list drifts from ``metadata.create_all``).
+
+    Also sets ``MCP_PROXY_PROXY_PUBLIC_URL`` to the operator-visible
+    ``:9443`` URL so the B-1 fix path is exercised end-to-end.
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-b1")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", _TEST_PUBLIC_URL)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "enroll_b1.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(enrollment_router)
+    return app
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def _ec_keypair_with_pop() -> tuple[str, str]:
+    """Generate an EC P-256 keypair and return ``(pubkey_pem,
+    pop_signature)`` over the canonical ``enrollment-pop:v1|<fp>``
+    string.
+
+    Mirrors what the SDK does on
+    ``CullisClient.enroll_via_dashboard_approval``: ECDSA-SHA256 over
+    the fingerprint-bound canonical, base64url-encoded.
+    """
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pubkey_pem = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    der = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fingerprint = hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fingerprint}".encode()
+    sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    return pubkey_pem, _b64u(sig)
+
+
+def _ec_dpop_jwk() -> dict:
+    """Minimal valid EC P-256 JWK for the start payload."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+
+    def _b64u_int(n: int) -> str:
+        return _b64u(n.to_bytes(32, "big"))
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _b64u_int(nums.x),
+        "y": _b64u_int(nums.y),
+    }
+
+
+@pytest.mark.asyncio
+async def test_b1_enrollment_poll_url_carries_public_port(
+    enrollment_proxy_db,
+) -> None:
+    """The enrollment start response ``poll_url`` must include
+    ``:9443`` (the operator-set public port from
+    ``MCP_PROXY_PROXY_PUBLIC_URL``).
+
+    Pre-fix the URL was derived from ``request.base_url`` which inside
+    the uvicorn container resolves to ``http://mcp-proxy:8080/`` —
+    Connector polls would land on the wrong port (and the wrong
+    hostname), so enrollment never completed end-to-end.
+    """
+    pubkey_pem, pop_sig = _ec_keypair_with_pop()
+    payload = {
+        "pubkey_pem": pubkey_pem,
+        "pop_signature": pop_sig,
+        "requester_name": "Alice",
+        "requester_email": "alice@example.com",
+        "reason": "B-1 regression pin",
+        "dpop_jwk": _ec_dpop_jwk(),
+    }
+
+    client = TestClient(_make_app())
+    r = client.post("/v1/enrollment/start", json=payload)
+    assert r.status_code == 201, r.text
+    body = r.json()
+    poll_url = body.get("poll_url", "")
+    enroll_url = body.get("enroll_url", "")
+
+    # Both URLs use the public hostname + port, not the internal
+    # uvicorn socket. The :9443 carry-through is the load-bearing
+    # check (the host string is also part of the public URL so it
+    # comes along for free, but the port is what the operator
+    # noticed dropping in the dogfood session).
+    assert poll_url.startswith(_TEST_PUBLIC_URL + "/"), (
+        f"poll_url should start with {_TEST_PUBLIC_URL!r}, got {poll_url!r}"
+    )
+    assert ":9443/" in poll_url, (
+        f"poll_url must carry the public :9443 port, got {poll_url!r}"
+    )
+    assert poll_url.endswith("/status")
+    assert enroll_url.startswith(_TEST_PUBLIC_URL + "/")
+    assert ":9443/enroll?session=" in enroll_url
+
+
+@pytest.mark.asyncio
+async def test_b1_enrollment_poll_url_falls_back_to_request_base_url(
+    tmp_path, monkeypatch,
+) -> None:
+    """When ``MCP_PROXY_PROXY_PUBLIC_URL`` is unset (cold dev / test
+    boot before the operator runs the setup wizard), the handler must
+    fall back to ``request.base_url`` so the response is still
+    well-formed instead of crashing. Pin the fallback path so a
+    future refactor does not accidentally make the public URL a hard
+    requirement of the start endpoint.
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-b1b")
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.delenv("MCP_PROXY_PROXY_PUBLIC_URL", raising=False)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "enroll_b1_fallback.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    try:
+        pubkey_pem, pop_sig = _ec_keypair_with_pop()
+        payload = {
+            "pubkey_pem": pubkey_pem,
+            "pop_signature": pop_sig,
+            "requester_name": "Bob",
+            "requester_email": "bob@example.com",
+            "reason": "B-1 fallback pin",
+            "dpop_jwk": _ec_dpop_jwk(),
+        }
+        client = TestClient(_make_app())
+        r = client.post("/v1/enrollment/start", json=payload)
+        assert r.status_code == 201, r.text
+        body = r.json()
+        poll_url = body.get("poll_url", "")
+        # TestClient default base is ``http://testserver``; the
+        # fallback path must produce a non-empty URL of that shape.
+        assert poll_url.startswith("http://testserver/"), poll_url
+        assert poll_url.endswith("/status")
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Low-impact polish from dogfood session 3 + current. Five findings batched into one PR because each is a few lines and shares the same risk profile (template / view-context tweaks plus one bundle shell helper).

* **D-10** `deploy.sh --down --wipe-data` silently skipped the busybox wipe when the host operator could not list the bind-dir contents (mode 0700 owned by uid 10001 post init-permissions). Drop the host-side `compgen` empty check; always mount + always run the idempotent `find -delete`. `--wipe-data` now actually wipes `data/mcp_proxy.db` so the next `./deploy.sh up` boots into a brand-new Org CA instead of the stale DB.
* **A-2** audit counter discrepancy (sidebar `3` / header `73/67/8` / chain-verify `8 entries` / DB `66`). Each number measures a different slice of `audit_log` (1-hour rolling vs filter-scoped total vs hash-chained verified vs lifetime row count). Added explicit `title=""` tooltips on every counter and rephrased "N entries" -> "N chained entries verified" so a hover answers what each number means.
* **A-4** typo `/proxy/update` (singular) returned FastAPI's bare `{"detail":"Not Found"}` JSON. Mounted a sibling `alias_router` that 301-redirects to `/proxy/updates` (preserving query string) so the typo lands on the dashboard page.
* **A-5** overview missing the inline update-available banner. `base.html` already mounts the HTMX advisory but it depends on JS + an extra round-trip. Populate `update_available` / `current_version` / `latest_version` on the overview view ctx from the same cached `update_check` values and render a lightweight inline banner so the operator sees the advisory even when HTMX fails.
* **B-1** enrollment start `poll_url` stripped `:9443`. `poll_url` was derived from `request.base_url` which inside the uvicorn container resolves to `http://mcp-proxy:8080/`, so Connector polls landed on the wrong port + hostname. Prefer `settings.proxy_public_url` over `base_url`, with a fallback for the cold dev / test boot.

## Files touched per fix

* D-10: `packaging/_common-deploy-helpers.sh`
* A-2: `mcp_proxy/dashboard/templates/audit.html`, `mcp_proxy/dashboard/badges_routes.py`
* A-4: `mcp_proxy/dashboard/updates_router.py`, `mcp_proxy/main.py`
* A-5: `mcp_proxy/dashboard/templates/overview.html`, `mcp_proxy/dashboard/core_routes.py`
* B-1: `mcp_proxy/enrollment/router.py`

## Test plan

- [x] 11 new unit tests in `test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py` covering each fix
- [x] Full `pytest test/unit/ -n auto --dist=loadfile` green (267/267)
- [x] `python -m compileall -q mcp_proxy packaging` clean
- [x] `bash -n` clean on `_common-deploy-helpers.sh` + `mastio-bundle/deploy.sh`
- [ ] Bundle dogfood: `./deploy.sh --down --wipe-data` on a VM with init-permissions-owned `data/` actually removes `mcp_proxy.db` (manual step on next dogfood)