### PR TITLE
chore(site+readme): drop pilot-conversation CTA, community-only for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 | **Cullis Mastio** | [`mastio-v0.5.4.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.5.4.1) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
 | **Cullis SDK** | [`cullis-sdk 0.1.3`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file) and `from_systemd_credentials` (Linux production tmpfs delivery) |
 
-Use Cullis in evaluation, integration, and internal deploys. Talk to us before putting it in front of regulated production traffic.
+Use Cullis in evaluation, integration, and internal deploys. The community release is the only release; there is no commercial tier today. Feedback, bug reports, and PRs in the public repo.
 
 ---
 

--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -370,17 +370,15 @@ result = client.call_mcp_tool("sanctions_lookup", &#123;"full_name": "Acme Holdi
       <div class="closing-rule"></div>
       <div class="eyebrow reveal">
         <span class="eyebrow-number">07</span>
-        Pilot conversation
+        Try the community release
       </div>
-      <h2 class="reveal" data-delay="1">Read the code. <em>Then schedule a 30-minute call.</em></h2>
+      <h2 class="reveal" data-delay="1">Read the code. <em>Run the bundle. File an issue.</em></h2>
       <p class="reveal" data-delay="2">
-        Two to three design partners in EU regulated banking and
-        insurance for H2 2026. Conservative scope, reversible, no SLA,
-        signed audit bundle of real production journeys as output.
+        Cullis is alpha and open-core. The community release runs end-to-end on a Linux laptop in a few minutes. Feedback, bug reports, and PRs land in the public GitHub repo.
       </p>
       <div class="hero-actions reveal" data-delay="3">
         <a href="https://github.com/cullis-security/cullis" target="_blank" rel="noopener" class="btn btn-primary">GitHub</a>
-        <a href="mailto:hello@cullis.io?subject=Cullis%20pilot%20enquiry" class="btn btn-ghost">Pilot enquiry</a>
+        <a href="https://github.com/cullis-security/cullis/discussions" target="_blank" rel="noopener" class="btn btn-ghost">Discussions</a>
       </div>
     </div>
   </section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -448,16 +448,14 @@ result = client.call_mcp_tool("sanctions_lookup", &#123;"full_name": "Acme Holdi
   <!-- 09 CLOSING -->
   <section class="closing">
     <div class="container narrow">
-      <p class="eyebrow reveal">Pilot conversation</p>
-      <h2 class="reveal" data-delay="1">Read the code. Then schedule a 30-minute call.</h2>
+      <p class="eyebrow reveal">Try the community release</p>
+      <h2 class="reveal" data-delay="1">Read the code. Run the bundle. File an issue.</h2>
       <p class="section-lead reveal" data-delay="2">
-        Two or three design partners in regulated EU industries for
-        H2 2026. Conservative scope, reversible, no SLA. Output is a
-        signed audit bundle of real production journeys.
+        Cullis is alpha and open-core. The community release runs end-to-end on a Linux laptop in a few minutes. Feedback, bug reports, and PRs land in the public GitHub repo.
       </p>
       <div class="hero-actions reveal" data-delay="3">
         <a href="https://github.com/cullis-security/cullis" target="_blank" rel="noopener" class="btn btn-primary">GitHub</a>
-        <a href="mailto:hello@cullis.io?subject=Cullis%20pilot%20enquiry" class="btn btn-ghost">Pilot enquiry</a>
+        <a href="https://github.com/cullis-security/cullis/discussions" target="_blank" rel="noopener" class="btn btn-ghost">Discussions</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Site + README no longer reference a non-existent commercial tier. Community release is the only release today; HN cold-readers should land on a coherent message, not a sales pipeline that does not exist.

- cullis.io closing section: 'Pilot conversation' → 'Try the community release'. 'schedule a 30-minute call' → 'Run the bundle. File an issue.' 'Pilot enquiry' mailto button → Discussions link.
- README Status: drop the 'Talk to us before regulated production' caveat. Replace with plain 'community release is the only release today' + repo feedback paths.

When the commercial tier actually exists (post-tier-scope decisions for Merkle, Rego, LLM guardian, KMS cloud), a real pilot CTA can land in v0.6.x.

## Test plan
- [x] cullis.io renders both index.astro and index-dark.astro changes
- [x] README Status section reads coherent with the alpha + open-core framing
