### PR TITLE
fix(dashboard): separate sidebar footer divider from last nav item

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -139,7 +139,7 @@
         </div>
 
         <!-- Footer status -->
-        <div class="px-4 py-3 border-t border-gray-800/60 space-y-2">
+        <div class="px-4 pt-4 pb-3 mt-2 border-t border-gray-800/60 space-y-2">
             <!-- Update advisory: empty unless GHCR has a newer mastio-v* tag.
                  Polled every 30 minutes — the version_check cache rounds it
                  down to ~1 GitHub API call/h regardless of how many admins


### PR DESCRIPTION
## Summary

Dashboard sidebar footer ('Mastio Online' + Logout) had its top border drawn immediately under the last nav item (Settings). Operators reading the sidebar perceived Settings as 'end of list with underline' instead of 'Settings then divider then footer block'.

## Fix

`mcp_proxy/dashboard/templates/base.html`:
- `py-3` → `pt-4 pb-3`
- Added `mt-2` (8px top margin)

Divider now sits visually attached to the footer block.

## Test plan

- [x] Visually compared before/after on the VM dogfood dashboard
- [x] Template renders, base.html jinja parses
