### PR TITLE
fix(pki): lazy reload Intermediate CA when memory state missing (D-13)

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -171,7 +171,7 @@ async def create_agent(
             detail="cert_pem and private_key_pem must be provided together",
         )
     else:
-        cert_pem, key_pem = mgr._generate_agent_cert(agent_name)
+        cert_pem, key_pem = await mgr._generate_agent_cert(agent_name)
         minted_locally = True
 
     # Bug #6 tactical fix: persist the agent row atomically with the

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -704,12 +704,20 @@ class AgentManager:
         if not self.ca_loaded:
             raise RuntimeError("Org CA not loaded — cannot emit nginx server cert")
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
-            raise RuntimeError(
-                "Mastio Intermediate CA not loaded, cannot emit nginx "
-                "server cert. Three-tier PKI hardening (audit 2026-05-18) "
-                "requires the nginx server cert to be signed by the "
-                "Intermediate, not the Org Root. Call ensure_mastio_identity() first.",
-            )
+            # D-13 — lazy reload. Another worker may have minted and
+            # persisted the Intermediate while this worker's bootstrap
+            # silently failed (transient DB lock, KMS provider initial
+            # probe race). The pair is on disk; just re-read it.
+            # Mirrors the D-9 winner-election adopt pattern at runtime
+            # instead of only at boot.
+            reloaded = await self._reload_intermediate_ca_from_persistence()
+            if not reloaded:
+                raise RuntimeError(
+                    "Mastio Intermediate CA not loaded, cannot emit nginx "
+                    "server cert. Three-tier PKI hardening (audit 2026-05-18) "
+                    "requires the nginx server cert to be signed by the "
+                    "Intermediate, not the Org Root. Call ensure_mastio_identity() first.",
+                )
 
         from pathlib import Path
 
@@ -940,7 +948,7 @@ class AgentManager:
 
     # ── Certificate generation ──────────────────────────────────────
 
-    def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
+    async def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
         """Generate EC P-256 key + x509 cert for an internal agent.
 
         Cert fields:
@@ -968,10 +976,18 @@ class AgentManager:
         in EC at the next enrollment.
         """
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
-            raise RuntimeError(
-                "Mastio Intermediate CA not loaded, cannot sign agent cert. "
-                "Call ensure_mastio_identity() first.",
-            )
+            # D-13 — lazy reload. Another worker may have minted and
+            # persisted the Intermediate while this worker's bootstrap
+            # silently failed (transient DB lock, KMS provider initial
+            # probe race). The pair is on disk; just re-read it.
+            # Mirrors the D-9 winner-election adopt pattern at runtime
+            # instead of only at boot.
+            reloaded = await self._reload_intermediate_ca_from_persistence()
+            if not reloaded:
+                raise RuntimeError(
+                    "Mastio Intermediate CA not loaded, cannot sign agent cert. "
+                    "Call ensure_mastio_identity() first.",
+                )
 
         # Generate agent key pair
         agent_key = ec.generate_private_key(ec.SECP256R1())
@@ -1015,7 +1031,7 @@ class AgentManager:
         )
         return cert_pem, key_pem
 
-    def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
+    async def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
         """Sign an externally-generated public key with the Mastio Intermediate CA.
 
         Used by the Connector enrollment flow: the Connector keeps its
@@ -1032,10 +1048,18 @@ class AgentManager:
         loaded or the PEM is malformed.
         """
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
-            raise RuntimeError(
-                "Mastio Intermediate CA not loaded, cannot sign external pubkey. "
-                "Call ensure_mastio_identity() first.",
-            )
+            # D-13 — lazy reload. Another worker may have minted and
+            # persisted the Intermediate while this worker's bootstrap
+            # silently failed (transient DB lock, KMS provider initial
+            # probe race). The pair is on disk; just re-read it.
+            # Mirrors the D-9 winner-election adopt pattern at runtime
+            # instead of only at boot.
+            reloaded = await self._reload_intermediate_ca_from_persistence()
+            if not reloaded:
+                raise RuntimeError(
+                    "Mastio Intermediate CA not loaded, cannot sign external pubkey. "
+                    "Call ensure_mastio_identity() first.",
+                )
 
         public_key = serialization.load_pem_public_key(pubkey_pem.encode())
 
@@ -1114,7 +1138,7 @@ class AgentManager:
         agent_id = f"{self._org_id}::{agent_name}"
 
         # 1. Generate cert + key
-        cert_pem, key_pem = self._generate_agent_cert(agent_name)
+        cert_pem, key_pem = await self._generate_agent_cert(agent_name)
 
         # 2. Store private key
         try:
@@ -1186,6 +1210,77 @@ class AgentManager:
         current signer.
         """
         self._active_key = await self._keystore.current_signer()
+
+    async def _reload_intermediate_ca_from_persistence(self) -> bool:
+        """D-13 cold-reader dogfood (2026-05-26) — lazy reload helper.
+
+        Re-reads the Mastio Intermediate CA pair from the source-of-truth
+        (KMS provider first, legacy ``proxy_config`` rows as fallback) and
+        adopts it into ``self._mastio_ca_key`` / ``self._mastio_ca_cert``.
+        Returns ``True`` on a successful reload, ``False`` when no
+        persisted pair is available anywhere.
+
+        Why this exists: ``main.py:332-336`` wraps
+        ``ensure_mastio_identity()`` in a try/except Exception that
+        swallows any transient bootstrap failure silently (DB lock race,
+        KMS provider probe timeout, etc). With ``MASTIO_WORKERS=4`` one
+        of the uvicorn workers can lose the race and end up with
+        ``_mastio_ca_key=None`` while every other worker has the pair
+        loaded. The dashboard load-balances admin requests across all
+        four workers, so roughly one in four ``Create Agent`` clicks
+        hits the broken worker and 500s with the lottery pattern that
+        frustrates cold-readers. The pair IS on disk — some other
+        worker won the persist race in ``_persist_intermediate_ca`` —
+        so we just need to re-read it instead of failing.
+
+        Mirrors the loser-adoption branch inside ``_mint_mastio_ca``
+        (see line 1772+) but exposes it as a runtime entrypoint signers
+        can call when their in-memory state went missing post-boot.
+        Idempotent: safe to call on a manager that already has the pair
+        loaded (it overwrites with the same persisted material).
+        """
+        ca_key_pem: str | None = None
+        ca_cert_pem: str | None = None
+        try:
+            from mcp_proxy.kms import get_kms_provider
+            loaded = await get_kms_provider().load_intermediate_ca()
+            if loaded is not None:
+                ca_key_pem, ca_cert_pem = loaded
+        except Exception as exc:  # noqa: BLE001 — defensive on KMS failure
+            logger.warning(
+                "D-13 lazy reload: KMSProvider.load_intermediate_ca "
+                "failed: %s — falling back to legacy proxy_config rows",
+                exc,
+            )
+        if not ca_key_pem or not ca_cert_pem:
+            ca_key_pem = await get_config("mastio_ca_key")
+            ca_cert_pem = await get_config("mastio_ca_cert")
+
+        if not ca_key_pem or not ca_cert_pem:
+            return False
+
+        try:
+            self._mastio_ca_key = serialization.load_pem_private_key(
+                ca_key_pem.encode(), password=None,
+            )
+            self._mastio_ca_cert = x509.load_pem_x509_certificate(
+                ca_cert_pem.encode(),
+            )
+        except Exception as exc:  # noqa: BLE001 — corrupt PEM
+            logger.warning(
+                "D-13 lazy reload: failed to parse persisted Mastio "
+                "Intermediate CA pair: %s",
+                exc,
+            )
+            return False
+
+        logger.info(
+            "D-13 lazy reload: Mastio Intermediate CA adopted from "
+            "persistence (CN=%s) — bootstrap had silently failed on "
+            "this worker",
+            self._mastio_ca_cert.subject.rfc4514_string(),
+        )
+        return True
 
     async def ensure_mastio_identity(self) -> None:
         """Load or generate the Mastio CA + leaf identity (EC P-256 / ES256).
@@ -1946,7 +2041,15 @@ class AgentManager:
         signing / counter-signing calls see the new row.
         """
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
-            raise RuntimeError("Mastio CA not loaded — cannot sign leaf")
+            # D-13 — lazy reload. Another worker may have minted and
+            # persisted the Intermediate while this worker's bootstrap
+            # silently failed (transient DB lock, KMS provider initial
+            # probe race). The pair is on disk; just re-read it.
+            # Mirrors the D-9 winner-election adopt pattern at runtime
+            # instead of only at boot.
+            reloaded = await self._reload_intermediate_ca_from_persistence()
+            if not reloaded:
+                raise RuntimeError("Mastio CA not loaded — cannot sign leaf")
 
         leaf_key = ec.generate_private_key(ec.SECP256R1())
         proxy_spiffe = f"spiffe://{self._trust_domain}/proxy/{self._org_id}"

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -454,7 +454,7 @@ async def approve(
             http_status=503,
         )
 
-    cert_pem = agent_manager.sign_external_pubkey(
+    cert_pem = await agent_manager.sign_external_pubkey(
         pubkey_pem=record["pubkey_pem"],
         agent_name=agent_id,
     )

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -302,6 +302,17 @@ async def sign_user_csr(
     ca_key = agent_manager._mastio_ca_key  # type: ignore[attr-defined]
     ca_cert = agent_manager._mastio_ca_cert  # type: ignore[attr-defined]
     if ca_key is None or ca_cert is None:
+        # D-13 — lazy reload. Another worker may have minted and
+        # persisted the Intermediate while this worker's bootstrap
+        # silently failed (transient DB lock, KMS provider initial
+        # probe race). The pair is on disk; just re-read it.
+        # Mirrors the D-9 winner-election adopt pattern at runtime
+        # instead of only at boot.
+        reloaded = await agent_manager._reload_intermediate_ca_from_persistence()  # type: ignore[attr-defined]
+        if reloaded:
+            ca_key = agent_manager._mastio_ca_key  # type: ignore[attr-defined]
+            ca_cert = agent_manager._mastio_ca_cert  # type: ignore[attr-defined]
+    if ca_key is None or ca_cert is None:
         raise RuntimeError(
             "Mastio Intermediate CA not loaded — ensure_mastio_identity() "
             "must complete before user-principal CSRs can be signed",

--- a/test/unit/test_admin_agents_atomic_enroll.py
+++ b/test/unit/test_admin_agents_atomic_enroll.py
@@ -80,7 +80,7 @@ class _StubAgentManager:
         self._vault_succeeds = vault_succeeds
         self._mint_counter = 0
 
-    def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
+    async def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
         # Unique per-mint output so the test can tell a stale key from a
         # fresh one byte-perfect.
         self._mint_counter += 1

--- a/test/unit/test_intermediate_ca_lazy_reload.py
+++ b/test/unit/test_intermediate_ca_lazy_reload.py
@@ -1,0 +1,241 @@
+"""D-13 cold-reader dogfood (2026-05-26) tests — lazy Intermediate CA
+reload guarantee.
+
+Pre-fix ``mcp_proxy/main.py:332-336`` wraps ``ensure_mastio_identity()``
+in a try/except Exception that swallows any transient bootstrap failure
+silently (DB lock race, KMS provider initial probe timeout, etc).
+Under ``MASTIO_WORKERS=4`` (Mastio bundle default) every uvicorn worker
+runs the lifespan independently; if one worker loses the race or hits a
+transient error its ``_mastio_ca_key`` stays ``None`` while the other
+three workers complete bootstrap and persist the Intermediate pair to
+the source-of-truth (KMS or legacy ``proxy_config.mastio_ca_{key,cert}``
+rows). The dashboard load-balances admin requests across all workers,
+so roughly one in four ``POST /v1/admin/agents`` clicks hits the broken
+worker and 500s with::
+
+    Mastio Intermediate CA not loaded, cannot sign agent cert.
+    Call ensure_mastio_identity() first.
+
+The fix mirrors the D-9 ``_mint_mastio_ca`` winner-adopt pattern but at
+runtime instead of boot: when a signer hits ``_mastio_ca_key=None``,
+lazily re-read the persisted pair via
+``_reload_intermediate_ca_from_persistence`` before raising. The pair
+IS on disk — some other worker won the persist race in
+``_persist_intermediate_ca`` — so just re-read it.
+
+Sister race-bootstrap tests live in
+``test_pki_bootstrap_concurrent.py`` (D-9). Keep the fixture shape
+aligned so both files exercise the same KMS+proxy_config source-of-truth
+primitive.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from datetime import datetime, timedelta, timezone
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, init_db, set_config
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+_ADMIN_SECRET = "test-intermediate-ca-lazy-reload-secret"
+
+
+# ── Helpers to mint a plausible Intermediate CA pair ──────────────────
+
+
+def _mint_intermediate_pair(org_id: str) -> tuple[str, str]:
+    """Mint a self-signed Intermediate CA pair (EC P-256, valid 30 days).
+
+    Self-signed is fine for the lazy-reload tests — we are only
+    exercising the "re-read PEMs from persistence and parse them into
+    in-memory state" code path, not the full three-tier chain. The
+    PEM bytes are what the helper round-trips through
+    ``load_pem_private_key`` / ``load_pem_x509_certificate``.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} Mastio CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=0),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key_pem, cert_pem
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite + dev-fallback persistence path.
+
+    Matches the ``test_pki_bootstrap_concurrent.py`` fixture: skips
+    migrations (the lazy-reload helper only touches ``proxy_config``
+    rows the metadata-defined schema already covers), disables the
+    audit chain, and forces the local-KMS dev fallback by clearing
+    ``MCP_PROXY_DB_ENCRYPTION_KEY``. The encrypted ``pki_key_store``
+    path is provider-level and tested separately when the provider
+    plugin is exercised.
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
+    monkeypatch.delenv("MCP_PROXY_DB_ENCRYPTION_KEY", raising=False)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "intermediate_ca_lazy_reload.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sign_agent_cert_lazy_reload_succeeds_when_pair_in_db(proxy_db):
+    """Manager with ``_mastio_ca_key=None`` and the persisted pair
+    populated in ``proxy_config`` succeeds at ``_generate_agent_cert``:
+    the lazy reload kicks in, parses the pair, and the cert is signed
+    against the persisted Intermediate. This is the exact cold-reader
+    repro — one worker's bootstrap silently failed but the
+    source-of-truth has the pair another worker minted."""
+    org_id = "cold-reader-org"
+    key_pem, cert_pem = _mint_intermediate_pair(org_id)
+
+    # Populate the source-of-truth as if another worker had won the
+    # mint race and persisted the Intermediate via _persist_intermediate_ca.
+    await set_config("mastio_ca_key", key_pem)
+    await set_config("mastio_ca_cert", cert_pem)
+
+    # The "broken" worker — bootstrap silently failed, _mastio_ca_key
+    # stays None. _generate_agent_cert MUST not raise; it should
+    # lazy-reload the persisted pair and sign successfully.
+    mgr = AgentManager(org_id)
+    assert mgr._mastio_ca_key is None
+    assert mgr._mastio_ca_cert is None
+
+    agent_cert_pem, agent_key_pem = await mgr._generate_agent_cert("test-agent")
+
+    # The returned cert must verify under the persisted Intermediate's
+    # subject (issuer match). Without the lazy reload this call would
+    # have raised RuntimeError with the cold-reader 500 message.
+    agent_cert = x509.load_pem_x509_certificate(agent_cert_pem.encode())
+    persisted_cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    assert agent_cert.issuer.rfc4514_string() == persisted_cert.subject.rfc4514_string()
+    # And the agent key PEM is a parseable private key.
+    assert serialization.load_pem_private_key(
+        agent_key_pem.encode(), password=None,
+    ) is not None
+
+
+@pytest.mark.asyncio
+async def test_sign_agent_cert_raises_when_pair_absent_anywhere(proxy_db):
+    """When neither the KMS provider nor the legacy ``proxy_config``
+    rows hold a persisted pair, the lazy reload must report failure and
+    the original RuntimeError must surface with its helpful message.
+    Otherwise we'd silently sign with a None CA and crash deeper in the
+    crypto stack with a less-actionable trace."""
+    mgr = AgentManager("org-with-no-mastio-yet")
+    assert mgr._mastio_ca_key is None
+    assert mgr._mastio_ca_cert is None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await mgr._generate_agent_cert("test-agent")
+
+    # The helpful operator-facing message must survive the lazy-reload
+    # detour — cold-readers depend on it to know which lifecycle hook
+    # to call.
+    msg = str(exc_info.value)
+    assert "Mastio Intermediate CA not loaded" in msg
+    assert "ensure_mastio_identity" in msg
+
+
+@pytest.mark.asyncio
+async def test_lazy_reload_populates_in_memory_state(proxy_db):
+    """After a successful lazy reload, ``_mastio_ca_key`` and
+    ``_mastio_ca_cert`` are populated on the manager. Subsequent signing
+    calls hit the in-memory pair directly without paying the reload cost
+    again — important so a steady stream of admin Create Agent clicks
+    on a previously-broken worker doesn't re-query the DB for every
+    signature."""
+    org_id = "lazy-reload-state-org"
+    key_pem, cert_pem = _mint_intermediate_pair(org_id)
+
+    await set_config("mastio_ca_key", key_pem)
+    await set_config("mastio_ca_cert", cert_pem)
+
+    mgr = AgentManager(org_id)
+    assert mgr._mastio_ca_key is None
+    assert mgr._mastio_ca_cert is None
+
+    reloaded = await mgr._reload_intermediate_ca_from_persistence()
+    assert reloaded is True
+
+    # In-memory state now holds the persisted pair (parsed).
+    assert mgr._mastio_ca_key is not None
+    assert mgr._mastio_ca_cert is not None
+
+    # The reloaded cert must be byte-identical to what was persisted —
+    # no split-brain where the lazy reload parses a different cert from
+    # the one another signer would see.
+    persisted_cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    assert (
+        mgr._mastio_ca_cert.fingerprint(hashes.SHA256())
+        == persisted_cert.fingerprint(hashes.SHA256())
+    )
+
+    # And the reloaded private key matches the cert's pubkey (no
+    # cross-wiring from a stale prior run).
+    reloaded_pub_der = mgr._mastio_ca_key.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    cert_pub_der = mgr._mastio_ca_cert.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert reloaded_pub_der == cert_pub_der
+
+
+@pytest.mark.asyncio
+async def test_lazy_reload_returns_false_when_only_one_row_persisted(proxy_db):
+    """Partial persistence (one of the two ``proxy_config`` rows
+    present, the other missing) must be treated as "no pair available"
+    — the helper returns False instead of crashing on an unbound
+    variable or persisting a half-populated state into memory. This
+    pins the defensive behaviour for the corrupted-DB / interrupted-
+    write edge case."""
+    # Only the key row, no cert row.
+    key_pem, _cert_pem = _mint_intermediate_pair("partial-org")
+    await set_config("mastio_ca_key", key_pem)
+
+    mgr = AgentManager("partial-org")
+    reloaded = await mgr._reload_intermediate_ca_from_persistence()
+    assert reloaded is False
+    # Memory state stays clean — no partial assignment.
+    assert mgr._mastio_ca_key is None
+    assert mgr._mastio_ca_cert is None


### PR DESCRIPTION
## Summary

- Cold-reader dogfood (embodied-demo VM, 2026-05-26) hit 500 ``Mastio Intermediate CA not loaded`` on the admin Create Agent form. Root cause: ``main.py:332-336`` wraps ``ensure_mastio_identity()`` in a ``try/except Exception`` that swallows any transient bootstrap failure silently. Under ``MASTIO_WORKERS=4``, one worker losing a DB lock race or hitting a transient KMS probe error leaves ``_mastio_ca_key=None`` on that worker — roughly one in four admin requests hits it and 500s with a lottery pattern.
- The pair IS on disk (some other worker won the persist race in ``_persist_intermediate_ca``). New helper ``AgentManager._reload_intermediate_ca_from_persistence`` re-reads via KMS provider first, then legacy ``proxy_config`` rows, and adopts the pair into in-memory state. Same loser-adoption pattern D-9 uses at boot, applied at signing-time.
- Guards updated to lazy-reload before raising: ``_generate_agent_cert`` (admin Create Agent), ``sign_external_pubkey`` (Connector enrollment), ``ensure_nginx_server_cert`` (nginx leaf emit), ``_mint_mastio_leaf`` (lifespan path), ``sign_user_csr`` (Connector user-principal CSRs). ``_generate_agent_cert`` + ``sign_external_pubkey`` promoted to ``async`` so they can ``await`` the reload; the two non-test call sites are already in async context.

## Test plan

- [x] ``python -m compileall -q mcp_proxy`` clean
- [x] ``pytest test/unit/test_intermediate_ca_lazy_reload.py -v`` (4/4 pass)
- [x] ``pytest test/unit/ -k "mastio or ca or agent" -n auto --dist=loadfile`` (41/41 pass)
- [x] ``pytest test/unit/ -n auto --dist=loadfile`` (278/278 pass, no regressions)
- [ ] Re-dogfood on the embodied-demo VM: click Create Agent ~20x with ``MASTIO_WORKERS=4``; previously hit 500 roughly 25% of the time, expect 0/20 after the fix.