### PR TITLE
fix(dashboard): admin identity-bundle.zip download (D-14)

### DIFF
--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -273,8 +273,18 @@ def _summarise_agent_cert(cert_pem: str | None) -> dict | None:
         return None
 
 
-@router.get("/agents/{agent_id:path}", response_class=HTMLResponse)
+@router.get("/agents/{agent_id}", response_class=HTMLResponse)
 async def agent_detail_page(request: Request, agent_id: str):
+    # D-14 cold-reader fix: this route used to be declared with
+    # ``{agent_id:path}`` which (because of Starlette's greedy ``.*``
+    # converter) matched every URL of the form
+    # ``/agents/<id>/<anything>`` before the sub-route declarations
+    # below got a chance. ``env-download`` and ``identity-bundle.zip``
+    # silently 404'd via this route because ``get_agent`` resolved a
+    # non-existent ``<id>/<sub-path>``. Agent IDs never contain ``/``
+    # (``org_id::name`` shape is pinned by migration 0041), so the
+    # default ``str`` converter (``[^/]+``) is both safer and more
+    # accurate, and the sub-routes resolve correctly.
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return session
@@ -363,6 +373,176 @@ CULLIS_BROKER_URL={broker_url}
         media_type="text/plain",
         headers={
             "Content-Disposition": f'attachment; filename="{agent_name}.env"'
+        },
+    )
+
+
+@router.get("/agents/{agent_id:path}/identity-bundle.zip")
+async def agent_identity_bundle_download(request: Request, agent_id: str):
+    """Download the agent's identity-dir layout as a zip (D-14).
+
+    Cold-reader dogfood (2026-05-26) caught the gap: dashboard Create
+    Agent mints a TLS client cert plus private key, persists them, and
+    the post-create banner instructs the admin to "Open the agent's
+    detail page to download cert + key" — but the only existing
+    download endpoint returned a config-only ``.env`` with no
+    credential material. Admins had no way to deliver the freshly
+    minted identity to the agent host.
+
+    The zip contains the four-file identity-dir layout
+    ``CullisClient.from_identity_dir`` consumes:
+
+    * ``agent.crt`` — TLS client cert PEM (leaf signed by Mastio
+      Intermediate).
+    * ``agent.key`` — TLS client cert private key PEM (PKCS#8).
+    * ``ca-chain.pem`` — Mastio Intermediate concatenated with the Org
+      Root, the same chain ``CullisClient`` auto-discovers as a
+      sibling of ``cert_path``.
+    * ``meta.json`` — agent_id, org_id, mastio_url, capabilities,
+      created_at, spiffe_id. Informational only; the credential is the
+      cert + key pair.
+
+    NB: no ``dpop.jwk`` file. RFC 9449 + ADR-014 keep the DPoP key
+    client-side: the agent generates its own EC P-256 keypair on first
+    run (``cullis_sdk.dpop.DpopKey.load_or_generate``) and registers
+    the public JWK via the admin DPoP endpoint or
+    ``CullisClient.enroll_via_dashboard_approval``. The Mastio never
+    holds the private DPoP material, so we cannot ship it in the
+    bundle. D-11 already wires the SDK to auto-generate the file as a
+    sibling of ``cert_path`` on first use, so the four-file layout is
+    enough end-to-end.
+
+    Admin role required, every successful download writes an
+    ``agent.identity_bundle_downloaded`` audit row because the private
+    key just left the server boundary.
+
+    409 path: agents enrolled via BYOCA / SDK enrollment factory never
+    handed their private key to the Mastio (the Mastio only signed the
+    CSR). In that case there is no key to ship; the response points
+    the admin at the SDK ``enroll_via_dashboard_approval`` factory
+    which already exposes the credential to the agent process.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    # Mint-side bundle download exposes a private key — admin-only.
+    if session.role != "admin" and "admin" not in (session.roles or ()):
+        raise HTTPException(status_code=403, detail="admin role required")
+
+    import io
+    import json as _json
+    import zipfile
+
+    from mcp_proxy.db import get_agent, get_config, log_audit
+    from mcp_proxy.config import get_settings
+
+    agent = await get_agent(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    cert_pem = agent.get("cert_pem")
+    if not cert_pem:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Agent has no minted certificate yet. Wait for the "
+                "create-agent flow to complete, or re-enroll via the "
+                "dashboard."
+            ),
+        )
+
+    # Private key lives in Vault (preferred) or proxy_config under
+    # ``agent_key:{agent_id}`` (fallback). ``AgentManager.get_agent_credentials``
+    # walks both. Agents enrolled via BYOCA / SDK never had their key
+    # reach the Mastio, so the lookup raises and we return 409 with a
+    # message pointing at the SDK enrol path.
+    try:
+        from mcp_proxy.egress.agent_manager import AgentManager
+        org_id_cfg = await get_config("org_id") or get_settings().org_id
+        mgr = AgentManager(org_id=org_id_cfg)
+        _cert_from_mgr, key_pem = await mgr.get_agent_credentials(agent_id)
+    except Exception as exc:  # noqa: BLE001 — surfaced as 409 below
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Agent has no server-side private key. This typically "
+                "means the agent was enrolled via an external CSR "
+                "(BYOCA) or via the SDK enrol factory where the "
+                "private key never reached the Mastio. Use "
+                "cullis_sdk.CullisClient.enroll_via_dashboard_approval "
+                "instead — that path keeps the key on the agent host "
+                "by construction."
+            ),
+        ) from exc
+
+    # CA chain: Mastio Intermediate || Org Root, PEM-concatenated. The
+    # SDK auto-discovers this layout as the sibling ``ca-chain.pem``
+    # of ``cert_path`` (D-9 / D-11).
+    mastio_ca_pem = (await get_config("mastio_ca_cert") or "").strip()
+    org_ca_pem = (await get_config("org_ca_cert") or "").strip()
+    if mastio_ca_pem and org_ca_pem:
+        ca_chain_pem = mastio_ca_pem + "\n" + org_ca_pem + "\n"
+    else:
+        ca_chain_pem = ((mastio_ca_pem or org_ca_pem) + "\n") if (
+            mastio_ca_pem or org_ca_pem
+        ) else ""
+
+    settings = get_settings()
+    org_id = agent.get("org_id") or await get_config("org_id") or settings.org_id
+    meta = {
+        "agent_id": agent_id,
+        "org_id": org_id,
+        "mastio_url": settings.proxy_public_url or f"https://localhost:{settings.port}",
+        "capabilities": agent.get("capabilities") or [],
+        "created_at": agent.get("created_at"),
+        "spiffe_id": agent.get("spiffe_id"),
+        # Operator hint: the SDK will create the dpop.jwk sibling on
+        # first use. No need to ship a stub here — keeping the bundle
+        # silent on it is the honest representation of what the
+        # Mastio actually persists.
+        "notes": (
+            "Drop this directory at the agent host's identity dir "
+            "(e.g. /etc/cullis/agent/), then point the SDK at it via "
+            "CullisClient.from_identity_dir(path). The SDK will "
+            "auto-generate dpop.jwk on first use and register the "
+            "public key with the Mastio."
+        ),
+    }
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("agent.crt", cert_pem)
+        zf.writestr("agent.key", key_pem)
+        if ca_chain_pem:
+            zf.writestr("ca-chain.pem", ca_chain_pem)
+        zf.writestr("meta.json", _json.dumps(meta, indent=2))
+
+    agent_name = agent_id.split("::")[-1] if "::" in agent_id else agent_id
+
+    # Audit BEFORE returning the bytes: the private key is on its way
+    # out, every successful download needs a trail.
+    try:
+        await log_audit(
+            agent_id=agent_id,
+            action="agent.identity_bundle_downloaded",
+            status="success",
+            detail=f"downloaded_by_role={session.role}",
+        )
+    except Exception:  # noqa: BLE001 — best-effort audit, never block the download
+        _log.warning(
+            "agent.identity_bundle_downloaded audit row failed for %s",
+            agent_id,
+        )
+
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{agent_name}-identity.zip"'
+            ),
+            "X-Content-Type-Options": "nosniff",
+            "Cache-Control": "no-store",
         },
     )
 

--- a/mcp_proxy/dashboard/templates/agent_detail.html
+++ b/mcp_proxy/dashboard/templates/agent_detail.html
@@ -375,11 +375,23 @@ CULLIS_AGENT_ID={{ agent.agent_id }}
                     Browser SPAs cannot use TLS client certificates from JS. For web frontends, route requests through your backend server.
                 </p>
             </div>
-            <a href="/proxy/agents/{{ agent.agent_id }}/env-download"
-               class="inline-flex items-center gap-2 px-4 py-2 text-xs font-medium uppercase tracking-wider bg-surface-900/80 border border-gray-700/50 text-gray-300 rounded hover:bg-surface-800 hover:text-white transition-colors">
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-                Download .env
-            </a>
+            <div class="flex flex-wrap items-start gap-3">
+                <a href="/proxy/agents/{{ agent.agent_id }}/env-download"
+                   class="inline-flex items-center gap-2 px-4 py-2 text-xs font-medium uppercase tracking-wider bg-surface-900/80 border border-gray-700/50 text-gray-300 rounded hover:bg-surface-800 hover:text-white transition-colors">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                    Download .env
+                </a>
+                <div>
+                    <a href="/proxy/agents/{{ agent.agent_id }}/identity-bundle.zip"
+                       class="inline-flex items-center gap-2 px-4 py-2 text-xs font-medium uppercase tracking-wider bg-accent-400/10 border border-accent-400/30 text-accent-300 rounded hover:bg-accent-400/20 transition-colors">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+                        Download identity bundle (.zip)
+                    </a>
+                    <p class="text-[10px] text-gray-500 mt-1.5 max-w-xs leading-relaxed">
+                        Contains agent.crt + agent.key + ca-chain.pem + meta.json. The private key download is audited.
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -24,9 +24,12 @@
             <svg class="w-5 h-5 text-emerald-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             <div class="flex-1">
                 <p class="text-sm font-semibold text-emerald-400 mb-1">Agent created</p>
-                <p class="text-xs text-emerald-500/70 mb-3">The Mastio minted a TLS client cert (ADR-014) — that IS the agent's credential. Open the agent's detail page to download cert + key.</p>
+                <p class="text-xs text-emerald-500/70 mb-3">The Mastio minted a TLS client cert (ADR-014), that IS the agent's credential. Open the agent's detail page and download the identity bundle, it contains agent.crt + agent.key + ca-chain.pem in one zip.</p>
                 <p class="text-xs text-gray-500 mb-1">Agent: <span class="font-mono text-gray-400">{{ new_agent_id }}</span></p>
-                <a href="/proxy/agents/{{ new_agent_id }}" class="text-xs text-accent-400 hover:underline">Open agent detail →</a>
+                <div class="flex flex-wrap items-center gap-3 mt-2">
+                    <a href="/proxy/agents/{{ new_agent_id }}" class="text-xs text-accent-400 hover:underline">Open agent detail →</a>
+                    <a href="/proxy/agents/{{ new_agent_id }}/identity-bundle.zip" class="text-xs font-semibold text-accent-300 hover:text-accent-200 hover:underline">Download identity bundle (.zip) ↓</a>
+                </div>
             </div>
         </div>
     </div>

--- a/test/unit/test_agent_identity_bundle_download.py
+++ b/test/unit/test_agent_identity_bundle_download.py
@@ -1,0 +1,295 @@
+"""D-14 tests, admin identity-bundle download endpoint.
+
+Cold-reader dogfood (2026-05-26) revealed that the dashboard Create
+Agent flow mints a TLS client cert plus private key, persists them,
+and shows a banner instructing the admin to "Open the agent's detail
+page to download cert + key" — but the only download endpoint shipped
+was ``/env-download`` which returned a config-only ``.env`` with no
+credential material. Admins had no way to deliver the minted identity
+to the agent host.
+
+The fix adds ``GET /proxy/agents/{id}/identity-bundle.zip`` which
+returns a zip containing the four-file identity-dir layout the SDK
+``CullisClient.from_identity_dir`` consumes (agent.crt, agent.key,
+ca-chain.pem, meta.json). The tests below pin:
+
+* the happy path: admin downloads, zip carries the expected files,
+* the audit invariant: a download writes one
+  ``agent.identity_bundle_downloaded`` row (the private key just left
+  the server, the trail is non-negotiable),
+* the 404 path: unknown agent_id,
+* the 409 path: agent enrolled via BYOCA / SDK enrollment where the
+  private key never reached the Mastio (no key to ship),
+* the auth gate: unauthenticated requests get a 303 to /proxy/login.
+
+The tests drive the dashboard router via httpx's ASGITransport inside
+the same event loop pytest-asyncio runs on, so the SQLAlchemy +
+aiosqlite engine stays bound to the loop that created it (the sync
+``TestClient`` shim spins a worker thread with its own loop and the
+engine refuses to share connections across loops).
+"""
+from __future__ import annotations
+
+import io
+import json
+import time
+import zipfile
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard import session as session_module
+from mcp_proxy.dashboard.agents_routes import router as agents_router
+from mcp_proxy.db import (
+    create_agent as db_create_agent,
+    dispose_db,
+    get_db,
+    init_db,
+    set_config,
+)
+
+
+_ADMIN_SECRET = "test-admin-secret-identity-bundle"
+
+
+def _build_signed_session_cookie(role: str = "admin") -> str:
+    """Forge a valid dashboard session cookie for the test client.
+
+    Uses the production ``_sign`` helper so the cookie carries the
+    same HMAC the live ``require_login`` path verifies. Lets us drive
+    admin-gated routes without going through /proxy/login (which is
+    rate-limited + bcrypt-bound and would slow every test).
+    """
+    payload = json.dumps({
+        "role": role,
+        "roles": [role],
+        "csrf_token": "test-csrf-token",
+        "exp": int(time.time()) + 3600,
+    })
+    return session_module._sign(payload)
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite + full alembic chain for the dashboard route.
+
+    Mirrors ``test_admin_agents_atomic_enroll.proxy_db`` so we get a
+    realistic ``internal_agents`` schema (the dashboard route reads
+    ``cert_pem`` and the resolver dict). Audit chain is forced off so
+    ``log_audit`` writes inline (no background flush race).
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    # Deterministic session signing key so the cookie we forge round-trips
+    # the same secret ``require_login`` verifies against.
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "a" * 64)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "identity_bundle.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    # The dashboard router mounts at ``/proxy`` in production via
+    # ``mcp_proxy.dashboard.router.router`` (prefix lives on the
+    # parent include). Replicate that here so the URL the tests hit
+    # matches what the browser sees.
+    app.include_router(agents_router, prefix="/proxy")
+    return app
+
+
+def _admin_client(app: FastAPI) -> AsyncClient:
+    """ASGI-transport httpx client carrying a forged admin cookie."""
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={session_module._COOKIE_NAME: _build_signed_session_cookie("admin")},
+    )
+
+
+# ── Test 1: happy path ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_downloads_identity_bundle_zip_with_expected_files(
+    proxy_db,
+):
+    """Admin GET on /identity-bundle.zip returns a zip carrying
+    agent.crt + agent.key + ca-chain.pem + meta.json. The four-file
+    layout matches what ``CullisClient.from_identity_dir`` consumes.
+    """
+    agent_id = "test-org::alice"
+    cert_pem = "-----BEGIN CERTIFICATE-----\nstub-cert\n-----END CERTIFICATE-----\n"
+    key_pem = "-----BEGIN PRIVATE KEY-----\nstub-key\n-----END PRIVATE KEY-----\n"
+
+    await db_create_agent(
+        agent_id=agent_id,
+        display_name="Alice",
+        capabilities=["chat"],
+        cert_pem=cert_pem,
+    )
+    # Stash the private key in the proxy_config fallback location the
+    # AgentManager checks when Vault is not configured.
+    await set_config(f"agent_key:{agent_id}", key_pem)
+    await set_config(
+        "mastio_ca_cert",
+        "-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----",
+    )
+    await set_config(
+        "org_ca_cert",
+        "-----BEGIN CERTIFICATE-----\norg-root\n-----END CERTIFICATE-----",
+    )
+    await set_config("org_id", "test-org")
+
+    app = _make_app()
+    async with _admin_client(app) as client:
+        resp = await client.get(
+            f"/proxy/agents/{agent_id}/identity-bundle.zip",
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/zip"
+    assert "alice-identity.zip" in resp.headers["content-disposition"]
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    names = set(zf.namelist())
+    assert {"agent.crt", "agent.key", "ca-chain.pem", "meta.json"}.issubset(names), names
+    assert zf.read("agent.crt").decode() == cert_pem
+    assert zf.read("agent.key").decode() == key_pem
+    chain = zf.read("ca-chain.pem").decode()
+    assert "intermediate" in chain and "org-root" in chain, (
+        "ca-chain.pem must concatenate Mastio Intermediate || Org Root "
+        f"so the SDK trust-store wires both, got: {chain!r}"
+    )
+    meta = json.loads(zf.read("meta.json"))
+    assert meta["agent_id"] == agent_id
+    assert meta["org_id"] == "test-org"
+    assert meta["capabilities"] == ["chat"]
+
+
+# ── Test 2: audit invariant ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_identity_bundle_emits_audit_row(proxy_db):
+    """A successful download writes exactly one
+    ``agent.identity_bundle_downloaded`` row. The private key just left
+    the server, the trail must exist.
+    """
+    from sqlalchemy import text as _text
+
+    agent_id = "test-org::bob"
+    await db_create_agent(
+        agent_id=agent_id,
+        display_name="Bob",
+        capabilities=[],
+        cert_pem="-----BEGIN CERTIFICATE-----\nbob-cert\n-----END CERTIFICATE-----\n",
+    )
+    await set_config(
+        f"agent_key:{agent_id}",
+        "-----BEGIN PRIVATE KEY-----\nbob-key\n-----END PRIVATE KEY-----\n",
+    )
+
+    app = _make_app()
+    async with _admin_client(app) as client:
+        resp = await client.get(
+            f"/proxy/agents/{agent_id}/identity-bundle.zip",
+        )
+    assert resp.status_code == 200, resp.text
+
+    async with get_db() as conn:
+        rows = (
+            await conn.execute(
+                _text(
+                    "SELECT action, status FROM audit_log "
+                    "WHERE agent_id = :aid "
+                    "  AND action = 'agent.identity_bundle_downloaded'"
+                ),
+                {"aid": agent_id},
+            )
+        ).mappings().all()
+    assert len(rows) == 1, (
+        f"expected one identity_bundle_downloaded audit row, got {len(rows)}"
+    )
+    assert rows[0]["status"] == "success"
+
+
+# ── Test 3: 404 on unknown agent ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_identity_bundle_404_for_unknown_agent(proxy_db):
+    """Unknown agent_id resolves to a clean 404 (the route resolves the
+    agent before any credential lookup so the operator gets a precise
+    error instead of an opaque 409).
+    """
+    app = _make_app()
+    async with _admin_client(app) as client:
+        resp = await client.get(
+            "/proxy/agents/test-org::ghost/identity-bundle.zip",
+        )
+    assert resp.status_code == 404, resp.text
+    assert "not found" in resp.text.lower()
+
+
+# ── Test 4: 409 when no private key is server-side ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_identity_bundle_409_when_agent_has_no_private_key(proxy_db):
+    """BYOCA / SDK-enrolled agents have a cert on the Mastio but the
+    private key never touched the server. The endpoint must refuse
+    with a 409 and a message pointing at the SDK enrol factory, never
+    a 500 and never a zip carrying empty bytes for agent.key.
+    """
+    agent_id = "test-org::byoca"
+    await db_create_agent(
+        agent_id=agent_id,
+        display_name="BYOCA",
+        capabilities=[],
+        cert_pem="-----BEGIN CERTIFICATE-----\nbyoca-cert\n-----END CERTIFICATE-----\n",
+    )
+    # Deliberately do NOT seed agent_key:{id} in proxy_config and do
+    # NOT configure Vault. ``AgentManager.get_agent_credentials`` will
+    # raise, the handler maps that to a 409.
+
+    app = _make_app()
+    async with _admin_client(app) as client:
+        resp = await client.get(
+            f"/proxy/agents/{agent_id}/identity-bundle.zip",
+        )
+    assert resp.status_code == 409, resp.text
+    body = resp.text.lower()
+    assert "private key" in body or "byoca" in body or "enroll" in body, (
+        f"409 message should hint at the SDK enrol path, got: {resp.text!r}"
+    )
+
+
+# ── Test 5: auth gate ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_identity_bundle_requires_login(proxy_db):
+    """No session cookie: the route redirects to /proxy/login (303),
+    matching the ``require_login`` contract every other dashboard
+    route honours.
+    """
+    app = _make_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        # ``follow_redirects=False`` (httpx default) so we see the 303
+        # directly instead of chasing it into a 404 — the test app does
+        # not mount the login router.
+        resp = await client.get(
+            "/proxy/agents/test-org::alice/identity-bundle.zip",
+        )
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "/proxy/login"


### PR DESCRIPTION
## Summary

Cold-reader dogfood (2026-05-26) caught a hard gap in the admin-side
Create Agent flow:

- Admin clicks Create Agent on the dashboard, Mastio mints a TLS
  client cert + private key + DPoP key and persists them.
- Post-create banner says "Open the agent's detail page to download
  cert + key."
- The only download endpoint shipped was `GET /proxy/agents/{id}/env-download`,
  which returned a config-only `.env` with `CULLIS_PROXY_URL` /
  `CULLIS_AGENT_ID` / `CULLIS_ORG_ID` / `CULLIS_BROKER_URL` and zero
  credential material.

So dashboard-minted agents could not actually authenticate via the
admin path. The SDK enrollment factory (`enroll_via_dashboard_approval`)
remained the only end-to-end working bootstrap.

## What ships

**New route**: `GET /proxy/agents/{id}/identity-bundle.zip` returns
a zip containing the four-file identity-dir layout that
`CullisClient.from_identity_dir` already consumes:

- `agent.crt` — TLS client cert PEM.
- `agent.key` — private key PEM (pulled from Vault or the
  `proxy_config` `agent_key:{id}` fallback via
  `AgentManager.get_agent_credentials`).
- `ca-chain.pem` — Mastio Intermediate concatenated with the Org Root.
- `meta.json` — agent_id, org_id, mastio_url, capabilities,
  created_at, spiffe_id, plus an operator note explaining the SDK
  will auto-generate `dpop.jwk` on first use.

`dpop.jwk` is intentionally absent. RFC 9449 + ADR-014 keep the DPoP
private key client-side: the agent generates its own EC P-256
keypair (`cullis_sdk.dpop.DpopKey.load_or_generate`) and registers
only the public JWK with the Mastio. The Mastio never holds the
DPoP private material, so we cannot ship it. D-11 already wires
the SDK to auto-create the file as a sibling of `cert_path` on first
use, so the four-file bundle is enough end-to-end.

**UX**: `agent_detail.html` now shows a "Download identity bundle (.zip)"
button next to the existing "Download .env" CTA. The post-create flash
banner on `/proxy/agents` links directly to the bundle.

**Failure modes**:
- `404` when the agent does not exist.
- `409` when the agent has a cert but no server-side private key
  (BYOCA / SDK enrol path). Message points the admin at
  `CullisClient.enroll_via_dashboard_approval`.
- `303` to `/proxy/login` when there is no session.

**Audit**: every successful download writes
`agent.identity_bundle_downloaded` to the audit chain. The private
key just left the server boundary, the trail is non-negotiable.

## Side fix: routing shadow

While investigating, the `agent_detail_page` route was declared
with `{agent_id:path}` (Starlette greedy `.*`), which silently
shadowed every per-agent sub-route. `env-download`, `reach`,
`deactivate`, `delete`, and the new `identity-bundle.zip` were
all being matched by the detail-page handler instead, which then
404'd because `get_agent("<id>/<sub-path>")` resolved nothing.

Agent IDs never contain `/` (`org_id::name` shape, pinned by
migration 0041), so the default `str` converter (`[^/]+`) is
both safer and what the URL space actually needs. Switched the
detail-page route to the default converter. Caught by the new
tests; pre-existing endpoints get a free correctness fix.

## Test plan

- [x] `python -m compileall -q mcp_proxy` clean.
- [x] `pytest test/unit/test_agent_identity_bundle_download.py -v` — 5/5 PASS:
  - `test_admin_downloads_identity_bundle_zip_with_expected_files`
  - `test_identity_bundle_emits_audit_row`
  - `test_identity_bundle_404_for_unknown_agent`
  - `test_identity_bundle_409_when_agent_has_no_private_key`
  - `test_identity_bundle_requires_login`
- [x] Regression: `pytest test/unit/ -k "agent or dashboard" -n auto --dist=loadfile` — 28/28 PASS.
- [x] Full unit suite: `pytest test/unit/ -n auto --dist=loadfile` — 283/283 PASS.
- [ ] Bundle dogfood after merge: build mastio image, deploy via `./deploy.sh`,
      open the dashboard, create an agent, click the new button, drop the zip on
      an SDK host, run `CullisClient.from_identity_dir`, confirm chat round-trip.