### PR TITLE
chore(dashboard): move Setup from sidebar into Settings page

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -45,11 +45,6 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/></svg>
                 Overview
             </a>
-            <a href="/proxy/setup"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'setup' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                Setup
-            </a>
             <a href="/proxy/agents"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'agents' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>

--- a/mcp_proxy/dashboard/templates/settings.html
+++ b/mcp_proxy/dashboard/templates/settings.html
@@ -11,6 +11,24 @@
     <div class="p-3 bg-emerald-500/10 border border-emerald-500/20 rounded text-sm text-emerald-400">{{ success }}</div>
     {% endif %}
 
+    <!-- Initial setup wizard card -->
+    <div class="bg-surface-900/60 border border-gray-800/60 rounded-lg p-6">
+        <div class="mb-4">
+            <h2 class="text-base font-semibold text-white" style="font-family: 'Chakra Petch', sans-serif; letter-spacing: 0.06em;">
+                Initial setup wizard
+            </h2>
+            <p class="text-xs text-gray-500 mt-1">
+                Re-run the broker uplink + organisation-details wizard. Standalone deployments do not need this after first boot;
+                it lives here for operators who want to revisit the choices made at install time or attach a Court federation.
+            </p>
+        </div>
+        <a href="/proxy/setup"
+           class="inline-flex items-center gap-2 px-3 py-2 rounded text-sm font-semibold bg-accent-400/10 border border-accent-400/30 text-accent-300 hover:bg-accent-400/20 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+            Open setup wizard
+        </a>
+    </div>
+
     <!-- OIDC card -->
     <div class="bg-surface-900/60 border border-gray-800/60 rounded-lg p-6">
         <div class="mb-5">


### PR DESCRIPTION
## Summary

The Setup wizard configures broker uplink (Court federation) plus org details — a first-boot one-shot. For community-only deploys (the only release today), having Setup as a top-level sidebar item next to Overview/Agents reads as 'ongoing operator surface' rather than 'install-time wizard'.

- Removed sidebar entry
- Added 'Initial setup wizard' card in `/proxy/settings` with 'Open setup wizard' button → `/proxy/setup`
- Route handler unchanged; wizard reachable for operators revisiting broker uplink or attaching Court later

## Test plan
- [x] Template jinja parses (compileall)
- [ ] Reviewer: visual check — Settings page card placement
