### PR TITLE
fix(dashboard): sidebar stretches full viewport height (min-h-screen)

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body class="h-full">
-<div class="flex h-full">
+<div class="flex min-h-screen">
 
     <!-- Sidebar -->
     <nav class="w-56 flex-shrink-0 bg-surface-900 border-r border-gray-800/60 flex flex-col">


### PR DESCRIPTION
## Summary

Operator reported a darker strip below the sidebar that 'follows' the viewport when the window is short enough that the 13 nav items + footer overflow. Sidebar bg is `surface-900` (lighter), body bg is hard-coded `#0a0f1a` (`surface-950`, darker). When the `h-full` chain resolved to less than 100vh, the sidebar shrank and the body bg behind it became visible.

Fix: `<div class="flex h-full">` → `<div class="flex min-h-screen">`. The flex container is always at least 100vh tall; sidebar stretches with it via flex default `align-items: stretch`.

## Test plan
- [x] Visual check on screenshots
- [ ] Reviewer: tall viewport + short viewport both render sidebar full height
