### PR TITLE
feat(dashboard): Cloudflare-style floating sidebar + main panels

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -10,10 +10,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body class="h-full">
-<div class="flex min-h-screen">
+<div class="flex min-h-screen gap-3 p-3">
 
-    <!-- Sidebar -->
-    <nav class="w-56 flex-shrink-0 bg-surface-900 border-r border-gray-800/60 flex flex-col">
+    <!-- Sidebar — floating panel, gap visible to the body bg around -->
+    <nav class="w-56 flex-shrink-0 bg-surface-900 border border-gray-800/60 rounded-xl flex flex-col self-stretch">
         <!-- Brand -->
         <div class="px-4 py-5 border-b border-gray-800/60">
             <div class="flex items-center gap-2.5 mb-1">
@@ -157,10 +157,10 @@
         </div>
     </nav>
 
-    <!-- Main content -->
-    <div class="flex-1 flex flex-col overflow-hidden">
+    <!-- Main content — floating panel matching the sidebar -->
+    <div class="flex-1 flex flex-col overflow-hidden bg-surface-900 border border-gray-800/60 rounded-xl self-stretch">
         <!-- Top bar -->
-        <header class="flex items-center justify-between px-6 py-3 border-b border-gray-800/60 bg-surface-950">
+        <header class="flex items-center justify-between px-6 py-3 border-b border-gray-800/60 rounded-t-xl bg-surface-950/40">
             <div class="flex items-center gap-3">
                 <h1 class="font-heading text-sm font-semibold text-white uppercase tracking-wider">{% block header_title %}Mastio{% endblock %}</h1>
             </div>


### PR DESCRIPTION
## Summary

Sidebar and main content now read as two floating panels separated by visible body bg. Pattern matches Cloudflare / Vercel / Linear dashboard aesthetics.

Before: sidebar flush against main, separated only by a 1px border-r.
After: 3-unit gap + p-3 around both, both wrapped in `rounded-xl border`, body bg breathes between.

## Test plan
- [ ] Visual: tall + short viewport both render correctly
- [ ] Inner cards in overview.html still readable (some may need contrast bump in follow-up)
