### PR TITLE
fix(dashboard): bump floating-panel gap to p-4/gap-4

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -9,8 +9,8 @@
     <script src="/static/vendor/htmx.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
-<body class="h-full">
-<div class="flex min-h-screen gap-3 p-3">
+<body class="h-full bg-surface-950">
+<div class="flex min-h-screen gap-4 p-4">
 
     <!-- Sidebar — floating panel, gap visible to the body bg around -->
     <nav class="w-56 flex-shrink-0 bg-surface-900 border border-gray-800/60 rounded-xl flex flex-col self-stretch">


### PR DESCRIPTION
Subtle gap of p-3/gap-3 from #958 was not visually distinct in the dark theme. Bumped to 16px + explicit bg-surface-950 on body.