### PR TITLE
fix(dashboard): force pure-black body + p-6/gap-6 for visible panel split

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -9,8 +9,8 @@
     <script src="/static/vendor/htmx.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
-<body class="h-full bg-surface-950">
-<div class="flex min-h-screen gap-4 p-4">
+<body class="h-full bg-black">
+<div class="flex min-h-screen gap-6 p-6" style="background-color:#000;">
 
     <!-- Sidebar — floating panel, gap visible to the body bg around -->
     <nav class="w-56 flex-shrink-0 bg-surface-900 border border-gray-800/60 rounded-xl flex flex-col self-stretch">


### PR DESCRIPTION
Two prior attempts failed because surface-950 vs surface-900 is 1 tint step (~6 luminance units) — below human-eye threshold for 'distinct surfaces' on most monitors. Pure-black body bg + p-6/gap-6 produces the Cloudflare-style separation operators were asking for.