### PR TITLE
fix(dashboard): independent scrollbars for sidebar and main + revert cosmetic

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -9,11 +9,11 @@
     <script src="/static/vendor/htmx.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
-<body class="h-full bg-black">
-<div class="flex min-h-screen gap-6 p-6" style="background-color:#000;">
+<body class="h-full">
+<div class="flex min-h-screen h-screen">
 
-    <!-- Sidebar — floating panel, gap visible to the body bg around -->
-    <nav class="w-56 flex-shrink-0 bg-surface-900 border border-gray-800/60 rounded-xl flex flex-col self-stretch">
+    <!-- Sidebar — fixed height, internal scroll on the nav block -->
+    <nav class="w-56 flex-shrink-0 bg-surface-900 border-r border-gray-800/60 flex flex-col h-screen">
         <!-- Brand -->
         <div class="px-4 py-5 border-b border-gray-800/60">
             <div class="flex items-center gap-2.5 mb-1">
@@ -38,8 +38,8 @@
             </div>
         </div>
 
-        <!-- Navigation -->
-        <div class="flex-1 px-2 py-3 space-y-0.5">
+        <!-- Navigation — independent scrollbar when items overflow -->
+        <div class="flex-1 overflow-y-auto px-2 py-3 space-y-0.5">
             <a href="/proxy/overview"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'overview' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/></svg>
@@ -157,10 +157,10 @@
         </div>
     </nav>
 
-    <!-- Main content — floating panel matching the sidebar -->
-    <div class="flex-1 flex flex-col overflow-hidden bg-surface-900 border border-gray-800/60 rounded-xl self-stretch">
+    <!-- Main content — independent scrollbar on <main> below -->
+    <div class="flex-1 flex flex-col overflow-hidden h-screen">
         <!-- Top bar -->
-        <header class="flex items-center justify-between px-6 py-3 border-b border-gray-800/60 rounded-t-xl bg-surface-950/40">
+        <header class="flex items-center justify-between px-6 py-3 border-b border-gray-800/60 bg-surface-950">
             <div class="flex items-center gap-3">
                 <h1 class="font-heading text-sm font-semibold text-white uppercase tracking-wider">{% block header_title %}Mastio{% endblock %}</h1>
             </div>


### PR DESCRIPTION
Sidebar and main now scroll independently. Reverted the unrelated cosmetic restyle from #958/#959/#960.