### PR TITLE
fix(security): never interpolate str(exc) into HTTP responses

### DIFF
--- a/mcp_proxy/admin/ai_providers.py
+++ b/mcp_proxy/admin/ai_providers.py
@@ -223,9 +223,23 @@ async def upsert_provider(
     try:
         cleaned = validate_creds(p, body.creds)
     except InvalidCredentialsError as exc:
+        # The exception text echoes admin-supplied values (api_base URL,
+        # missing field names, type errors that include type(input)). The
+        # admin-secret API is a machine surface (scripts, Terraform) so a
+        # structured trace_id + redacted hint is more useful than raw
+        # str(exc), and it stops the validator's internal text from
+        # landing in non-Mastio log aggregators.
+        from mcp_proxy._http_safety import safe_http_detail
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=safe_http_detail(
+                exc,
+                public_hint=(
+                    f"credentials for provider {p!r} rejected by validator"
+                ),
+                log_context="admin.ai_providers.upsert",
+                extra={"provider": p},
+            ),
         ) from exc
 
     await upsert_ai_provider_creds(
@@ -479,9 +493,24 @@ async def _probe_openai(creds: dict[str, str]) -> TestResult:
     # ``feedback_third_party_ai_gateway_key_leak.md``.
     try:
         _enforce_openai_compat_endpoint(base, allow_byo=_byo_endpoint_allowed())
-    except ValueError as exc:
+    except ValueError:
+        # The validator's str(exc) interpolates the rejected api_base
+        # (admin-supplied) back into the JSON body. Even though the admin
+        # typed it in, the live-probe response can be relayed downstream
+        # (CI bot logs, Terraform state) where the URL adds nothing. Log
+        # the full reason to stderr and return a generic detail.
+        _log.exception(
+            "openai live-probe rejected api_base=%s (allow_byo=%s)",
+            base, _byo_endpoint_allowed(),
+        )
         return TestResult(
-            provider="openai", status="error", detail=str(exc),
+            provider="openai", status="error",
+            detail=(
+                "api_base not on live-probe allow-list. Set "
+                "MCP_PROXY_AI_PROBE_ALLOW_BYO_ENDPOINT=true to enable "
+                "bring-your-own endpoints; the Mastio container logs "
+                "carry the exact reason."
+            ),
         )
     async with httpx.AsyncClient(timeout=5.0) as client:
         resp = await client.get(
@@ -534,9 +563,18 @@ async def _probe_ollama(creds: dict[str, str]) -> TestResult:
     # still refuse non-http schemes and validate the URL is parseable.
     try:
         _enforce_self_hosted_endpoint(api_base)
-    except ValueError as exc:
+    except ValueError:
+        # See _probe_openai for rationale on swallowing str(exc).
+        _log.exception(
+            "ollama live-probe rejected api_base=%s", api_base,
+        )
         return TestResult(
-            provider="ollama", status="error", detail=str(exc),
+            provider="ollama", status="error",
+            detail=(
+                "api_base rejected: must be a parseable http/https URL "
+                "with a hostname. Check the Mastio container logs for "
+                "the exact reason."
+            ),
         )
     models = await fetch_ollama_models(api_base, timeout_s=3.0)
     if not models:

--- a/mcp_proxy/admin/api_tokens.py
+++ b/mcp_proxy/admin/api_tokens.py
@@ -158,9 +158,23 @@ async def mint_token(body: MintRequest) -> MintResponse:
             expires_at=body.expires_at,
         )
     except ValueError as exc:
+        # mint_user_api_token raises ValueError for unknown principal /
+        # malformed expiry / unknown scope. The exception text can carry
+        # SQLAlchemy parameter dicts on driver fall-through. The
+        # admin-secret API is a machine surface so a trace_id + redacted
+        # hint is more useful for the caller than raw str(exc).
+        from mcp_proxy._http_safety import safe_http_detail
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=safe_http_detail(
+                exc,
+                public_hint="api_token mint rejected",
+                log_context="admin.api_tokens.mint",
+                extra={
+                    "principal_id": body.principal_id,
+                    "label": body.label,
+                },
+            ),
         ) from exc
 
     await log_audit(

--- a/mcp_proxy/admin/mastio_ca.py
+++ b/mcp_proxy/admin/mastio_ca.py
@@ -159,9 +159,19 @@ async def rotate_mastio_ca(
             ),
         ) from exc
     except ValueError as exc:
+        # rotate_mastio_ca raises ValueError for arg validation (bad
+        # grace_days, dry_run conflict, etc.). Even though these are
+        # caller-controlled, the exception text can carry filesystem
+        # paths / KMS keystore detail when the underlying serializer
+        # complains. Surface a redacted detail.
+        from mcp_proxy._http_safety import safe_http_detail
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=safe_http_detail(
+                exc,
+                public_hint="invalid rotation arguments",
+                log_context="rotate_mastio_ca",
+            ),
         ) from exc
 
     return RotateMastioCaResponse(

--- a/mcp_proxy/dashboard/ai_providers.py
+++ b/mcp_proxy/dashboard/ai_providers.py
@@ -148,8 +148,17 @@ async def save(request: Request, provider: str) -> RedirectResponse:
 
     try:
         cleaned = validate_creds(p, inbound)
-    except InvalidCredentialsError as exc:
-        # Re-render the page with the error inline.
+    except InvalidCredentialsError:
+        # InvalidCredentialsError messages can echo admin-supplied values
+        # (api_base URLs, header dicts, raw key prefixes) back into the
+        # HTML body. Even though the admin typed them in, rendering them
+        # untrusted into the page makes the form a self-XSS trampoline
+        # and obscures upstream stack frames the validator may have
+        # captured. Surface a generic hint instead and log the full text.
+        _log.exception(
+            "ai_provider upsert rejected by validate_creds: provider=%s",
+            p,
+        )
         providers = await _all_providers_view()
         return templates.TemplateResponse(
             "ai_providers.html",
@@ -157,9 +166,34 @@ async def save(request: Request, provider: str) -> RedirectResponse:
                 request, session,
                 providers=providers,
                 error_provider=p,
-                error=str(exc),
+                error=(
+                    f"Credentials for provider {p!r} were rejected. "
+                    "Check required fields are filled and that api_base "
+                    "(if any) is an HTTPS URL on the allow-list, then "
+                    "consult the Mastio container logs for the exact "
+                    "validator reason."
+                ),
             ),
             status_code=400,
+        )
+    except Exception:
+        _log.exception(
+            "ai_provider upsert crashed during validate_creds: provider=%s",
+            p,
+        )
+        providers = await _all_providers_view()
+        return templates.TemplateResponse(
+            "ai_providers.html",
+            _ctx(
+                request, session,
+                providers=providers,
+                error_provider=p,
+                error=(
+                    "Failed to save provider credentials. Check the "
+                    "Mastio container logs and try again."
+                ),
+            ),
+            status_code=500,
         )
 
     updated_by = (

--- a/mcp_proxy/dashboard/api_tokens.py
+++ b/mcp_proxy/dashboard/api_tokens.py
@@ -98,10 +98,36 @@ async def create_api_token(
             scope_providers=scope_list,
             expires_at=clean_expiry,
         )
-    except ValueError as exc:
+    except ValueError:
+        # mint_user_api_token raises ValueError for unknown principal /
+        # bad scope / malformed expiry. The exception text can carry the
+        # full SQLAlchemy parameter dict on driver fall-through; surface
+        # a generic action-oriented hint instead and log the full text.
+        _log.exception(
+            "api_token.mint rejected: principal=%s label=%s",
+            principal_id, clean_label,
+        )
         return _back_to_user(
             principal_id,
-            f"token_error={quote(str(exc))}",
+            "token_error="
+            + quote(
+                "Failed to mint API token. Verify the user exists, the "
+                "label is unique, and the expiry date is valid; the "
+                "Mastio container logs carry the exact reason."
+            ),
+        )
+    except Exception:
+        _log.exception(
+            "api_token.mint crashed: principal=%s label=%s",
+            principal_id, clean_label,
+        )
+        return _back_to_user(
+            principal_id,
+            "token_error="
+            + quote(
+                "Failed to mint API token. Check the Mastio container "
+                "logs and try again."
+            ),
         )
 
     await log_audit(

--- a/mcp_proxy/dashboard/auth_routes.py
+++ b/mcp_proxy/dashboard/auth_routes.py
@@ -245,12 +245,36 @@ async def register_submit(request: Request):
 
     try:
         await set_admin_password(password)
-    except ValueError as exc:
+    except ValueError:
+        # set_admin_password enforces MIN_PASSWORD_LENGTH and may evolve
+        # to enforce additional policy. The exception text can leak the
+        # configured policy values (which are deployment-specific and
+        # not meant to be advertised on the pre-auth registration page).
+        # Surface a generic hint and log the full reason to stderr.
+        _log.exception(
+            "admin registration rejected by set_admin_password",
+        )
         return templates.TemplateResponse("register.html", {
             "request": request,
-            "error": str(exc),
+            "error": (
+                f"Password rejected by policy. It must be at least "
+                f"{MIN_PASSWORD_LENGTH} characters; pick a stronger value "
+                "and try again."
+            ),
             "min_length": MIN_PASSWORD_LENGTH,
         }, status_code=400)
+    except Exception:
+        # Anything else (DB write failure, etc.) is an internal error —
+        # absolutely do NOT echo it on the pre-auth registration page.
+        _log.exception("admin registration crashed")
+        return templates.TemplateResponse("register.html", {
+            "request": request,
+            "error": (
+                "Failed to register the admin password. Check the "
+                "Mastio container logs and try again."
+            ),
+            "min_length": MIN_PASSWORD_LENGTH,
+        }, status_code=500)
 
     from mcp_proxy.db import log_audit
     await log_audit(

--- a/mcp_proxy/dashboard/enrollments_routes.py
+++ b/mcp_proxy/dashboard/enrollments_routes.py
@@ -180,8 +180,34 @@ async def enrollments_approve(request: Request, session_id: str):
                 admin_name=session.role or "admin",
                 agent_manager=agent_manager,
             )
-    except _enrollment_service.EnrollmentError as exc:
-        return _enroll_error_response(request, str(exc))
+    except _enrollment_service.EnrollmentError:
+        # EnrollmentError messages can carry cryptography backend text
+        # from the underlying serialization layer (e.g. "Invalid public
+        # key PEM: <openssl error>") or other internal validator state.
+        # Log the full text + stack to stderr but surface a generic hint.
+        _log.exception(
+            "enrollment_approve rejected: session_id=%s agent_id=%s",
+            session_id, agent_id,
+        )
+        return _enroll_error_response(
+            request,
+            "Approval rejected. Verify the enrollment session is still "
+            "pending and that agent_id is unique, then check the Mastio "
+            "container logs for the exact reason.",
+        )
+    except Exception:
+        # Anything else (DB write failure, cert sign crash, etc.) is an
+        # internal error — the operator inspects container logs.
+        _log.exception(
+            "enrollment_approve crashed: session_id=%s agent_id=%s",
+            session_id, agent_id,
+        )
+        return _enroll_error_response(
+            request,
+            "Failed to approve enrollment. Check the Mastio container "
+            "logs and try again.",
+            status_code=500,
+        )
 
     _log.info(
         "enrollment_approved via dashboard: session=%s agent=%s admin=%s",
@@ -220,8 +246,26 @@ async def enrollments_reject(request: Request, session_id: str):
                 reason=reason,
                 admin_name=session.role or "admin",
             )
-    except _enrollment_service.EnrollmentError as exc:
-        return _enroll_error_response(request, str(exc))
+    except _enrollment_service.EnrollmentError:
+        # See enrollments_approve for rationale on swallowing the str(exc).
+        _log.exception(
+            "enrollment_reject rejected: session_id=%s", session_id,
+        )
+        return _enroll_error_response(
+            request,
+            "Reject rejected. Verify the enrollment session is still "
+            "pending; the Mastio container logs carry the exact reason.",
+        )
+    except Exception:
+        _log.exception(
+            "enrollment_reject crashed: session_id=%s", session_id,
+        )
+        return _enroll_error_response(
+            request,
+            "Failed to reject enrollment. Check the Mastio container "
+            "logs and try again.",
+            status_code=500,
+        )
 
     _log.info(
         "enrollment_rejected via dashboard: session=%s admin=%s",

--- a/mcp_proxy/dashboard/mastio_key_routes.py
+++ b/mcp_proxy/dashboard/mastio_key_routes.py
@@ -341,14 +341,19 @@ async def mastio_key_rotate(request: Request):
         )
         raise
     except Exception as exc:
-        # Audit H-IO-2, audit row carries the full reason; HTTP detail
-        # is generic so an attacker can't probe rotation internals.
-        _log.warning("mastio_key.rotate failed (old_kid=%s): %s", old_kid, exc)
+        # Audit H-IO-2, the full reason lands in stderr via _log.exception
+        # below; the audit row carries only the operator-visible kid so a
+        # later JSON export of the audit chain (which can travel outside
+        # the host, ADR-030) does NOT carry raw exception text. The HTTP
+        # detail is generic so an attacker can't probe rotation internals.
+        _log.exception(
+            "mastio_key.rotate failed (old_kid=%s)", old_kid,
+        )
         await log_audit(
             agent_id="admin",
             action="mastio_key.rotate",
             status="failure",
-            detail=f"old_kid={old_kid}, reason={exc}",
+            detail=f"old_kid={old_kid}",
         )
         raise HTTPException(
             status_code=500,
@@ -443,17 +448,18 @@ async def mastio_key_complete_staged(request: Request):
     try:
         result = await agent_mgr.complete_staged_rotation(decision)
     except RuntimeError as exc:
-        # Audit H-IO-2, audit row carries the full reason; HTTP detail
-        # is generic so an attacker can't probe internal staging state.
-        _log.warning(
-            "mastio_key.complete_staged failed (decision=%s): %s",
-            decision, exc,
+        # Audit H-IO-2, full reason in stderr via _log.exception; audit
+        # row carries only the operator-visible decision so a JSON export
+        # of the chain does NOT carry raw exception text. HTTP detail is
+        # generic so an attacker can't probe internal staging state.
+        _log.exception(
+            "mastio_key.complete_staged failed (decision=%s)", decision,
         )
         await log_audit(
             agent_id="admin",
             action="mastio_key.complete_staged",
             status="failure",
-            detail=f"decision={decision}, reason={exc}",
+            detail=f"decision={decision}",
         )
         raise HTTPException(
             status_code=409,

--- a/mcp_proxy/dashboard/settings_routes.py
+++ b/mcp_proxy/dashboard/settings_routes.py
@@ -261,12 +261,42 @@ async def settings_admin_password_change(request: Request):
 
     try:
         await set_admin_password(new)
-    except ValueError as exc:
+    except ValueError:
         # set_admin_password enforces MIN_PASSWORD_LENGTH and possibly
-        # other complexity rules; surface the constraint to the operator.
+        # other complexity rules. We do NOT interpolate str(exc) into the
+        # redirect URL: the helper's __str__ can mention the configured
+        # minimum length and other internal policy details. Instead we
+        # surface a generic, action-oriented hint and log the full text
+        # to the container stderr where the operator can inspect it.
         from urllib.parse import quote
+        _log.exception(
+            "admin password rotation rejected by set_admin_password "
+            "(actor=%s)",
+            getattr(session, "username", "?"),
+        )
         return RedirectResponse(
-            f"/proxy/settings?error={quote(str(exc))}",
+            "/proxy/settings?error="
+            + quote(
+                "Password rejected by policy. Pick a longer / stronger "
+                "value and try again; the Mastio container logs carry "
+                "the exact reason."
+            ),
+            status_code=303,
+        )
+    except Exception:
+        # Anything else (DB write failure, etc.) is an internal error
+        # the operator should investigate in the container logs.
+        from urllib.parse import quote
+        _log.exception(
+            "admin password rotation crashed (actor=%s)",
+            getattr(session, "username", "?"),
+        )
+        return RedirectResponse(
+            "/proxy/settings?error="
+            + quote(
+                "Failed to rotate admin password. Check the Mastio "
+                "container logs and try again."
+            ),
             status_code=303,
         )
 
@@ -346,11 +376,16 @@ async def settings_license_swap(request: Request):
 
     try:
         claims = swap_token(candidate)
-    except LicenseSwapError as exc:
+    except LicenseSwapError:
         # Audit the failed swap attempt so a paste-error / hostile JWT
         # is forensically visible. The candidate token itself is NOT
         # logged (it may be a valid JWT for the wrong tenant and we do
-        # not want to leak it via grep).
+        # not want to leak it via grep). The exception text can carry
+        # signing-key fingerprints / internal verifier state, so we keep
+        # it out of the HTTP response AND out of the audit detail row
+        # (audit detail is operator-readable but also exported in JSON
+        # bundles to customers). The full stack lands in stderr.
+        _log.exception("license swap rejected")
         actor = (
             getattr(session, "principal_id", None)
             or getattr(session, "username", None)
@@ -360,10 +395,15 @@ async def settings_license_swap(request: Request):
             agent_id=actor,
             action="license_swap",
             status="error",
-            detail=f"reason={exc} actor={actor}",
+            detail=f"actor={actor}",
         )
         return RedirectResponse(
-            f"/proxy/settings?error={quote(f'License swap rejected: {exc}')}",
+            "/proxy/settings?error="
+            + quote(
+                "License swap rejected. Check the JWT was issued for "
+                "this tenant and inspect the Mastio container logs for "
+                "the exact validator reason."
+            ),
             status_code=303,
         )
 

--- a/mcp_proxy/dashboard/vault_routes.py
+++ b/mcp_proxy/dashboard/vault_routes.py
@@ -87,8 +87,21 @@ async def vault_page(request: Request):
                     }
                 else:
                     vault_status = {"connected": False, "error": f"HTTP {resp.status_code}"}
-        except Exception as exc:
-            vault_status = {"connected": False, "error": str(exc)}
+        except Exception:
+            # httpx / TLS / DNS exceptions can carry the configured
+            # VAULT_ADDR, intermediate CA paths, and other infrastructure
+            # detail that the dashboard should not render in the browser.
+            # Log to stderr with full context and surface a generic hint.
+            _log.exception(
+                "vault status probe failed: addr=%s", vault_addr,
+            )
+            vault_status = {
+                "connected": False,
+                "error": (
+                    "Vault unreachable. Check VAULT_ADDR + token "
+                    "configuration and the Mastio container logs."
+                ),
+            }
 
     return templates.TemplateResponse("vault.html", _ctx(
         request, session,


### PR DESCRIPTION
## Summary

Audit + fix of `except Exception as exc: ... str(exc) / f"...{exc}"` leaks across
`mcp_proxy/dashboard/` and `mcp_proxy/admin/`. Triggered by an operator hitting
a `SQLAlchemy IntegrityError` on Create Agent and seeing the full SQL statement
+ bound parameters (including a freshly-minted x509 certificate PEM) in the
dashboard error banner. CLAUDE.md memory rule explicitly forbids leaking stack
traces / exception detail into HTTP responses; the same pattern was repeated
in 13 other handlers.

## What changed

Replaced every `f"...{exc}"` / `str(exc)` / `exc.args` in HTTP-visible response
bodies, audit-row details, and JSON detail strings with one of:

- a specific catch (`IntegrityError`, `ValueError`, `LicenseSwapError`,
  `EnrollmentError`, `InvalidCredentialsError`) plus a user-friendly hint
  naming the field or action the operator should adjust, never the raw
  exception text
- a generic catch + `_log.exception(...)` so the full stack lands in the
  container stderr (where the operator can read it via `docker logs`) but
  never reaches the browser or an external API caller
- on the admin/ JSON surface, `safe_http_detail(...)` which returns a
  short `trace_id` linking the redacted response to the full log line

## Files touched (10)

Dashboard:
- `mcp_proxy/dashboard/settings_routes.py` (admin password rotate + license JWT hot-swap)
- `mcp_proxy/dashboard/enrollments_routes.py` (Connector enrollment approve + reject)
- `mcp_proxy/dashboard/vault_routes.py` (Vault connectivity probe)
- `mcp_proxy/dashboard/ai_providers.py` (provider credentials save)
- `mcp_proxy/dashboard/api_tokens.py` (user API token mint)
- `mcp_proxy/dashboard/auth_routes.py` (first-time admin register)
- `mcp_proxy/dashboard/mastio_key_routes.py` (Mastio key rotate + complete-staged recovery, audit-row detail too)

Admin:
- `mcp_proxy/admin/mastio_ca.py` (intermediate CA rotate, ValueError branch)
- `mcp_proxy/admin/ai_providers.py` (provider upsert + openai/ollama live-probe)
- `mcp_proxy/admin/api_tokens.py` (admin-secret token mint)

## Instances kept as-is

- `mcp_proxy/dashboard/rego_rules.py:192/213` (OPA compile error on admin-typed Rego, already `[:500]` truncated)
- `mcp_proxy/dashboard/oidc_routes.py:152` (IdP discovery error on admin-typed URL, already `[:200]` truncated)

These three surface inline feedback on operator-provided input the admin just
submitted in the same form, so they pay their way; pre-existing truncation
already prevents a runaway parameter dump.

## Test plan

- [x] `python -m compileall -q mcp_proxy/dashboard mcp_proxy/admin` — clean
- [x] `pytest test/unit/ -n auto --dist=loadfile` — 283 pass
- [ ] Cold-reader smoke: deploy bundle locally, intentionally fail Create Agent / Approve Enrollment / Save AI Provider / Save Vault / Register Admin / Mint API Token / License Swap, verify the dashboard banner no longer surfaces the underlying SQL / PEM / cryptography text, and the same reason still lands in `docker logs cullis-mastio` via `_log.exception`