### PR TITLE
fix(dashboard): never leak str(exc) on agent create failure

### DIFF
--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -23,6 +23,7 @@ sub-router because the Mastio surface is simpler than Court's.
 from __future__ import annotations
 
 import logging
+from sqlalchemy.exc import IntegrityError
 import pathlib
 
 from fastapi import APIRouter, HTTPException, Request
@@ -185,7 +186,12 @@ async def agents_create(request: Request):
 
         agent_info, _key_pem = await mgr.create_agent(agent_name, display_name, capabilities)
         agent_id = agent_info["agent_id"]
-    except Exception as exc:
+    except IntegrityError:
+        # Most common path: admin submitted an agent_name that already
+        # exists. The UNIQUE constraint on internal_agents.agent_id is
+        # the brake. Surface a user-friendly hint instead of leaking
+        # the raw SQL exception (which also contains the cert PEM in
+        # parameters; see CLAUDE.md "Mai esporre stack trace").
         agents = await list_agents()
         _org_status = await get_config("org_status") or ""
         _has_ca = bool(await get_config("org_ca_cert"))
@@ -195,7 +201,32 @@ async def agents_create(request: Request):
             agents=agents,
             org_status=_org_status,
             has_ca=_has_ca,
-            error=f"Failed to create agent: {exc}",
+            error=(
+                f"Agent name '{agent_name}' is already taken in this org. "
+                f"Pick a different name, or delete the existing agent first."
+            ),
+            new_agent_id=None,
+        ))
+    except Exception:
+        # Defensive catch-all: log the full stack for the operator
+        # (via uvicorn stderr / docker logs) but show only a generic
+        # error to the dashboard. Never interpolate ``exc`` into the
+        # response body — SQLAlchemy IntegrityError ``str(exc)`` already
+        # bit us once with the cert PEM in parameters.
+        _log.exception("agent.create failed for agent_id=%s", agent_name)
+        agents = await list_agents()
+        _org_status = await get_config("org_status") or ""
+        _has_ca = bool(await get_config("org_ca_cert"))
+        return templates.TemplateResponse("agents.html", _ctx(
+            request, session,
+            active="agents",
+            agents=agents,
+            org_status=_org_status,
+            has_ca=_has_ca,
+            error=(
+                "Failed to create the agent. Check the Mastio container "
+                "logs for the underlying cause."
+            ),
             new_agent_id=None,
         ))
 


### PR DESCRIPTION
## Summary

- Extends the #962 pattern (never interpolate `str(exc)` into HTTP responses) to `agents_routes.py::agents_create`.
- Splits the previous bare `except Exception` into a specific `IntegrityError` handler (UNIQUE conflict on `internal_agents.agent_id`) and a defensive catch-all that logs the traceback but renders a generic message.
- Removes the last code path that could have spilled the freshly minted cert PEM into the dashboard error banner, since SQLAlchemy's `str(exc)` serialises the bound parameters.

## Test plan

- [ ] curl-equivalent: submit a duplicate agent_name via the dashboard, verify the error banner shows "Agent name '<name>' is already taken in this org" with no SQL fragment.
- [ ] Trigger a different failure (e.g. KMS unreachable), verify the banner shows "Failed to create the agent. Check the Mastio container logs..." and the traceback lands in stderr.
- [ ] /security-review (pattern continuation of #962).

🤖 Generated with [Claude Code](https://claude.com/claude-code)