### PR TITLE
fix(bundle): community SSRF guard default-allow private IPs (C-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Polish on `main` accumulating for the next minor (target v0.5.5, mid next week).
 ### Bundle
 
 - **`deploy.sh --wipe-data` actually wipes the bind-mounted dirs** (#949, D-10). The host-side `compgen -G` empty-check short-circuited the busybox wipe because the data dir is mode 0700 owned by uid 10001 post init-permissions, so the operator's host uid saw the dir as "empty" even when `mcp_proxy.db` was inside. Removed the compgen probe.
+- **Community bundle `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS` default flipped to `1`** (C-3 tier-aware fix). `proxy.env.example` and the compose fallback in both `packaging/mastio-bundle/docker-compose.yml` and `deploy/compose/docker-compose.proxy.yml` now ship `1` instead of `0`. The first-Save-of-an-MCP-backend HTTP 400 (resolves to RFC 1918) no longer hits every cold-reader of the community bundle out of the box, since the primary scenario for the community release is docker-compose with sibling MCP-backend containers on the bridge network. Cloud-metadata (`169.254/16`) and CGNAT (`100.64/10`) stay blocked at the helper level regardless of this knob (`mcp_proxy/utils/url_safety.py:80-83`); the IMDS attack surface is not re-openable from `proxy.env`. The enterprise bundle keeps default-deny because its primary scenario is cloud-hosted with externally-routable backends. Runbook `site/src/content/docs/operate/internal-mcp-backends.md` updated to describe the per-bundle default + posture matrix.
 
 ### Enrollment
 

--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -62,7 +62,7 @@ services:
       # env vars into the container, so the SSRF guard escape knobs must
       # be forwarded explicitly here too.
       MCP_PROXY_INTERNAL_HOST_ALLOWLIST:        ${MCP_PROXY_INTERNAL_HOST_ALLOWLIST:-}
-      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-0}
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-1}
       # Broker uplink — empty by default in standalone. The shared-broker
       # override fills these with the in-compose service name; production
       # federated deploys set them via proxy.env.

--- a/deploy/proxy/proxy.env.example
+++ b/deploy/proxy/proxy.env.example
@@ -131,14 +131,27 @@ MCP_PROXY_STANDALONE=true
 #     blocked even for allowlisted FQDNs.
 MCP_PROXY_INTERNAL_HOST_ALLOWLIST=
 
-# (2) Global private-range escape — dev / sandbox sledgehammer.
-#     Set to ``1`` to allow ANY RFC 1918 / loopback address. Use only
-#     for single-tenant dev stacks where you control every backend on
-#     the bridge; never set in production. Cloud-metadata + CGNAT stay
-#     blocked even when this is on.
+# (2) Global private-range escape — community bundle default ON.
+#     The community Mastio bundle ships as docker-compose, and the
+#     primary scenario is a sibling MCP-backend container reachable
+#     over the bridge on an RFC 1918 address. Default-deny here forced
+#     every new operator to grep the source for the escape knob on the
+#     first Save (C-3 dogfood, 2026-05-25). Default-allow keeps the
+#     first-run experience smooth; the enterprise bundle (separate
+#     overlay) flips this back to ``0`` because its primary scenario is
+#     cloud-hosted with externally-routable backends.
 #
-#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
-MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+#     Cloud-metadata (169.254/16) and CGNAT (100.64/10) stay blocked
+#     even with this on — IMDS attacks are the whole point of the
+#     defence and cannot be re-enabled from this knob.
+#
+#     If you are running the community bundle on a cloud VPS with
+#     externally-routable MCP backends only, flip this to ``0`` and
+#     pair with ``MCP_PROXY_INTERNAL_HOST_ALLOWLIST`` if any specific
+#     internal FQDN still needs to reach through.
+#
+#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
 
 # Runbook: https://cullis.io/docs/operate/internal-mcp-backends
 

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       # site/src/content/docs/operate/internal-mcp-backends.md for the
       # operator runbook + posture matrix.
       MCP_PROXY_INTERNAL_HOST_ALLOWLIST:        ${MCP_PROXY_INTERNAL_HOST_ALLOWLIST:-}
-      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-0}
+      MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: ${MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS:-1}
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -335,13 +335,26 @@ MCP_PROXY_ANTHROPIC_API_KEY=
 #
 MCP_PROXY_INTERNAL_HOST_ALLOWLIST=
 
-# (2) Global private-range escape — dev / sandbox sledgehammer.
-#     Set to ``1`` to allow ANY RFC 1918 / loopback address. Use only
-#     for single-tenant dev stacks where you control every backend on
-#     the bridge; never set in production. Cloud-metadata + CGNAT stay
-#     blocked even when this is on.
+# (2) Global private-range escape — community bundle default ON.
+#     The community Mastio bundle ships as docker-compose, and the
+#     primary scenario is a sibling MCP-backend container reachable
+#     over the bridge on an RFC 1918 address. Default-deny here forced
+#     every new operator to grep the source for the escape knob on the
+#     first Save (C-3 dogfood, 2026-05-25). Default-allow keeps the
+#     first-run experience smooth; the enterprise bundle (separate
+#     overlay) flips this back to ``0`` because its primary scenario is
+#     cloud-hosted with externally-routable backends.
 #
-#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
-MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+#     Cloud-metadata (169.254/16) and CGNAT (100.64/10) stay blocked
+#     even with this on — IMDS attacks are the whole point of the
+#     defence and cannot be re-enabled from this knob.
+#
+#     If you are running the community bundle on a cloud VPS with
+#     externally-routable MCP backends only, flip this to ``0`` and
+#     pair with ``MCP_PROXY_INTERNAL_HOST_ALLOWLIST`` if any specific
+#     internal FQDN still needs to reach through.
+#
+#       MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
+MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
 
 # Runbook: https://cullis.io/docs/operate/internal-mcp-backends

--- a/site/src/content/docs/operate/internal-mcp-backends.md
+++ b/site/src/content/docs/operate/internal-mcp-backends.md
@@ -3,16 +3,23 @@ title: "Internal MCP backends (SSRF guard escape)"
 description: "Allow the Mastio to register MCP backends on a private network (Docker bridge, on-prem) without disabling the SSRF defence. FQDN-scoped allowlist preferred; global private-range escape as a dev/sandbox fallback."
 category: "Operate"
 order: 6
-updated: "2026-05-25"
+updated: "2026-05-26"
 ---
 
 # Internal MCP backends (SSRF guard escape)
 
-**Who this is for**: an operator registering an MCP backend whose endpoint URL points at a private (RFC 1918), loopback, or Docker-bridge address — for example, a sibling `mcp-pitchbook` container on the same compose network, or an on-prem `internal-mcp.corp.example` that resolves to `10.20.30.40`. By default the Mastio refuses these, by design.
+**Who this is for**: an operator registering an MCP backend whose endpoint URL points at a private (RFC 1918), loopback, or Docker-bridge address — for example, a sibling `mcp-pitchbook` container on the same compose network, or an on-prem `internal-mcp.corp.example` that resolves to `10.20.30.40`.
+
+**Default by bundle**:
+
+- **Community bundle** ships `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1` in `proxy.env.example`. RFC 1918 + loopback addresses are accepted out-of-the-box — the docker-compose-with-sibling-MCP-container scenario is the primary use case, so the first-run experience is smooth. Cloud-metadata (`169.254/16`) and CGNAT (`100.64/10`) stay blocked regardless.
+- **Enterprise bundle** ships the same knob set to `0`. The primary scenario there is cloud-hosted with externally-routable backends, so a private-range URL is almost always a misconfiguration or an IMDS attempt. You will see the HTTP 400 below the first time you register an internal backend, and you opt in explicitly via Option A or B.
+
+If you are on the community bundle and want to tighten posture (e.g. running on a cloud VPS with externally-routable MCP backends only), flip `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0` in `proxy.env` and adopt Option A.
 
 ## The error you hit
 
-In the dashboard, **Backends → Save**, you see HTTP 400 with a message like:
+When the SSRF guard is in default-deny mode (enterprise bundle, or community bundle with the knob explicitly flipped to `0`), in the dashboard **Backends → Save**, you see HTTP 400 with a message like:
 
 ```
 endpoint_url is blocked by the SSRF guard: hostname 'mcp-pitchbook' resolves to
@@ -55,14 +62,14 @@ Then:
 
 Re-open the dashboard, **Backends → Save** the same `http://mcp-pitchbook:8080` URL — green.
 
-## Option B — Global private-range escape (dev / sandbox only)
+## Option B — Global private-range escape (community bundle default)
 
-`MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1` opens up the entire RFC 1918 + loopback range. Any URL the admin types is accepted as long as it is not in the cloud-metadata or CGNAT family.
+`MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1` opens up the entire RFC 1918 + loopback range. Any URL the admin types is accepted as long as it is not in the cloud-metadata or CGNAT family. This is the **community bundle default**, on the assumption that the primary scenario is a single docker-compose stack the operator controls end-to-end.
 
 Trade-offs:
 
-- **Pros**: zero per-backend config; a single-tenant dev stack where you control every container on the bridge just works.
-- **Cons**: an admin (or a leaked admin session) can register **any** internal address as an MCP backend. Not defensible in a regulated production deploy.
+- **Pros**: zero per-backend config; a single-tenant dev or on-prem-LAN stack where you control every container on the bridge just works.
+- **Cons**: an admin (or a leaked admin session) can register **any** internal address as an MCP backend. Not defensible in a regulated production deploy — the enterprise bundle therefore ships with this knob off.
 
 Compose snippet:
 
@@ -76,9 +83,10 @@ Restart the same way (`./deploy.sh --upgrade`).
 
 | Deployment | Recommendation |
 |---|---|
-| Single-tenant dev / hack day / laptop demo | **B** is fine. |
-| Pilot with a CISO in the room | **A**. Name every backend you trust; let the dashboard reject the rest. |
-| Production on-prem / cloud | **A**, full stop. The audit trail of which hostnames were added (and when) lives in your config management; `B` leaves no per-backend record. |
+| Single-tenant dev / hack day / laptop demo (community bundle) | **B**, which is the community bundle default. No action needed. |
+| On-prem LAN, one operator, MCP backends are sibling containers (community bundle) | **B** is fine. The community bundle default already covers you. |
+| Pilot with a CISO in the room (community bundle, hardened) | Flip `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0` and adopt **A**. Name every backend you trust; let the dashboard reject the rest. |
+| Production on-prem / cloud (enterprise bundle) | **A**, full stop. The enterprise bundle already ships default-deny; you add hostnames you trust. The audit trail of which hostnames were added (and when) lives in your config management; `B` leaves no per-backend record. |
 | Mixed (dev compose + real internal backend) | **A** for the real backend; spin a separate dev compose stack with `B` for sandbox experimentation. |
 
 ## What stays blocked either way


### PR DESCRIPTION
## Summary

Closes the **C-3 finding** from the 2026-05-25 cold-reader dogfood. Tier-aware part of the fix; the UX (stylized 400 with escape-knob hints) was already shipped in #936.

The community Mastio bundle ships as docker-compose, and the primary scenario is a sibling MCP-backend container on the bridge (RFC 1918). Default-deny forced every cold-reader to hit a 400 on the first Backend → Save and then dig through the source to find the escape knob. C-3 documented this as the first visible failure of the community quickstart out-of-the-box.

## Change

Flip the community-shipped default of `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS` from `0` to `1` in four places:

- `deploy/proxy/proxy.env.example`
- `packaging/mastio-bundle/proxy.env.example`
- `deploy/compose/docker-compose.proxy.yml` (compose fallback `:-1`)
- `packaging/mastio-bundle/docker-compose.yml` (compose fallback `:-1`)

Runbook `site/src/content/docs/operate/internal-mcp-backends.md` rewritten to describe the per-bundle default + the operator posture matrix.

## Security posture unchanged

The IMDS attack surface is **not** re-openable from this knob. `mcp_proxy/utils/url_safety.py::is_safe_ip` (lines 80-83) blocks cloud-metadata (`169.254/16`, `fe80::/10`) and CGNAT (`100.64.0.0/10`) **before** the `allow_private` bypass executes. The knob only relaxes the generic RFC 1918 + loopback block.

The enterprise bundle (separate overlay in `cullis-enterprise`) keeps the default-deny posture because its primary scenario is cloud-hosted with externally-routable backends.

Operators on the community bundle who want CISO-friendly posture (e.g. running on a cloud VPS):

```bash
# in proxy.env
MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0
MCP_PROXY_INTERNAL_HOST_ALLOWLIST=mcp-internal-1,mcp-internal-2
```

## Test plan

- [ ] Fresh community bundle (`cd packaging/mastio-bundle && cp proxy.env.example proxy.env && ./deploy.sh`), register an MCP backend pointing at a sibling container on the bridge — Save succeeds with HTTP 200 (no 400).
- [ ] Same bundle but `MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=0` in `proxy.env`, `./deploy.sh --upgrade`, retry Save — gets the stylized 400 from #936 with both escape hints.
- [ ] With default `=1`, try to register `http://169.254.169.254/latest/meta-data/` — blocked with `link-local (169.254.0.0/16, fe80::/10) — cloud metadata` (proves IMDS still defended).
- [ ] With default `=1`, try `http://100.64.1.1/` — blocked with `CGNAT (100.64.0.0/10) — AWS internal range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)