### PR TITLE
ci: trigger Cloudflare Pages deploy on push to main

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,31 @@
+name: cloudflare-deploy
+
+# Triggers a Cloudflare Pages build via Deploy Hook URL on every push to main.
+# Backstop for the native GitHub webhook, which intermittently marks
+# auto-deployments as "skipped" (root cause unknown; Cloudflare side).
+# The Deploy Hook URL lives in repo secret CLOUDFLARE_DEPLOY_HOOK_URL.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    name: POST Cloudflare deploy hook
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Call deploy hook
+        env:
+          HOOK_URL: ${{ secrets.CLOUDFLARE_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "${HOOK_URL:-}" ]; then
+            echo "::error::CLOUDFLARE_DEPLOY_HOOK_URL secret not set"
+            exit 1
+          fi
+          http_code=$(curl -fsS -X POST -o /dev/null -w '%{http_code}' "$HOOK_URL")
+          echo "Cloudflare deploy hook returned HTTP $http_code"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cloudflare-deploy.yml` — one job, one curl, POST to a Deploy Hook URL on every push to `main`.
- Backstop for the native Cloudflare GitHub webhook, which has been marking auto-deployments as `skipped` since around 2026-05-26. Site was pinned at commit `4a0c1b44` for 17 commits — including the v0.5.5 release (#967) — until manual "Retry deployment" was clicked. This eliminates that friction for every future release.
- Deploy Hook URL is held in repo secret `CLOUDFLARE_DEPLOY_HOOK_URL` (already configured).
- Does NOT replace the native webhook — preview deploys for PR branches keep working through it. This only deterministically triggers production builds on main.

## Caveat

Re-introduces a (tiny) GitHub Actions workflow against the `cloud-ci-is-overhead-for-solo-founder` policy. Justified as "necessità reale": alternative is manual "Retry deployment" clicks indefinitely. File is 31 lines, no test matrix, ~5s of Actions minutes per push.

## Test plan

- [ ] Merge PR
- [ ] Push a trivial commit to main (e.g. amend CHANGELOG note) — verify workflow `cloudflare-deploy` runs green
- [ ] Check Cloudflare Deployments tab — new build for `main <sha>` should show Status: Success (not skipped)
- [ ] `curl -sL https://cullis.io/quickstart/sdk/ | grep mastio-v` shows the latest version