### PR TITLE
fix(bundle): auto-detect public URL host instead of host.docker.internal default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ cd cullis-mastio-bundle && ./deploy.sh
 echo 'MCP_PROXY_ANTHROPIC_API_KEY=sk-ant-...' >> proxy.env
 ./deploy.sh --pull
 
-# 3. Open https://localhost:9443/proxy/login, accept the self-signed TLS warning,
-#    create the admin account, go to Agents > Enroll new, and copy the one-shot
-#    enrollment URL the dashboard displays.
+# 3. Open the dashboard URL the deploy script prints (auto-detected per host:
+#    host.docker.internal on Docker Desktop, an interface IP on Linux pure so
+#    a browser on a separate laptop on the same LAN can reach the VM).
+#    Accept the self-signed TLS warning, create the admin account, go to
+#    Agents > Enroll new, and copy the one-shot enrollment URL the dashboard
+#    displays.
 
 # 4. Install the SDK.
 pip install cullis-sdk

--- a/packaging/_common-deploy-helpers.sh
+++ b/packaging/_common-deploy-helpers.sh
@@ -318,3 +318,43 @@ _hint_on_bind_mount_failure() {
        See README "Troubleshooting" → "not a directory: mount".
 EOF
 }
+
+# Pick a default public hostname for MCP_PROXY_PROXY_PUBLIC_URL.
+#
+# The previous default ``host.docker.internal`` worked on macOS and
+# Windows (where Docker Desktop pins it in /etc/hosts to the host's
+# loopback) but silently broke on Linux hosts without Docker Desktop:
+# the magic name does not resolve from the host browser, from a sibling
+# container, or from a SDK client on a different machine. Cold-readers
+# hit DNS errors or 401 ``Invalid DPoP proof: htu mismatch`` and could
+# not tell from the deploy banner that the URL itself was the problem.
+#
+# Detection order:
+#   1. host.docker.internal already in /etc/hosts → use it (Docker
+#      Desktop on any OS, or operator who pinned it themselves).
+#   2. macOS / Windows (uname not Linux) → use host.docker.internal
+#      anyway; Docker Desktop maps it at runtime even when not in
+#      /etc/hosts.
+#   3. Linux pure: best non-loopback IPv4 of the interface that holds
+#      the default route. Reachable from a sibling container, from the
+#      host browser, AND from another machine on the same LAN.
+#   4. No default route (very minimal containers) → ``localhost`` as
+#      last resort. Same behaviour as the legacy default.
+_detect_default_public_host() {
+    if grep -q "host.docker.internal" /etc/hosts 2>/dev/null; then
+        echo "host.docker.internal"
+        return
+    fi
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        echo "host.docker.internal"
+        return
+    fi
+    local _ip
+    _ip="$(ip -4 -o route get 1.1.1.1 2>/dev/null \
+            | awk '{for (i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"
+    if [[ -n "$_ip" ]]; then
+        echo "$_ip"
+        return
+    fi
+    echo "localhost"
+}

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -30,9 +30,13 @@ release. The full Mastio version list is at
 > newer bundle. The cullis.io/download page above is updated atomically
 > with each release.
 
-Open `https://localhost:9443/proxy/login` (the browser will warn — the
-TLS cert is signed by your auto-generated Org CA, not a public CA).
-Complete the first-boot wizard and enroll your first agent.
+When `deploy.sh` finishes it prints the dashboard URL it picked for
+your host (auto-detected: `host.docker.internal` on macOS / Windows /
+Docker Desktop, an interface IP on Linux pure so a remote laptop on
+the same LAN can reach the VM). Open that URL — the browser will
+warn, the TLS cert is signed by your auto-generated Org CA, not a
+public CA. Complete the first-boot wizard and enroll your first
+agent.
 
 ## Enable chat (Anthropic API key)
 

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -744,24 +744,30 @@ if [[ ! -f "$SCRIPT_DIR/proxy.env" ]]; then
     # ``Invalid DPoP proof: htu mismatch`` on every egress. Ask up front
     # so the operator never finds out post-deploy.
     #
-    # The default ``host.docker.internal:9443`` covers BOTH the browser
-    # on the host (resolves to 127.0.0.1 via the host's hosts file or
-    # docker desktop's automatic mapping) AND a sibling docker container
-    # such as the Frontdesk Connector reaching the Mastio across docker
-    # networks. ``localhost:9443`` only works for the host browser case
-    # and silently breaks the moment a second component (Frontdesk,
-    # second Mastio, agent on a different docker network) is introduced.
+    # The default URL is detected at boot via _detect_default_public_host
+    # (in _common-deploy-helpers.sh): host.docker.internal on macOS /
+    # Windows / Docker Desktop, an interface IP on Linux pure (so a
+    # remote agent SDK or LAN browser can reach the Mastio), localhost
+    # as last-resort fallback. The historical hardcoded
+    # ``host.docker.internal:9443`` silently broke VM / remote-laptop
+    # setups: the magic name does not resolve from the host browser or
+    # from a client on a different machine.
+    _default_public_host="$(_detect_default_public_host)"
+    _default_public_url="https://${_default_public_host}:9443"
     echo ""
     echo "  ${BOLD}Where will agents reach this Mastio?${RESET}"
-    echo "    ${GRAY}- Laptop / single VM: just press Enter (uses https://host.docker.internal:9443)${RESET}"
-    echo "      ${GRAY}covers host browser AND sibling containers (Frontdesk bundle, etc.)${RESET}"
-    echo "    ${GRAY}- Internal server with stable DNS: enter the public URL agents resolve at${RESET}"
-    echo "    ${GRAY}  e.g. https://mastio.acme.local  or  https://192.168.10.42:9443${RESET}"
-    echo "    ${GRAY}- Internet-facing: the LB/ingress hostname${RESET}"
-    echo "    ${GRAY}  e.g. https://mastio.myorg.example.com${RESET}"
+    echo "    ${GRAY}- Single laptop / VM (Mastio + browser + SDK on the same host):${RESET}"
+    echo "      ${GRAY}  just press Enter — uses ${_default_public_url}${RESET}"
+    echo "    ${GRAY}- VM hosting Mastio, browser/SDK on a separate machine:${RESET}"
+    echo "      ${GRAY}  press Enter if the default above is reachable from that machine,${RESET}"
+    echo "      ${GRAY}  or enter the explicit hostname / LAN IP (e.g. https://192.168.10.42:9443)${RESET}"
+    echo "    ${GRAY}- Internal server with stable DNS:${RESET}"
+    echo "      ${GRAY}  e.g. https://mastio.acme.local${RESET}"
+    echo "    ${GRAY}- Internet-facing: the LB / ingress hostname${RESET}"
+    echo "      ${GRAY}  e.g. https://mastio.myorg.example.com${RESET}"
     echo ""
-    read -rp "  Public URL [https://host.docker.internal:9443]: " _public_url
-    _public_url="${_public_url:-https://host.docker.internal:9443}"
+    read -rp "  Public URL [${_default_public_url}]: " _public_url
+    _public_url="${_public_url:-${_default_public_url}}"
 
     # Strip any pre-existing line and re-add (proxy.env from the
     # generator may already carry an empty one).
@@ -783,6 +789,17 @@ if [[ ! -f "$SCRIPT_DIR/proxy.env" ]]; then
     _san="mastio.local,localhost,host.docker.internal"
     if [[ -n "$_public_host" && "$_public_host" != "localhost" && "$_public_host" != "host.docker.internal" ]]; then
         _san="${_public_host},${_san}"
+    fi
+    # Also include the detected default host (e.g. an interface IP on
+    # Linux pure) when it differs from the operator-typed public host.
+    # An agent SDK + the browser may reach the Mastio via different
+    # names (IP from the host browser, DNS from sibling agents), and
+    # both have to land on the same nginx TLS cert without SAN errors.
+    if [[ -n "${_default_public_host:-}" \
+          && "$_default_public_host" != "$_public_host" \
+          && "$_default_public_host" != "localhost" \
+          && "$_default_public_host" != "host.docker.internal" ]]; then
+        _san="${_default_public_host},${_san}"
     fi
     sed -i.bak '/^#*[[:space:]]*MCP_PROXY_NGINX_SAN=/d' "$SCRIPT_DIR/proxy.env"
     rm -f "$SCRIPT_DIR/proxy.env.bak"

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -30,6 +30,17 @@ warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
 err()  { echo -e "  ${RED}✗${RESET}  $1"; }
 die()  { err "$1"; exit 1; }
 
+# Pick up _detect_default_public_host from the shared helpers. The file
+# ships sibling inside the bundle tarball; in the repo it lives one dir
+# up (``packaging/``). Tolerate both so the script works from either
+# layout. See stage-mastio-bundle.sh for the tarball-staging contract.
+# shellcheck source=../_common-deploy-helpers.sh
+if [ -f "$SCRIPT_DIR/_common-deploy-helpers.sh" ]; then
+    source "$SCRIPT_DIR/_common-deploy-helpers.sh"
+elif [ -f "$SCRIPT_DIR/../_common-deploy-helpers.sh" ]; then
+    source "$SCRIPT_DIR/../_common-deploy-helpers.sh"
+fi
+
 MODE="interactive"
 FORCE=0
 # Opt-in to auto-seed the first-boot admin password. Default behavior
@@ -137,18 +148,18 @@ case "$MODE" in
         ;;
     defaults)
         BROKER="${BROKER_URL:-http://broker:8000}"
-        # Default ``https://host.docker.internal:9443`` matches the
-        # docker-compose.yml fallback and the deploy.sh interactive
-        # prompt default. This is the same URL the interactive flow
-        # writes when the operator presses Enter at the public-URL
-        # prompt. Emitting it explicitly keeps ``--defaults`` self-
-        # contained for CI / Ansible / quick-laptop boot: the resulting
-        # proxy.env survives standalone (no extra deploy.sh post-fix)
-        # and the operator never hits 401 ``htu mismatch`` because the
-        # field was empty. Operators fronting the Mastio with a stable
-        # public hostname override via ``PROXY_PUBLIC_URL=...`` env or
-        # by editing proxy.env after generation.
-        PUBLIC="${PROXY_PUBLIC_URL:-https://host.docker.internal:9443}"
+        # Default URL is detected at boot rather than hardcoded so a
+        # Linux pure host (no Docker Desktop) gets an IP reachable from
+        # a remote agent SDK or LAN browser, while macOS/Windows or
+        # Docker Desktop on Linux keep getting ``host.docker.internal``
+        # (the historical default, still correct in those scenarios).
+        # See _detect_default_public_host in _common-deploy-helpers.sh.
+        # Emitting an explicit non-empty value keeps ``--defaults``
+        # self-contained for CI / Ansible / quick-laptop boot and avoids
+        # the 401 ``Invalid DPoP proof: htu mismatch`` on every agent
+        # enrollment caused by an unset PROXY_PUBLIC_URL.
+        _default_public_host="$(_detect_default_public_host 2>/dev/null || echo host.docker.internal)"
+        PUBLIC="${PROXY_PUBLIC_URL:-https://${_default_public_host}:9443}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
@@ -156,14 +167,15 @@ case "$MODE" in
         echo ""
         read -rp "  Broker URL [http://broker:8000]: " BROKER
         BROKER="${BROKER:-http://broker:8000}"
-        # Same default the deploy.sh interactive prompt offers (line ~611):
-        # covers host browser + sibling containers in the laptop / single
-        # VM scenario. Empty input → laptop default, never the empty
-        # string (MINOR-F: empty triggers 401 htu mismatch on every agent
-        # enrollment because the docker-compose ${VAR:-...} fallback does
-        # NOT apply uniformly across all consumers of proxy.env).
-        read -rp "  Proxy public URL [https://host.docker.internal:9443]: " PUBLIC
-        PUBLIC="${PUBLIC:-https://host.docker.internal:9443}"
+        # Same default the deploy.sh interactive prompt offers. Empty
+        # input → detected default, never the empty string (MINOR-F:
+        # empty triggers 401 htu mismatch on every agent enrollment
+        # because the docker-compose ${VAR:-...} fallback does NOT
+        # apply uniformly across all consumers of proxy.env).
+        _default_public_host="$(_detect_default_public_host 2>/dev/null || echo host.docker.internal)"
+        _default_public_url="https://${_default_public_host}:9443"
+        read -rp "  Proxy public URL [${_default_public_url}]: " PUBLIC
+        PUBLIC="${PUBLIC:-${_default_public_url}}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;

--- a/site/src/content/docs/install/mastio-bundle.md
+++ b/site/src/content/docs/install/mastio-bundle.md
@@ -51,7 +51,16 @@ cd cullis-mastio-bundle/
 ./deploy.sh
 ```
 
-The script prompts once for the **public URL** agents will use to reach this Mastio (e.g. `https://localhost:9443` for a local trial, or `https://mastio.acme.local` once you have DNS). It then:
+The script prompts once for the **public URL** agents will use to reach this Mastio. The default is auto-detected:
+
+- **Single laptop / VM** (Mastio + browser + SDK on the same host): just press Enter — the script picks `https://host.docker.internal:9443` on macOS / Windows / Docker Desktop, or an interface IP on Linux pure.
+- **VM hosting Mastio, browser/SDK on a separate machine** (e.g. a libvirt VM reached from your laptop over a bridge network): the auto-detected default is the VM's primary interface IP, reachable from the laptop. Press Enter unless you have a stable DNS name.
+- **Internal server with stable DNS**: enter `https://mastio.acme.local` (or whatever your DNS resolves).
+- **Internet-facing**: enter the LB / ingress hostname (e.g. `https://mastio.myorg.example.com`).
+
+Whatever you pick, the deploy script bakes it into both `MCP_PROXY_PROXY_PUBLIC_URL` (so DPoP `htu` validation accepts it) and the nginx TLS server certificate SAN list (so agents using `verify_tls=True` complete the handshake). The next deploy reuses these values; rerun `./deploy.sh` with a different answer to rotate.
+
+The script also:
 
 - Generates `proxy.env` from `proxy.env.example` if missing
 - Mints the Org CA and the nginx server certificate into `./nginx-certs/`
@@ -60,7 +69,7 @@ The script prompts once for the **public URL** agents will use to reach this Mas
 
 ## 3. First-boot wizard
 
-Open <https://localhost:9443/proxy/login> in a browser. The browser will warn about the certificate — that is expected: the TLS cert is signed by your auto-generated Org CA, not a public CA. Accept the warning once, or import `./certs/org-ca.pem` (also exported to `./nginx-certs/org-ca.crt`) into your OS trust store.
+Open the dashboard URL printed by the deploy script (e.g. `https://<your-host>:9443/proxy/login`) in a browser. The browser will warn about the certificate — that is expected: the TLS cert is signed by your auto-generated Org CA, not a public CA. Accept the warning once, or import `./certs/org-ca.pem` (also exported to `./nginx-certs/org-ca.crt`) into your OS trust store.
 
 Complete the wizard:
 


### PR DESCRIPTION
## Summary

Cold-reader finding from the 2026-05-27 v0.5.5 dogfood on the mastio-demo libvirt VM. The bundle quickstart said "press Enter for laptop / single VM" and defaulted to `https://host.docker.internal:9443`. On the cold-reader path that splits Mastio (on a VM) from the browser + SDK (on a laptop), this silently broke at three layers:

- Browser on the host laptop could not resolve `host.docker.internal` (Linux pure, no `/etc/hosts` entry, no Docker Desktop pinning) — DNS error before TLS.
- Banner printed `Dashboard: https://localhost:9443/proxy/login` (post Linux-rewrite). On a remote-laptop setup `localhost` is the laptop, not the VM, so the URL was wrong even after the rewrite.
- Agent SDKs on the laptop received enrollment URLs stamped `host.docker.internal` from Mastio and failed transport at DPoP `htu` validation.

## Fix

Detection-based, not policy:

- **`packaging/_common-deploy-helpers.sh`** — new `_detect_default_public_host` helper. Returns `host.docker.internal` when `/etc/hosts` has the entry (Docker Desktop on any OS, or operator-pinned), or when the host is not Linux. On Linux pure, returns the IPv4 of the interface holding the default route. Falls back to `localhost` only when no default route exists.
- **`packaging/mastio-bundle/deploy.sh`** — interactive Public URL prompt uses the detected default; prompt copy now distinguishes "single laptop / VM" from "VM + remote browser/SDK". nginx SAN list includes the detected default host alongside the operator-typed one.
- **`packaging/mastio-bundle/generate-proxy-env.sh`** — `--defaults` and interactive modes both source the helper and use the detected default; CI / Ansible boot on a Linux VM no longer bakes in a non-resolvable URL.
- **`README.md`, `packaging/mastio-bundle/README.md`, `site/src/content/docs/install/mastio-bundle.md`** — describe auto-detection, call out VM + remote-laptop scenario, point at "the URL the deploy script prints" instead of hardcoded `https://localhost:9443`.

## Test plan

- [x] `bash -n` on all three modified shell scripts → pass
- [x] Source helper on NixOS host (Linux pure, no Docker Desktop, no `/etc/hosts` entry): `_detect_default_public_host` returns `192.168.8.179` (LAN IP of default-route interface)
- [ ] After merge: build dev image off this commit, push to GHCR, redeploy on VM mastio-demo (192.168.122.62), verify deploy banner prints the VM's IP and not `host.docker.internal`
- [ ] On the same VM dogfood: browser from host laptop reaches the printed URL without DNS error
- [ ] `proxy.env` contains `MCP_PROXY_PROXY_PUBLIC_URL=https://192.168.122.62:9443` and `MCP_PROXY_NGINX_SAN` includes the IP

## Out of scope

- Cold-reader finding #1 (`/health` → `"version":"dev"` on a fresh v0.5.5 install): already fixed in PR #968 (`9d0611d5`), will be gone in v0.6.0 builds.
- The `BROWSER_URL` Linux-rewrite (`host.docker.internal` → `localhost`) in `deploy.sh:1011-1016` stays as a safety net for operators who explicitly type `host.docker.internal` on Linux pure.