### PR TITLE
release(sdk): cullis-sdk 0.2.0 — chat_completion + MCP + enrollment paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,12 +78,15 @@ packaging/pypi/NOTICE
 packaging/pypi/CHANGELOG.md
 
 # Same staging pattern for the standalone `cullis-sdk` PyPI build.
+# CHANGELOG.md is the exception: it is the SDK-specific PyPI release
+# history, authored in-place next to the pyproject so the build.sh
+# helper does not need to copy it over from the monorepo root (whose
+# CHANGELOG.md covers Mastio / Connector / Court too).
 packaging/pypi-sdk/cullis_sdk/
 packaging/pypi-sdk/README_PKG.md
 packaging/pypi-sdk/LICENSE
 packaging/pypi-sdk/LICENSE-APACHE-2.0
 packaging/pypi-sdk/NOTICE
-packaging/pypi-sdk/CHANGELOG.md
 
 # Cullis Chat SPA static — built artefact, not source. Copied here by
 # scripts/build-spa.sh before packaging the Connector wheel (ADR-019

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -56,4 +56,4 @@ __all__ = [
     "log_msg",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"

--- a/packaging/pypi-sdk/.gitignore
+++ b/packaging/pypi-sdk/.gitignore
@@ -5,9 +5,14 @@
 # though it is copied in fresh on every build. Hatchling respects
 # `.gitignore` when selecting sdist/wheel contents, so ignoring the
 # package directory here would result in an empty wheel.
+#
+# CHANGELOG.md is also deliberately NOT listed: it is the SDK-only
+# PyPI release history, authored in-place and committed to the repo so
+# distributors seeing only the published wheel get a self-contained
+# history. (The monorepo root CHANGELOG.md bundles Mastio + Connector
+# + Court releases too, which is noise for SDK consumers.)
 
 README_PKG.md
 LICENSE
 LICENSE-APACHE-2.0
 NOTICE
-CHANGELOG.md

--- a/packaging/pypi-sdk/CHANGELOG.md
+++ b/packaging/pypi-sdk/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+PyPI release history for `cullis-sdk`. The monorepo's top-level
+`CHANGELOG.md` covers all components (Mastio, Connector, Court, SDK)
+on their respective release cadences; this file is the SDK-only
+slice, kept next to the PyPI `pyproject.toml` so distributors who
+only see the published wheel have a self-contained history.
+
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-05-27
+
+First release on PyPI since 2026-05-01 (0.1.3). Closes a ~4-week drift
+between the published wheel and the repo HEAD that left the public
+README quickstart examples broken on a fresh `pip install cullis-sdk`.
+
+### Added
+
+- `CullisClient.chat_completion(...)` and `.chat_completion_stream(...)` -
+  route LLM completions through Mastio's embedded AI gateway (LiteLLM,
+  ADR-017). Accepts either an OpenAI-shape request dict or kwargs.
+  mTLS client cert + DPoP signing applied automatically; the audit
+  trail carries a per-call `cullis_trace_id`.
+- `CullisClient.list_mcp_tools()` / `.call_mcp_tool(name, arguments)` -
+  MCP reverse-proxy surface. Capability gate enforced server-side.
+- `CullisClient.from_enrollment(enroll_url, verify_tls=False)` quickstart
+  constructor: paste a one-shot enrollment URL from the dashboard,
+  get a ready-to-use client. No file paths to wire up.
+- `CullisClient.enroll_via_dashboard_approval(mastio_url, requester_name=,
+  requester_email=, save_to=)` scripted bootstrap path for CI/CD
+  onboarding: SDK submits a CSR, polls until admin clicks Approve,
+  persists identity-dir.
+
+### Changed
+
+- `CullisClient.from_identity_dir(...)` auto-discovers `ca-chain.pem`
+  sibling and `dpop.jwk` sibling, so an admin-minted
+  identity-bundle.zip just works after `unzip` (no manual wiring of
+  `dpop_key_path` / `ca_chain_path`).
+- All authenticated egress now flows through the cert-pinned DPoP path
+  (no plain Bearer accepted).
+
+### Compatibility
+
+- Python >= 3.10 (unchanged).
+- Wire-compatible with Mastio >= 0.5.0. Older Mastios may 404 on
+  `/v1/llm/chat` and the MCP endpoints - these landed server-side
+  in 0.5.x.
+
+## [0.1.3] - 2026-05-01
+
+Last release before the ~4-week drift window. ADR-008 one-shot
+messaging + ADR-014 mTLS-cert-as-credential surface, plus legacy
+session API kept around as deprecated.

--- a/packaging/pypi-sdk/build.sh
+++ b/packaging/pypi-sdk/build.sh
@@ -38,7 +38,10 @@ cp -f "${REPO_ROOT}/cullis_sdk/README.md" "${STAGE_DIR}/README_PKG.md"
 cp -f "${REPO_ROOT}/LICENSE"            "${STAGE_DIR}/LICENSE"
 cp -f "${REPO_ROOT}/LICENSE-APACHE-2.0" "${STAGE_DIR}/LICENSE-APACHE-2.0"
 cp -f "${REPO_ROOT}/NOTICE"             "${STAGE_DIR}/NOTICE"
-cp -f "${REPO_ROOT}/CHANGELOG.md"       "${STAGE_DIR}/CHANGELOG.md"
+
+# CHANGELOG.md is authored in-place at ${STAGE_DIR}/CHANGELOG.md (SDK-
+# specific PyPI release history, distinct from the monorepo CHANGELOG
+# which covers Mastio / Connector / Court too). No copy step needed.
 
 mkdir -p "${OUT_DIR}"
 

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.1.3"
+version = "0.2.0"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for Cullis, federated agent trust broker"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Why

`pip install cullis-sdk` had been pinned at **0.1.3 (2026-05-01)** for almost four weeks while the repo HEAD kept growing the SDK surface. The public README quickstart (top-level `README.md` + `site/src/content/docs/quickstart/*.md`) advertises:

- `client.chat_completion(...)` — embedded LiteLLM AI gateway (ADR-017)
- `client.list_mcp_tools()` / `client.call_mcp_tool(...)` — MCP reverse-proxy surface
- `CullisClient.from_enrollment(enroll_url)` — paste-an-URL quickstart
- `CullisClient.enroll_via_dashboard_approval(...)` — CI/CD scripted onboarding
- `CullisClient.from_identity_dir(...)` with sibling auto-discovery for `ca-chain.pem` + `dpop.jwk`

…none of which existed on the published 0.1.3 wheel. Cold-reader path was broken: `pip install cullis-sdk` then copy-paste any quickstart example -> `AttributeError`. This PR cuts a new minor release so the next `twine upload` re-aligns PyPI with HEAD.

## Bumps

| File | From | To |
|------|------|----|
| `cullis_sdk/__init__.py::__version__` | `0.1.3` | `0.2.0` |
| `packaging/pypi-sdk/pyproject.toml::version` | `0.1.3` | `0.2.0` |
| `pyproject.toml` (top-level, monorepo) | `0.1.0` | `0.2.0` |

Minor bump, not patch: the surface added since 0.1.3 (LLM gateway + MCP proxy + two new enrollment factories) is large enough to count as a feature release. No breaking changes.

## Changelog

New SDK-specific PyPI changelog at `packaging/pypi-sdk/CHANGELOG.md`, authored in-place. Previously the build helper `cp`-ed the monorepo root `CHANGELOG.md` (which mixes Mastio / Connector / Court release notes) into the staging dir; that was noise for SDK consumers. Now:

- `packaging/pypi-sdk/CHANGELOG.md` is committed (removed the `.gitignore` entry that was suppressing it)
- `build.sh` no longer copies the monorepo CHANGELOG over it
- The SDK-only file ships in the sdist and is what PyPI consumers see when they browse the project history

## Build verification

```
$ bash packaging/pypi-sdk/build.sh
…
Successfully built cullis_sdk-0.2.0.tar.gz and cullis_sdk-0.2.0-py3-none-any.whl

$ sha256sum dist/cullis_sdk-0.2.0*
3e1446310db9c50decb1db474fefcd15c912cb081cf718286b49fd29bd6f0db1  dist/cullis_sdk-0.2.0-py3-none-any.whl
0e8c26483aa6ba68a56d7ac005da0f1182c3d3af667f6837a9f553186c4b9188  dist/cullis_sdk-0.2.0.tar.gz
```

Fresh-venv smoke against the wheel:

```python
from cullis_sdk import CullisClient, __version__
assert __version__ == "0.2.0"
for m in ["chat_completion", "chat_completion_stream",
          "list_mcp_tools", "call_mcp_tool",
          "from_enrollment", "from_identity_dir",
          "enroll_via_dashboard_approval"]:
    assert hasattr(CullisClient, m), m
```

All seven methods present.

## Out of scope

- `twine upload` to PyPI — operator runs this after merge (needs API token).
- SDK source changes — version bumps + packaging + changelog only.

## Test plan

- [x] `packaging/pypi-sdk/build.sh` runs green
- [x] wheel + sdist produced at expected names + sizes
- [x] `pip install` into a clean venv succeeds
- [x] `CullisClient.chat_completion`, `.list_mcp_tools`, `.call_mcp_tool`, `.from_enrollment`, `.enroll_via_dashboard_approval`, `.from_identity_dir`, `.chat_completion_stream` all present on the installed wheel
- [x] DCO sign-off present, no `Co-Authored-By` trailer