### PR TITLE
chore: gitignore .data/ working dir for dogfood sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ scripts/stress/*.log
 
 # Git worktree management dir, used to isolate parallel agent work.
 /.worktrees/
+
+# Local working state for dogfood sessions (venvs, downloaded zips, identity bundles).
+.data/


### PR DESCRIPTION
Cold-reader dogfood sessions stage venvs / zips / identity bundles inside `.data/`; the dir was previously not gitignored, so `./scripts/release-mastio.sh` preflight refused to proceed with 'working tree has uncommitted changes'. Adds a single `.data/` entry next to the existing `/.worktrees/` exclusion.