### PR TITLE
fix(release): use POSIX char class in CHANGELOG extractor awk pattern

### DIFF
--- a/scripts/release-mastio.sh
+++ b/scripts/release-mastio.sh
@@ -170,7 +170,12 @@ ok "  pushed both image tags to GHCR"
 banner "Create GitHub release"
 NOTES_FILE="$(mktemp /tmp/cullis-release-notes-XXXXXX.md)"
 trap 'rm -f "$NOTES_FILE"' EXIT
-awk -v v="^## \\[v${VERSION}\\]" '
+# POSIX character class ``[[]`` / ``[]]`` portably matches literal
+# ``[`` / ``]`` across awk implementations. The previous ``\[`` /
+# ``\]`` form raised "escape sequence treated as plain" warnings in
+# GNU awk's strict mode and the pattern then failed to match, leaving
+# the extracted notes file empty and blocking gh release create.
+awk -v v="^## [[]v${VERSION}[]]" '
   $0 ~ v { p = 1 }
   /^## / && p && $0 !~ v { exit }
   p { print }


### PR DESCRIPTION
Hit running `./scripts/release-mastio.sh 0.6.0` on NixOS today: preflight `grep -q '^## \[v0.6.0\]'` passed (grep accepts `\[`), but body extraction used the same form inside awk and GNU awk strict mode emitted `escape sequence \`\[' treated as plain '['` warnings + matched nothing. `$NOTES_FILE` empty → script aborted at the size guard, AFTER tag + image push had already landed.

Fix uses POSIX bracket-expression form `[[]` / `[]]` (portable across GNU strict, mawk, BWK awk). Tested locally: pattern correctly extracts the v0.6.0 section + v0.5.5 regression check.

Mastio v0.6.0 already shipped via manual `gh release create`; this just keeps the next release from needing the same workaround.