### PR TITLE
release(sdk): cullis-sdk 0.2.1 — ship ADR-038 providers_compat helper

### DIFF
--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -56,4 +56,4 @@ __all__ = [
     "log_msg",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/packaging/pypi-sdk/CHANGELOG.md
+++ b/packaging/pypi-sdk/CHANGELOG.md
@@ -8,6 +8,35 @@ only see the published wheel have a self-contained history.
 
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-27
+
+Patch release on top of 0.2.0 to ship the ADR-038 Phase 0 provider
+SDK drop-in helper. The 0.2.0 wheel was built before the ADR-038 PR
+landed on `main`, so `cullis_sdk.providers_compat` was missing from
+the published package even though `chat_completion` and the MCP
+surface had already shipped. Same-day catch-up.
+
+### Added
+
+- `cullis_sdk.providers_compat.cullis_httpx_client(identity_dir=...)` —
+  LLM-agnostic helper returning an `httpx.Client` with mTLS client
+  cert + DPoP signing transport. Plug into the vanilla Anthropic SDK
+  (`Anthropic(base_url="https://mastio:9443", api_key="cullis",
+  http_client=cullis_httpx_client(identity_dir="..."))`) or the
+  vanilla OpenAI SDK (`OpenAI(base_url="https://mastio:9443/v1", ...,
+  http_client=cullis_httpx_client(...))`) so agent code uses the
+  upstream SDK directly while Cullis stays in the transport path
+  for identity, audit, and policy. Three-line constructor; no
+  Cullis SDK on the agent business-logic path.
+
+### Compatibility
+
+- Wire-compatible with Mastio >= 0.6.0 for the Anthropic SDK path
+  (the `POST /v1/messages` endpoint that translates Anthropic
+  Messages requests to the LiteLLM dispatch landed server-side in
+  v0.6.0). OpenAI SDK path works against any Mastio with
+  `/v1/chat/completions` (>= v0.5.0).
+
 ## [0.2.0] - 2026-05-27
 
 First release on PyPI since 2026-05-01 (0.1.3). Closes a ~4-week drift

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for Cullis, federated agent trust broker"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
0.2.0 was built when `main` was at `73bedf3b` (post-PR #973). PR #969 (ADR-038 Phase 0, `cullis_sdk/providers_compat.py`) landed shortly after as `c83cd097`. The 0.2.0 wheel uploaded to PyPI therefore does not contain `providers_compat` even though the server-side `/v1/messages` endpoint shipped in Mastio v0.6.0. Customers running `pip install cullis-sdk` hit `ModuleNotFoundError: No module named 'cullis_sdk.providers_compat'`.

Same-day catch-up: bump 0.2.0 → 0.2.1 and rebuild from current `main` which now carries `providers_compat.py`. No code change; just the missing module finally lands on PyPI.

Build verified:
- `packaging/pypi-sdk/build.sh` → wheel + sdist; both `twine check` PASSED.
- Fresh-venv install: `from cullis_sdk.providers_compat import cullis_httpx_client` resolves with signature `(*, identity_dir, timeout=60.0, extra_httpx_kwargs=None) -> httpx.Client`.
- `cullis_sdk.__version__ == '0.2.1'`.

PyPI upload remains operator action after merge.