### PR TITLE
fix(version-check): accept 4-component hotfix versions in semver regex

### DIFF
--- a/mcp_proxy/version_check.py
+++ b/mcp_proxy/version_check.py
@@ -54,12 +54,14 @@ _cache_at: float = 0.0
 _cache_lock = asyncio.Lock()
 
 
-# Loose semver: ``MAJOR.MINOR.PATCH`` plus an optional ``-PRERELEASE``
-# (rc1, rc2, beta, …). Captures pieces so ``_version_key`` can build a
-# sortable tuple. Anything more exotic falls through and gets sorted
-# lexically — fine for our naming convention.
+# Loose semver: ``MAJOR.MINOR.PATCH`` with an optional ``.HOTFIX`` 4th
+# component (``0.5.4.1`` for the v0.5.4 emergency patch line), plus an
+# optional ``-PRERELEASE`` (rc1, rc2, beta, …). Captures pieces so
+# ``_version_key`` can build a sortable tuple. Anything more exotic
+# falls through and gets sorted lexically — fine for our naming
+# convention.
 _SEMVER_RE = re.compile(
-    r"^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(\d+)?)?$"
+    r"^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-([a-zA-Z]+)(\d+)?)?$"
 )
 
 
@@ -69,20 +71,31 @@ def _version_key(v: str) -> tuple:
     Final releases (``0.3.0``) sort AFTER any of their prereleases
     (``0.3.0-rc1``, ``0.3.0-beta3``) — same convention as PEP 440 and
     npm/cargo. ``rc2`` sorts after ``rc1`` even when the major.minor
-    part is the same. Unparseable strings sort last.
+    part is the same. A 4th hotfix component (``0.5.4.1``) sorts
+    after the corresponding 3-component release (``0.5.4``) but
+    before the next minor's 3-component release (``0.5.5``).
+    Unparseable strings sort BEFORE everything parseable so the
+    fallback never wins ``max()`` and shows up as a confusing
+    "Update available" pointing at older garbage.
     """
     m = _SEMVER_RE.match(v)
     if not m:
-        return (1, v)  # garbage versions sort after everything parseable
+        # Garbage versions sort BEFORE anything parseable. Previous
+        # behaviour (sort AFTER) caused 4-digit hotfix tags like
+        # ``0.5.4.1`` to win ``max()`` against ``0.6.0`` and trigger a
+        # confidence-killer sidebar banner "Update: 0.5.4.1 (running
+        # 0.6.0)" on every fresh v0.6.0 install.
+        return (-1, v)
     major, minor, patch = int(m[1]), int(m[2]), int(m[3])
-    pre_tag = m[4] or ""
-    pre_num = int(m[5]) if m[5] else 0
+    hotfix = int(m[4]) if m[4] else 0
+    pre_tag = m[5] or ""
+    pre_num = int(m[6]) if m[6] else 0
     # ``is_release = 1`` for full releases, ``0`` for prereleases —
     # so the same major.minor.patch sorts ``rc1 < rc2 < (release)``.
     is_release = 1 if not pre_tag else 0
     # Pre-release tag ordering: alpha < beta < rc < anything-else.
     pre_rank = {"alpha": 0, "beta": 1, "rc": 2}.get(pre_tag, 3) if pre_tag else 0
-    return (0, major, minor, patch, is_release, pre_rank, pre_num)
+    return (0, major, minor, patch, hotfix, is_release, pre_rank, pre_num)
 
 
 def get_current_version() -> str:

--- a/test/unit/test_version_check_hotfix_regex.py
+++ b/test/unit/test_version_check_hotfix_regex.py
@@ -1,0 +1,84 @@
+"""Regression test for the v0.6.0 sidebar banner bug.
+
+The sidebar update advisory rendered "Update: 0.5.4.1 (running 0.6.0)"
+on a fresh v0.6.0 install. Root cause: ``mcp_proxy.version_check._SEMVER_RE``
+only accepted 3-component versions, so ``0.5.4.1`` fell into the
+"unparseable" fallback ``(1, v)`` that sorted AFTER all parseable
+tuples ``(0, ...)``. ``max(candidates, key=_version_key)`` therefore
+picked the garbage tag, the banner compared it against running
+``0.6.0``, and the cold-reader saw a confidence-killer.
+
+These tests pin the corrected behaviour:
+  - 4-component hotfix versions parse and sort between the 3-component
+    base and the next minor.
+  - Unparseable strings sort BEFORE everything parseable.
+  - ``get_latest_version``-shaped selection (``max`` over real release
+    list) picks the highest 3-component release when a 4-component
+    hotfix is present.
+"""
+from mcp_proxy.version_check import _SEMVER_RE, _version_key
+
+
+def test_regex_accepts_3_component_version():
+    assert _SEMVER_RE.match("0.6.0")
+    assert _SEMVER_RE.match("1.0.0")
+
+
+def test_regex_accepts_4_component_hotfix():
+    assert _SEMVER_RE.match("0.5.4.1")
+    assert _SEMVER_RE.match("1.2.3.4")
+
+
+def test_regex_accepts_prerelease_suffix():
+    assert _SEMVER_RE.match("0.5.0-rc1")
+    assert _SEMVER_RE.match("0.5.0-alpha")
+    assert _SEMVER_RE.match("0.5.0-beta3")
+
+
+def test_regex_accepts_hotfix_with_prerelease_suffix():
+    """``0.5.4.1-rc1`` is unusual but should not break."""
+    assert _SEMVER_RE.match("0.5.4.1-rc1")
+
+
+def test_regex_rejects_garbage():
+    assert _SEMVER_RE.match("foo") is None
+    assert _SEMVER_RE.match("v0.6.0") is None  # leading v not stripped here
+    assert _SEMVER_RE.match("0.6") is None  # too few components
+    assert _SEMVER_RE.match("0.6.0.1.2") is None  # too many components
+
+
+def test_garbage_sorts_before_parseable():
+    """Regression: unparseable strings used to sort AFTER parseable
+    (key ``(1, v)``) which let ``max()`` pick a garbage tag from the
+    GitHub releases list and render it into the operator's sidebar.
+    """
+    assert _version_key("foo") < _version_key("0.0.1")
+    assert _version_key("garbage") < _version_key("0.6.0")
+
+
+def test_hotfix_sorts_between_base_and_next_minor():
+    """The bug case: ``0.5.4.1`` should be > ``0.5.4`` but < ``0.5.5``."""
+    assert _version_key("0.5.4") < _version_key("0.5.4.1")
+    assert _version_key("0.5.4.1") < _version_key("0.5.5")
+    assert _version_key("0.5.4.1") < _version_key("0.6.0")
+
+
+def test_prerelease_sorts_before_release():
+    assert _version_key("0.5.0-rc1") < _version_key("0.5.0")
+    assert _version_key("0.5.0-rc1") < _version_key("0.5.0-rc2")
+    assert _version_key("0.5.0-alpha") < _version_key("0.5.0-beta")
+    assert _version_key("0.5.0-beta") < _version_key("0.5.0-rc1")
+
+
+def test_max_picks_highest_3_component_against_hotfix_in_list():
+    """The exact ``get_latest_version`` shape that the bug manifested in."""
+    tags = ["0.6.0", "0.5.5", "0.5.4.1", "0.5.4", "0.5.3", "0.5.0-rc1"]
+    assert max(tags, key=_version_key) == "0.6.0"
+
+
+def test_max_picks_highest_hotfix_when_no_newer_3_component():
+    """Inverse: if 0.6.0 didn't exist, the hotfix would correctly win."""
+    tags = ["0.5.5", "0.5.4.1", "0.5.4", "0.5.3"]
+    assert max(tags, key=_version_key) == "0.5.5"
+    tags = ["0.5.4.1", "0.5.4", "0.5.3"]
+    assert max(tags, key=_version_key) == "0.5.4.1"


### PR DESCRIPTION
Cold-reader finding from the 2026-05-27 v0.6.0 fresh-install dogfood: the dashboard sidebar rendered `Update: 0.5.4.1 (running 0.6.0)` on the v0.6.0 install we had just shipped. Operator sees "update available" pointing at a tag strictly older than what's running.

## Root cause

`mcp_proxy/version_check.py::_SEMVER_RE` only matches 3-component versions. v0.5.4.1 emergency hotfix fell into the "unparseable" branch of `_version_key` which returned `(1, v)` — strictly greater than every parseable tuple `(0, ...)`. `get_latest_version` calls `max(candidates, key=_version_key)` over the GitHub releases list, garbage tag won max, banner compared 0.5.4.1 against running 0.6.0 and (correctly given inputs) reported an update.

Companion `dashboard/update_check.py` not affected: its `_parse_semver` returns `None` and the call site filters.

## Fix

- Extend `_SEMVER_RE` for optional `.HOTFIX` 4th component.
- Carry hotfix int into `_version_key`: 0.5.4 < 0.5.4.1 < 0.5.5.
- Flip unparseable fallback `(1, v)` → `(-1, v)` so garbage sorts BEFORE parseable. Defence in depth for the same banner surface.

## Test

10/10 in `test/unit/test_version_check_hotfix_regex.py` pass. Covers regex acceptance (3-comp, 4-comp hotfix, prerelease), rejection (garbage), sort-order pins, and the exact `max()` selection scenario.