### PR TITLE
chore(release): bump references + CHANGELOG to mastio-v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ flow until the next `## ` heading.
 
 Polish on `main` accumulating for the next minor. No release tag is cut for each individual patch any more; release cadence is intentionally throttled to one minor every 2-3 weeks plus emergency-only patches, matching the practice of comparable alpha-stage open-core projects.
 
+## [v0.6.1] — Sidebar update-advisory regex fix — 2026-05-27
+
+Same-day patch on top of v0.6.0. The sidebar update advisory on a fresh v0.6.0 install rendered "Update: 0.5.4.1 (running 0.6.0)" — pointing the operator at a tag strictly older than the one they were running. Confidence-killer banner that cold-readers see within seconds of first login.
+
+### Dashboard
+
+- **`mcp_proxy/version_check.py::_SEMVER_RE` accepts 4-component hotfix versions** (#978). The regex matched only `MAJOR.MINOR.PATCH[-PRE]` and the `_version_key` fallback for unparseable strings returned `(1, v)` — strictly greater than every parseable `(0, ...)` tuple. The v0.5.4.1 emergency hotfix tag therefore won `max(candidates, key=_version_key)` over the GitHub releases list, and the banner reported it as the latest. Extended regex to accept `.HOTFIX` 4th component, flipped the unparseable fallback to `(-1, v)` so garbage sorts BEFORE parseable (defence in depth: even if a future tag style slips past the regex, `max()` can no longer pick it). 10/10 new unit tests in `test/unit/test_version_check_hotfix_regex.py` pin the corrected behaviour: 3- and 4-component acceptance, prerelease ordering, hotfix-between-minors, `max()` selection against the exact GitHub release shape that triggered the bug.
+
 ## [v0.6.0] — Provider SDK drop-in + VM cold-reader fixes + SDK PyPI catch-up — 2026-05-27
 
 End-to-end cold-reader gate cut on top of v0.5.5. Bundle deploy script auto-detects an interface IP on Linux pure hosts so a VM-on-libvirt + browser-on-laptop setup just works without `host.docker.internal` DNS detours. Vanilla Anthropic SDK and OpenAI SDK reach Mastio via a 3-line `cullis_httpx_client(identity_dir=...)` helper that returns an `httpx.Client` with mTLS + DPoP baked in (ADR-038 Phase 0). And the public PyPI wheel `cullis-sdk` finally catches up with the 4-week monorepo drift: `chat_completion`, `list_mcp_tools`, `call_mcp_tool`, and the post-ADR-014 identity factories are now installable via `pip install cullis-sdk` instead of only readable in the repo.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Pull the Mastio bundle, set an Anthropic key, enroll an agent, install the SDK, 
 
 ```bash
 # 1. Pull and deploy the Mastio bundle.
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.0/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Enable chat by setting an Anthropic key in proxy.env, then restart.
@@ -174,7 +174,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 
 | Component | Latest | What it is |
 |---|---|---|
-| **Cullis Mastio** | [`mastio-v0.6.0`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.6.0) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
+| **Cullis Mastio** | [`mastio-v0.6.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.6.1) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
 | **Cullis SDK** | [`cullis-sdk 0.2.0`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file) and `from_systemd_credentials` (Linux production tmpfs delivery) |
 
 Use Cullis in evaluation, integration, and internal deploys. The community release is the only release; there is no commercial tier today. Feedback, bug reports, and PRs in the public repo.

--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -328,7 +328,7 @@ import Layout from '../layouts/Layout.astro';
         boot. The SDK is on PyPI.
       </p>
       <pre class="reveal" data-delay="3"><code># 1. Mastio — org gateway + dashboard on :9443
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.0/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
       <pre class="reveal" data-delay="4"><code># 2. Python SDK for your autonomous agent
 pip install cullis-sdk</code></pre>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -407,7 +407,7 @@ import Layout from '../layouts/Layout.astro';
       </p>
 
       <pre class="reveal" data-delay="3"><code># 1. Mastio — organisation gateway on :9443
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.0/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
 
       <pre class="reveal" data-delay="4"><code># 2. Python SDK for your autonomous agent


### PR DESCRIPTION
Preflight for `./scripts/release-mastio.sh 0.6.1`. Same-day patch on top of v0.6.0 to ship the sidebar update-advisory regex fix (PR #978). Without v0.6.1 every fresh v0.6.0 cold-reader sees the bogus 'Update: 0.5.4.1 (running 0.6.0)' banner.