### PR TITLE
chore(docs): bump SDK references to 0.2.1 post-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 | Component | Latest | What it is |
 |---|---|---|
 | **Cullis Mastio** | [`mastio-v0.6.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.6.1) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
-| **Cullis SDK** | [`cullis-sdk 0.2.0`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file) and `from_systemd_credentials` (Linux production tmpfs delivery) |
+| **Cullis SDK** | [`cullis-sdk 0.2.1`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file), `from_systemd_credentials` (Linux production tmpfs delivery), and `cullis_httpx_client` drop-in for vanilla Anthropic/OpenAI SDKs |
 
 Use Cullis in evaluation, integration, and internal deploys. The community release is the only release; there is no commercial tier today. Feedback, bug reports, and PRs in the public repo.
 

--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -32,7 +32,7 @@ Python 3.10+. No required system dependencies. Linux, macOS, Windows supported.
 Pin to a released minor in your `pyproject.toml` so a breaking minor bump doesn't surprise a future-you:
 
 ```toml
-cullis-sdk = ">=0.1,<0.2"
+cullis-sdk = ">=0.2,<0.3"
 ```
 
 For SPIRE/SPIFFE workload-API integration (only if you provision via SPIRE — section 2c), install the extra:


### PR DESCRIPTION
## Summary

Yesterday (2026-05-27) we shipped `cullis-sdk 0.2.1` to PyPI (PR #977) carrying the `cullis_httpx_client` drop-in helper (PR #969). Two docs references missed the bump:

- **`README.md` Status table** still listed `cullis-sdk 0.2.0`. Cold-readers hitting the landing page after `pip install cullis-sdk` got 0.2.1 from PyPI but read 0.2.0 on the README, with no mention of the `cullis_httpx_client` helper at all.
- **`site/src/content/docs/quickstart/sdk.md`** example pin was `cullis-sdk = ">=0.1,<0.2"`, which **silently excludes every 0.2.x release**. Anyone copy-pasting the pin would have skipped 0.2.0 AND 0.2.1.

## Changes

- `README.md`: SDK row → `0.2.1`, with `cullis_httpx_client` surfaced as a supported entry-point.
- `site/.../quickstart/sdk.md`: pin bumped to `">=0.2,<0.3"`.

No code, no version bump, no CHANGELOG touch (this is a same-day post-release sync).

## Test plan

- [x] `grep -n "cullis-sdk 0\.2" README.md` confirms only `0.2.1` references remain.
- [x] `grep -rn "cullis-sdk = " site/src/content/` confirms no leftover `<0.2` pins.
- [x] PR #977 confirmed as the canonical 0.2.1 ship; `cullis_httpx_client` (via `providers_compat`) verified absent from 0.2.0 wheel (race between PR #972 wheel build and PR #969 merge) and present in 0.2.1.