### PR TITLE
fix(dashboard): user_detail scope_providers note reflects actual enforcement (#648)

### DIFF
--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -279,7 +279,7 @@
                         </label>
                         {% endfor %}
                     </div>
-                    <p class="text-[10px] text-gray-600 mt-1">No selection = all configured providers. Hint for the policy layer, not yet enforced as ACL.</p>
+                    <p class="text-[10px] text-gray-600 mt-1">No selection = all configured providers. Enforced on <code>/v1/chat/completions</code> for callers using this token: a request whose model maps to a provider outside this list returns 403 <code>token_scope_provider_mismatch</code>. The audit log records the denial.</p>
                 </div>
 
                 <button type="submit"


### PR DESCRIPTION
## Summary

Closes #648.

1-line copy fix: `mcp_proxy/dashboard/templates/user_detail.html:282` still said `scope_providers` was "Hint for the policy layer, not yet enforced as ACL". That stopped being true when Wave A PR #609 wired the enforcement into `mcp_proxy/egress/llm_chat_router.py:77-104` — out-of-scope provider requests now return `403 token_scope_provider_mismatch` with an audit-chain `denied` row.

The customer in VM dogfood (2026-05-12) literally ticked `anthropic`, asked "ma queste funzionano?", and the dashboard text answered no while the backend answered yes. Drift.

## Changes

- `mcp_proxy/dashboard/templates/user_detail.html:282` — replace the stale "not yet enforced" line with one that names the gate (`/v1/chat/completions`, 403 `token_scope_provider_mismatch`) and the audit-log denial row.

## Test plan

- [x] grep confirms only the one stale line removed: `grep -n "not yet enforced" mcp_proxy/dashboard/templates/user_detail.html` returns no match after the change.
- [ ] (Reviewer) browser dogfood the `/proxy/users/<id>` page and verify the helper text reads the new wording.

No code changes, no migration, no version bump.