### PR TITLE
fix(bundle): deploy.sh --pull graceful upgrade against running stack (#980)

### DIFF
--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -886,13 +886,37 @@ if [[ -n "$UPGRADE_TO" ]]; then
 fi
 
 # ── Pre-flight: host port not already in use ───────────────────────────────
+# Refusing on port-in-use is correct for fresh installs and for the case
+# where an unrelated service owns the port. But `./deploy.sh --pull`
+# (and `--upgrade*`) against an already-running cullis-mastio stack is a
+# legitimate in-place upgrade scenario: docker handles `compose up -d
+# --force-recreate` gracefully, stopping the old container before
+# starting the new one. Distinguish via the docker compose project label.
 _host_port="$(grep -E '^MCP_PROXY_PORT=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
 _host_port="${_host_port:-9443}"
+_PORT_OWNED_BY_OUR_STACK=0
 if command -v ss >/dev/null 2>&1 && ss -tlnH "sport = :${_host_port}" 2>/dev/null | grep -q .; then
-    err "Host port ${_host_port} is already in use — another service is bound there."
-    err "Override with MCP_PROXY_PORT=<free-port> in proxy.env, and update"
-    err "MCP_PROXY_PROXY_PUBLIC_URL to use the same port (otherwise agents 401)."
-    die "Refusing to start — fix the port conflict first."
+    _port_owner_project=""
+    if command -v docker >/dev/null 2>&1; then
+        _port_owner_project="$(docker ps \
+            --filter "publish=${_host_port}" \
+            --format '{{ index .Labels "com.docker.compose.project" }}' \
+            2>/dev/null | head -1)"
+    fi
+
+    if [[ "$_port_owner_project" == "$COMPOSE_PROJECT_NAME" ]] \
+        && { [[ $FORCE_PULL -eq 1 ]] || [[ -n "${UPGRADE_TO:-}" ]]; }; then
+        ok "Port ${_host_port} held by existing $COMPOSE_PROJECT_NAME stack — graceful in-place upgrade"
+        _PORT_OWNED_BY_OUR_STACK=1
+    else
+        err "Host port ${_host_port} is already in use — another service is bound there."
+        if [[ -n "$_port_owner_project" ]]; then
+            err "Detected docker compose project owning this port: ${_port_owner_project}"
+        fi
+        err "Override with MCP_PROXY_PORT=<free-port> in proxy.env, and update"
+        err "MCP_PROXY_PROXY_PUBLIC_URL to use the same port (otherwise agents 401)."
+        die "Refusing to start — fix the port conflict first."
+    fi
 fi
 
 # ── Pull + Start ────────────────────────────────────────────────────────────
@@ -929,10 +953,18 @@ mkdir -p "$CERT_DIR"
 # / open-core / enterprise projects on the same host stay untouched.
 _cleanup_orphan_shims "$COMPOSE_PROJECT_NAME"
 
-echo -e "  ${GRAY}$COMPOSE $COMPOSE_FILES --env-file proxy.env up -d${RESET}"
+# Use --force-recreate for in-place upgrade so docker stops the old
+# container before starting the new one (zero-downtime swap with the
+# image we just pulled). Skip it on fresh install to keep the boring
+# fast path boring.
+_UP_EXTRA_FLAGS=""
+if [[ $_PORT_OWNED_BY_OUR_STACK -eq 1 ]]; then
+    _UP_EXTRA_FLAGS="--force-recreate"
+fi
+echo -e "  ${GRAY}$COMPOSE $COMPOSE_FILES --env-file proxy.env up -d ${_UP_EXTRA_FLAGS}${RESET}"
 # Capture exit BEFORE the if-else: `!` negation rewrites $? to 0 inside
 # the branch, which would make _hint_on_bind_mount_failure dead code.
-$COMPOSE $COMPOSE_FILES --env-file proxy.env up -d
+$COMPOSE $COMPOSE_FILES --env-file proxy.env up -d ${_UP_EXTRA_FLAGS}
 _rc=$?
 if [[ $_rc -ne 0 ]]; then
     _hint_on_bind_mount_failure "$_rc" "$COMPOSE_PROJECT_NAME"


### PR DESCRIPTION
## Summary

Closes #980.

Surfaced during the 2026-05-27 v0.6.0 → v0.6.1 upgrade dogfood on VM `mastio-demo`. `./deploy.sh --pull` refused with `port 9443 in use` because the pre-flight port check could not distinguish:

- **(A)** Another unrelated service owns :9443 → true conflict, refuse correctly.
- **(B)** The `cullis-mastio` compose stack from this same bundle dir owns :9443 → false positive. This is the documented upgrade scenario and docker handles it gracefully via `compose up -d --force-recreate`.

The dogfood operator (me, on the VM) ended up bypassing `deploy.sh` entirely and running the raw compose dance by hand. That was the trigger for filing #980.

## Changes

`packaging/mastio-bundle/deploy.sh`:

1. **Pre-flight port gate** (`:888-918`) now queries docker for the `com.docker.compose.project` label on the container that publishes the port. If the owner is `$COMPOSE_PROJECT_NAME` (our own stack) AND the caller passed `--pull` or `--upgrade*`, set `_PORT_OWNED_BY_OUR_STACK=1` and proceed instead of refusing.
2. **`compose up -d`** call (`:935`) now passes `--force-recreate` whenever `_PORT_OWNED_BY_OUR_STACK=1`. Docker stops the old container before starting the new one, so the freshly-pulled image takes over with all volumes (DB + nginx certs + Org CA) preserved.
3. Error path retains the original message but now surfaces the detected owner project name (helps operator debug when the conflict is a sibling cullis-* project like cullis-frontdesk).
4. Fresh-install fast path is unchanged: no `--force-recreate`, no docker `ps` query if the port is free.

## Test plan

- [x] `bash -n packaging/mastio-bundle/deploy.sh` → syntax OK
- [ ] (Reviewer) repro: start `v0.6.1` bundle, edit `proxy.env` to `CULLIS_MASTIO_VERSION=0.6.1-test`, push a `0.6.1-test` image to GHCR, run `./deploy.sh --pull` → expect graceful recreate with new image, /health back up.
- [ ] (Reviewer) negative: kill bundle stack, start unrelated process on :9443 (e.g. `python -m http.server 9443`), run `./deploy.sh --pull` → expect refusal with extended error message naming the detected owner.

## Memory note

This closes the "upgrade-path graceful" gap referenced in `feedback_bundle_upgrade_must_use_deploy_sh`. The codified `--pull` path now matches the codified `--upgrade-bundle` path's UX: same predictability, no manual compose dance.