### PR TITLE
fix(deps): pin litellm>=1.83.7,<2.0 against CVE-2026-42208 / 42271 / 35029

### DIFF
--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -23,7 +23,14 @@ redis>=5.0.0
 # ADR-017 native AI gateway on Mastio (architectural fix: Court is
 # federation-only, AI gateway egress runs in-process on Mastio).
 # Required when MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded.
-litellm>=1.50.0
+# Floor 1.83.7 closes the same CVE set documented in requirements.txt
+# (CVE-2026-42208 SQLi on CISA KEV, CVE-2026-42271 + 35029 RCE, OIDC
+# cache collision, pass-the-hash exposure, March 2026 supply chain
+# compromise of PyPI 1.82.7 / 1.82.8). Ceiling matches the root
+# requirements pin so the proxy image and the SDK install stay in
+# lock-step. ADR-038 Phase 1 will replace this with proprietary
+# provider adapters.
+litellm>=1.83.7,<2.0
 # ADR-033 Phase 2 WebAuthn user assertion binding (PR #789). The lazy
 # importer in mcp_proxy/auth/webauthn/_lib.py raises
 # WebAuthnLibraryMissingError on every register/authenticate path and

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,19 @@ anthropic>=0.40.0
 openai>=1.0.0
 # ADR-017 Phase 3 — embedded LiteLLM as default AI gateway backend.
 # Pinned to <2.0 to avoid major-version churn (BerriAI ships frequently).
-# The dispatcher in app/egress/ai_gateway.py routes around it when
-# ai_gateway_backend != "litellm_embedded", so deployments that pin a
-# different backend are insulated from breakage in this dep.
-litellm>=1.83,<2.0
+# Floor 1.83.7 closes:
+#   - CVE-2026-42208 (pre-auth SQL injection, CVSS 9.3, CISA KEV 2026-05-08)
+#   - CVE-2026-42271 (RCE via MCP preview endpoints)
+#   - CVE-2026-35029 (RCE via /config/update without admin role check)
+#   - CVE-2026-35030 (OIDC cache collision with enable_jwt_auth)
+#   - GHSA-69x8-hrgq-fjj8 (SHA-256 unsalted password hash exposure)
+#   - Supply chain compromise of PyPI litellm 1.82.7 / 1.82.8 (2026-03-24)
+# Cullis uses LiteLLM embedded (in-process litellm.acompletion), not as
+# proxy server, so the RCE/SQLi/auth-bypass vectors above are not directly
+# exploitable, but the floor closes the supply-chain window and tracks
+# downstream hardening. ADR-038 Phase 1 will replace this critical-path
+# dependency with proprietary provider adapters.
+litellm>=1.83.7,<2.0
 cryptography>=46.0.6
 authlib>=1.3.0
 redis>=5.0.0


### PR DESCRIPTION
## Summary

- Defensive floor bump of `litellm` on both `requirements.txt` (was `>=1.83,<2.0`) and `mcp_proxy/requirements-proxy.txt` (was `>=1.50.0`, which still permitted the supply-chain compromised 1.82.7 / 1.82.8 PyPI builds)
- Closes the disclosure window around the April-May 2026 LiteLLM CVE cluster, including **CVE-2026-42208** (pre-auth SQLi, CVSS 9.3, on CISA KEV since 2026-05-08, exploited in the wild ~26h after advisory indexing)
- No code change. Pure dependency posture hardening.

## CVE coverage

| ID | Severity | Component | Status |
|---|---|---|---|
| CVE-2026-42208 | Critical (9.3) | proxy server | CISA KEV |
| CVE-2026-42271 | High | proxy server MCP preview | exploited |
| CVE-2026-35029 | High | proxy server `/config/update` | fixed 1.83.0 |
| CVE-2026-35030 | High | proxy OIDC cache (with `enable_jwt_auth`) | fixed 1.83.0 |
| GHSA-69x8-hrgq-fjj8 | High | proxy password hashing | fixed 1.83.0 |
| Supply chain | Critical | PyPI 1.82.7 / 1.82.8 | excluded by floor |

## Exploitability against Cullis

Cullis uses LiteLLM **embedded in-process** via `litellm.acompletion()` (see `mcp_proxy/egress/ai_gateway.py:_call_litellm_embedded`), not as a proxy server with admin endpoints exposed. The RCE / SQLi / auth-bypass attack surface above lives on the LiteLLM proxy server endpoints (`/config/update`, MCP preview, OIDC) which **Cullis does not expose**.

The relevant residual risk Cullis carries is **supply chain on the package itself** (PyPI 1.82.7 / 1.82.8 were compromised for ~40 minutes on 2026-03-24). The previous `>=1.50.0` floor on the proxy image left that window open; the new floor closes it.

## Follow-up

ADR-038 Phase 1 (server-side native provider adapters) will retire this dependency from the Mastio's critical path. Scope decision pending; pin is the bridge.

## Test plan

- [ ] CI green on the bumped pins
- [ ] Bundle build resolves to litellm >= 1.83.7
- [ ] No runtime regression on `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` path (Anthropic chat completion smoke)