### PR TITLE
refactor(egress): introduce ProviderAdapter scaffold (ADR-039 PR-A)

### DIFF
--- a/mcp_proxy/egress/adapters/__init__.py
+++ b/mcp_proxy/egress/adapters/__init__.py
@@ -1,0 +1,64 @@
+"""Provider adapter scaffolding (ADR-039).
+
+The dispatcher in ``mcp_proxy.egress.ai_gateway`` resolves an adapter for
+the configured ``ai_gateway_backend`` and delegates the upstream call to
+it. Each backend has at least one adapter implementation; adapters carry
+the per-backend wire knowledge (LiteLLM library, Portkey REST, native
+provider SDK, raw HTTP) while the dispatcher stays generic.
+
+ADR-039 phasing:
+  - Phase 1a (PR-A, this scaffold): factor out ``LiteLLMAdapter`` and
+    ``PortkeyAdapter`` from the existing ``ai_gateway.py`` monolith. Zero
+    behaviour change on the wire — same dispatch decisions, same error
+    surface, same audit log line — but the dispatcher now goes through
+    the adapter protocol.
+  - Phase 1b-d (PR-B/C/D): introduce ``cullis_native`` backend with one
+    native adapter per provider (Anthropic SDK, OpenAI SDK, Ollama HTTP).
+  - Phase 1e (PR-E): flip the default backend to ``cullis_native`` and
+    deprecate ``litellm_embedded`` (removed in v0.8).
+
+See ``imp/adrs/adr-039-native-provider-adapters-server-side-drop-litellm.md``
+for the full design.
+"""
+from __future__ import annotations
+
+from mcp_proxy.egress.adapters.base import DispatchContext, ProviderAdapter
+from mcp_proxy.egress.adapters.litellm import LiteLLMAdapter
+from mcp_proxy.egress.adapters.portkey import PortkeyAdapter
+
+
+def resolve_adapter(backend: str) -> ProviderAdapter:
+    """Return the adapter instance configured for ``backend``.
+
+    Raises ``GatewayError(501)`` for unknown backend values. The lookup
+    is intentionally explicit (no registry import side-effects, no
+    plugin discovery) so an operator misconfiguration surfaces a clear
+    error on the first request rather than an obscure import-time crash.
+
+    Adapter instances are cheap stateless objects; we create one per
+    call to keep the call site obvious. If profiling ever flags this as
+    hot, swap to module-level singletons.
+    """
+    # Local import avoids a cycle: ai_gateway imports adapters, adapters
+    # raise GatewayError defined in ai_gateway.
+    from mcp_proxy.egress.ai_gateway import GatewayError
+
+    backend = backend.lower()
+    if backend == "litellm_embedded":
+        return LiteLLMAdapter()
+    if backend == "portkey":
+        return PortkeyAdapter()
+    raise GatewayError(
+        501,
+        f"backend_not_implemented:{backend}",
+        detail=f"AI gateway backend {backend!r} is not wired.",
+    )
+
+
+__all__ = [
+    "DispatchContext",
+    "LiteLLMAdapter",
+    "PortkeyAdapter",
+    "ProviderAdapter",
+    "resolve_adapter",
+]

--- a/mcp_proxy/egress/adapters/base.py
+++ b/mcp_proxy/egress/adapters/base.py
@@ -1,0 +1,83 @@
+"""Provider adapter protocol (ADR-039).
+
+Every concrete adapter implements ``chat_completion`` and optionally
+``stream_chat_completion``. The dispatcher in ``ai_gateway.dispatch``
+resolves the adapter for the configured backend, calls
+``_resolve_provider_creds`` once to translate the request's model id to
+``(provider, creds)``, builds a ``DispatchContext`` from the
+trusted-identity envelope the router reconstructs from the DPoP-bound
+mTLS cert, then delegates.
+
+Adapters never derive identity from the request body and never re-read
+the DB. The dispatcher is the trust boundary; adapters are the wire
+boundary.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import httpx
+
+if TYPE_CHECKING:
+    from mcp_proxy.config import ProxySettings as Settings
+    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+
+@dataclass(frozen=True)
+class DispatchContext:
+    """Trusted-identity envelope passed by the dispatcher into adapters.
+
+    All fields come from the cert + DPoP reconstruction the inbound
+    router already performed; the adapter does not validate them.
+
+    ``http_client`` is populated only for the legacy Portkey backend
+    (which still talks REST and accepts an injected client for test
+    instrumentation). Native adapters ignore it.
+    """
+
+    agent_id: str
+    org_id: str
+    trace_id: str
+    http_client: httpx.AsyncClient | None = None
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Backend-to-provider call boundary.
+
+    ``backend_name`` is the canonical tag emitted into the audit row
+    and the ``backend`` field on ``GatewayResult`` / ``StreamingDispatch``.
+    It matches the value the operator sets on ``MCP_PROXY_AI_GATEWAY_BACKEND``.
+    """
+
+    backend_name: str
+
+    async def chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "GatewayResult":
+        """Run a non-streaming chat completion and return the result."""
+        ...
+
+    async def stream_chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "StreamingDispatch":
+        """Open a streaming chat completion.
+
+        Adapters that do not support streaming raise
+        ``GatewayError(501, "streaming_not_implemented_for_backend:...")``.
+        """
+        ...

--- a/mcp_proxy/egress/adapters/litellm.py
+++ b/mcp_proxy/egress/adapters/litellm.py
@@ -1,0 +1,359 @@
+"""LiteLLM embedded adapter (ADR-017 Phase 3, retained for back-compat).
+
+This module wraps the in-process ``litellm.acompletion`` call path that
+``mcp_proxy/egress/ai_gateway.py`` carried directly prior to ADR-039.
+The behaviour, log lines, error tags, and audit semantics are unchanged
+relative to the pre-refactor code; only the call site moved.
+
+ADR-039 phases out this adapter:
+  - v0.7.x — adapter remains the default, native adapters opt-in via
+    ``MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native``.
+  - v0.7.x +1 — default flips to ``cullis_native``, this adapter emits
+    a startup deprecation ``_log.warning`` when explicitly pinned.
+  - v0.8.x — ``litellm`` is removed from ``requirements.txt`` and the
+    import here becomes a hard failure (operators who explicitly pin
+    the legacy backend pip-install the package out-of-band).
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING, AsyncIterator
+
+from mcp_proxy.egress.adapters.base import DispatchContext
+
+if TYPE_CHECKING:
+    from mcp_proxy.config import ProxySettings as Settings
+    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+
+_log = logging.getLogger("agent_trust.egress")
+
+
+# Map LiteLLM exception class names to (status_code, reason) tuples.
+# We compare by class name rather than isinstance() so the import of
+# litellm stays lazy (the dispatcher must boot in deployments that pin
+# a non-LiteLLM backend without litellm installed).
+_LITELLM_ERROR_MAP: dict[str, tuple[int, str]] = {
+    "AuthenticationError": (401, "provider_auth_failed"),
+    "PermissionDeniedError": (403, "provider_permission_denied"),
+    "NotFoundError": (404, "provider_not_found"),
+    "RateLimitError": (429, "provider_rate_limited"),
+    "BadRequestError": (400, "provider_bad_request"),
+    "UnprocessableEntityError": (422, "provider_unprocessable"),
+    "Timeout": (504, "provider_timeout"),
+    "APIConnectionError": (502, "provider_unreachable"),
+    "ContextWindowExceededError": (400, "provider_context_too_long"),
+    "ContentPolicyViolationError": (400, "provider_content_policy"),
+    "InternalServerError": (502, "provider_internal_error"),
+    "ServiceUnavailableError": (502, "provider_unavailable"),
+    "APIError": (502, "provider_api_error"),
+}
+
+
+def _map_litellm_exception(exc: Exception) -> "GatewayError":
+    from mcp_proxy.egress.ai_gateway import GatewayError, scrub_secrets
+
+    cls = type(exc).__name__
+    status, reason = _LITELLM_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
+    # B2 — LiteLLM stringifies provider 4xx/5xx into ``str(exc)`` and
+    # those bodies frequently echo the rejected API key prefix. Scrub
+    # before the detail flows into ``upstream_detail`` on the audit row.
+    detail = scrub_secrets((str(exc) or cls)[:512])
+    return GatewayError(status, reason, detail=detail)
+
+
+class LiteLLMAdapter:
+    """Embed ``litellm.acompletion`` in-process.
+
+    Holds no per-call state; one instance can serve every dispatch. The
+    LiteLLM library handles its own connection pooling internally.
+    """
+
+    backend_name = "litellm_embedded"
+
+    async def chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "GatewayResult":
+        """Call the upstream provider via the LiteLLM library, in-process.
+
+        The model id from the request drives provider resolution (done
+        by the dispatcher before this point) and the credentials are
+        read from the ``ai_provider_credentials`` table. The Mastio
+        metadata is attached via the ``metadata`` kwarg so any LiteLLM
+        callback the operator wires up (Datadog, Langfuse, Postgres)
+        sees the agent identity without extra plumbing.
+        """
+        from mcp_proxy.egress.ai_gateway import (
+            GatewayError,
+            GatewayResult,
+        )
+        from mcp_proxy.egress.provider_catalog import litellm_kwargs
+        from mcp_proxy.egress.schemas import ChatCompletionResponse
+
+        body = req.model_dump(exclude_none=True)
+        model = body.pop("model")
+
+        try:
+            import litellm
+            from litellm import acompletion
+        except ImportError as exc:
+            raise GatewayError(
+                503,
+                "litellm_not_installed",
+                detail=(
+                    "ai_gateway_backend='litellm_embedded' requires the litellm "
+                    "package. Install it via requirements.txt."
+                ),
+            ) from exc
+
+        # Drop unsupported params silently rather than raising — keeps the
+        # OpenAI-compat contract usable across providers that vary on minor
+        # fields (e.g. Anthropic does not accept all OpenAI knobs).
+        litellm.drop_params = True
+
+        provider_kwargs = litellm_kwargs(provider, creds)
+
+        metadata = {
+            "cullis_agent_id": ctx.agent_id,
+            "cullis_org_id": ctx.org_id,
+            "cullis_trace_id": ctx.trace_id,
+        }
+
+        started = time.perf_counter()
+        try:
+            response = await acompletion(
+                model=model,
+                metadata=metadata,
+                **provider_kwargs,
+                **body,
+            )
+        except Exception as exc:
+            # Only the LiteLLM-shaped exceptions land in the map; anything
+            # else (e.g. ValueError on bad input) becomes provider_unknown.
+            gw_err = _map_litellm_exception(exc)
+            _log.warning(
+                "litellm_embedded error agent=%s model=%s reason=%s detail=%s",
+                ctx.agent_id, model, gw_err.reason, gw_err.detail,
+            )
+            raise gw_err from exc
+
+        latency_ms = int((time.perf_counter() - started) * 1000)
+
+        usage = getattr(response, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+
+        # response_cost is not on every LiteLLM build; compute it on demand
+        # so we always surface a number in the audit row when the model is
+        # in the LiteLLM cost catalogue. Failures here are informational —
+        # the call succeeded, the cost is just unknown.
+        cost_usd: float | None = None
+        try:
+            cost_usd = litellm.completion_cost(completion_response=response)
+        except Exception as exc:
+            _log.debug("litellm.completion_cost failed for model=%s: %s", model, exc)
+
+        payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+        payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+        payload.setdefault("object", "chat.completion")
+        payload.setdefault("created", int(time.time()))
+        payload.setdefault("model", model)
+        payload["cullis_trace_id"] = ctx.trace_id
+        # Force usage shape so Mastio's schema sees the canonical fields
+        # even when LiteLLM adds provider-specific extras (cached_tokens,
+        # reasoning_tokens) that our pydantic model would reject.
+        payload["usage"] = {
+            "prompt_tokens": int(prompt_tokens),
+            "completion_tokens": int(completion_tokens),
+            "total_tokens": int(prompt_tokens + completion_tokens),
+        }
+
+        try:
+            parsed = ChatCompletionResponse.model_validate(payload)
+        except Exception as exc:
+            # Audit F-B-119 — LiteLLM payload echoes through pydantic
+            # ValidationError ``str()``. Same redaction posture as the
+            # portkey branch.
+            from mcp_proxy._http_safety import safe_http_detail
+            raise GatewayError(
+                502,
+                "schema_mismatch",
+                detail=safe_http_detail(
+                    exc,
+                    public_hint="LiteLLM response failed Mastio schema",
+                    log_context="ai_gateway.litellm.parse_response",
+                ),
+            ) from exc
+
+        upstream_request_id = (
+            getattr(response, "id", None)
+            or (response.get("id") if isinstance(response, dict) else None)
+        )
+
+        _log.info(
+            "egress.llm dispatched backend=litellm_embedded provider=%s agent=%s "
+            "org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d cost_usd=%s",
+            provider, ctx.agent_id, ctx.org_id, model, latency_ms,
+            prompt_tokens, completion_tokens,
+            f"{cost_usd:.6f}" if cost_usd is not None else "n/a",
+        )
+
+        return GatewayResult(
+            response=parsed,
+            latency_ms=latency_ms,
+            upstream_request_id=upstream_request_id,
+            backend="litellm_embedded",
+            provider=provider,
+            prompt_tokens=int(prompt_tokens),
+            completion_tokens=int(completion_tokens),
+            cost_usd=cost_usd,
+        )
+
+    async def stream_chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "StreamingDispatch":
+        """Build a ``StreamingDispatch`` backed by
+        ``litellm.acompletion(stream=True)``.
+
+        Resolve the provider + credentials before opening the SSE response
+        so configuration errors (provider not configured, disabled, litellm
+        not installed) are surfaced as a regular non-stream error. The
+        underlying ``acompletion`` call still happens lazily on first
+        iteration of ``_aiter`` so the SSE headers can flush immediately.
+        """
+        from mcp_proxy.egress.ai_gateway import GatewayError, StreamingDispatch
+        from mcp_proxy.egress.provider_catalog import litellm_kwargs
+
+        body = req.model_dump(exclude_none=True)
+        model = body.pop("model")
+        body.pop("stream", None)
+        # Ask the upstream for a final usage chunk so we can audit accurate
+        # token + cost numbers after the stream drains. Anthropic + OpenAI +
+        # most LiteLLM-routed providers honour this OpenAI-spec field.
+        stream_options = body.pop("stream_options", None) or {}
+        stream_options.setdefault("include_usage", True)
+
+        try:
+            import litellm
+            from litellm import acompletion
+        except ImportError as exc:
+            raise GatewayError(
+                503,
+                "litellm_not_installed",
+                detail=(
+                    "ai_gateway_backend='litellm_embedded' requires the litellm "
+                    "package. Install it via requirements.txt."
+                ),
+            ) from exc
+        litellm.drop_params = True
+
+        provider_kwargs = litellm_kwargs(provider, creds)
+
+        metadata = {
+            "cullis_agent_id": ctx.agent_id,
+            "cullis_org_id": ctx.org_id,
+            "cullis_trace_id": ctx.trace_id,
+        }
+
+        dispatch_obj = StreamingDispatch(
+            backend="litellm_embedded",
+            provider=provider,
+            model=model,
+            trace_id=ctx.trace_id,
+        )
+
+        async def _aiter() -> AsyncIterator[dict]:
+            try:
+                stream = await acompletion(
+                    model=model,
+                    metadata=metadata,
+                    stream=True,
+                    stream_options=stream_options,
+                    **provider_kwargs,
+                    **body,
+                )
+            except Exception as exc:
+                raise _map_litellm_exception(exc) from exc
+
+            try:
+                async for chunk in stream:
+                    payload = (
+                        chunk.model_dump() if hasattr(chunk, "model_dump")
+                        else dict(chunk)
+                    )
+                    payload.setdefault("object", "chat.completion.chunk")
+                    payload.setdefault("model", model)
+                    if dispatch_obj.upstream_request_id is None:
+                        upstream_id = payload.get("id")
+                        if upstream_id:
+                            dispatch_obj.upstream_request_id = upstream_id
+                    # The final usage chunk has empty choices and a populated
+                    # ``usage`` dict; harvest it for the audit row, normalise
+                    # the shape so the SSE consumer always sees the canonical
+                    # OpenAI usage fields.
+                    usage = payload.get("usage")
+                    if isinstance(usage, dict):
+                        pt = int(usage.get("prompt_tokens") or 0)
+                        ct = int(usage.get("completion_tokens") or 0)
+                        if pt or ct:
+                            dispatch_obj.prompt_tokens = pt
+                            dispatch_obj.completion_tokens = ct
+                            payload["usage"] = {
+                                "prompt_tokens": pt,
+                                "completion_tokens": ct,
+                                "total_tokens": pt + ct,
+                            }
+                    yield payload
+            except GatewayError:
+                raise
+            except Exception as exc:
+                raise _map_litellm_exception(exc) from exc
+            finally:
+                dispatch_obj.latency_ms = int(
+                    (time.perf_counter() - dispatch_obj.started_at) * 1000
+                )
+                if dispatch_obj.prompt_tokens or dispatch_obj.completion_tokens:
+                    # ``completion_cost`` wants a full response object; in the
+                    # streaming path we've already drained it, so go through
+                    # ``cost_per_token`` (returns the (input, output) USD
+                    # tuple already multiplied by the token counts).
+                    try:
+                        in_cost, out_cost = litellm.cost_per_token(
+                            model=model,
+                            prompt_tokens=dispatch_obj.prompt_tokens,
+                            completion_tokens=dispatch_obj.completion_tokens,
+                        )
+                        dispatch_obj.cost_usd = float(in_cost) + float(out_cost)
+                    except Exception as exc:  # pragma: no cover — informational
+                        _log.debug(
+                            "litellm.cost_per_token (stream) failed model=%s: %s",
+                            model, exc,
+                        )
+                _log.info(
+                    "egress.llm streamed backend=litellm_embedded provider=%s "
+                    "agent=%s org=%s model=%s latency_ms=%d tokens_in=%d "
+                    "tokens_out=%d cost_usd=%s",
+                    provider, ctx.agent_id, ctx.org_id, model,
+                    dispatch_obj.latency_ms,
+                    dispatch_obj.prompt_tokens, dispatch_obj.completion_tokens,
+                    f"{dispatch_obj.cost_usd:.6f}"
+                    if dispatch_obj.cost_usd is not None else "n/a",
+                )
+
+        dispatch_obj._aiter_factory = _aiter
+        return dispatch_obj

--- a/mcp_proxy/egress/adapters/portkey.py
+++ b/mcp_proxy/egress/adapters/portkey.py
@@ -1,0 +1,207 @@
+"""Portkey REST adapter (legacy, Anthropic-only).
+
+This adapter wraps the Portkey gateway HTTP call path that
+``mcp_proxy/egress/ai_gateway.py`` carried directly prior to ADR-039.
+Behaviour, log lines, error tags, and audit semantics are unchanged
+relative to the pre-refactor ``_call_portkey`` function.
+
+The Portkey backend was the original ADR-017 Phase 1 implementation and
+only ever supported Anthropic. It is deprecated alongside the LiteLLM
+backend in v0.7.x and removed in v0.8.x. Operators on Portkey today
+migrate to ``cullis_native`` (Anthropic via the native SDK adapter).
+
+Portkey does not support streaming through this adapter today;
+``stream_chat_completion`` raises 501 just like the pre-refactor code.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from typing import TYPE_CHECKING
+
+import httpx
+
+from mcp_proxy.egress.adapters.base import DispatchContext
+
+if TYPE_CHECKING:
+    from mcp_proxy.config import ProxySettings as Settings
+    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+
+_log = logging.getLogger("agent_trust.egress")
+
+
+CULLIS_FORWARD_HEADERS = "X-Cullis-Agent,X-Cullis-Org,X-Cullis-Trace"
+
+
+class PortkeyAdapter:
+    """Forward chat completions to a configured Portkey gateway.
+
+    The Portkey path only validates ``provider=anthropic`` against
+    Portkey's chat-completions shim. The credential is still sourced
+    through the dispatcher's DB-first resolver so deployments that have
+    migrated to dashboard-managed keys keep working whichever backend
+    they pin.
+    """
+
+    backend_name = "portkey"
+
+    async def chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "GatewayResult":
+        from mcp_proxy.egress.ai_gateway import (
+            GatewayError,
+            GatewayResult,
+            scrub_secrets,
+        )
+        from mcp_proxy.egress.schemas import ChatCompletionResponse
+
+        if provider != "anthropic":
+            raise GatewayError(
+                501,
+                f"provider_not_implemented:{provider}",
+                detail="The Portkey backend only supports Anthropic. "
+                       "Switch ai_gateway_backend to litellm_embedded.",
+            )
+        api_key = creds.get("api_key", "")
+        if not api_key:
+            raise GatewayError(503, "provider_key_missing")
+
+        upstream_url = f"{settings.ai_gateway_url.rstrip('/')}/v1/chat/completions"
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "x-portkey-provider": provider,
+            "x-portkey-trace-id": ctx.trace_id,
+            "x-portkey-forward-headers": CULLIS_FORWARD_HEADERS,
+            "x-portkey-metadata": json.dumps(
+                {
+                    "_user": ctx.agent_id,
+                    "org_id": ctx.org_id,
+                    "trace_id": ctx.trace_id,
+                },
+                separators=(",", ":"),
+            ),
+            "X-Cullis-Agent": ctx.agent_id,
+            "X-Cullis-Org": ctx.org_id,
+            "X-Cullis-Trace": ctx.trace_id,
+        }
+
+        body = req.model_dump(exclude_none=True)
+
+        started = time.perf_counter()
+        owns_client = ctx.http_client is None
+        client = ctx.http_client or httpx.AsyncClient(
+            timeout=settings.ai_gateway_request_timeout_s
+        )
+        try:
+            try:
+                resp = await client.post(upstream_url, headers=headers, json=body)
+            except httpx.TimeoutException as exc:
+                raise GatewayError(504, "upstream_timeout", detail=str(exc)) from exc
+            except httpx.HTTPError as exc:
+                raise GatewayError(
+                    502, "upstream_unreachable", detail=str(exc),
+                ) from exc
+        finally:
+            if owns_client:
+                await client.aclose()
+
+        latency_ms = int((time.perf_counter() - started) * 1000)
+
+        if resp.status_code // 100 != 2:
+            # Surface the upstream body in the audit detail (capped) so
+            # operators can debug without re-running the call. Scrub
+            # provider key shapes (B2) so a 401 echo like "Incorrect API
+            # key provided: sk-ant-..." doesn't immortalise the rejected
+            # key in the hash-chained audit log.
+            detail = scrub_secrets(resp.text[:512]) if resp.text else None
+            raise GatewayError(
+                502,
+                f"upstream_status_{resp.status_code}",
+                detail=detail,
+            )
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise GatewayError(
+                502, "malformed_upstream_body", detail=str(exc),
+            ) from exc
+
+        payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+        payload.setdefault("object", "chat.completion")
+        payload.setdefault("created", int(time.time()))
+        payload.setdefault("model", req.model)
+        payload["cullis_trace_id"] = ctx.trace_id
+
+        try:
+            parsed = ChatCompletionResponse.model_validate(payload)
+        except Exception as exc:  # pydantic ValidationError or similar
+            # Audit F-B-119 — pydantic ValidationError ``str()`` interpolates
+            # the offending input into the message. The input is the raw
+            # upstream response — model output, tool args, conversation
+            # context — and must not echo back to the OpenAI-shape caller.
+            from mcp_proxy._http_safety import safe_http_detail
+            raise GatewayError(
+                502,
+                "schema_mismatch",
+                detail=safe_http_detail(
+                    exc,
+                    public_hint="upstream payload failed Mastio schema",
+                    log_context="ai_gateway.portkey.parse_response",
+                ),
+            ) from exc
+
+        upstream_request_id = (
+            resp.headers.get("x-portkey-request-id")
+            or resp.headers.get("x-request-id")
+        )
+
+        _log.info(
+            "egress.llm dispatched backend=portkey provider=%s agent=%s org=%s "
+            "model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
+            provider, ctx.agent_id, ctx.org_id, parsed.model, latency_ms,
+            parsed.usage.prompt_tokens, parsed.usage.completion_tokens,
+        )
+
+        return GatewayResult(
+            response=parsed,
+            latency_ms=latency_ms,
+            upstream_request_id=upstream_request_id,
+            backend="portkey",
+            provider=provider,
+            prompt_tokens=int(parsed.usage.prompt_tokens or 0),
+            completion_tokens=int(parsed.usage.completion_tokens or 0),
+            cost_usd=None,
+        )
+
+    async def stream_chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "StreamingDispatch":
+        from mcp_proxy.egress.ai_gateway import GatewayError
+
+        raise GatewayError(
+            501,
+            "streaming_not_implemented_for_backend:portkey",
+            detail=(
+                "Streaming on backend 'portkey' is not wired. "
+                "Set ai_gateway_backend=litellm_embedded for stream=true."
+            ),
+        )

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -1,23 +1,31 @@
-"""AI gateway dispatch (ADR-017 Phase 1).
+"""AI gateway dispatch (ADR-039 refactor).
 
 The dispatcher takes an OpenAI-compatible ChatCompletionRequest plus the
 trusted agent identity (already reconstructed from the DPoP-bound cert
-by the router) and forwards the call to the configured gateway. The
-agent identity is injected as both the gateway-native attribution
-header (e.g. x-portkey-metadata._user) and a canonical Cullis header
-(X-Cullis-Agent) propagated through to the upstream provider, so audit
-correlations work whether the dashboard speaks Cullis or gateway-native.
+by the router), resolves the configured backend's adapter, and delegates
+the upstream call. The adapter carries the per-backend wire knowledge
+(LiteLLM library, Portkey REST, native provider SDK, raw HTTP) while
+this module stays small and generic.
 
-Phase 1 supports Portkey only. LiteLLM and Kong land in Phase 2 once
-the smoke test confirms the contract.
+History:
+
+- ADR-017 Phase 1 (2026-Q1) shipped Portkey as the single supported
+  backend, in-line in this file.
+- ADR-017 Phase 3 (2026-05) added the embedded LiteLLM backend, also
+  in-line.
+- ADR-039 (this refactor, 2026-05-27) moved both backend bodies behind
+  the ``ProviderAdapter`` protocol and prepared the ``cullis_native``
+  slot for the upcoming native Anthropic / OpenAI / Ollama adapters.
+
+The shared helpers below (``GatewayResult``, ``StreamingDispatch``,
+``GatewayError``, ``scrub_secrets``, ``_resolve_provider_creds``) are
+used by every adapter and stay here.
 """
 from __future__ import annotations
 
-import json
 import logging
 import re
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import AsyncIterator
 
@@ -25,23 +33,15 @@ import httpx
 
 from mcp_proxy.config import ProxySettings as Settings
 from mcp_proxy.db import get_ai_provider_creds
+from mcp_proxy.egress.adapters import DispatchContext, resolve_adapter
 from mcp_proxy.egress.provider_catalog import (
     PROVIDERS,
-    litellm_kwargs,
     parse_provider_from_model,
 )
 from mcp_proxy.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
 
 
-# LiteLLM is imported lazily inside _call_litellm_embedded so deployments
-# that pin ai_gateway_backend != "litellm_embedded" do not pay the import
-# cost on startup. Spike validated 2026-05-03 against Anthropic Haiku 4.5
-# (see imp/sandbox-gateways/test/spike_litellm_acompletion.py).
-
 _log = logging.getLogger("agent_trust.egress")
-
-
-CULLIS_FORWARD_HEADERS = "X-Cullis-Agent,X-Cullis-Org,X-Cullis-Trace"
 
 
 # Audit Wave A B2 (2026-05-11) — provider error bodies routinely echo
@@ -139,236 +139,6 @@ class GatewayError(Exception):
         self.detail = detail
 
 
-async def dispatch(
-    *,
-    req: ChatCompletionRequest,
-    agent_id: str,
-    org_id: str,
-    trace_id: str,
-    settings: Settings,
-    http_client: httpx.AsyncClient | None = None,
-) -> GatewayResult:
-    backend = settings.ai_gateway_backend.lower()
-    if backend == "litellm_embedded":
-        return await _call_litellm_embedded(
-            req=req,
-            agent_id=agent_id,
-            org_id=org_id,
-            trace_id=trace_id,
-            settings=settings,
-        )
-    if backend == "portkey":
-        return await _call_portkey(
-            req=req,
-            agent_id=agent_id,
-            org_id=org_id,
-            trace_id=trace_id,
-            settings=settings,
-            http_client=http_client,
-        )
-    raise GatewayError(
-        501,
-        f"backend_not_implemented:{backend}",
-        detail=f"AI gateway backend '{backend}' is not wired.",
-    )
-
-
-async def dispatch_stream(
-    *,
-    req: ChatCompletionRequest,
-    agent_id: str,
-    org_id: str,
-    trace_id: str,
-    settings: Settings,
-) -> StreamingDispatch:
-    """Open a streaming dispatch.
-
-    Returns a ``StreamingDispatch`` whose ``aiter()`` yields OpenAI-shape
-    chunk dicts (``object=chat.completion.chunk``). The router converts
-    them to SSE frames. Token usage + cost land on the dispatch object
-    once the iterator drains, so the post-stream audit/rate-limit logic
-    can read them without inspecting the chunks itself.
-    """
-    backend = settings.ai_gateway_backend.lower()
-    if backend == "litellm_embedded":
-        return await _build_litellm_stream(
-            req=req,
-            agent_id=agent_id,
-            org_id=org_id,
-            trace_id=trace_id,
-            settings=settings,
-        )
-    raise GatewayError(
-        501,
-        f"streaming_not_implemented_for_backend:{backend}",
-        detail=(
-            f"Streaming on backend '{backend}' is not wired. "
-            "Set ai_gateway_backend=litellm_embedded for stream=true."
-        ),
-    )
-
-
-async def _call_portkey(
-    *,
-    req: ChatCompletionRequest,
-    agent_id: str,
-    org_id: str,
-    trace_id: str,
-    settings: Settings,
-    http_client: httpx.AsyncClient | None,
-) -> GatewayResult:
-    # Portkey path is Phase 1 (legacy). It only validates provider=anthropic
-    # against Portkey's chat-completions shim. The credential is still
-    # sourced through the same DB-first resolver so deployments that
-    # have already migrated to dashboard-managed keys keep working
-    # whichever backend they pin.
-    provider, creds = await _resolve_provider_creds(req.model, settings)
-    if provider != "anthropic":
-        raise GatewayError(
-            501,
-            f"provider_not_implemented:{provider}",
-            detail="The Portkey backend only supports Anthropic. "
-                   "Switch ai_gateway_backend to litellm_embedded.",
-        )
-    api_key = creds.get("api_key", "")
-    if not api_key:
-        raise GatewayError(503, "provider_key_missing")
-
-    upstream_url = f"{settings.ai_gateway_url.rstrip('/')}/v1/chat/completions"
-
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}",
-        "x-portkey-provider": provider,
-        "x-portkey-trace-id": trace_id,
-        "x-portkey-forward-headers": CULLIS_FORWARD_HEADERS,
-        "x-portkey-metadata": json.dumps(
-            {"_user": agent_id, "org_id": org_id, "trace_id": trace_id},
-            separators=(",", ":"),
-        ),
-        "X-Cullis-Agent": agent_id,
-        "X-Cullis-Org": org_id,
-        "X-Cullis-Trace": trace_id,
-    }
-
-    body = req.model_dump(exclude_none=True)
-
-    started = time.perf_counter()
-    owns_client = http_client is None
-    client = http_client or httpx.AsyncClient(timeout=settings.ai_gateway_request_timeout_s)
-    try:
-        try:
-            resp = await client.post(upstream_url, headers=headers, json=body)
-        except httpx.TimeoutException as exc:
-            raise GatewayError(504, "upstream_timeout", detail=str(exc)) from exc
-        except httpx.HTTPError as exc:
-            raise GatewayError(502, "upstream_unreachable", detail=str(exc)) from exc
-    finally:
-        if owns_client:
-            await client.aclose()
-
-    latency_ms = int((time.perf_counter() - started) * 1000)
-
-    if resp.status_code // 100 != 2:
-        # Surface the upstream body in the audit detail (capped) so
-        # operators can debug without re-running the call. Scrub
-        # provider key shapes (B2) so a 401 echo like "Incorrect API
-        # key provided: sk-ant-..." doesn't immortalise the rejected
-        # key in the hash-chained audit log.
-        detail = scrub_secrets(resp.text[:512]) if resp.text else None
-        raise GatewayError(
-            502,
-            f"upstream_status_{resp.status_code}",
-            detail=detail,
-        )
-
-    try:
-        payload = resp.json()
-    except ValueError as exc:
-        raise GatewayError(502, "malformed_upstream_body", detail=str(exc)) from exc
-
-    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
-    payload.setdefault("object", "chat.completion")
-    payload.setdefault("created", int(time.time()))
-    payload.setdefault("model", req.model)
-    payload["cullis_trace_id"] = trace_id
-
-    try:
-        parsed = ChatCompletionResponse.model_validate(payload)
-    except Exception as exc:  # pydantic ValidationError or similar
-        # Audit F-B-119 — pydantic ValidationError ``str()`` interpolates
-        # the offending input into the message. The input is the raw
-        # upstream response — model output, tool args, conversation
-        # context — and must not echo back to the OpenAI-shape caller.
-        from mcp_proxy._http_safety import safe_http_detail
-        raise GatewayError(
-            502,
-            "schema_mismatch",
-            detail=safe_http_detail(
-                exc,
-                public_hint="upstream payload failed Mastio schema",
-                log_context="ai_gateway.portkey.parse_response",
-            ),
-        ) from exc
-
-    upstream_request_id = (
-        resp.headers.get("x-portkey-request-id")
-        or resp.headers.get("x-request-id")
-    )
-
-    _log.info(
-        "egress.llm dispatched backend=portkey provider=%s agent=%s org=%s "
-        "model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
-        provider, agent_id, org_id, parsed.model, latency_ms,
-        parsed.usage.prompt_tokens, parsed.usage.completion_tokens,
-    )
-
-    return GatewayResult(
-        response=parsed,
-        latency_ms=latency_ms,
-        upstream_request_id=upstream_request_id,
-        backend="portkey",
-        provider=provider,
-        prompt_tokens=int(parsed.usage.prompt_tokens or 0),
-        completion_tokens=int(parsed.usage.completion_tokens or 0),
-        cost_usd=None,
-    )
-
-
-# ── LiteLLM embedded backend (ADR-017 Phase 3) ─────────────────────────
-
-
-# Map LiteLLM exception class names to (status_code, reason) tuples.
-# We compare by class name rather than isinstance() so the import of
-# litellm stays lazy (the dispatcher must boot in deployments that pin
-# a non-LiteLLM backend without litellm installed).
-_LITELLM_ERROR_MAP: dict[str, tuple[int, str]] = {
-    "AuthenticationError": (401, "provider_auth_failed"),
-    "PermissionDeniedError": (403, "provider_permission_denied"),
-    "NotFoundError": (404, "provider_not_found"),
-    "RateLimitError": (429, "provider_rate_limited"),
-    "BadRequestError": (400, "provider_bad_request"),
-    "UnprocessableEntityError": (422, "provider_unprocessable"),
-    "Timeout": (504, "provider_timeout"),
-    "APIConnectionError": (502, "provider_unreachable"),
-    "ContextWindowExceededError": (400, "provider_context_too_long"),
-    "ContentPolicyViolationError": (400, "provider_content_policy"),
-    "InternalServerError": (502, "provider_internal_error"),
-    "ServiceUnavailableError": (502, "provider_unavailable"),
-    "APIError": (502, "provider_api_error"),
-}
-
-
-def _map_litellm_exception(exc: Exception) -> GatewayError:
-    cls = type(exc).__name__
-    status, reason = _LITELLM_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
-    # B2 — LiteLLM stringifies provider 4xx/5xx into ``str(exc)`` and
-    # those bodies frequently echo the rejected API key prefix. Scrub
-    # before the detail flows into ``upstream_detail`` on the audit row.
-    detail = scrub_secrets((str(exc) or cls)[:512])
-    return GatewayError(status, reason, detail=detail)
-
-
 async def _resolve_provider_creds(
     model: str,
     settings: Settings,
@@ -415,146 +185,34 @@ async def _resolve_provider_creds(
     return provider, dict(row["creds"] or {})
 
 
-async def _call_litellm_embedded(
+async def dispatch(
     *,
     req: ChatCompletionRequest,
     agent_id: str,
     org_id: str,
     trace_id: str,
     settings: Settings,
+    http_client: httpx.AsyncClient | None = None,
 ) -> GatewayResult:
-    """Call the upstream provider via the LiteLLM library, in-process.
-
-    The model id from the request drives provider resolution
-    (``parse_provider_from_model``) and the credentials are read from
-    the ``ai_provider_credentials`` table populated by the Mastio
-    admin dashboard. The Mastio metadata is attached via the
-    ``metadata`` kwarg so any LiteLLM callback the operator wires up
-    (Datadog, Langfuse, Postgres) sees the agent identity without us
-    doing extra plumbing.
-    """
-    body = req.model_dump(exclude_none=True)
-    model = body.pop("model")
-    provider, creds = await _resolve_provider_creds(model, settings)
-
-    try:
-        import litellm
-        from litellm import acompletion
-    except ImportError as exc:
-        raise GatewayError(
-            503,
-            "litellm_not_installed",
-            detail=(
-                "ai_gateway_backend='litellm_embedded' requires the litellm "
-                "package. Install it via requirements.txt."
-            ),
-        ) from exc
-
-    # Drop unsupported params silently rather than raising — keeps the
-    # OpenAI-compat contract usable across providers that vary on minor
-    # fields (e.g. Anthropic does not accept all OpenAI knobs).
-    litellm.drop_params = True
-
-    provider_kwargs = litellm_kwargs(provider, creds)
-
-    metadata = {
-        "cullis_agent_id": agent_id,
-        "cullis_org_id": org_id,
-        "cullis_trace_id": trace_id,
-    }
-
-    started = time.perf_counter()
-    try:
-        response = await acompletion(
-            model=model,
-            metadata=metadata,
-            **provider_kwargs,
-            **body,
-        )
-    except Exception as exc:
-        # Only the LiteLLM-shaped exceptions land in the map; anything
-        # else (e.g. ValueError on bad input) becomes provider_unknown.
-        gw_err = _map_litellm_exception(exc)
-        _log.warning(
-            "litellm_embedded error agent=%s model=%s reason=%s detail=%s",
-            agent_id, model, gw_err.reason, gw_err.detail,
-        )
-        raise gw_err from exc
-
-    latency_ms = int((time.perf_counter() - started) * 1000)
-
-    usage = getattr(response, "usage", None)
-    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
-    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
-
-    # response_cost is not on every LiteLLM build; compute it on demand
-    # so we always surface a number in the audit row when the model is
-    # in the LiteLLM cost catalogue. Failures here are informational —
-    # the call succeeded, the cost is just unknown.
-    cost_usd: float | None = None
-    try:
-        cost_usd = litellm.completion_cost(completion_response=response)
-    except Exception as exc:
-        _log.debug("litellm.completion_cost failed for model=%s: %s", model, exc)
-
-    payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
-    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
-    payload.setdefault("object", "chat.completion")
-    payload.setdefault("created", int(time.time()))
-    payload.setdefault("model", model)
-    payload["cullis_trace_id"] = trace_id
-    # Force usage shape so Mastio's schema sees the canonical fields
-    # even when LiteLLM adds provider-specific extras (cached_tokens,
-    # reasoning_tokens) that our pydantic model would reject.
-    payload["usage"] = {
-        "prompt_tokens": int(prompt_tokens),
-        "completion_tokens": int(completion_tokens),
-        "total_tokens": int(prompt_tokens + completion_tokens),
-    }
-
-    try:
-        parsed = ChatCompletionResponse.model_validate(payload)
-    except Exception as exc:
-        # Audit F-B-119 — LiteLLM payload echoes through pydantic
-        # ValidationError ``str()``. Same redaction posture as the
-        # portkey branch above.
-        from mcp_proxy._http_safety import safe_http_detail
-        raise GatewayError(
-            502,
-            "schema_mismatch",
-            detail=safe_http_detail(
-                exc,
-                public_hint="LiteLLM response failed Mastio schema",
-                log_context="ai_gateway.litellm.parse_response",
-            ),
-        ) from exc
-
-    upstream_request_id = (
-        getattr(response, "id", None)
-        or (response.get("id") if isinstance(response, dict) else None)
+    backend = settings.ai_gateway_backend.lower()
+    adapter = resolve_adapter(backend)
+    provider, creds = await _resolve_provider_creds(req.model, settings)
+    ctx = DispatchContext(
+        agent_id=agent_id,
+        org_id=org_id,
+        trace_id=trace_id,
+        http_client=http_client,
     )
-
-    _log.info(
-        "egress.llm dispatched backend=litellm_embedded provider=%s agent=%s "
-        "org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d cost_usd=%s",
-        provider, agent_id, org_id, model, latency_ms,
-        prompt_tokens, completion_tokens,
-        f"{cost_usd:.6f}" if cost_usd is not None else "n/a",
-    )
-
-    return GatewayResult(
-        response=parsed,
-        latency_ms=latency_ms,
-        upstream_request_id=upstream_request_id,
-        backend="litellm_embedded",
+    return await adapter.chat_completion(
+        req=req,
         provider=provider,
-        prompt_tokens=int(prompt_tokens),
-        completion_tokens=int(completion_tokens),
-        cost_usd=cost_usd,
+        creds=creds,
+        ctx=ctx,
+        settings=settings,
     )
 
 
-async def _build_litellm_stream(
+async def dispatch_stream(
     *,
     req: ChatCompletionRequest,
     agent_id: str,
@@ -562,130 +220,26 @@ async def _build_litellm_stream(
     trace_id: str,
     settings: Settings,
 ) -> StreamingDispatch:
-    """Build a ``StreamingDispatch`` backed by ``litellm.acompletion(stream=True)``.
+    """Open a streaming dispatch.
 
-    Resolve the provider + credentials before opening the SSE response
-    so configuration errors (provider not configured, disabled, litellm
-    not installed) are surfaced as a regular non-stream error. The
-    underlying ``acompletion`` call still happens lazily on first
-    iteration of ``_aiter`` so the SSE headers can flush immediately.
+    Returns a ``StreamingDispatch`` whose ``aiter()`` yields OpenAI-shape
+    chunk dicts (``object=chat.completion.chunk``). The router converts
+    them to SSE frames. Token usage + cost land on the dispatch object
+    once the iterator drains, so the post-stream audit/rate-limit logic
+    can read them without inspecting the chunks itself.
     """
-    body = req.model_dump(exclude_none=True)
-    model = body.pop("model")
-    body.pop("stream", None)
-    # Ask the upstream for a final usage chunk so we can audit accurate
-    # token + cost numbers after the stream drains. Anthropic + OpenAI +
-    # most LiteLLM-routed providers honour this OpenAI-spec field.
-    stream_options = body.pop("stream_options", None) or {}
-    stream_options.setdefault("include_usage", True)
-
-    provider, creds = await _resolve_provider_creds(model, settings)
-
-    try:
-        import litellm
-        from litellm import acompletion
-    except ImportError as exc:
-        raise GatewayError(
-            503,
-            "litellm_not_installed",
-            detail=(
-                "ai_gateway_backend='litellm_embedded' requires the litellm "
-                "package. Install it via requirements.txt."
-            ),
-        ) from exc
-    litellm.drop_params = True
-
-    provider_kwargs = litellm_kwargs(provider, creds)
-
-    metadata = {
-        "cullis_agent_id": agent_id,
-        "cullis_org_id": org_id,
-        "cullis_trace_id": trace_id,
-    }
-
-    dispatch_obj = StreamingDispatch(
-        backend="litellm_embedded",
-        provider=provider,
-        model=model,
+    backend = settings.ai_gateway_backend.lower()
+    adapter = resolve_adapter(backend)
+    provider, creds = await _resolve_provider_creds(req.model, settings)
+    ctx = DispatchContext(
+        agent_id=agent_id,
+        org_id=org_id,
         trace_id=trace_id,
     )
-
-    async def _aiter() -> AsyncIterator[dict]:
-        try:
-            stream = await acompletion(
-                model=model,
-                metadata=metadata,
-                stream=True,
-                stream_options=stream_options,
-                **provider_kwargs,
-                **body,
-            )
-        except Exception as exc:
-            raise _map_litellm_exception(exc) from exc
-
-        try:
-            async for chunk in stream:
-                payload = (
-                    chunk.model_dump() if hasattr(chunk, "model_dump")
-                    else dict(chunk)
-                )
-                payload.setdefault("object", "chat.completion.chunk")
-                payload.setdefault("model", model)
-                if dispatch_obj.upstream_request_id is None:
-                    upstream_id = payload.get("id")
-                    if upstream_id:
-                        dispatch_obj.upstream_request_id = upstream_id
-                # The final usage chunk has empty choices and a populated
-                # ``usage`` dict; harvest it for the audit row, normalise
-                # the shape so the SSE consumer always sees the canonical
-                # OpenAI usage fields.
-                usage = payload.get("usage")
-                if isinstance(usage, dict):
-                    pt = int(usage.get("prompt_tokens") or 0)
-                    ct = int(usage.get("completion_tokens") or 0)
-                    if pt or ct:
-                        dispatch_obj.prompt_tokens = pt
-                        dispatch_obj.completion_tokens = ct
-                        payload["usage"] = {
-                            "prompt_tokens": pt,
-                            "completion_tokens": ct,
-                            "total_tokens": pt + ct,
-                        }
-                yield payload
-        except GatewayError:
-            raise
-        except Exception as exc:
-            raise _map_litellm_exception(exc) from exc
-        finally:
-            dispatch_obj.latency_ms = int(
-                (time.perf_counter() - dispatch_obj.started_at) * 1000
-            )
-            if dispatch_obj.prompt_tokens or dispatch_obj.completion_tokens:
-                # ``completion_cost`` wants a full response object; in the
-                # streaming path we've already drained it, so go through
-                # ``cost_per_token`` (returns the (input, output) USD
-                # tuple already multiplied by the token counts).
-                try:
-                    in_cost, out_cost = litellm.cost_per_token(
-                        model=model,
-                        prompt_tokens=dispatch_obj.prompt_tokens,
-                        completion_tokens=dispatch_obj.completion_tokens,
-                    )
-                    dispatch_obj.cost_usd = float(in_cost) + float(out_cost)
-                except Exception as exc:  # pragma: no cover — informational
-                    _log.debug(
-                        "litellm.cost_per_token (stream) failed model=%s: %s",
-                        model, exc,
-                    )
-            _log.info(
-                "egress.llm streamed backend=litellm_embedded provider=%s "
-                "agent=%s org=%s model=%s latency_ms=%d tokens_in=%d "
-                "tokens_out=%d cost_usd=%s",
-                provider, agent_id, org_id, model, dispatch_obj.latency_ms,
-                dispatch_obj.prompt_tokens, dispatch_obj.completion_tokens,
-                f"{dispatch_obj.cost_usd:.6f}"
-                if dispatch_obj.cost_usd is not None else "n/a",
-            )
-
-    dispatch_obj._aiter_factory = _aiter
-    return dispatch_obj
+    return await adapter.stream_chat_completion(
+        req=req,
+        provider=provider,
+        creds=creds,
+        ctx=ctx,
+        settings=settings,
+    )


### PR DESCRIPTION
## Summary

PR-A of the ADR-039 series. Factors the inline LiteLLM and Portkey call paths out of `ai_gateway.py` behind a `ProviderAdapter` protocol so PR-B/C/D can drop in native Anthropic / OpenAI / Ollama adapters without touching the dispatcher again. **Zero behaviour change on the wire.**

Stacks on top of #987 (defensive pin `litellm>=1.83.7,<2.0` against the April-May 2026 CVE cluster). This refactor is unaffected by the pin and unaffected by the in-flight `MCP_PROXY_AI_GATEWAY_BACKEND` semantics.

## Why now

The April-May 2026 LiteLLM disclosure cycle made the dependency a continuous cost on the regulated-banking pitch, even though Cullis uses LiteLLM embedded in-process (not as a proxy server) and is not directly exploitable against the headline RCE / SQLi / auth-bypass CVEs. ADR-039 retires the dependency from the AI dispatch critical path over five sub-PRs (refactor, Anthropic adapter, OpenAI adapter, Ollama adapter, default flip + drop). This is the first.

## What changed

| File | Change |
|---|---|
| `mcp_proxy/egress/adapters/__init__.py` | `resolve_adapter(backend)` factory + package surface |
| `mcp_proxy/egress/adapters/base.py` | `ProviderAdapter` Protocol + `DispatchContext` dataclass |
| `mcp_proxy/egress/adapters/litellm.py` | `LiteLLMAdapter` wrapping the prior `_call_litellm_embedded` + `_build_litellm_stream` |
| `mcp_proxy/egress/adapters/portkey.py` | `PortkeyAdapter` wrapping the prior `_call_portkey` |
| `mcp_proxy/egress/ai_gateway.py` | 691 → 230 lines. Keeps the dispatcher, shared dataclasses, secret scrub, provider resolution. |

Net delta: +768 / -501 (refactor splits an inline monolith into four files; the surface area to read is smaller per file).

## Behaviour invariants verified

- `MCP_PROXY_AI_GATEWAY_BACKEND` values unchanged (`litellm_embedded` default, `portkey` legacy)
- Audit row `backend` tag unchanged (`"litellm_embedded"` / `"portkey"`)
- Error reasons unchanged (`provider_auth_failed`, `provider_rate_limited`, `streaming_not_implemented_for_backend:portkey`, etc.)
- External imports from `ai_gateway` still resolve: `dispatch`, `dispatch_stream`, `GatewayError`, `StreamingDispatch`, `scrub_secrets`
- No external module referenced the moved internals (`_call_litellm_embedded`, `_call_portkey`, `_build_litellm_stream`, `_LITELLM_ERROR_MAP`, `_map_litellm_exception`, `CULLIS_FORWARD_HEADERS`); verified by grep across `mcp_proxy/`, `tests/`, `cullis_sdk/`

## Local smoke

- `python -c "from mcp_proxy.egress.ai_gateway import dispatch, dispatch_stream, GatewayError, GatewayResult, StreamingDispatch"` clean
- Full chain boot `import mcp_proxy.egress.{ai_gateway, llm_chat_router, anthropic_messages_router}` clean
- `resolve_adapter("litellm_embedded")` returns `LiteLLMAdapter`; `resolve_adapter("portkey")` returns `PortkeyAdapter`; `resolve_adapter("cullis_native")` raises `GatewayError(501, "backend_not_implemented:cullis_native")` as designed (the `cullis_native` slot is reserved for PR-B)
- `isinstance(LiteLLMAdapter(), ProviderAdapter)` and `isinstance(PortkeyAdapter(), ProviderAdapter)` both `True` (runtime-checkable Protocol)
- `scrub_secrets("Bearer sk-ant-api03-AAAABBBBCCCCDD")` → trailing `[REDACTED]` ✓
- `scrub_secrets(None)` → `None` ✓ (idempotency)

`./smoke.sh full` runs in the enterprise repo (not in this public tree); a maintainer-side smoke is recommended before merge against the Anthropic / LiteLLM path.

## Next sub-PRs in the ADR-039 series

- PR-B — `AnthropicAdapter` (anthropic.AsyncAnthropic SDK, streaming + tool use + prompt caching)
- PR-C — `OpenAIAdapter` (openai.AsyncOpenAI SDK, effectively passthrough)
- PR-D — `OllamaAdapter` (raw httpx against `/api/chat`, JSONL streaming)
- PR-E — flip `MCP_PROXY_AI_GATEWAY_BACKEND` default to `cullis_native`, deprecation warning on `litellm_embedded`
- v0.8.x — remove `litellm` from `requirements.txt` and `mcp_proxy/requirements-proxy.txt`

## Test plan

- [ ] CI green
- [ ] Maintainer smoke against `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` + Anthropic chat completion (non-stream)
- [ ] Maintainer smoke against streaming path (`stream=true`, Anthropic Haiku)
- [ ] Bundle build resolves with no extra dependencies