### PR TITLE
feat(egress): native OpenAI adapter via official SDK (ADR-039 PR-C)

### DIFF
--- a/mcp_proxy/egress/adapters/__init__.py
+++ b/mcp_proxy/egress/adapters/__init__.py
@@ -12,11 +12,13 @@ ADR-039 phasing:
   - Phase 1a (PR-A): factor out ``LiteLLMAdapter`` and ``PortkeyAdapter``
     from the existing ``ai_gateway.py`` monolith. Zero behaviour change
     on the wire.
-  - Phase 1b (PR-B, this commit): introduce ``cullis_native`` backend
-    with ``AnthropicAdapter`` (anthropic.AsyncAnthropic SDK). Default
-    backend stays ``litellm_embedded``; ``cullis_native`` is opt-in via
-    env var.
-  - Phase 1c (PR-C): add ``OpenAIAdapter`` under ``cullis_native``.
+  - Phase 1b (PR-B): introduce ``cullis_native`` backend with
+    ``AnthropicAdapter`` (anthropic.AsyncAnthropic SDK). Default
+    backend stays ``litellm_embedded``; ``cullis_native`` is opt-in
+    via env var.
+  - Phase 1c (PR-C, this commit): add ``OpenAIAdapter`` under
+    ``cullis_native`` (openai.AsyncOpenAI SDK, mostly passthrough on
+    request shape).
   - Phase 1d (PR-D): add ``OllamaAdapter`` under ``cullis_native``.
   - Phase 1e (PR-E): flip the default backend to ``cullis_native`` and
     deprecate ``litellm_embedded`` (removed in v0.8).
@@ -29,6 +31,7 @@ from __future__ import annotations
 from mcp_proxy.egress.adapters.anthropic import AnthropicAdapter
 from mcp_proxy.egress.adapters.base import DispatchContext, ProviderAdapter
 from mcp_proxy.egress.adapters.litellm import LiteLLMAdapter
+from mcp_proxy.egress.adapters.openai import OpenAIAdapter
 from mcp_proxy.egress.adapters.portkey import PortkeyAdapter
 
 
@@ -60,9 +63,12 @@ def resolve_adapter(backend: str, provider: str | None = None) -> ProviderAdapte
     if backend == "cullis_native":
         if provider == "anthropic":
             return AnthropicAdapter()
-        # PR-C (OpenAI) and PR-D (Ollama) wire here. Until then, fall
-        # through to the explicit "no native adapter" error so operators
-        # see a clear message instead of "backend_not_implemented".
+        if provider == "openai":
+            return OpenAIAdapter()
+        # PR-D (Ollama) wires here. Gemini / Bedrock / Vertex stay on
+        # litellm_embedded until a customer asks; fall through to the
+        # explicit "no native adapter" error so the dashboard surface
+        # gives a clear pointer rather than a generic 501.
         raise GatewayError(
             501,
             f"provider_native_not_implemented:{provider or 'unknown'}",
@@ -71,7 +77,7 @@ def resolve_adapter(backend: str, provider: str | None = None) -> ProviderAdapte
                 f"{provider!r} yet. Pin "
                 f"MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded to keep "
                 f"using LiteLLM for this provider, or wait for the "
-                f"upcoming native adapter (ADR-039 PR-C/D)."
+                f"upcoming native adapter (ADR-039 PR-D)."
             ),
         )
     raise GatewayError(
@@ -85,6 +91,7 @@ __all__ = [
     "AnthropicAdapter",
     "DispatchContext",
     "LiteLLMAdapter",
+    "OpenAIAdapter",
     "PortkeyAdapter",
     "ProviderAdapter",
     "resolve_adapter",

--- a/mcp_proxy/egress/adapters/openai.py
+++ b/mcp_proxy/egress/adapters/openai.py
@@ -1,0 +1,307 @@
+"""Native OpenAI adapter (ADR-039 PR-C).
+
+Uses ``openai.AsyncOpenAI`` directly, no LiteLLM. The Mastio's request
+shape is already OpenAI ChatCompletion, so this adapter is effectively
+passthrough on the request/response wire. The only Cullis-side
+responsibilities are:
+
+  - Build the SDK client from the dashboard-stored credentials.
+  - Inject ``X-Cullis-{Agent,Org,Trace}`` headers so any upstream
+    observability the operator wires up sees the agent identity.
+  - Map ``openai.*Error`` to ``GatewayError`` with the same reason tags
+    other adapters use, so audit and dashboard counters stay coherent.
+  - Drain stream chunks as OpenAI dicts the existing SSE router can
+    forward unchanged, and harvest the final ``usage`` chunk for the
+    per-call telemetry / audit row.
+
+Out of scope for PR-C, same as PR-B:
+  - Cost computation (cost_usd stays None; the Cullis-owned price
+    table lands as a separate PR alongside the per-agent cost meter
+    in ADR-040 territory).
+  - Multi-modal pass-through is fine on OpenAI (the shape is the same
+    going in and out); no special handling needed here.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+from mcp_proxy.egress.adapters.base import DispatchContext
+
+if TYPE_CHECKING:
+    from mcp_proxy.config import ProxySettings as Settings
+    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+
+_log = logging.getLogger("agent_trust.egress")
+
+
+# OpenAI SDK exception class names → (HTTP status, audit reason).
+# Comparing by class name keeps the import of ``openai`` lazy. Tags
+# match the Anthropic and LiteLLM maps so dashboard error counters and
+# audit aggregations stay coherent across adapters.
+_OPENAI_ERROR_MAP: dict[str, tuple[int, str]] = {
+    "AuthenticationError": (401, "provider_auth_failed"),
+    "PermissionDeniedError": (403, "provider_permission_denied"),
+    "NotFoundError": (404, "provider_not_found"),
+    "RateLimitError": (429, "provider_rate_limited"),
+    "BadRequestError": (400, "provider_bad_request"),
+    "UnprocessableEntityError": (422, "provider_unprocessable"),
+    "ConflictError": (409, "provider_conflict"),
+    "APITimeoutError": (504, "provider_timeout"),
+    "Timeout": (504, "provider_timeout"),
+    "APIConnectionError": (502, "provider_unreachable"),
+    "InternalServerError": (502, "provider_internal_error"),
+    "APIStatusError": (502, "provider_api_error"),
+    "APIError": (502, "provider_api_error"),
+    "ContentFilterFinishReasonError": (400, "provider_content_policy"),
+    "LengthFinishReasonError": (400, "provider_context_too_long"),
+}
+
+
+def _map_openai_exception(exc: Exception) -> "GatewayError":
+    from mcp_proxy.egress.ai_gateway import GatewayError, scrub_secrets
+
+    cls = type(exc).__name__
+    status, reason = _OPENAI_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
+    detail = scrub_secrets((str(exc) or cls)[:512])
+    return GatewayError(status, reason, detail=detail)
+
+
+def _client(creds: dict[str, str], settings: "Settings") -> Any:
+    """Build an AsyncOpenAI client from the catalog row.
+
+    Supports the OpenAI-compatible endpoints customers run behind
+    enterprise gateways (Azure OpenAI deployment URL, vLLM, etc) via
+    ``api_base`` / ``base_url``. ``organization`` is honoured when
+    present so enterprise OpenAI accounts that bill per-org work
+    out-of-the-box.
+    """
+    from mcp_proxy.egress.ai_gateway import GatewayError
+
+    try:
+        from openai import AsyncOpenAI
+    except ImportError as exc:  # pragma: no cover — openai is a hard dep
+        raise GatewayError(
+            503,
+            "provider_sdk_missing",
+            detail=(
+                "openai SDK is required for the native OpenAI adapter. "
+                "It ships as a top-level dependency in requirements.txt."
+            ),
+        ) from exc
+
+    api_key = creds.get("api_key") or ""
+    if not api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    kwargs: dict[str, Any] = {"api_key": api_key}
+    base_url = creds.get("api_base") or creds.get("base_url")
+    if base_url:
+        kwargs["base_url"] = base_url
+    organization = creds.get("organization") or creds.get("org_id")
+    if organization:
+        kwargs["organization"] = organization
+    timeout = getattr(settings, "ai_gateway_request_timeout_s", None)
+    if timeout:
+        kwargs["timeout"] = float(timeout)
+    return AsyncOpenAI(**kwargs)
+
+
+def _cullis_headers(ctx: DispatchContext) -> dict[str, str]:
+    return {
+        "X-Cullis-Agent": ctx.agent_id,
+        "X-Cullis-Org": ctx.org_id,
+        "X-Cullis-Trace": ctx.trace_id,
+    }
+
+
+def _strip_passthrough_body(body: dict[str, Any]) -> dict[str, Any]:
+    """Remove fields the SDK manages itself; preserve everything else.
+
+    ``stream`` / ``stream_options`` are set by the adapter explicitly
+    for each path so the request body the caller built is normalised.
+    """
+    out = dict(body)
+    out.pop("stream", None)
+    out.pop("stream_options", None)
+    return out
+
+
+class OpenAIAdapter:
+    """Talk to OpenAI (or OpenAI-compatible) via the official SDK.
+
+    Effectively a passthrough on the wire shape; the value-add is
+    identity injection + error mapping + telemetry capture for the
+    Cullis audit row.
+    """
+
+    backend_name = "cullis_native"
+
+    async def chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "GatewayResult":
+        from mcp_proxy.egress.ai_gateway import GatewayError, GatewayResult
+        from mcp_proxy.egress.schemas import ChatCompletionResponse
+
+        body = _strip_passthrough_body(req.model_dump(exclude_none=True))
+        model = body.get("model")
+        client = _client(creds, settings)
+
+        started = time.perf_counter()
+        try:
+            response = await client.chat.completions.create(
+                **body,
+                extra_headers=_cullis_headers(ctx),
+            )
+        except Exception as exc:
+            gw_err = _map_openai_exception(exc)
+            _log.warning(
+                "openai_native error agent=%s model=%s reason=%s detail=%s",
+                ctx.agent_id, model, gw_err.reason, gw_err.detail,
+            )
+            raise gw_err from exc
+        latency_ms = int((time.perf_counter() - started) * 1000)
+
+        payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+        payload["cullis_trace_id"] = ctx.trace_id
+        # Normalise the usage shape so the canonical OpenAI fields are
+        # always present even if a non-OpenAI endpoint (Azure deployment,
+        # vLLM, LM Studio) returns a slim usage block.
+        usage = payload.get("usage") or {}
+        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        completion_tokens = int(usage.get("completion_tokens") or 0)
+        payload["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+
+        try:
+            parsed = ChatCompletionResponse.model_validate(payload)
+        except Exception as exc:
+            from mcp_proxy._http_safety import safe_http_detail
+            raise GatewayError(
+                502,
+                "schema_mismatch",
+                detail=safe_http_detail(
+                    exc,
+                    public_hint="OpenAI response failed Mastio schema",
+                    log_context="ai_gateway.openai_native.parse_response",
+                ),
+            ) from exc
+
+        upstream_request_id = (
+            getattr(response, "id", None)
+            or payload.get("id")
+        )
+
+        _log.info(
+            "egress.llm dispatched backend=cullis_native provider=openai "
+            "agent=%s org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
+            ctx.agent_id, ctx.org_id, model, latency_ms,
+            prompt_tokens, completion_tokens,
+        )
+
+        return GatewayResult(
+            response=parsed,
+            latency_ms=latency_ms,
+            upstream_request_id=upstream_request_id,
+            backend="cullis_native",
+            provider=provider,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=None,
+        )
+
+    async def stream_chat_completion(
+        self,
+        *,
+        req: "ChatCompletionRequest",
+        provider: str,
+        creds: dict[str, str],
+        ctx: DispatchContext,
+        settings: "Settings",
+    ) -> "StreamingDispatch":
+        from mcp_proxy.egress.ai_gateway import StreamingDispatch
+
+        body = _strip_passthrough_body(req.model_dump(exclude_none=True))
+        model = body.get("model")
+        # Always request a final usage chunk so the audit row gets
+        # accurate token counts. The OpenAI streaming spec drains this
+        # as a final chunk with empty choices and a populated ``usage``.
+        body["stream_options"] = {"include_usage": True}
+
+        client = _client(creds, settings)
+
+        dispatch_obj = StreamingDispatch(
+            backend="cullis_native",
+            provider=provider,
+            model=model,
+            trace_id=ctx.trace_id,
+        )
+
+        async def _aiter() -> AsyncIterator[dict]:
+            try:
+                stream = await client.chat.completions.create(
+                    **body,
+                    stream=True,
+                    extra_headers=_cullis_headers(ctx),
+                )
+            except Exception as exc:
+                raise _map_openai_exception(exc) from exc
+
+            try:
+                async for chunk in stream:
+                    payload = (
+                        chunk.model_dump() if hasattr(chunk, "model_dump")
+                        else dict(chunk)
+                    )
+                    payload.setdefault("object", "chat.completion.chunk")
+                    if model and not payload.get("model"):
+                        payload["model"] = model
+                    if dispatch_obj.upstream_request_id is None:
+                        cid = payload.get("id")
+                        if cid:
+                            dispatch_obj.upstream_request_id = cid
+                    # The final chunk has empty choices and a populated
+                    # ``usage`` block. Harvest it for telemetry and
+                    # normalise the wire shape so the OpenAI SSE consumer
+                    # always sees the canonical totals.
+                    usage = payload.get("usage")
+                    if isinstance(usage, dict):
+                        pt = int(usage.get("prompt_tokens") or 0)
+                        ct = int(usage.get("completion_tokens") or 0)
+                        if pt or ct:
+                            dispatch_obj.prompt_tokens = pt
+                            dispatch_obj.completion_tokens = ct
+                            payload["usage"] = {
+                                "prompt_tokens": pt,
+                                "completion_tokens": ct,
+                                "total_tokens": pt + ct,
+                            }
+                    yield payload
+            except Exception as exc:
+                raise _map_openai_exception(exc) from exc
+            finally:
+                dispatch_obj.latency_ms = int(
+                    (time.perf_counter() - dispatch_obj.started_at) * 1000
+                )
+                _log.info(
+                    "egress.llm streamed backend=cullis_native provider=openai "
+                    "agent=%s org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
+                    ctx.agent_id, ctx.org_id, model,
+                    dispatch_obj.latency_ms,
+                    dispatch_obj.prompt_tokens, dispatch_obj.completion_tokens,
+                )
+
+        dispatch_obj._aiter_factory = _aiter
+        return dispatch_obj


### PR DESCRIPTION
## Summary

PR-C of the ADR-039 series. Adds the second native server-side adapter under the new `cullis_native` backend, retiring LiteLLM from the OpenAI dispatch path. **Stacked on top of #989 (PR-B AnthropicAdapter).**

## ⚠ Merge order

This branch contains the PR-B commit because it branched off `feat/adr-039-anthropic-adapter`. **Merge #989 first**, then this PR rebases cleanly onto main with only the PR-C diff (the PR-B commit collapses into the squash on main).

`--base main` per Cullis convention (memoria `feedback_stacked_pr_base_branch`: always main, never parent branch).

## What's new

`OpenAIAdapter.chat_completion` / `.stream_chat_completion` call `openai.AsyncOpenAI` directly. The Mastio's input shape is already OpenAI ChatCompletion, so the adapter is effectively passthrough on the wire. The value-add:

- **Identity headers**: injects `X-Cullis-Agent`, `X-Cullis-Org`, `X-Cullis-Trace` on every upstream call via `extra_headers`. Operators who run their own OpenAI-side observability (Langfuse, Datadog) see the agent identity per call without extra plumbing.
- **Error mapping**: `openai.*Error` → `GatewayError` with reason tags aligned to the Anthropic and LiteLLM maps so dashboard counters and audit aggregations stay coherent across adapters.
- **Streaming telemetry**: forces `stream_options.include_usage = true` so the audit row gets accurate token counts even when the caller didn't ask. The final chunk's usage block drives `dispatch_obj.prompt_tokens` / `.completion_tokens`.

## OpenAI compat surface

Works out-of-the-box against the OpenAI cloud and any OpenAI-compatible endpoint via `api_base`:

- **Azure OpenAI deployments**: set `api_base=https://<resource>.openai.azure.com/openai/deployments/<name>` and `api_key=<azure-key>` in the dashboard credentials row. Streaming works.
- **vLLM / LM Studio / llama.cpp / TGI**: same pattern, set `api_base=http://host:8000/v1` and any string as `api_key` (most of these don't check).
- **Multi-org enterprise OpenAI**: `organization` credential field honoured (or `org_id` as alias) so per-org billing routes correctly.

## Out of scope (same boundary as PR-B)

- **Cost computation**: `cost_usd = None`. The Cullis-owned price table lands with the per-agent cost meter (ADR-040 territory). LiteLLM's `completion_cost()` was the only feature we leveraged from the package for this; trade-off accepted in ADR-039.
- **Azure AD auth**: managed identity / AAD token rotation deferred. The `api_key` path covers Azure OpenAI today; AAD-flow lands when an enterprise customer asks.

## Files

| File | Change |
|---|---|
| `mcp_proxy/egress/adapters/openai.py` | New. `OpenAIAdapter` + helpers `_client`, `_cullis_headers`, `_strip_passthrough_body`, `_map_openai_exception`, `_OPENAI_ERROR_MAP`. ~307 LOC. |
| `mcp_proxy/egress/adapters/__init__.py` | Wire `cullis_native + openai` → `OpenAIAdapter`. 501 fallthrough now only for `ollama` (PR-D) and the explicit deferred set (Gemini/Bedrock/Vertex). |

## Tests

`tests/test_openai_adapter.py` (gitignored — enterprise pattern). 25 pure-function tests covering every surface the adapter owns:

- `_strip_passthrough_body`: stream/stream_options drop + everything-else preserved + output is a copy
- `_cullis_headers`: three canonical keys
- `_map_openai_exception`: parametrised over the full `_OPENAI_ERROR_MAP` (15 known SDK classes) + unknown-class fallback + secret redaction in detail body + 512-char cap
- `_client`: api_key required → 503, base_url / organization / org_id alias honoured, AsyncOpenAI instance built

Combined with PR-B: **55/55 green**.

```
$ pytest tests/test_openai_adapter.py tests/test_anthropic_translator.py -v
...
============================== 55 passed in 0.80s ==============================
```

## Verification

- Import boot of `mcp_proxy.egress.adapters.{openai, __init__}` clean
- `isinstance(OpenAIAdapter(), ProviderAdapter)` → `True`
- `resolve_adapter('cullis_native', 'openai')` → `OpenAIAdapter`
- `resolve_adapter('cullis_native', 'anthropic')` unchanged → `AnthropicAdapter`
- `resolve_adapter('cullis_native', 'gemini')` → 501 `provider_native_not_implemented:gemini`
- `resolve_adapter('cullis_native', 'ollama')` → 501 `provider_native_not_implemented:ollama` (PR-D will wire)
- Legacy `resolve_adapter('litellm_embedded')` / `('portkey')` unchanged

## How to dogfood

```bash
export MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native
# OpenAI cloud:
#   dashboard → AI Providers → OpenAI → set api_key, optional organization
# Azure OpenAI deployment:
#   set api_key + api_base=https://<r>.openai.azure.com/openai/deployments/<n>
docker compose -f deploy/compose/docker-compose.proxy.yml up -d

# POST /v1/chat/completions with model=gpt-4o
# Audit row backend should be "cullis_native", provider="openai"
```

## Next sub-PRs

- **PR-D** — `OllamaAdapter` (raw httpx against `/api/chat`, JSONL stream parsing). ~400-600 LOC. The last cloud-or-local provider that takes the native path.
- **PR-E** — flip default `MCP_PROXY_AI_GATEWAY_BACKEND` to `cullis_native`, startup deprecation warning on `litellm_embedded`.
- **v0.8.x** — drop `litellm` from `requirements.txt` + `mcp_proxy/requirements-proxy.txt`, lazy import for `LiteLLMAdapter`.

## Test plan

- [ ] Merge #989 first
- [ ] After #989 squashes to main, this branch rebases clean (only PR-C commit remains)
- [ ] CI green
- [ ] Maintainer smoke against `MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native` + OpenAI gpt-4o chat completion (non-stream)
- [ ] Maintainer smoke against streaming path with `stream=true`, gpt-4o-mini
- [ ] Tool-use round-trip dogfood (OpenAI function calling, multi-step)
- [ ] Optional: Azure OpenAI deployment URL smoke if an Azure tenant is available
- [ ] Verify audit row `backend` column = `"cullis_native"`, `provider` = `"openai"`