### PR TITLE
feat(config): flip default AI gateway backend to cullis_native (ADR-039 PR-E)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -651,12 +651,28 @@ class ProxySettings(BaseSettings):
     # allow-list — narrow this in production.
     webauthn_expected_origin: str = ""
 
-    # ADR-017 native AI gateway on Mastio. When the Mastio runs litellm
-    # in-process (default: ``litellm_embedded``), every chat completion
-    # is dispatched without a Court round trip. Set ``backend=portkey``
-    # to delegate to a Portkey gateway sidecar instead.
+    # AI gateway dispatch backend (ADR-017 then ADR-039).
+    #
+    # Default since v0.7.x: ``cullis_native``. Dispatches per-provider
+    # to a Cullis-owned adapter that wraps the official SDK (Anthropic,
+    # OpenAI) or a thin httpx client (Ollama). No LiteLLM in the
+    # critical path. Gemini / Bedrock / Vertex are not yet wired
+    # natively and return HTTP 501 with a clear ``pin litellm_embedded``
+    # message under this backend.
+    #
+    # Other accepted values:
+    #   ``litellm_embedded`` — legacy. Routes every provider through
+    #     the embedded LiteLLM library. Deprecated in v0.7.x, removed
+    #     from ``requirements.txt`` in v0.8.x. Still useful for
+    #     operators who depend on Gemini / Bedrock / Vertex today.
+    #   ``portkey`` — legacy Anthropic-only Portkey sidecar. Deprecated
+    #     alongside ``litellm_embedded``.
+    #
+    # ``validate_config`` emits a deprecation warning when an operator
+    # explicitly pins ``litellm_embedded`` or ``portkey`` so the
+    # transition to native is visible in startup logs.
     anthropic_api_key: str = ""
-    ai_gateway_backend: str = "litellm_embedded"  # litellm_embedded | portkey
+    ai_gateway_backend: str = "cullis_native"  # cullis_native | litellm_embedded | portkey
     ai_gateway_provider: str = "anthropic"
     ai_gateway_url: str = "http://localhost:8787"  # Portkey sidecar URL
     ai_gateway_request_timeout_s: float = 30.0
@@ -1397,13 +1413,43 @@ def validate_config(settings: ProxySettings) -> None:
             settings.dashboard_signing_key_path,
         )
 
+    # ADR-039 — AI gateway backend posture. New default ``cullis_native``
+    # routes Anthropic / OpenAI / Ollama through native adapters with no
+    # LiteLLM in the critical path. Operators pinned to the legacy
+    # backends see a deprecation warning so the v0.8.x removal is not a
+    # surprise.
+    backend = settings.ai_gateway_backend.lower()
+    if backend == "cullis_native":
+        _log.info(
+            "AI gateway backend: cullis_native (ADR-039). Native adapters "
+            "active for anthropic, openai, ollama. Gemini / Bedrock / "
+            "Vertex still require MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded.",
+        )
+    elif backend == "litellm_embedded":
+        _log.warning(
+            "AI gateway backend: litellm_embedded (LEGACY, deprecated by "
+            "ADR-039). This backend will be removed in v0.8.x; the "
+            "``litellm`` package will be dropped from requirements.txt. "
+            "Migrate to MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native unless "
+            "you depend on Gemini / Bedrock / Vertex (native adapters "
+            "TBD).",
+        )
+    elif backend == "portkey":
+        _log.warning(
+            "AI gateway backend: portkey (LEGACY, Anthropic-only). "
+            "Deprecated by ADR-039 alongside litellm_embedded; will be "
+            "removed in v0.8.x. Migrate to "
+            "MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native.",
+        )
+
     _log.info(
         "Startup validation passed (environment=%s, secret_backend=%s, "
-        "kms_backend=%s, standalone=%s).",
+        "kms_backend=%s, standalone=%s, ai_gateway_backend=%s).",
         settings.environment,
         settings.secret_backend,
         settings.kms_backend,
         settings.standalone,
+        settings.ai_gateway_backend,
     )
 
 

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -261,9 +261,12 @@ MCP_PROXY_STANDALONE=true
 # models, dynamic discovery, no API key). Configure credentials per
 # provider from the dashboard at ``Settings -> AI Providers``; the SPA
 # dropdown surfaces only models from enabled providers. The default
-# backend is the embedded LiteLLM library; switch to a Portkey sidecar
-# by setting ``MCP_PROXY_AI_GATEWAY_BACKEND=portkey`` (Portkey path is
-# legacy Phase-1 and only routes Anthropic).
+# backend is ``cullis_native`` (ADR-039): per-provider native adapters
+# wrap the official Anthropic / OpenAI SDKs and a thin httpx client for
+# Ollama, with no LiteLLM in the critical path. Gemini / Bedrock /
+# Vertex still need ``MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded``
+# (native adapters TBD); the legacy ``portkey`` sidecar is also still
+# wired.
 
 # [OPTIONAL legacy] Anthropic API key, env-only path kept for backward
 # compatibility with deployments that pre-date the dashboard provider
@@ -273,10 +276,23 @@ MCP_PROXY_STANDALONE=true
 # instead so the credential is org-scoped, rotatable, and auditable.
 MCP_PROXY_ANTHROPIC_API_KEY=
 
-# Backend dispatcher. ``litellm_embedded`` (default) calls LiteLLM in
-# the same process; ``portkey`` proxies through a Portkey sidecar at
-# ``MCP_PROXY_AI_GATEWAY_URL`` (legacy, Anthropic-only).
-#MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded
+# Backend dispatcher.
+#
+# Default since v0.7.x: ``cullis_native`` (ADR-039). Routes Anthropic,
+# OpenAI, and Ollama through Cullis-owned native adapters that wrap the
+# official provider SDKs (Anthropic, OpenAI) or a thin httpx client
+# (Ollama). No LiteLLM in the critical path. Gemini / Bedrock / Vertex
+# still need ``MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`` for now
+# (native adapters are TBD until a customer drives the work).
+#
+# Legacy values, kept for v0.7.x and removed in v0.8.x:
+#   ``litellm_embedded`` — routes every provider through LiteLLM
+#     in-process. Required for Gemini / Bedrock / Vertex until the
+#     native adapters land. Pinning this backend emits a deprecation
+#     warning at startup.
+#   ``portkey`` — Anthropic-only Portkey sidecar at
+#     ``MCP_PROXY_AI_GATEWAY_URL`` (legacy Phase-1 from ADR-017).
+#MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native
 
 # Default upstream provider when the request model id has no explicit
 # ``provider/model`` prefix and no heuristic matches. Routing for


### PR DESCRIPTION
## Summary

PR-E of the ADR-039 series. Flips the default `MCP_PROXY_AI_GATEWAY_BACKEND` from `litellm_embedded` to `cullis_native`. With PR-A through PR-D landed, all three native adapters (Anthropic, OpenAI, Ollama) are wired; an operator who never sets the env var explicitly now routes them through the native path on next restart.

**No code path change** for operators who pin `litellm_embedded` explicitly. They just see a deprecation warning at startup so the v0.8.x removal isn't a surprise.

## Changes

`mcp_proxy/config.py`
- `ProxySettings.ai_gateway_backend` default: `"litellm_embedded"` → `"cullis_native"`. Comment block lists all three accepted values with their lifecycle.
- `validate_config()` emits one of three messages on startup:
  - `cullis_native` (new default) → **INFO**: "Native adapters active for anthropic, openai, ollama. Gemini / Bedrock / Vertex still require litellm_embedded."
  - `litellm_embedded` (legacy) → **WARNING**: "LEGACY, deprecated by ADR-039. Removed in v0.8.x. Migrate to cullis_native unless you depend on Gemini / Bedrock / Vertex."
  - `portkey` (legacy Anthropic-only) → **WARNING**: "LEGACY, Anthropic-only. Removed in v0.8.x."
- Final "Startup validation passed" line now includes `ai_gateway_backend` for log scrapes.

`packaging/mastio-bundle/proxy.env.example`
- Doc block above the AI provider section updated: default is now `cullis_native`; `litellm_embedded` remains opt-in for Gemini / Bedrock / Vertex.
- The commented-out `MCP_PROXY_AI_GATEWAY_BACKEND` line shows the new default value.

## Behaviour change summary

An operator who never set `MCP_PROXY_AI_GATEWAY_BACKEND` explicitly now:

- ✓ **Anthropic** routes through `AnthropicAdapter` (anthropic.AsyncAnthropic SDK)
- ✓ **OpenAI** routes through `OpenAIAdapter` (openai.AsyncOpenAI SDK)
- ✓ **Ollama** routes through `OllamaAdapter` (raw httpx + JSONL stream)
- ⚠ **Gemini / Bedrock / Vertex** start returning HTTP 501 `provider_native_not_implemented` with a clear "pin `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`" message

The wire contract on `/v1/chat/completions` and `/v1/messages` is unchanged. The audit row's `backend` field flips from `"litellm_embedded"` to `"cullis_native"` for the three native providers.

## Rollback

Setting `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` restores the prior dispatch behaviour **exactly**. The legacy adapter is still in tree until v0.8.x and continues to work; the only difference for operators rolling back is the new deprecation warning at startup.

## Verification

```
$ MCP_PROXY_ADMIN_SECRET=x python -c "from mcp_proxy.config import ProxySettings; print(ProxySettings(_env_file=None).ai_gateway_backend)"
cullis_native

$ MCP_PROXY_ADMIN_SECRET=x MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded \
  MCP_PROXY_ENVIRONMENT=development \
  python -c "from mcp_proxy.config import ProxySettings, validate_config; \
             import logging; logging.basicConfig(level=logging.INFO); \
             validate_config(ProxySettings(_env_file=None))"
WARNING AI gateway backend: litellm_embedded (LEGACY, deprecated by ADR-039). This
backend will be removed in v0.8.x; the ``litellm`` package will be dropped from
requirements.txt. Migrate to MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native unless you
depend on Gemini / Bedrock / Vertex (native adapters TBD).
INFO Startup validation passed (..., ai_gateway_backend=litellm_embedded).
```

Native adapter test suite still 91/91 green (anthropic 30, openai 25, ollama 36).

## Next steps

- **v0.8.x — PR-F**: drop `litellm` from `requirements.txt` + `mcp_proxy/requirements-proxy.txt`, make `LiteLLMAdapter`'s `import litellm` lazy + emit a hard 503 if the operator pins `litellm_embedded` without the package installed.
- **Marketing follow-up** (separate PR): de-evidenziare LiteLLM from `README.md`, `site/`, `docs/integrations/`, `docs/security/threat-model.md`. Reframe as "vanilla SDK per cloud provider, native adapter per Ollama, zero third-party in the AI dispatch critical path".

## Test plan

- [ ] CI green
- [ ] Maintainer smoke against default backend (no env var set) — verify Anthropic chat completion + streaming + tool use round through the native path
- [ ] Maintainer smoke with `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` pinned — verify the deprecation warning fires and the legacy path still works
- [ ] Verify audit row `backend="cullis_native"` is now the default for fresh deployments
- [ ] Bundle dogfood: confirm `packaging/mastio-bundle/proxy.env.example` reads correctly to a fresh operator