### PR TITLE
docs: reframe AI gateway narrative as native per-provider (ADR-039 PR-G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Banks, insurers, and other regulated organizations are starting to put AI agents
 
 Cullis sits underneath any agent stack (Claude Agent SDK, OpenAI Agents SDK, custom loops) and provides the three primitives a regulated deployment is missing: per-agent cryptographic identity bound to whoever or whatever authorized the agent, a policy decision point that runs before the LLM call lands, and a hash-chained append-only audit log that an external auditor can verify without trusting Cullis or your IT team.
 
-Cullis is LLM-agnostic by design. The embedded gateway is wired to Anthropic today; OpenAI, Gemini, and Ollama route through LiteLLM and are rolling out. An alternative AI gateway can be configured as a sidecar. The identity, policy, and audit primitives stay the same regardless of the provider.
+Cullis is LLM-agnostic by design. The default dispatch path uses Cullis-owned native adapters: the official Anthropic and OpenAI Python SDKs for the cloud providers, a thin httpx client for Ollama. No third-party AI gateway in the critical path. Gemini, Bedrock, and Vertex still ride the legacy LiteLLM backend, opt-in via `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`, until their native adapters land. The identity, policy, and audit primitives stay the same regardless of the provider.
 
 ---
 
@@ -34,7 +34,7 @@ Mastio is the gateway. One container, one organization, one source of truth for 
 
 **Audit.** Every accepted action lands as a row in an append-only audit log, hash-chained per organization, optionally anchored to RFC 3161 TSA on a configurable cadence. The chain replays deterministically: an external auditor can verify it offline without holding any Cullis credentials.
 
-**Embedded AI gateway.** LiteLLM is bundled. Anthropic is wired out of the box (set `MCP_PROXY_ANTHROPIC_API_KEY` in `proxy.env`); OpenAI, Gemini, and Ollama are on the roadmap and currently return HTTP 501. Per-agent identity is propagated into every upstream call as part of the audit trail. The provider can be switched by env var without touching agent code.
+**AI gateway.** Native adapters for Anthropic, OpenAI, and Ollama wrap the providers directly: the official Anthropic and OpenAI SDKs for the cloud paths, raw httpx against `/api/chat` for Ollama. No third-party dispatch library in the critical path (ADR-039). Anthropic is wired out of the box (set `MCP_PROXY_ANTHROPIC_API_KEY` in `proxy.env`); OpenAI and Ollama configure from the dashboard. Gemini, Bedrock, and Vertex still flow through the legacy LiteLLM backend (opt-in via `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`) until their native adapters land. Per-agent identity is propagated into every upstream call as part of the audit trail; the provider can be switched by env var without touching agent code.
 
 **MCP reverse proxy.** Mastio terminates MCP traffic from agents, applies the capability gate, propagates the agent identity into the tool call, and logs the result. Both stdio and HTTP transports are supported. Resources are declared per tool with explicit allowed-domain lists.
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -20,9 +20,10 @@ Topology:
 Cursor's **agentic** features (Composer, Agents, multi-step edits)
 make heavy use of provider-specific extensions to the chat completion
 API — tool-call streaming patterns, system prompt injection,
-context-window stuffing. The Mastio's embedded LiteLLM normalises
-the common subset, but some agentic operations may degrade or fail
-when routed through a custom endpoint.
+context-window stuffing. The Mastio's native per-provider adapter
+(Anthropic SDK, OpenAI SDK, raw httpx for Ollama) handles the common
+subset, but some agentic operations may degrade or fail when routed
+through a custom endpoint.
 
 What works reliably today:
 
@@ -156,7 +157,8 @@ that don't always round-trip through normalisation. Workarounds:
   agentic flows (loses audit attribution for those calls, but the
   feature works).
 - File an issue on the Cullis repo with the failing payload — we
-  can extend the LiteLLM normaliser for common Cursor patterns.
+  can extend the native adapter's translator for common Cursor
+  patterns.
 
 ### Cursor Tab (inline autocomplete) doesn't use Cullis
 

--- a/docs/integrations/librechat.md
+++ b/docs/integrations/librechat.md
@@ -228,8 +228,9 @@ LibreChat shows fewer/different models than expected:
 ### Tool calls behave inconsistently
 
 LibreChat agents v2 emit OpenAI-flavoured tool calls. The Mastio's
-embedded LiteLLM normalises them to the upstream provider's format
-(Anthropic / Bedrock / etc). Some edge cases (parallel tool calls
+native per-provider adapter (Anthropic SDK for Claude, OpenAI SDK for
+gpt-*, raw httpx for Ollama) translates them to the upstream provider's
+format. Some edge cases (parallel tool calls
 against Claude) may not round-trip cleanly today. Workaround: pick a
 provider whose native tool-call format matches what LibreChat emits
 (OpenAI native is the safest), or disable agents v2 and use single-shot

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -27,7 +27,7 @@ organisation. Inside the boundary:
 - The audit chain (append-only hash chain + optional Merkle batch
   + RFC 3161 TSA external anchor).
 - The PDP webhook hook (operator-supplied policy engine).
-- The AI gateway (embedded LiteLLM) and the MCP reverse-proxy.
+- The AI gateway (native dispatch path: official Anthropic / OpenAI SDKs, raw httpx for Ollama; LiteLLM remains in tree as the legacy backend for Gemini / Bedrock / Vertex, opt-in only — ADR-039) and the MCP reverse-proxy.
 
 Outside the boundary:
 

--- a/site/src/content/docs/quickstart/chat-completion.md
+++ b/site/src/content/docs/quickstart/chat-completion.md
@@ -17,7 +17,7 @@ updated: "2026-05-23"
 
 ## 1. The minimal call
 
-OpenAI ChatCompletion request shape. Mastio forwards to the configured upstream via LiteLLM:
+OpenAI ChatCompletion request shape. Mastio dispatches to the configured upstream through a native adapter (official Anthropic / OpenAI SDKs, raw httpx for Ollama):
 
 ```python
 response = client.chat_completion({

--- a/site/src/content/docs/quickstart/provider-sdk-drop-in.md
+++ b/site/src/content/docs/quickstart/provider-sdk-drop-in.md
@@ -59,13 +59,13 @@ client = OpenAI(
 )
 
 resp = client.chat.completions.create(
-    model="claude-sonnet-4-6",   # or any LiteLLM-supported model
+    model="claude-sonnet-4-6",   # any model configured on the Mastio dashboard
     messages=[{"role": "user", "content": "hello"}],
 )
 print(resp.choices[0].message.content)
 ```
 
-The OpenAI SDK targets `/v1/chat/completions`, which is the Mastio's native OpenAI-shape endpoint (LiteLLM under the hood). Streaming, tool use, and prompt caching all work because the Mastio is transparent on the request/response payload — the helper only adds the transport-layer wrapping.
+The OpenAI SDK targets `/v1/chat/completions`, which is the Mastio's native OpenAI-shape endpoint. Cloud providers dispatch through their own official SDKs server-side (`anthropic.AsyncAnthropic`, `openai.AsyncOpenAI`); Ollama uses raw httpx against `/api/chat`. Streaming, tool use, and prompt caching all work because the Mastio is transparent on the request/response payload — the helper only adds the transport-layer wrapping.
 
 ## Framework integration (LangChain, LlamaIndex, DSPy, ...)
 

--- a/site/src/content/docs/security/threat-model.md
+++ b/site/src/content/docs/security/threat-model.md
@@ -123,8 +123,10 @@ per trust boundary. For each component we:
 │                                 │                            │     │
 │   ┌───────────┐                 │   ┌─────────────────┐      │     │
 │   │  MCP tool │  reverse proxy  │   │  AI gateway     │      │     │
-│   │  upstream │  ◀───────────▶  │   │ (embedded       │      │     │
-│   │ (Slack…)  │                 │   │  LiteLLM)       │      │     │
+│   │  upstream │  ◀───────────▶  │   │ (native:        │      │     │
+│   │ (Slack…)  │                 │   │  Anthropic SDK, │      │     │
+│   │           │                 │   │  OpenAI SDK,    │      │     │
+│   │           │                 │   │  httpx→Ollama)  │      │     │
 │   └───────────┘                 │   └─────────────────┘      │     │
 │                                 │                            │     │
 │                                 │   ┌─────────────────┐      │     │
@@ -274,22 +276,29 @@ directly. The proxy:
 - `mcp_proxy/audit_chain.py` (per-org chain, retry path
   `_AUDIT_CHAIN_MAX_RETRIES = 5`)
 
-## Component: AI gateway (embedded LiteLLM)
+## Component: AI gateway (native per-provider dispatch)
 
 ### Data flow
 
-ADR-017: Mastio embeds LiteLLM as the default AI gateway for outbound
-LLM calls (`/v1/llm/...`). The gateway is selected by
-`settings.ai_gateway_backend` (`mcp_proxy/config.py`); the default
-`litellm_embedded` runs in-process. It terminates an OpenAI-shaped
-or Anthropic-shaped client request, applies per-agent rate limits
-and key selection, and forwards to the configured upstream provider.
+ADR-039 (supersedes ADR-017 on the dispatch layer): Mastio dispatches
+outbound LLM calls (`/v1/llm/...`, `/v1/chat/completions`,
+`/v1/messages`) through a per-provider native adapter. The selection is
+driven by `settings.ai_gateway_backend` (`mcp_proxy/config.py`); the
+default `cullis_native` routes Anthropic through
+`anthropic.AsyncAnthropic`, OpenAI through `openai.AsyncOpenAI`, and
+Ollama through raw httpx against `/api/chat`. No third-party AI
+gateway library is in the critical path. The legacy `litellm_embedded`
+backend remains in tree as an opt-in fallback for providers not yet
+wired natively (Gemini, Bedrock, Vertex); operators pinning it see a
+deprecation warning at startup. The gateway terminates an OpenAI-shaped
+or Anthropic-shaped client request, applies per-agent rate limits and
+key selection, and forwards to the configured upstream provider.
 
 ### STRIDE
 
 | Threat | Detail | Mitigation | Residual |
 |---|---|---|---|
-| Spoofing of the gateway | Agent thinks it is calling Anthropic, hits a proxy | The gateway runs in-process inside Mastio (`mcp_proxy/egress/ai_gateway.py` calls `litellm.acompletion()` directly); no extra hop. The upstream URL is operator-configured; upstream **credentials** are encrypted at rest using Fernet (`mcp_proxy/tools/secret_encrypt.py`, prefix `enc:v1:`). The Fernet master key is **not** KMS-backed today: it lives in `MCP_PROXY_SECRET_ENCRYPTION_KEY_B64` (env) or is auto-generated and stored in the `proxy_config` table. HSM-backed encryption is on the roadmap (see open items). | If the operator points the upstream to an attacker-controlled URL, no Cullis mitigation helps. Use TLS pinning at the bundle's outbound boundary (NetworkPolicy in k8s, host firewall on VPS). If you need HSM-grade protection of the Fernet master key today, mount the env var from a secrets manager such as Vault Agent. |
+| Spoofing of the gateway | Agent thinks it is calling Anthropic, hits a proxy | The gateway runs in-process inside Mastio. Under the default `cullis_native` backend, the per-provider adapter (`mcp_proxy/egress/adapters/anthropic.py`, `openai.py`, `ollama.py`) calls the provider's own SDK or raw HTTP directly; no extra hop. The legacy `litellm_embedded` backend, when explicitly pinned, goes through `litellm.acompletion()` in-process — same trust boundary. The upstream URL is operator-configured; upstream **credentials** are encrypted at rest using Fernet (`mcp_proxy/tools/secret_encrypt.py`, prefix `enc:v1:`). The Fernet master key is **not** KMS-backed today: it lives in `MCP_PROXY_SECRET_ENCRYPTION_KEY_B64` (env) or is auto-generated and stored in the `proxy_config` table. HSM-backed encryption is on the roadmap (see open items). | If the operator points the upstream to an attacker-controlled URL, no Cullis mitigation helps. Use TLS pinning at the bundle's outbound boundary (NetworkPolicy in k8s, host firewall on VPS). If you need HSM-grade protection of the Fernet master key today, mount the env var from a secrets manager such as Vault Agent. |
 | Tampering with the prompt or response | A man-in-the-middle alters the LLM payload | The gateway terminates TLS to the upstream; we do not re-encrypt or sign payloads. Customers needing payload integrity guarantees on the wire should run their own provider proxy with their own pinning. | This is a known limitation of any LLM gateway: prompt/response signing is not standardised. We default-deny on TLS errors. |
 | Repudiation | Agent denies sending a prompt | Every LLM call is audited identically to a tool call (per-agent, per-DPoP-`jti`, with a hash of the prompt and response and the response summary surfaced under `details`). | The prompt hash is one-way: we cannot reproduce the prompt from the log. This is intentional (privacy / no plaintext retention by default), but means a forensic investigation must rely on the agent's logs for prompt reconstruction. |
 | Information disclosure of upstream API keys | The gateway logs the upstream API key | Mastio's gateway never logs the upstream API key. Several competing AI gateways do log upstream keys to their telemetry endpoint as part of their value proposition; we explicitly do not. Upstream credentials live as Fernet-encrypted `creds_json` in `ai_provider_credentials` (migration `0027_ai_provider_creds.py`, encryption added in `0032_ai_creds_at_rest_encrypt.py`). | Operator-side observability that scrapes the gateway's stderr could pick up the key if the upstream emits it in an error message. We sanitise known upstream error patterns; new upstreams should be reviewed. |
@@ -299,8 +308,12 @@ and key selection, and forwards to the configured upstream provider.
 
 ### References
 
-- ADR-017 (embedded LiteLLM)
-- `mcp_proxy/egress/ai_gateway.py`,
+- ADR-017 (original embedded gateway)
+- ADR-039 (native per-provider adapters, drop LiteLLM critical path)
+- `mcp_proxy/egress/ai_gateway.py` (dispatcher),
+  `mcp_proxy/egress/adapters/{anthropic,openai,ollama}.py`
+  (native providers),
+  `mcp_proxy/egress/adapters/{litellm,portkey}.py` (legacy backends),
   `mcp_proxy/egress/llm_chat_router.py`,
   `mcp_proxy/egress/provider_catalog.py`
 - `mcp_proxy/tools/secret_encrypt.py`

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -172,7 +172,7 @@ const commonPaths = [
             written to a tamper-evident audit chain.
           </p>
           <ul>
-            <li><strong>Mastio</strong> — org gateway. Cert mint, policy enforcement, audit chain, MCP reverse-proxy, embedded AI gateway (LiteLLM).</li>
+            <li><strong>Mastio</strong> — org gateway. Cert mint, policy enforcement, audit chain, MCP reverse-proxy, native AI dispatch (Anthropic / OpenAI SDKs, raw httpx for Ollama).</li>
             <li><strong>Python SDK</strong> — agent client. Loads cert + DPoP key from disk, presents mTLS to Mastio, makes chat completions and MCP tool calls.</li>
           </ul>
         </article>

--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -119,9 +119,12 @@ import Layout from '../layouts/Layout.astro';
       </ul>
 
       <p class="reveal" data-delay="4">
-        LLM-agnostic by design. The embedded gateway routes to
-        Anthropic, OpenAI, Gemini, or Ollama via LiteLLM, and an
-        alternative AI gateway can be wired in as a sidecar.
+        LLM-agnostic by design. Anthropic, OpenAI, and Ollama route
+        through Cullis-owned native adapters (official Anthropic /
+        OpenAI SDKs, raw httpx for Ollama) with no third-party
+        dispatch library in the critical path. Gemini, Bedrock, and
+        Vertex still ride the legacy LiteLLM backend until their
+        native adapters land.
       </p>
     </div>
   </section>
@@ -301,9 +304,9 @@ import Layout from '../layouts/Layout.astro';
           <h3>DORA Vendor/TPA Compliance Reporter</h3>
           <p>
             Cullis-unique. No Anthropic template. Runs on
-            <strong>OpenAI GPT-5 via LiteLLM</strong> to prove
-            LLM-agnostic. Per-agent cryptographic identity bound to
-            every reporting action satisfies DORA Art. 28.
+            <strong>OpenAI GPT-5 via the native OpenAI adapter</strong>
+            to prove LLM-agnostic. Per-agent cryptographic identity
+            bound to every reporting action satisfies DORA Art. 28.
           </p>
         </article>
       </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -238,14 +238,14 @@ import Layout from '../layouts/Layout.astro';
           <header class="topo-card-head">
             <span class="topo-tag">Default</span>
             <h3>Embedded</h3>
-            <p class="topo-sub">Mastio runs LiteLLM in-process and speaks directly to the provider. One container, no extra gateway to operate.</p>
+            <p class="topo-sub">Mastio dispatches to the provider through a native adapter (official Anthropic / OpenAI SDKs, raw httpx for Ollama) — no third-party gateway in the critical path. One container, nothing extra to operate.</p>
           </header>
           <div class="topo-flow">
             <div class="topo-node">Agent</div>
             <div class="topo-edge" data-label="mTLS + DPoP"></div>
             <div class="topo-node topo-node-primary">
               <span class="topo-node-title">Mastio</span>
-              <span class="topo-node-sub">LiteLLM embedded</span>
+              <span class="topo-node-sub">Native AI dispatch</span>
             </div>
             <div class="topo-edge" data-label="API call"></div>
             <div class="topo-node">LLM provider</div>


### PR DESCRIPTION
## Summary

PR-G of the ADR-039 series. Aligns the public copy with the shipped reality on main: with the default backend flipped to `cullis_native` (#992 merged), describing the dispatch path as "embedded LiteLLM" is no longer accurate. 10 files touched across README, site, integrations, and the threat model.

**No code change.** Pure documentation.

## Framing across all touched files

- **Default dispatch path** is now described as per-provider native adapter:
  - Anthropic → `anthropic.AsyncAnthropic` SDK
  - OpenAI → `openai.AsyncOpenAI` SDK
  - Ollama → raw httpx against `/api/chat`
- **No third-party AI gateway library in the critical path.**
- **Legacy LiteLLM backend remains in tree**, opt-in via `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`, for Gemini / Bedrock / Vertex until their native adapters land. Operators pinning it see a deprecation warning at startup.

## Files

| File | Change |
|---|---|
| `README.md` | Intro paragraph + Mastio "AI gateway" feature bullet rewritten |
| `site/src/pages/index.astro` | Topology card: "LiteLLM in-process" → "native AI dispatch" |
| `site/src/pages/index-dark.astro` | Hero copy + DORA use-case card ("OpenAI GPT-5 via the native OpenAI adapter") |
| `site/src/pages/docs/index.astro` | Mastio bullet updated |
| `site/src/content/docs/quickstart/chat-completion.md` | Forwarding description |
| `site/src/content/docs/quickstart/provider-sdk-drop-in.md` | Comment + paragraph |
| `site/src/content/docs/security/threat-model.md` | Topology ASCII + Component section + STRIDE spoofing row + References |
| `docs/security/threat-model.md` | Inside-the-boundary list line |
| `docs/integrations/cursor.md` | Two "embedded LiteLLM normalises" mentions |
| `docs/integrations/librechat.md` | One "embedded LiteLLM normalises" mention |

## What this is NOT

- **Not a claim that Cullis is LiteLLM-free.** The package is still in `requirements.txt` until v0.8.x (PR-F). The copy throughout says "no third-party AI gateway library in the **critical path**", which is the accurate statement once the default backend is `cullis_native`.
- **Not a removal of LiteLLM functionality.** Operators who depend on Gemini / Bedrock / Vertex still pin `litellm_embedded` and the legacy adapter handles their dispatch unchanged.
- **Not a "we replaced X" boast.** The framing throughout is plain: default path is native, legacy path remains for the providers we haven't ported yet.

## Follow-up

- **v0.8.x — PR-F**: drops `litellm` from `requirements.txt` and `mcp_proxy/requirements-proxy.txt`, makes `LiteLLMAdapter`'s `import litellm` lazy + emits a hard 503 if pinned without the package installed. That's the point at which Cullis becomes **officially LiteLLM-free** in the pip manifest, and the copy can be tightened further to say so explicitly. Until then this framing is the accurate version.

## Test plan

- [ ] CI green (docs-only, low risk)
- [ ] Site builds (`./scripts/build-spa.sh` or Astro dev preview) — verify no broken links or stale code-fenced model ids
- [ ] Read-through: a CISO doing due-diligence sees "native dispatch, LiteLLM legacy opt-in", not "embedded LiteLLM" anywhere as the headline architecture claim