### PR TITLE
feat(helm): expose aiGatewayBackend value (ADR-039 PR-H)

### DIFF
--- a/deploy/helm/cullis-mastio/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-mastio/templates/proxy-configmap.yaml
@@ -34,6 +34,16 @@ data:
   MCP_PROXY_ORG_ID: {{ .Values.proxy.orgId | quote }}
   {{- end }}
 
+  # ADR-039 — AI gateway dispatch backend. Default ``cullis_native``:
+  # per-provider native adapters (Anthropic SDK, OpenAI SDK, raw httpx
+  # for Ollama), no third-party library in the critical path. Operators
+  # pinning ``litellm_embedded`` for Gemini / Bedrock / Vertex must also
+  # ship the ``litellm-legacy`` extra in the image (or install
+  # ``litellm>=1.83.7,<2.0`` out-of-band) — see PR-F.
+  {{- if .Values.proxy.aiGatewayBackend }}
+  MCP_PROXY_AI_GATEWAY_BACKEND: {{ .Values.proxy.aiGatewayBackend | quote }}
+  {{- end }}
+
   # ADR-014 — nginx sidecar TLS material. Empty when nginx.enabled=false
   # so the lifespan skips the cert-provisioning path (no consumer to
   # serve the certs to).

--- a/deploy/helm/cullis-mastio/values.yaml
+++ b/deploy/helm/cullis-mastio/values.yaml
@@ -79,6 +79,24 @@ proxy:
   # configured through the setup wizard (DB-resident).
   orgId: ""
 
+  # -- AI gateway dispatch backend (ADR-039).
+  #
+  # Default since v0.7.x: ``cullis_native``. Per-provider native
+  # adapters: official Anthropic / OpenAI SDKs, raw httpx for Ollama.
+  # No third-party AI gateway library in the critical path.
+  #
+  # Override to ``litellm_embedded`` if you depend on Gemini / Bedrock
+  # / Vertex (no native adapter yet) — the legacy LiteLLM backend
+  # remains wired but ``litellm`` is no longer in requirements.txt
+  # since PR-F. Operators pinning the legacy backend must also pull
+  # the ``litellm-legacy`` extra in their image (or install
+  # ``litellm>=1.83.7,<2.0`` out-of-band).
+  #
+  # ``portkey`` is the original ADR-017 Phase 1 backend; Anthropic-only,
+  # deprecated alongside ``litellm_embedded`` in v0.7.x and removed in
+  # v0.8.x.
+  aiGatewayBackend: "cullis_native"
+
   # -- SPIFFE trust domain this proxy serves (ADR-001 Phase 2). Used by
   # the routing decision to classify recipients as intra vs cross-org.
   # Must match the trust domain configured on the broker.


### PR DESCRIPTION
## Summary

ADR-039 follow-up PR-H. Adds `proxy.aiGatewayBackend` to the Helm chart values so operators on managed K8s (EKS / GKE / AKS) can pin the AI gateway backend from `values.yaml` without reaching for `extraEnv`.

Default is `cullis_native`, aligned with the Python side default flipped in PR-E (#992).

## Helm validation matrix

```
$ helm lint deploy/helm/cullis-mastio/
1 chart(s) linted, 0 chart(s) failed

$ helm template t deploy/helm/cullis-mastio/ | grep AI_GATEWAY
  MCP_PROXY_AI_GATEWAY_BACKEND: "cullis_native"        # default

$ helm template t ... --set proxy.aiGatewayBackend=litellm_embedded
  MCP_PROXY_AI_GATEWAY_BACKEND: "litellm_embedded"     # override

$ helm template t ... --set proxy.aiGatewayBackend=''
  # env var absent → container falls back to Pydantic default
```

Full chart render with `--set proxy.image.tag=adr039-pr-f-test` (the PR-F build) carries zero `litellm` / `LITELLM` references outside the docstring on the configmap key itself.

## Why this is a gap worth closing now

Pre-PR-H, the chart had no toggle for the AI gateway backend. Operators wanting to keep `litellm_embedded` (for Gemini / Bedrock / Vertex, no native adapter yet) had to either bake the env var into a custom image or use `extraEnv`. Neither is discoverable from `values.yaml`. With this PR the override is a one-line values change with the same docstring as the Python side.

## Operator note

On managed K8s where Gemini / Bedrock / Vertex are still in scope, the override looks like:

```yaml
proxy:
  aiGatewayBackend: litellm_embedded
  image:
    repository: ghcr.io/yourorg/cullis-mastio-litellm-legacy
    tag: "0.8.0"   # derived image that pulled the litellm-legacy extra
```

The derived image is required because PR-F (#994) removed `litellm` from the default `requirements.txt`; the upstream `ghcr.io/cullis-security/cullis-mastio` image does not carry the package. Recommended path is one Dockerfile layer that runs `pip install 'cullis-sdk[litellm-legacy]'`.

## Files

| File | Change |
|---|---|
| `deploy/helm/cullis-mastio/values.yaml` | New `proxy.aiGatewayBackend` value with full docstring |
| `deploy/helm/cullis-mastio/templates/proxy-configmap.yaml` | Conditional render of `MCP_PROXY_AI_GATEWAY_BACKEND` env var |

## Test plan

- [ ] CI green
- [ ] (Optional) Maintainer-side `helm install` on a real cluster with default values → pod boots with `MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native`, dispatch hits native adapter on Anthropic / OpenAI / Ollama
- [ ] (Optional) `helm upgrade` with `--set proxy.aiGatewayBackend=litellm_embedded` against a derived image that carries the `litellm-legacy` extra → legacy backend wired without warnings