### PR TITLE
chore(release): bump references + CHANGELOG to mastio-v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ flow until the next `## ` heading.
 
 Polish on `main` accumulating for the next minor. No release tag is cut for each individual patch any more; release cadence is intentionally throttled to one minor every 2-3 weeks plus emergency-only patches, matching the practice of comparable alpha-stage open-core projects.
 
+## [v0.6.2] — ADR-039 drop LiteLLM from the critical path — 2026-05-28
+
+Dependency-hygiene patch on top of v0.6.1. Removes LiteLLM from the default chat-completion dispatch path and replaces it with three Cullis-owned native adapters (Anthropic, OpenAI, Ollama). The LiteLLM library is no longer a runtime requirement; operators on Gemini, Bedrock, or Vertex can still opt in via the legacy backend (`pip install 'cullis-sdk[litellm-legacy]'` + `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`) until their native adapters land.
+
+Triggered by the CVE cluster on the LiteLLM 1.x line in April–May (SQLi `CVE-2026-42208` listed in CISA KEV; RCE `CVE-2026-42271`, RCE `CVE-2026-35029`, OIDC `CVE-2026-35030`, multiple `GHSA-69x8…` advisories). Pinning was the v0.6.x posture; v0.6.2 removes the dependency from the default path entirely.
+
+This is a dependency-hygiene release, not a performance release. End-to-end stress against a mock provider (200 ms artificial latency, single agent, peak 200 VU, 4 minutes) showed `cullis_native` ~5% above `litellm_embedded` in sustained throughput and ~9% lower p50 latency; against Ollama (`qwen2.5:0.5b`, peak 60 VU) the delta is statistically irrelevant (model queue dominates). Image size on disk drops by ~360 MB once the `litellm` wheel and transitive deps are removed from the runtime layer.
+
+### Egress (ADR-039)
+
+- **`mcp_proxy.egress.ProviderAdapter` scaffold** (#988, PR-A). Defines the per-provider dispatch interface (`dispatch`, `dispatch_stream`, model-id resolution, error mapping to `GatewayError`) so each provider lives behind a small, testable surface instead of an `if backend == "...":` ladder in `ai_gateway.py`. Zero behaviour change at this step.
+- **`AnthropicAdapter` (`anthropic.AsyncAnthropic`)** (#989, PR-B). Native dispatch via the official Anthropic Python SDK. Maps `claude-…` model ids to the SDK's `messages.create` / `messages.stream`. Preserves the existing audit row shape (`backend="cullis_native", provider="anthropic"`) and the per-agent identity propagation.
+- **`OpenAIAdapter` (`openai.AsyncOpenAI`)** (#990, PR-C). Same treatment for the official OpenAI SDK. `gpt-…`, `o1-…`, and any `openai/<model>` prefix resolve here; streaming uses the SDK's `chat.completions.create(stream=True)`.
+- **`OllamaAdapter` (raw `httpx`)** (#991, PR-D). Thin client against `POST /api/chat`. No SDK in between because `ollama` Python doesn't add anything we use, and a raw `httpx.AsyncClient` lets us reuse the connection-pool primitive PR-I introduces. `ollama_chat/<model>` resolves here.
+- **Default backend flipped to `cullis_native`** (#992, PR-E). `settings.ai_gateway_backend` default is now `"cullis_native"`. Existing deployments that pinned the env var explicitly are unaffected. Operators on Gemini / Bedrock / Vertex still need `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` until their native adapters land.
+- **AI gateway docs reframed** (#993, PR-G). README, site landing page, and the threat model now lead with the native-adapter narrative ("no third-party AI gateway in the critical path"); LiteLLM is presented as the opt-in legacy backend for the still-unported providers, not the default.
+- **`litellm` removed from `requirements.txt`** (#994, PR-F). The runtime dependency line is gone from the default install. Operators who still want the legacy backend install it explicitly via the new `litellm-legacy` extra on `cullis-sdk` (or, equivalently, `pip install 'litellm>=1.83.7,<2.0'` next to the Mastio). The `LiteLLMAdapter` in `mcp_proxy/egress/adapters/litellm.py` lazy-imports the package and emits `GatewayError(503, "litellm_not_installed")` on the first dispatch when the operator forgot the extra. Image size drops ~360 MB on the Mastio container.
+- **Helm `proxy.aiGatewayBackend` value** (#995, PR-H). New top-level Helm value so Kubernetes operators can flip the backend without templating the env var by hand. Default mirrors the code default (`cullis_native`).
+- **Client pooling for the native adapters** (#996, PR-I). The Anthropic, OpenAI, and Ollama adapters now cache their `AsyncAnthropic` / `AsyncOpenAI` / `httpx.AsyncClient` instances in a module-level dict keyed on credential fingerprint. Earlier revisions of the PR-B/C/D adapters built a fresh client per request, which paid the TCP/TLS handshake + auth-header bootstrap cost on every chat call. Measured 4× speedup in the local micro-benchmark; the visible delta in the end-to-end stress is smaller because the audit chain global lock is the next bottleneck.
+
+### Defensive pin retained
+
+- **`litellm>=1.83.7,<2.0` floor on the legacy extra** (#987). The pin landed before the native adapters did, while LiteLLM was still in the default critical path; it now applies only when an operator explicitly installs the `litellm-legacy` extra. Matches the upstream advisory floor for `CVE-2026-42208` / `42271` / `35029` / `35030`.
+
+### CHANGELOG hygiene
+
+- `CHANGELOG.md` — new `[v0.6.2]` section above `[v0.6.1]`.
+- `README.md` — quickstart curl + project-component table flipped to `mastio-v0.6.2`.
+- `site/src/pages/index.astro` + `index-dark.astro` — hero quickstart curl flipped to `mastio-v0.6.2`.
+
 ## [v0.6.1] — Sidebar update-advisory regex fix — 2026-05-27
 
 Same-day patch on top of v0.6.0. The sidebar update advisory on a fresh v0.6.0 install rendered "Update: 0.5.4.1 (running 0.6.0)" — pointing the operator at a tag strictly older than the one they were running. Confidence-killer banner that cold-readers see within seconds of first login.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Pull the Mastio bundle, set an Anthropic key, enroll an agent, install the SDK, 
 
 ```bash
 # 1. Pull and deploy the Mastio bundle.
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Enable chat by setting an Anthropic key in proxy.env, then restart.
@@ -174,7 +174,7 @@ Alpha. The Mastio runs end-to-end on a laptop and ships from a public release tr
 
 | Component | Latest | What it is |
 |---|---|---|
-| **Cullis Mastio** | [`mastio-v0.6.1`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.6.1) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
+| **Cullis Mastio** | [`mastio-v0.6.2`](https://github.com/cullis-security/cullis/releases/tag/mastio-v0.6.2) | Org gateway, agent CA, Rego + allowlist policy engine, audit chain, MCP reverse proxy, embedded AI gateway, OPA Data API + CloudEvents bridge for external data planes |
 | **Cullis SDK** | [`cullis-sdk 0.2.1`](https://pypi.org/project/cullis-sdk/) | Python client used by autonomous agents to talk to Mastio. Supports `from_identity_dir` (plain file), `from_systemd_credentials` (Linux production tmpfs delivery), and `cullis_httpx_client` drop-in for vanilla Anthropic/OpenAI SDKs |
 
 Use Cullis in evaluation, integration, and internal deploys. The community release is the only release; there is no commercial tier today. Feedback, bug reports, and PRs in the public repo.

--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -331,7 +331,7 @@ import Layout from '../layouts/Layout.astro';
         boot. The SDK is on PyPI.
       </p>
       <pre class="reveal" data-delay="3"><code># 1. Mastio — org gateway + dashboard on :9443
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
       <pre class="reveal" data-delay="4"><code># 2. Python SDK for your autonomous agent
 pip install cullis-sdk</code></pre>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -407,7 +407,7 @@ import Layout from '../layouts/Layout.astro';
       </p>
 
       <pre class="reveal" data-delay="3"><code># 1. Mastio — organisation gateway on :9443
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.1/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.6.2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
 
       <pre class="reveal" data-delay="4"><code># 2. Python SDK for your autonomous agent


### PR DESCRIPTION
## Summary

- Cuts the ADR-039 series as `mastio-v0.6.2` (patch on top of v0.6.1).
- Removes LiteLLM from the default chat-completion dispatch path; native adapters for Anthropic, OpenAI, and Ollama now own the critical path. Operators on Gemini / Bedrock / Vertex stay on the legacy backend via `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded` + `pip install 'cullis-sdk[litellm-legacy]'`.

## Why a patch, not a minor

Dependency-hygiene release, not a performance release. The 4-min mock-provider stress (200 ms artificial latency, single agent, peak 200 VU) gives `cullis_native` ~5% above `litellm_embedded` in sustained throughput and ~9% lower p50 latency. Against Ollama (`qwen2.5:0.5b`, peak 60 VU) the model queue dominates and the delta is statistically irrelevant. Image size on disk drops ~360 MB. No customer-visible feature change, no API change — patch bump is the honest call.

## What ships

- `mcp_proxy/egress/adapters/{anthropic,openai,ollama,litellm}.py` + `mcp_proxy/egress/ai_gateway.py` — the `ProviderAdapter` interface and the three new native adapters with module-level client pooling (PR-B/C/D/I).
- `MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native` is now the default (PR-E).
- `litellm` is gone from `requirements.txt`; the `LiteLLMAdapter` lazy-imports and emits `GatewayError(503, "litellm_not_installed")` if an operator pins the legacy backend without installing the package (PR-F).
- Helm chart exposes `proxy.aiGatewayBackend` (PR-H).
- README, site landing, threat model lead with the native-adapter narrative (PR-G).
- `litellm>=1.83.7,<2.0` floor retained on the legacy extra against the CVE cluster (PR #987).

## Test plan

- [x] Stress harness run on mastio-demo VM (4-min mock @ 200 VU + 2-min Ollama @ 60 VU) for both backends, full report at `imp/2026-05-28-adr-039-ab-stress-report.md`.
- [x] PR-G docs reframe already on `main` (PR #993); README + site `index.astro` + `index-dark.astro` were the post-pivot vocabulary, only version refs to bump.
- [x] CHANGELOG section matches the 10 PRs in the ADR-039 series, with the PR-F drop and the PR-I client pooling clearly separated.
- [ ] Tag `mastio-v0.6.2` cut on `main` after merge, then GHCR image + bundle staging follow.
- [ ] Cold-reader pass on the tarball before the PyPI push and the public announcement.