### PR TITLE
fix(pki): serialise mastio_keys mint across uvicorn workers (#997)

### DIFF
--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -123,6 +123,65 @@ def _detect_legacy_unstamped(sync_conn) -> bool:
     return bool(_LEGACY_TABLES & table_names)
 
 
+def _acquire_mastio_mint_lock(sqlite_path: str) -> int:
+    """Open + flock-exclusive a lockfile next to the SQLite DB.
+
+    Serialises the leaf-mint critical section in
+    ``AgentManager._mint_mastio_leaf`` across the N uvicorn worker
+    processes that race at lifespan startup. Without this, every worker
+    enters the mint path with ``self._active_key is None`` (per-process
+    in-memory cache, never populated yet) and they all INSERT a fresh
+    active row. ``mastio_keys`` then carries N>1 rows where
+    ``activated_at IS NOT NULL AND deprecated_at IS NULL``, and the
+    first call to ``LocalKeyStore.current_signer()`` raises
+    ``RuntimeError("N active mastio keys — rotation invariant
+    violated")``. The caught exception leaves ``app.state.local_issuer``
+    as None and ``/v1/auth/token`` returns 503 "local issuer not
+    initialized" for the lifetime of the deploy. Issue cullis#997.
+
+    Pattern mirrors :func:`_run_migrations_sync_under_flock`: blocking
+    ``fcntl.LOCK_EX`` on a sibling-of-DB lockfile that the kernel
+    auto-releases on worker exit. SQLite-only — Postgres deploys rely
+    on a different code path (today: still racy, fix follow-up; the
+    in-the-wild Postgres count is 0 so this is acceptable as a
+    same-day patch).
+    """
+    import fcntl
+    from pathlib import Path
+
+    db_path = Path(sqlite_path)
+    lock_path = db_path.with_name(f"{db_path.name}.mastio_mint.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError:
+        try:
+            os.close(fd)
+        finally:
+            raise
+    try:
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()}\n".encode())
+    except OSError:
+        pass  # diagnostic write, not load-bearing
+    return fd
+
+
+def _release_mastio_mint_lock(fd: int) -> None:
+    """Release the flock acquired by :func:`_acquire_mastio_mint_lock`."""
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
 def _run_migrations_sync_under_flock(url: str, sqlite_path: str) -> None:
     """Run ``_run_migrations_sync`` under an exclusive blocking flock.
 
@@ -1052,6 +1111,44 @@ async def set_config_if_absent(key: str, value: str) -> bool:
 # ─────────────────────────────────────────────────────────────────────────────
 # Mastio keys (ADR-012 Phase 2.0 multi-key store, issue #261)
 # ─────────────────────────────────────────────────────────────────────────────
+
+async def deprecate_mastio_keys_by_kids(
+    kids: list[str],
+    deprecated_at: str,
+) -> int:
+    """Mark a set of ``mastio_keys`` rows as deprecated.
+
+    Used by the issue cullis#997 repair path in
+    ``AgentManager._mint_mastio_leaf`` when the active-row invariant
+    ``len(get_mastio_keys_active()) <= 1`` is found violated under the
+    mint flock. The newest active row is kept; the older ones are
+    deprecated here in a single round-trip.
+
+    Returns the number of rows actually updated. Idempotent: a row
+    already deprecated (``deprecated_at IS NOT NULL``) is left alone
+    via the WHERE clause, so a repeat call after a crash mid-repair
+    converges instead of over-counting.
+    """
+    if not kids:
+        return 0
+    updated = 0
+    async with get_db() as conn:
+        for kid in kids:
+            result = await conn.execute(
+                text(
+                    """
+                    UPDATE mastio_keys
+                       SET deprecated_at = :deprecated
+                     WHERE kid = :kid
+                       AND activated_at IS NOT NULL
+                       AND deprecated_at IS NULL
+                    """
+                ),
+                {"deprecated": deprecated_at, "kid": kid},
+            )
+            updated += getattr(result, "rowcount", 0) or 0
+    return updated
+
 
 async def insert_mastio_key(
     *,

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -2035,10 +2035,24 @@ class AgentManager:
         """Mint a fresh EC P-256 leaf under the existing intermediate CA.
 
         The keypair + cert are inserted into ``mastio_keys`` with
-        ``activated_at=now`` (no previous active row in the Phase 2.0
-        cold-start path — multi-row transitions land in Phase 2.1).
-        The cached ``self._active_key`` is refreshed so subsequent
-        signing / counter-signing calls see the new row.
+        ``activated_at=now``. The cached ``self._active_key`` is
+        refreshed so subsequent signing / counter-signing calls see the
+        new row.
+
+        Issue cullis#997 — single-writer guard. The N uvicorn worker
+        processes all enter this method during lifespan startup with
+        ``self._active_key is None`` (in-memory cache, never populated
+        on a cold boot). Without the flock below, each worker INSERTs a
+        fresh active row; ``mastio_keys`` then carries N>1 rows where
+        ``activated_at IS NOT NULL AND deprecated_at IS NULL``;
+        ``LocalKeyStore.current_signer()`` raises
+        ``RuntimeError("N active mastio keys")``; ``app.state.local_
+        issuer`` stays None; ``/v1/auth/token`` returns 503 for the
+        rest of the deploy. The flock serialises mint across workers
+        against a sibling-of-DB lockfile; under it we re-read the
+        active set, adopt + repair if a sibling already minted (or a
+        previous boot left N>1 rows behind), and only mint when truly
+        absent.
         """
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
             # D-13 — lazy reload. Another worker may have minted and
@@ -2051,53 +2065,121 @@ class AgentManager:
             if not reloaded:
                 raise RuntimeError("Mastio CA not loaded — cannot sign leaf")
 
-        leaf_key = ec.generate_private_key(ec.SECP256R1())
-        proxy_spiffe = f"spiffe://{self._trust_domain}/proxy/{self._org_id}"
-        leaf_subject = x509.Name([
-            x509.NameAttribute(NameOID.COMMON_NAME, f"proxy:{self._org_id}"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
-        ])
-        leaf_cert = (
-            x509.CertificateBuilder()
-            .subject_name(leaf_subject)
-            .issuer_name(self._mastio_ca_cert.subject)
-            .public_key(leaf_key.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(now - timedelta(minutes=5))
-            .not_valid_after(now + timedelta(days=MASTIO_LEAF_VALIDITY_DAYS))
-            .add_extension(
-                SubjectAlternativeName([UniformResourceIdentifier(proxy_spiffe)]),
-                critical=False,
+        # ── Issue cullis#997: acquire flock + re-fetch active set ──
+        # SQLite-only; Postgres deploys (none in the wild today) take
+        # the racy branch until a follow-up adds an advisory lock.
+        from mcp_proxy.config import get_settings
+        from mcp_proxy.db import (
+            _acquire_mastio_mint_lock,
+            _release_mastio_mint_lock,
+            _sqlite_path,
+            deprecate_mastio_keys_by_kids,
+            get_mastio_keys_active,
+        )
+
+        lock_fd: int | None = None
+        sqlite_path = _sqlite_path(get_settings().database_url)
+        if sqlite_path:
+            lock_fd = await asyncio.to_thread(
+                _acquire_mastio_mint_lock, sqlite_path,
             )
-            .add_extension(
-                x509.BasicConstraints(ca=False, path_length=None),
-                critical=True,
+        try:
+            existing = await get_mastio_keys_active()
+            if existing:
+                # A sibling worker won the mint race, or a previous boot
+                # left N>1 rows behind. Keep the newest by
+                # ``activated_at``; deprecate any older to restore the
+                # one-active-row invariant. Then adopt the survivor and
+                # return without minting a fresh keypair.
+                newest = max(
+                    existing,
+                    key=lambda row: row.get("activated_at") or "",
+                )
+                stale_kids = [
+                    row["kid"] for row in existing if row["kid"] != newest["kid"]
+                ]
+                if stale_kids:
+                    deprecated = await deprecate_mastio_keys_by_kids(
+                        stale_kids, now.isoformat(),
+                    )
+                    logger.warning(
+                        "Mastio leaf invariant repaired (cullis#997) — "
+                        "kept kid=%s, deprecated %d stale rows: %s",
+                        newest["kid"], deprecated, stale_kids,
+                    )
+                self._active_key = await self._keystore.find_by_kid(
+                    newest["kid"],
+                )
+                logger.info(
+                    "Mastio leaf adopted from existing active row — kid=%s",
+                    newest["kid"],
+                )
+                return
+
+            # No active row under the lock — proceed with the original
+            # mint path.
+            leaf_key = ec.generate_private_key(ec.SECP256R1())
+            proxy_spiffe = (
+                f"spiffe://{self._trust_domain}/proxy/{self._org_id}"
             )
-            .sign(self._mastio_ca_key, hashes.SHA256())
-        )
+            leaf_subject = x509.Name([
+                x509.NameAttribute(
+                    NameOID.COMMON_NAME, f"proxy:{self._org_id}",
+                ),
+                x509.NameAttribute(
+                    NameOID.ORGANIZATION_NAME, self._org_id,
+                ),
+            ])
+            leaf_cert = (
+                x509.CertificateBuilder()
+                .subject_name(leaf_subject)
+                .issuer_name(self._mastio_ca_cert.subject)
+                .public_key(leaf_key.public_key())
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(now - timedelta(minutes=5))
+                .not_valid_after(
+                    now + timedelta(days=MASTIO_LEAF_VALIDITY_DAYS),
+                )
+                .add_extension(
+                    SubjectAlternativeName(
+                        [UniformResourceIdentifier(proxy_spiffe)],
+                    ),
+                    critical=False,
+                )
+                .add_extension(
+                    x509.BasicConstraints(ca=False, path_length=None),
+                    critical=True,
+                )
+                .sign(self._mastio_ca_key, hashes.SHA256())
+            )
 
-        priv_pem = _priv_to_pem(leaf_key)
-        cert_pem = _cert_to_pem(leaf_cert)
-        pub_pem = leaf_key.public_key().public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
-        kid = compute_kid(pub_pem)
-        now_iso = now.isoformat()
+            priv_pem = _priv_to_pem(leaf_key)
+            cert_pem = _cert_to_pem(leaf_cert)
+            pub_pem = leaf_key.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ).decode()
+            kid = compute_kid(pub_pem)
+            now_iso = now.isoformat()
 
-        await insert_mastio_key(
-            kid=kid,
-            pubkey_pem=pub_pem,
-            privkey_pem=priv_pem,
-            cert_pem=cert_pem,
-            created_at=now_iso,
-            activated_at=now_iso,
-        )
-        self._active_key = await self._keystore.find_by_kid(kid)
+            await insert_mastio_key(
+                kid=kid,
+                pubkey_pem=pub_pem,
+                privkey_pem=priv_pem,
+                cert_pem=cert_pem,
+                created_at=now_iso,
+                activated_at=now_iso,
+            )
+            self._active_key = await self._keystore.find_by_kid(kid)
 
-        logger.info(
-            "Mastio leaf minted — kid=%s, SAN=%s", kid, proxy_spiffe,
-        )
+            logger.info(
+                "Mastio leaf minted — kid=%s, SAN=%s", kid, proxy_spiffe,
+            )
+        finally:
+            if lock_fd is not None:
+                await asyncio.to_thread(
+                    _release_mastio_mint_lock, lock_fd,
+                )
 
     def _require_active(self) -> MastioKey:
         if self._active_key is None or self._mastio_ca_cert is None:

--- a/test/unit/test_mastio_keys_invariant_997.py
+++ b/test/unit/test_mastio_keys_invariant_997.py
@@ -1,0 +1,236 @@
+"""Regression tests for issue cullis#997.
+
+Before this fix, ``AgentManager._mint_mastio_leaf`` had no cross-worker
+guard: the N uvicorn workers at lifespan startup each generated their
+own EC keypair and INSERTed an active ``mastio_keys`` row. With N>1
+active rows, ``LocalKeyStore.current_signer()`` raised
+``RuntimeError("N active mastio keys")``, ``app.state.local_issuer``
+stayed None, and ``/v1/auth/token`` returned 503 "local issuer not
+initialized" for the rest of the deploy.
+
+These tests pin the fix:
+
+  - ``deprecate_mastio_keys_by_kids`` only touches active rows whose
+    kid is in the supplied list and idempotently no-ops on rows
+    already deprecated.
+  - ``AgentManager._mint_mastio_leaf`` invoked against a DB that
+    already carries N>1 active rows (the in-the-wild leftover from
+    pre-fix boots) repairs the invariant: the newest row by
+    ``activated_at`` survives, the older ones get a non-NULL
+    ``deprecated_at``, ``current_signer()`` returns the survivor, and
+    no additional row is inserted.
+  - ``AgentManager._mint_mastio_leaf`` invoked against a DB with
+    exactly 1 active row adopts it without inserting a duplicate.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+
+
+async def _insert_active_row(db_url: str, kid: str, activated_at: str) -> None:
+    """Bypass ``insert_mastio_key`` so the test can seed multiple
+    active rows (which the production helper does not prevent today
+    but the new flock guard avoids producing).
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO mastio_keys
+                        (kid, pubkey_pem, privkey_pem, cert_pem,
+                         created_at, activated_at, deprecated_at, expires_at)
+                    VALUES
+                        (:kid, :pub, :priv, NULL, :created, :activated,
+                         NULL, NULL)
+                    """
+                ),
+                {
+                    "kid": kid,
+                    "pub": f"PUB-{kid}",
+                    "priv": f"PRIV-{kid}",
+                    "created": activated_at,
+                    "activated": activated_at,
+                },
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _count_active(db_url: str) -> int:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            result = await conn.execute(
+                text(
+                    """
+                    SELECT COUNT(*) FROM mastio_keys
+                     WHERE activated_at IS NOT NULL
+                       AND deprecated_at IS NULL
+                    """
+                )
+            )
+            return result.scalar() or 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_deprecate_mastio_keys_by_kids_only_touches_listed_active_rows(
+    audit_test_env,
+):
+    """``deprecate_mastio_keys_by_kids`` deprecates exactly the kids
+    supplied that are still active. Already-deprecated rows and
+    rows not in the list are left alone.
+    """
+    from mcp_proxy.db import (
+        deprecate_mastio_keys_by_kids,
+        init_db,
+        get_mastio_keys_active,
+    )
+
+    db_url = audit_test_env
+    await init_db(db_url)
+
+    # 3 active rows + 1 already deprecated (out of scope).
+    now = datetime.now(timezone.utc).isoformat()
+    await _insert_active_row(db_url, "k1", now)
+    await _insert_active_row(db_url, "k2", now)
+    await _insert_active_row(db_url, "k3", now)
+    # Insert a row then manually mark it deprecated.
+    await _insert_active_row(db_url, "k4-deprecated", now)
+    from sqlalchemy.ext.asyncio import create_async_engine
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE mastio_keys SET deprecated_at = :d "
+                    "WHERE kid = :k"
+                ),
+                {"d": now, "k": "k4-deprecated"},
+            )
+    finally:
+        await engine.dispose()
+
+    assert await _count_active(db_url) == 3
+
+    # Deprecate k1 and k2 only; k3 stays; k4-deprecated stays deprecated.
+    updated = await deprecate_mastio_keys_by_kids(
+        ["k1", "k2", "k4-deprecated"], now,
+    )
+    # k4 was already deprecated; the WHERE clause excludes it.
+    assert updated == 2
+
+    remaining_active = {row["kid"] for row in await get_mastio_keys_active()}
+    assert remaining_active == {"k3"}
+
+    # Idempotency: a repeat call updates 0 rows.
+    updated_again = await deprecate_mastio_keys_by_kids(
+        ["k1", "k2", "k4-deprecated"], now,
+    )
+    assert updated_again == 0
+
+
+@pytest.mark.asyncio
+async def test_deprecate_mastio_keys_by_kids_empty_list_noop(audit_test_env):
+    from mcp_proxy.db import deprecate_mastio_keys_by_kids, init_db
+
+    db_url = audit_test_env
+    await init_db(db_url)
+
+    assert await deprecate_mastio_keys_by_kids([], "any") == 0
+
+
+@pytest.mark.asyncio
+async def test_mint_mastio_leaf_repairs_pre_existing_invariant_violation(
+    audit_test_env, monkeypatch,
+):
+    """When the DB carries N>1 active rows (the in-the-wild leftover
+    from pre-fix multi-worker boots), ``_mint_mastio_leaf`` keeps the
+    newest by ``activated_at`` and deprecates the older ones instead
+    of inserting yet another fresh row.
+    """
+    from mcp_proxy.db import init_db
+    from mcp_proxy.egress.agent_manager import AgentManager
+    from mcp_proxy.config import get_settings
+
+    db_url = audit_test_env
+    await init_db(db_url)
+
+    # Seed 4 active rows, newest is k-newest.
+    older = "2026-05-01T00:00:00+00:00"
+    newer = "2026-05-28T00:00:00+00:00"
+    await _insert_active_row(db_url, "k-old-1", older)
+    await _insert_active_row(db_url, "k-old-2", older)
+    await _insert_active_row(db_url, "k-old-3", older)
+    await _insert_active_row(db_url, "k-newest", newer)
+    assert await _count_active(db_url) == 4
+
+    # Boot a fresh AgentManager with the org_id derived from the
+    # cached Org CA (we mint one through the manager so the leaf-mint
+    # path can sign against it). Standalone proxy.
+    settings = get_settings()
+    mgr = AgentManager(
+        org_id="test-org-997",
+        trust_domain=settings.trust_domain,
+    )
+    # Mint the Org CA (idempotent on a fresh DB).
+    await mgr.generate_org_ca(derive_org_id=False)
+    # The CA loader caches; load it into the manager so the leaf-mint
+    # path has a parent to sign against.
+    await mgr.load_org_ca_from_config()
+
+    # Boot identity. The mint path acquires the flock, finds 4 active
+    # rows, keeps k-newest, deprecates the rest.
+    await mgr.ensure_mastio_identity()
+
+    assert await _count_active(db_url) == 1
+    # The survivor is k-newest, the newest by activated_at.
+    from mcp_proxy.db import get_mastio_keys_active
+    survivors = await get_mastio_keys_active()
+    assert len(survivors) == 1
+    assert survivors[0]["kid"] == "k-newest"
+
+
+@pytest.mark.asyncio
+async def test_mint_mastio_leaf_adopts_singleton_without_dup(
+    audit_test_env, monkeypatch,
+):
+    """When the DB carries exactly 1 active row (the happy steady
+    state), ``_mint_mastio_leaf`` adopts it without inserting a new
+    keypair.
+    """
+    from mcp_proxy.db import init_db
+    from mcp_proxy.egress.agent_manager import AgentManager
+    from mcp_proxy.config import get_settings
+
+    db_url = audit_test_env
+    await init_db(db_url)
+
+    now = datetime.now(timezone.utc).isoformat()
+    await _insert_active_row(db_url, "k-singleton", now)
+    assert await _count_active(db_url) == 1
+
+    settings = get_settings()
+    mgr = AgentManager(
+        org_id="test-org-997-singleton",
+        trust_domain=settings.trust_domain,
+    )
+    await mgr.generate_org_ca(derive_org_id=False)
+    await mgr.load_org_ca_from_config()
+    await mgr.ensure_mastio_identity()
+
+    # Still exactly 1 active row, the seeded one.
+    assert await _count_active(db_url) == 1
+    from mcp_proxy.db import get_mastio_keys_active
+    survivors = await get_mastio_keys_active()
+    assert len(survivors) == 1
+    assert survivors[0]["kid"] == "k-singleton"


### PR DESCRIPTION
## Summary

Closes #997. Adds an inter-worker flock guard around `AgentManager._mint_mastio_leaf` so the N uvicorn workers do not all race a fresh active `mastio_keys` row into the DB at lifespan startup, and repairs the invariant in place when N>1 active rows are already on disk from a pre-fix boot.

## Why this blocks the SDK quickstart

The 2026-05-28 cold-reader run on `mastio-demo` against fresh `mastio-v0.6.2`: the four uvicorn workers each minted a fresh leaf within 80 ms; `mastio_keys` carried 4 active rows on the first boot; `LocalKeyStore.current_signer()` raised `RuntimeError("4 active mastio keys")`; `main.py:704` swallowed the exception silently (no warning materialised in the JSON logs); `app.state.local_issuer` stayed None; `/v1/auth/token` returned 503 `local issuer not initialized`. Two of the three quickstart README snippets (`list_mcp_tools` and `call_mcp_tool`, which call `/v1/mcp` gated by LOCAL_TOKEN auth) failed end-to-end on a fresh install.

## What changes

- `mcp_proxy/db.py`: `_acquire_mastio_mint_lock` / `_release_mastio_mint_lock` mirroring the existing `_run_migrations_sync_under_flock` pattern (blocking `fcntl.LOCK_EX` on `<db>.mastio_mint.lock`).
- `mcp_proxy/db.py`: `deprecate_mastio_keys_by_kids` for the in-place repair path.
- `mcp_proxy/egress/agent_manager.py`: `_mint_mastio_leaf` acquires the flock via `asyncio.to_thread`, re-fetches `get_mastio_keys_active()` under it, and adopts / repairs / mints depending on the row count.

SQLite-only fix. Postgres deploys (0 in the wild today) take the original racy branch until a follow-up adds `pg_try_advisory_lock`. Repair runs lazily on the next boot after this lands — no manual SQL needed for operators with stale rows.

## Tests

`test/unit/test_mastio_keys_invariant_997.py` — 4 cases, all green locally:

```
test_deprecate_mastio_keys_by_kids_only_touches_listed_active_rows PASSED
test_deprecate_mastio_keys_by_kids_empty_list_noop                 PASSED
test_mint_mastio_leaf_repairs_pre_existing_invariant_violation     PASSED
test_mint_mastio_leaf_adopts_singleton_without_dup                 PASSED
```

## Cold-reader gate

Pre-merge: full quickstart README replay (chat_completion + list_mcp_tools + call_mcp_tool) on the v0.6.3 candidate image against a wiped `mastio-demo`, plus the same against a fresh VM cold-reader scenario (no prior Cullis state). Memory captured the lesson — every quickstart method must be exercised, not one representative endpoint.