### PR TITLE
fix(security): enforce llm.chat + mcp.tools.list capability gates (#22, #23)

### DIFF
--- a/mcp_proxy/admin/_capabilities.py
+++ b/mcp_proxy/admin/_capabilities.py
@@ -1,0 +1,86 @@
+"""Shared capability validation + parse helpers for the admin surfaces.
+
+The agent / user / workload create endpoints all accept a
+``capabilities`` field. They share the same shape: a JSON array of
+lowercase-identifier strings (``llm.chat``, ``mcp.tools.list``,
+``custom.read``). This module pins the constraints in one place so
+the three endpoints can't drift:
+
+  * ``Capability`` — single capability token (Pydantic-validated).
+  * ``CAPABILITIES_FIELD`` — ready-to-use ``Field`` for the list,
+    with item + length caps that keep an abusive admin push from
+    growing the row unbounded.
+  * ``decode_capabilities`` — defensive parse for rows read back
+    from the DB (handles legacy NULL, string, list, malformed JSON).
+
+The caps are intentionally **policy**, not **security**: behaviourally
+unknown caps no-op at every gate (the membership test compares
+literal strings like ``"llm.chat"``), so they cannot escalate. The
+caps are here to keep the row small and the admin UI sane.
+"""
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from pydantic import Field, StringConstraints
+
+
+# Lowercase identifier, dotted segments. Matches the convention used
+# in the existing static caps (``llm.chat``, ``mcp.tools.list``,
+# ``http.get``, ``erp.read``). ``[a-z_]`` start prevents purely
+# numeric tokens; the inner alphabet allows dots, underscores, digits.
+_CAPABILITY_PATTERN = r"^[a-z_][a-z0-9_.]{0,63}$"
+
+
+Capability = Annotated[
+    str,
+    StringConstraints(
+        pattern=_CAPABILITY_PATTERN,
+        min_length=1,
+        max_length=64,
+    ),
+]
+
+
+# Use this in admin BaseModels:
+#
+#     capabilities: list[Capability] = CAPABILITIES_FIELD
+#
+# Caps the list at 64 entries (no realistic operator needs more) and
+# each item at 64 chars via the Capability constraint above.
+CAPABILITIES_FIELD = Field(
+    default_factory=list,
+    max_length=64,
+    description=(
+        "Capability tokens granted to this principal. Each item: "
+        "lowercase identifier with optional dotted segments "
+        "(e.g. 'llm.chat', 'mcp.tools.list'). Empty list = "
+        "zero-trust default-deny."
+    ),
+)
+
+
+def decode_capabilities(raw: object) -> list[str]:
+    """Parse a ``capabilities`` value read from a DB row.
+
+    Tolerates the column being NULL (legacy rows pre-migration 0045),
+    a Python list (some drivers may already decode JSON), a JSON
+    string (the canonical encoding), or a comma-separated string
+    (defensive — should not happen in practice). Returns an empty
+    list on any error so the caller can fall through to zero-trust
+    default-deny.
+    """
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [c for c in raw if isinstance(c, str)]
+    if not isinstance(raw, str):
+        return []
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [c for c in loaded if isinstance(c, str)]

--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -40,6 +40,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
+from mcp_proxy.admin._capabilities import (
+    CAPABILITIES_FIELD,
+    Capability,
+)
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_db, log_audit
 
@@ -68,7 +72,9 @@ class AgentCreateRequest(BaseModel):
     # Short name only; the mastio scopes it to its own org_id.
     agent_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
     display_name: str = Field("", max_length=256)
-    capabilities: list[str] = Field(default_factory=list)
+    # v0.6.4 — shape constrained: lowercase identifier, max 64 items,
+    # max 64 chars each. See ``mcp_proxy.admin._capabilities``.
+    capabilities: list[Capability] = CAPABILITIES_FIELD
     federated: bool = False
     # Optional pre-generated cert+key pair, used by the sandbox bootstrap
     # that owns the same Org CA and wants to share the private key with
@@ -110,6 +116,10 @@ class AgentOut(BaseModel):
 
 class FederatedPatch(BaseModel):
     federated: bool
+
+
+class CapabilitiesPatch(BaseModel):
+    capabilities: list[Capability] = CAPABILITIES_FIELD
 
 
 # ── helpers ─────────────────────────────────────────────────────────────
@@ -378,6 +388,78 @@ async def patch_federated(agent_id: str, body: FederatedPatch) -> AgentOut:
         action="agent.federated_patched",
         status="success",
         detail=f"agent_id={agent_id} federated={body.federated}",
+    )
+
+    return AgentOut(
+        agent_id=updated["agent_id"],
+        display_name=updated["display_name"],
+        capabilities=json.loads(updated["capabilities"] or "[]"),
+        federated=bool(updated["federated"]),
+        federated_at=str(updated["federated_at"]) if updated["federated_at"] else None,
+        federation_revision=int(updated["federation_revision"]),
+        is_active=bool(updated["is_active"]),
+        created_at=str(updated["created_at"]),
+    )
+
+
+@router.patch(
+    "/{agent_id}/capabilities",
+    response_model=AgentOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def patch_capabilities(
+    agent_id: str, body: CapabilitiesPatch,
+) -> AgentOut:
+    """Replace the agent's capability set.
+
+    Idempotent set-replacement (NOT a delta apply). Pass the full
+    desired list each time — the admin UX is "edit + save the
+    whole list", not "add one cap" / "remove one cap", which keeps
+    the wire contract trivial and the audit row self-describing.
+
+    Bumps ``federation_revision`` so the Phase 3 publisher will
+    pick the change up on its next pass for federated agents. Phase 1
+    (this PR) does NOT propagate cap changes to the Court — that is
+    a follow-up; today the cap is enforced locally on the Mastio that
+    owns the row, which is enough for the LLM + MCP gates.
+    """
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT 1 FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )).first()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent not found",
+            )
+        await conn.execute(
+            text(
+                """
+                UPDATE internal_agents
+                   SET capabilities = :caps,
+                       federation_revision = federation_revision + 1
+                 WHERE agent_id = :aid
+                """
+            ),
+            {"caps": json.dumps(body.capabilities), "aid": agent_id},
+        )
+        updated = (await conn.execute(
+            text(
+                """
+                SELECT agent_id, display_name, capabilities, is_active,
+                       federated, federated_at, federation_revision, created_at
+                  FROM internal_agents WHERE agent_id = :aid
+                """
+            ),
+            {"aid": agent_id},
+        )).mappings().first()
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.capabilities_patched",
+        status="success",
+        detail=f"agent_id={agent_id} capabilities={body.capabilities}",
     )
 
     return AgentOut(

--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -31,7 +31,7 @@ from mcp_proxy.admin._capabilities import (
     decode_capabilities,
 )
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import get_db
+from mcp_proxy.db import get_db, log_audit
 
 
 _log = logging.getLogger("mcp_proxy.admin.users")
@@ -86,6 +86,10 @@ class UserOut(BaseModel):
 class UserListResponse(BaseModel):
     users: list[UserOut]
     total: int
+
+
+class UserCapabilitiesPatch(BaseModel):
+    capabilities: list[Capability] = CAPABILITIES_FIELD
 
 
 # ── helpers ─────────────────────────────────────────────────────────────
@@ -241,6 +245,63 @@ async def list_users(
         for r in rows
     ]
     return UserListResponse(users=items, total=len(items))
+
+
+@router.patch(
+    "/{principal_id:path}/capabilities",
+    response_model=UserOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def patch_user_capabilities(
+    principal_id: str, body: UserCapabilitiesPatch,
+) -> UserOut:
+    """Replace the user principal's capability set (set, not delta).
+
+    Symmetric to ``PATCH /v1/admin/agents/{id}/capabilities``. The
+    new list takes effect on the next token mint — sessions issued
+    before the change continue to carry the old scope until their
+    natural expiry.
+    """
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id, user_name, display_name, reach, "
+                "       surface, capabilities, created_at, last_active_at "
+                "  FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )).mappings().first()
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="user principal not found",
+            )
+        await conn.execute(
+            text(
+                "UPDATE local_user_principals "
+                "   SET capabilities = :caps "
+                " WHERE principal_id = :pid"
+            ),
+            {"caps": json.dumps(body.capabilities), "pid": principal_id},
+        )
+
+    await log_audit(
+        agent_id="admin",
+        action="user.capabilities_patched",
+        status="success",
+        detail=f"principal_id={principal_id} capabilities={body.capabilities}",
+    )
+
+    return UserOut(
+        principal_id=existing["principal_id"],
+        user_name=existing["user_name"],
+        display_name=existing["display_name"],
+        reach=existing["reach"],
+        surface=existing["surface"],
+        capabilities=body.capabilities,
+        last_active=existing["last_active_at"],
+        created_at=existing["created_at"],
+    )
 
 
 @router.post(

--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -16,6 +16,7 @@ Auth: ``X-Admin-Secret`` (same contract as ``/v1/admin/agents``).
 from __future__ import annotations
 
 import hmac
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Optional
@@ -58,6 +59,10 @@ class UserCreateRequest(BaseModel):
     display_name: str = Field("", max_length=256)
     reach: str = Field("intra")
     surface: Optional[str] = Field(None, max_length=64)
+    # v0.6.4 (#23 follow-up) — capability set granted to this user
+    # principal. Zero-trust default: an empty list denies on every
+    # capability gate (e.g. ``mcp.tools.list`` on POST /v1/mcp).
+    capabilities: list[str] = Field(default_factory=list)
 
 
 class UserOut(BaseModel):
@@ -66,6 +71,7 @@ class UserOut(BaseModel):
     display_name: Optional[str]
     reach: str
     surface: Optional[str]
+    capabilities: list[str]
     last_active: Optional[str]
     created_at: str
 
@@ -80,6 +86,20 @@ class UserListResponse(BaseModel):
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _decode_capabilities(raw: object) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [c for c in raw if isinstance(c, str)]
+    try:
+        loaded = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [c for c in loaded if isinstance(c, str)]
 
 
 def _principal_id(org_id: str, user_name: str) -> str:
@@ -125,7 +145,7 @@ async def create_user(
         existing = (await conn.execute(
             text(
                 "SELECT principal_id, user_name, display_name, reach, "
-                "       surface, created_at, last_active_at "
+                "       surface, capabilities, created_at, last_active_at "
                 "  FROM local_user_principals WHERE principal_id = :pid"
             ),
             {"pid": pid},
@@ -136,9 +156,9 @@ async def create_user(
                     """
                     INSERT INTO local_user_principals (
                         principal_id, user_name, display_name,
-                        reach, surface, created_at
+                        reach, surface, capabilities, created_at
                     ) VALUES (
-                        :pid, :uname, :disp, :reach, :surface, :now
+                        :pid, :uname, :disp, :reach, :surface, :caps, :now
                     )
                     """
                 ),
@@ -148,6 +168,7 @@ async def create_user(
                     "disp": body.display_name or None,
                     "reach": body.reach,
                     "surface": body.surface,
+                    "caps": json.dumps(body.capabilities),
                     "now": now,
                 },
             )
@@ -157,6 +178,7 @@ async def create_user(
                 display_name=body.display_name or None,
                 reach=body.reach,
                 surface=body.surface,
+                capabilities=body.capabilities,
                 last_active=None,
                 created_at=now,
             )
@@ -166,6 +188,7 @@ async def create_user(
             display_name=existing["display_name"],
             reach=existing["reach"],
             surface=existing["surface"],
+            capabilities=_decode_capabilities(existing["capabilities"]),
             last_active=existing["last_active_at"],
             created_at=existing["created_at"],
         )
@@ -189,7 +212,7 @@ async def list_users(
         )
     sql = (
         "SELECT principal_id, user_name, display_name, reach, surface, "
-        "       created_at, last_active_at "
+        "       capabilities, created_at, last_active_at "
         "  FROM local_user_principals "
     )
     where: list[str] = []
@@ -218,6 +241,7 @@ async def list_users(
             display_name=r["display_name"],
             reach=r["reach"],
             surface=r["surface"],
+            capabilities=_decode_capabilities(r["capabilities"]),
             last_active=r["last_active_at"],
             created_at=r["created_at"],
         )

--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -25,6 +25,11 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, s
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from mcp_proxy.admin._capabilities import (
+    CAPABILITIES_FIELD,
+    Capability,
+    decode_capabilities,
+)
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_db
 
@@ -62,7 +67,9 @@ class UserCreateRequest(BaseModel):
     # v0.6.4 (#23 follow-up) — capability set granted to this user
     # principal. Zero-trust default: an empty list denies on every
     # capability gate (e.g. ``mcp.tools.list`` on POST /v1/mcp).
-    capabilities: list[str] = Field(default_factory=list)
+    # Shape constrained by ``Capability`` + ``CAPABILITIES_FIELD``
+    # so an abusive admin push can't bloat the row.
+    capabilities: list[Capability] = CAPABILITIES_FIELD
 
 
 class UserOut(BaseModel):
@@ -86,20 +93,6 @@ class UserListResponse(BaseModel):
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
-
-
-def _decode_capabilities(raw: object) -> list[str]:
-    if raw is None or raw == "":
-        return []
-    if isinstance(raw, list):
-        return [c for c in raw if isinstance(c, str)]
-    try:
-        loaded = json.loads(raw) if isinstance(raw, str) else raw
-    except (TypeError, ValueError):
-        return []
-    if not isinstance(loaded, list):
-        return []
-    return [c for c in loaded if isinstance(c, str)]
 
 
 def _principal_id(org_id: str, user_name: str) -> str:
@@ -188,7 +181,7 @@ async def create_user(
             display_name=existing["display_name"],
             reach=existing["reach"],
             surface=existing["surface"],
-            capabilities=_decode_capabilities(existing["capabilities"]),
+            capabilities=decode_capabilities(existing["capabilities"]),
             last_active=existing["last_active_at"],
             created_at=existing["created_at"],
         )
@@ -241,7 +234,7 @@ async def list_users(
             display_name=r["display_name"],
             reach=r["reach"],
             surface=r["surface"],
-            capabilities=_decode_capabilities(r["capabilities"]),
+            capabilities=decode_capabilities(r["capabilities"]),
             last_active=r["last_active_at"],
             created_at=r["created_at"],
         )

--- a/mcp_proxy/admin/workloads.py
+++ b/mcp_proxy/admin/workloads.py
@@ -15,6 +15,7 @@ Auth: ``X-Admin-Secret``.
 from __future__ import annotations
 
 import hmac
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Optional
@@ -51,6 +52,9 @@ class WorkloadCreateRequest(BaseModel):
     display_name: str = Field("", max_length=256)
     image_digest: Optional[str] = Field(None, max_length=128)
     runtime_status: str = Field("unknown")
+    # v0.6.4 (#23 follow-up) — see UserCreateRequest. Empty list
+    # denies on every capability gate; admin grants explicitly.
+    capabilities: list[str] = Field(default_factory=list)
 
 
 class WorkloadOut(BaseModel):
@@ -59,6 +63,7 @@ class WorkloadOut(BaseModel):
     display_name: Optional[str]
     image_digest: Optional[str]
     runtime_status: str
+    capabilities: list[str]
     hosted_principals_count: int
     hosted_principals_sample: list[str]
     last_active: Optional[str]
@@ -72,6 +77,20 @@ class WorkloadListResponse(BaseModel):
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _decode_capabilities(raw: object) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [c for c in raw if isinstance(c, str)]
+    try:
+        loaded = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [c for c in loaded if isinstance(c, str)]
 
 
 def _principal_id(org_id: str, workload_name: str) -> str:
@@ -131,7 +150,7 @@ async def create_workload(
         existing = (await conn.execute(
             text(
                 "SELECT principal_id, workload_name, display_name, "
-                "       image_digest, runtime_status, "
+                "       image_digest, runtime_status, capabilities, "
                 "       created_at, last_active_at "
                 "  FROM local_workload_principals "
                 " WHERE principal_id = :pid"
@@ -144,9 +163,10 @@ async def create_workload(
                     """
                     INSERT INTO local_workload_principals (
                         principal_id, workload_name, display_name,
-                        image_digest, runtime_status, created_at
+                        image_digest, runtime_status, capabilities,
+                        created_at
                     ) VALUES (
-                        :pid, :wname, :disp, :img, :status, :now
+                        :pid, :wname, :disp, :img, :status, :caps, :now
                     )
                     """
                 ),
@@ -154,7 +174,9 @@ async def create_workload(
                     "pid": pid, "wname": body.workload_name,
                     "disp": body.display_name or None,
                     "img": body.image_digest,
-                    "status": body.runtime_status, "now": now,
+                    "status": body.runtime_status,
+                    "caps": json.dumps(body.capabilities),
+                    "now": now,
                 },
             )
             count, sample = await _hosted_principals(conn, mgr.org_id)
@@ -164,6 +186,7 @@ async def create_workload(
                 display_name=body.display_name or None,
                 image_digest=body.image_digest,
                 runtime_status=body.runtime_status,
+                capabilities=body.capabilities,
                 hosted_principals_count=count,
                 hosted_principals_sample=sample,
                 last_active=None,
@@ -176,6 +199,7 @@ async def create_workload(
             display_name=existing["display_name"],
             image_digest=existing["image_digest"],
             runtime_status=existing["runtime_status"],
+            capabilities=_decode_capabilities(existing["capabilities"]),
             hosted_principals_count=count,
             hosted_principals_sample=sample,
             last_active=existing["last_active_at"],
@@ -200,7 +224,7 @@ async def list_workloads(
         )
     sql = (
         "SELECT principal_id, workload_name, display_name, image_digest, "
-        "       runtime_status, created_at, last_active_at "
+        "       runtime_status, capabilities, created_at, last_active_at "
         "  FROM local_workload_principals "
     )
     where: list[str] = []
@@ -227,6 +251,7 @@ async def list_workloads(
             display_name=r["display_name"],
             image_digest=r["image_digest"],
             runtime_status=r["runtime_status"],
+            capabilities=_decode_capabilities(r["capabilities"]),
             hosted_principals_count=count,
             hosted_principals_sample=sample,
             last_active=r["last_active_at"],

--- a/mcp_proxy/admin/workloads.py
+++ b/mcp_proxy/admin/workloads.py
@@ -30,7 +30,7 @@ from mcp_proxy.admin._capabilities import (
     decode_capabilities,
 )
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import get_db
+from mcp_proxy.db import get_db, log_audit
 
 
 _log = logging.getLogger("mcp_proxy.admin.workloads")
@@ -78,6 +78,10 @@ class WorkloadOut(BaseModel):
 class WorkloadListResponse(BaseModel):
     workloads: list[WorkloadOut]
     total: int
+
+
+class WorkloadCapabilitiesPatch(BaseModel):
+    capabilities: list[Capability] = CAPABILITIES_FIELD
 
 
 def _now_iso() -> str:
@@ -251,3 +255,62 @@ async def list_workloads(
         for r in rows
     ]
     return WorkloadListResponse(workloads=items, total=len(items))
+
+
+@router.patch(
+    "/{principal_id:path}/capabilities",
+    response_model=WorkloadOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def patch_workload_capabilities(
+    principal_id: str, body: WorkloadCapabilitiesPatch, request: Request,
+) -> WorkloadOut:
+    """Replace the workload principal's capability set (set, not delta).
+
+    Symmetric to ``PATCH /v1/admin/agents/{id}/capabilities`` and
+    ``PATCH /v1/admin/users/{id}/capabilities``.
+    """
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id, workload_name, display_name, "
+                "       image_digest, runtime_status, capabilities, "
+                "       created_at, last_active_at "
+                "  FROM local_workload_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )).mappings().first()
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="workload principal not found",
+            )
+        await conn.execute(
+            text(
+                "UPDATE local_workload_principals "
+                "   SET capabilities = :caps "
+                " WHERE principal_id = :pid"
+            ),
+            {"caps": json.dumps(body.capabilities), "pid": principal_id},
+        )
+        count, sample = await _hosted_principals(conn, "")
+
+    await log_audit(
+        agent_id="admin",
+        action="workload.capabilities_patched",
+        status="success",
+        detail=f"principal_id={principal_id} capabilities={body.capabilities}",
+    )
+
+    return WorkloadOut(
+        principal_id=existing["principal_id"],
+        workload_name=existing["workload_name"],
+        display_name=existing["display_name"],
+        image_digest=existing["image_digest"],
+        runtime_status=existing["runtime_status"],
+        capabilities=body.capabilities,
+        hosted_principals_count=count,
+        hosted_principals_sample=sample,
+        last_active=existing["last_active_at"],
+        created_at=existing["created_at"],
+    )

--- a/mcp_proxy/admin/workloads.py
+++ b/mcp_proxy/admin/workloads.py
@@ -24,6 +24,11 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, s
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
+from mcp_proxy.admin._capabilities import (
+    CAPABILITIES_FIELD,
+    Capability,
+    decode_capabilities,
+)
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_db
 
@@ -54,7 +59,7 @@ class WorkloadCreateRequest(BaseModel):
     runtime_status: str = Field("unknown")
     # v0.6.4 (#23 follow-up) — see UserCreateRequest. Empty list
     # denies on every capability gate; admin grants explicitly.
-    capabilities: list[str] = Field(default_factory=list)
+    capabilities: list[Capability] = CAPABILITIES_FIELD
 
 
 class WorkloadOut(BaseModel):
@@ -77,20 +82,6 @@ class WorkloadListResponse(BaseModel):
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
-
-
-def _decode_capabilities(raw: object) -> list[str]:
-    if raw is None or raw == "":
-        return []
-    if isinstance(raw, list):
-        return [c for c in raw if isinstance(c, str)]
-    try:
-        loaded = json.loads(raw) if isinstance(raw, str) else raw
-    except (TypeError, ValueError):
-        return []
-    if not isinstance(loaded, list):
-        return []
-    return [c for c in loaded if isinstance(c, str)]
 
 
 def _principal_id(org_id: str, workload_name: str) -> str:
@@ -199,7 +190,7 @@ async def create_workload(
             display_name=existing["display_name"],
             image_digest=existing["image_digest"],
             runtime_status=existing["runtime_status"],
-            capabilities=_decode_capabilities(existing["capabilities"]),
+            capabilities=decode_capabilities(existing["capabilities"]),
             hosted_principals_count=count,
             hosted_principals_sample=sample,
             last_active=existing["last_active_at"],
@@ -251,7 +242,7 @@ async def list_workloads(
             display_name=r["display_name"],
             image_digest=r["image_digest"],
             runtime_status=r["runtime_status"],
-            capabilities=_decode_capabilities(r["capabilities"]),
+            capabilities=decode_capabilities(r["capabilities"]),
             hosted_principals_count=count,
             hosted_principals_sample=sample,
             last_active=r["last_active_at"],

--- a/mcp_proxy/alembic/versions/0045_principal_capabilities.py
+++ b/mcp_proxy/alembic/versions/0045_principal_capabilities.py
@@ -1,0 +1,73 @@
+"""Add ``capabilities`` to typed principals (users + workloads).
+
+Revision ID: 0045_principal_capabilities
+Revises: 0044_audit_merkle_anchors
+Create Date: 2026-05-28 21:00:00.000000
+
+v0.6.4 made the capability check fail-loud on ``llm.chat`` and
+``mcp.tools.list`` (issues #22, #23). On the agent path the
+capability set already lives in ``internal_agents.capabilities``;
+typed principals (``user::*``, ``workload::*``) had no equivalent
+storage, so ``mcp_proxy.auth.local_agent_dep`` was hardcoding
+``scope=[]`` for them and the new gate started 403-ing every
+Frontdesk user + workload that asked ``/v1/mcp tools/list``.
+
+This migration adds the missing column on both tables:
+
+  * ``local_user_principals.capabilities``     (Text, JSON array, default '[]')
+  * ``local_workload_principals.capabilities`` (Text, JSON array, default '[]')
+
+Same encoding as ``internal_agents.capabilities`` (JSON string of an
+array) so the lookup code in ``local_agent_dep`` can share the parse.
+Default ``'[]'`` keeps the column NOT NULL while preserving the
+zero-trust default-deny semantics: every existing user + workload
+starts cap-less and must be granted capabilities explicitly via the
+admin API.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0045_principal_capabilities"
+down_revision: Union[str, Sequence[str], None] = "0044_audit_merkle_anchors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_USERS = "local_user_principals"
+_WORKLOADS = "local_workload_principals"
+_COLUMN = "capabilities"
+
+
+def _has_column(inspector: sa.Inspector, table: str, column: str) -> bool:
+    if table not in set(inspector.get_table_names()):
+        return False
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in (_USERS, _WORKLOADS):
+        if _has_column(inspector, table, _COLUMN):
+            continue
+        op.add_column(
+            table,
+            sa.Column(
+                _COLUMN,
+                sa.Text(),
+                nullable=False,
+                server_default="[]",
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in (_USERS, _WORKLOADS):
+        if _has_column(inspector, table, _COLUMN):
+            op.drop_column(table, _COLUMN)

--- a/mcp_proxy/auth/builtin_capabilities.py
+++ b/mcp_proxy/auth/builtin_capabilities.py
@@ -1,0 +1,133 @@
+"""Single source of truth for the capability tokens shipped with the
+Mastio (v0.6.4, ADR pending).
+
+Background: a capability is the lowercase token an operator grants
+to a principal (agent, user, workload) in order to authorise the
+principal on a Mastio-gated endpoint. Three populations exist:
+
+  * **Built-in** — names baked into the Mastio because they gate
+    Mastio's own endpoints (chat, MCP discovery, MCP invocation,
+    generic HTTP egress). They live in this module.
+  * **Custom (per-tool)** — declared by MCP resources registered
+    via ``POST /v1/admin/mcp-resources`` with a ``required_capability``
+    column. They vary per deployment.
+  * **Operator-defined** — invented by the customer's Rego policy
+    (``if "compliance.signed_off" in caps``). The Mastio stores them
+    verbatim and surfaces them in audit, but does not enforce
+    anything beyond the policy that consumes them.
+
+This module is the registry for the first population. Routers,
+dashboard handlers, and the smoke scenarios all import from here
+so a rename of e.g. ``mcp.tools.list`` lands in one PR, not five.
+
+Adding a new built-in:
+
+  1. Add the constant + entry in ``BUILTIN_CAPABILITIES`` below.
+  2. Add the ``if X not in caps`` check on the gating router /
+     handler.
+  3. Add the smoke negative scenario under
+     ``test/smoke/scenarios/4X_<name>_denied.sh`` (mirror 41/42).
+  4. Update ``site/src/content/docs/reference/capabilities.md`` so
+     the doc page stays canonical (today written by hand —
+     refactor to autogen from this module is a v0.7 follow-up).
+
+The dashboard's capability suggestion chips iterate over
+``BUILTIN_CAPABILITIES.values()``; ``base.html`` exposes the dict
+to every template via the ``_ctx`` helper in
+``mcp_proxy.dashboard.session``.
+"""
+from __future__ import annotations
+
+from typing import Final
+
+
+# Constants. Use these via ``from mcp_proxy.auth.builtin_capabilities
+# import LLM_CHAT, MCP_TOOLS_LIST`` so a typo in the literal string
+# is a NameError, not a silent miss at the gate.
+
+LLM_CHAT: Final[str] = "llm.chat"
+"""Permits chat completions + Anthropic messages.
+
+Gates:
+  * ``POST /v1/chat/completions``  (OpenAI shape)
+  * ``POST /v1/llm/chat``          (alias, same handler)
+  * ``POST /v1/messages``          (Anthropic shape)
+"""
+
+MCP_TOOLS_LIST: Final[str] = "mcp.tools.list"
+"""Permits the MCP discovery method.
+
+Gates:
+  * ``POST /v1/mcp`` JSON-RPC ``method=tools/list``
+"""
+
+MCP_TOOLS_CALL: Final[str] = "mcp.tools.call"
+"""Permits the MCP invocation method.
+
+Gates:
+  * ``POST /v1/mcp`` JSON-RPC ``method=tools/call``  (v0.7 enforcement;
+    v0.6.x relies on the per-tool ``required_capability`` field on
+    the registered MCP resource)
+"""
+
+HTTP_GET: Final[str] = "http.get"
+"""Permits the Mastio's built-in HTTP-GET egress tool.
+
+Enforced via the built-in tool's ``required_capability`` (Phase 1
+PR #730 builtin capability gate).
+"""
+
+
+# Metadata for the dashboard suggestion chips + the capabilities
+# catalog page. ``order`` is the visual sort key in the chip group.
+# Mirrors the README of ``docs/reference/capabilities``.
+
+BUILTIN_CAPABILITIES: Final[dict[str, dict[str, object]]] = {
+    LLM_CHAT: {
+        "order": 10,
+        "description": (
+            "Chat completions + Anthropic messages "
+            "(/v1/chat/completions, /v1/llm/chat, /v1/messages)"
+        ),
+        "endpoints": [
+            "/v1/chat/completions",
+            "/v1/llm/chat",
+            "/v1/messages",
+        ],
+    },
+    MCP_TOOLS_LIST: {
+        "order": 20,
+        "description": (
+            "List MCP tools available to the principal "
+            "(/v1/mcp tools/list)"
+        ),
+        "endpoints": ["/v1/mcp (tools/list)"],
+    },
+    MCP_TOOLS_CALL: {
+        "order": 30,
+        "description": (
+            "Invoke MCP tools (/v1/mcp tools/call — "
+            "forward-compatible, method-level enforcement lands in v0.7)"
+        ),
+        "endpoints": ["/v1/mcp (tools/call)"],
+    },
+    HTTP_GET: {
+        "order": 40,
+        "description": "Generic HTTP GET egress (built-in MCP tool)",
+        "endpoints": ["/v1/mcp (tools/call name=http.get)"],
+    },
+}
+
+
+def builtin_capability_list() -> list[dict[str, object]]:
+    """Return ``BUILTIN_CAPABILITIES`` as a sorted list of dicts.
+
+    Each entry carries ``name``, ``description``, ``endpoints``,
+    ``order``. Shape that the dashboard template can iterate over
+    without any sort gymnastics in Jinja.
+    """
+    out: list[dict[str, object]] = []
+    for name, meta in BUILTIN_CAPABILITIES.items():
+        out.append({"name": name, **meta})
+    out.sort(key=lambda r: int(r["order"]))  # type: ignore[arg-type]
+    return out

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -25,7 +25,7 @@ import jwt as jose_jwt
 
 from mcp_proxy.auth.local_validator import LocalTokenError, validate_local_token
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import get_agent
+from mcp_proxy.db import get_agent, get_principal_capabilities
 from mcp_proxy.models import InternalAgent, TokenPayload
 
 _log = logging.getLogger("mcp_proxy.auth.local_agent_dep")
@@ -245,7 +245,6 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
         # default-deny: tools/list returns -32005 capability_missing
         # until the admin attaches ``mcp.tools.list`` via
         # ``POST /v1/admin/users`` or the dashboard form.
-        from mcp_proxy.db import get_principal_capabilities
         caps = await get_principal_capabilities(
             payload.agent_id, principal_type,
         )

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -234,6 +234,21 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
         or "::workload::" in payload.agent_id
     )
     if is_typed_principal:
+        principal_type = (
+            "user" if "::user::" in payload.agent_id else "workload"
+        )
+        # v0.6.4 (#23 follow-up) — load capabilities from
+        # ``local_user_principals`` / ``local_workload_principals``
+        # instead of hardcoding ``scope=[]``. Migration 0045 added
+        # the ``capabilities`` column on both tables. Pre-grant the
+        # principal goes capabilities=[] which is the zero-trust
+        # default-deny: tools/list returns -32005 capability_missing
+        # until the admin attaches ``mcp.tools.list`` via
+        # ``POST /v1/admin/users`` or the dashboard form.
+        from mcp_proxy.db import get_principal_capabilities
+        caps = await get_principal_capabilities(
+            payload.agent_id, principal_type,
+        )
         return TokenPayload(
             sub=payload.agent_id,
             agent_id=payload.agent_id,
@@ -241,11 +256,9 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
             exp=payload.expires_at,
             iat=payload.issued_at,
             jti=payload.jti,
-            scope=[],
+            scope=caps,
             cnf=None,
-            principal_type=(
-                "user" if "::user::" in payload.agent_id else "workload"
-            ),
+            principal_type=principal_type,
         )
 
     record = await get_agent(payload.agent_id)

--- a/mcp_proxy/dashboard/_helpers.py
+++ b/mcp_proxy/dashboard/_helpers.py
@@ -18,11 +18,20 @@ from mcp_proxy.dashboard.session import ProxyDashboardSession
 
 
 def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
-    """Build the standard template context."""
+    """Build the standard template context.
+
+    Exposes ``builtin_capabilities`` to every template — the
+    ``_capabilities_datalist.html`` partial iterates over it to
+    render the suggestion chips, so a new built-in token added in
+    ``mcp_proxy.auth.builtin_capabilities`` shows up across all
+    five capability forms without a template edit.
+    """
+    from mcp_proxy.auth.builtin_capabilities import builtin_capability_list
     return {
         "request": request,
         "session": session,
         "csrf_token": session.csrf_token,
+        "builtin_capabilities": builtin_capability_list(),
         **kwargs,
     }
 

--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -581,6 +581,92 @@ async def agent_identity_bundle_download(request: Request, agent_id: str):
 _VALID_REACH = {"intra", "cross", "both"}
 
 
+_CAPABILITY_RE = __import__("re").compile(r"^[a-z_][a-z0-9_.]{0,63}$")
+_MAX_CAP_ITEMS = 64
+
+
+def _parse_capabilities_form(raw: str) -> tuple[list[str], str | None]:
+    """Parse the comma-separated capability list from the dashboard form.
+
+    Returns ``(parsed, err)``. ``err`` is non-None when validation
+    fails — the caller renders the error back into the page rather
+    than touching the DB. Mirrors the constraints applied by
+    ``mcp_proxy.admin._capabilities.Capability`` so the dashboard
+    surface and the admin API cannot drift.
+    """
+    items = [c.strip() for c in raw.split(",") if c.strip()]
+    if len(items) > _MAX_CAP_ITEMS:
+        return [], f"too many capabilities (max {_MAX_CAP_ITEMS})"
+    for c in items:
+        if not _CAPABILITY_RE.match(c):
+            return (
+                [],
+                f"invalid capability {c!r}: must match "
+                f"[a-z_][a-z0-9_.]{{0,63}} (lowercase, dotted)",
+            )
+    return items, None
+
+
+@router.post("/agents/{agent_id:path}/capabilities")
+async def agent_set_capabilities(request: Request, agent_id: str):
+    """Replace the agent's capability set from the dashboard form.
+
+    Symmetric to the admin API ``PATCH /v1/admin/agents/{id}/capabilities``
+    — the dashboard talks to the DB directly (same pattern as
+    ``/reach`` above) to keep the form-POST flow simple and CSRF-bound.
+
+    Bumps ``federation_revision`` so the Phase 3 publisher will pick
+    the change up on its next pass. Audit row carries the new list
+    verbatim so an operator can replay history.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    capabilities_raw = str(form.get("capabilities", "")).strip()
+    capabilities, err = _parse_capabilities_form(capabilities_raw)
+    if err is not None:
+        return RedirectResponse(
+            url=f"/proxy/agents/{agent_id}?error={err}",
+            status_code=303,
+        )
+
+    from mcp_proxy.db import get_agent, get_db, log_audit
+    from sqlalchemy import text as _text
+    import json as _json
+
+    agent = await get_agent(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    async with get_db() as conn:
+        await conn.execute(
+            _text(
+                """
+                UPDATE internal_agents
+                   SET capabilities = :caps,
+                       federation_revision = federation_revision + 1
+                 WHERE agent_id = :aid
+                """
+            ),
+            {"caps": _json.dumps(capabilities), "aid": agent_id},
+        )
+
+    await log_audit(
+        agent_id=agent_id,
+        action="agent.capabilities_set",
+        status="success",
+        detail=f"source=dashboard capabilities={capabilities}",
+    )
+
+    return RedirectResponse(
+        url=f"/proxy/agents/{agent_id}", status_code=303,
+    )
+
+
 @router.post("/agents/{agent_id:path}/reach")
 async def agent_set_reach(request: Request, agent_id: str):
     """Set ``internal_agents.reach`` from the dashboard.

--- a/mcp_proxy/dashboard/templates/_capabilities_datalist.html
+++ b/mcp_proxy/dashboard/templates/_capabilities_datalist.html
@@ -1,21 +1,28 @@
-{# Shared datalist for capability autocomplete.
+{# Capability suggestion chips for the dashboard forms.
 
-   Used by the four capability input fields in the dashboard:
-     * agents.html   — Create form
-     * agent_detail.html — Update form
-     * users.html    — Create form
-     * user_detail.html — Update form
-     * enrollments.html — Approve form
+   Each chip is wired by the global ``data-cap-add`` click handler
+   in ``base.html``: it appends the token to the nearest
+   ``<input name="capabilities">`` in the same form, skipping
+   duplicates and dispatching an ``input`` event so any reactive
+   validation sees the change.
 
-   The four built-in tokens shipped with the Mastio appear as suggestions
-   when the operator types in the textbox. Custom (per-tool) and
-   operator-defined tokens are accepted by the same field but do NOT
-   appear as suggestions in v0.6.4 — they will once the capability
-   registry lands in v0.7. See ``docs/reference/capabilities``.
+   The list of suggestions is sourced from
+   ``mcp_proxy.auth.builtin_capabilities.builtin_capability_list()``,
+   injected into every dashboard context by ``_helpers._ctx``. Add a
+   built-in token there and it appears in all five forms (agent
+   create + detail, user create + detail, enrollment approve)
+   without touching this partial.
+
+   Note: the file is named ``_capabilities_datalist.html`` for
+   historical reasons (it used to render an HTML5 ``<datalist>`` —
+   that approach clobbered the comma-separated value on selection).
+   Renaming is a churn rebase nobody needs.
 #}
-<datalist id="cullis-capabilities">
-    <option value="llm.chat">Chat completions + Anthropic messages (/v1/chat/completions, /v1/llm/chat, /v1/messages)</option>
-    <option value="mcp.tools.list">List MCP tools available to the principal (/v1/mcp tools/list)</option>
-    <option value="mcp.tools.call">Invoke MCP tools (/v1/mcp tools/call — forward-compatible, enforced in v0.7)</option>
-    <option value="http.get">Generic HTTP GET egress (built-in MCP tool)</option>
-</datalist>
+<div class="flex flex-wrap gap-1.5 mt-2" data-cap-suggestions>
+    <span class="text-[10px] text-gray-600 self-center mr-1 uppercase tracking-wider">Suggest:</span>
+    {% for cap in builtin_capabilities %}
+    <button type="button" data-cap-add="{{ cap.name }}"
+            title="{{ cap.description }}"
+            class="px-1.5 py-0.5 rounded text-[10px] font-mono bg-info-400/10 text-info-400 border border-info-400/30 hover:bg-info-400/20 transition-colors cursor-pointer">+ {{ cap.name }}</button>
+    {% endfor %}
+</div>

--- a/mcp_proxy/dashboard/templates/_capabilities_datalist.html
+++ b/mcp_proxy/dashboard/templates/_capabilities_datalist.html
@@ -1,0 +1,21 @@
+{# Shared datalist for capability autocomplete.
+
+   Used by the four capability input fields in the dashboard:
+     * agents.html   — Create form
+     * agent_detail.html — Update form
+     * users.html    — Create form
+     * user_detail.html — Update form
+     * enrollments.html — Approve form
+
+   The four built-in tokens shipped with the Mastio appear as suggestions
+   when the operator types in the textbox. Custom (per-tool) and
+   operator-defined tokens are accepted by the same field but do NOT
+   appear as suggestions in v0.6.4 — they will once the capability
+   registry lands in v0.7. See ``docs/reference/capabilities``.
+#}
+<datalist id="cullis-capabilities">
+    <option value="llm.chat">Chat completions + Anthropic messages (/v1/chat/completions, /v1/llm/chat, /v1/messages)</option>
+    <option value="mcp.tools.list">List MCP tools available to the principal (/v1/mcp tools/list)</option>
+    <option value="mcp.tools.call">Invoke MCP tools (/v1/mcp tools/call — forward-compatible, enforced in v0.7)</option>
+    <option value="http.get">Generic HTTP GET egress (built-in MCP tool)</option>
+</datalist>

--- a/mcp_proxy/dashboard/templates/agent_detail.html
+++ b/mcp_proxy/dashboard/templates/agent_detail.html
@@ -86,7 +86,7 @@
                     <form method="post" action="/proxy/agents/{{ agent.agent_id }}/capabilities"
                           class="mt-3 flex items-center gap-2">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                        <input type="text" name="capabilities" list="cullis-capabilities"
+                        <input type="text" name="capabilities"
                                value="{{ agent.capabilities | join(', ') }}"
                                placeholder="llm.chat, mcp.tools.list"
                                class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">

--- a/mcp_proxy/dashboard/templates/agent_detail.html
+++ b/mcp_proxy/dashboard/templates/agent_detail.html
@@ -86,15 +86,19 @@
                     <form method="post" action="/proxy/agents/{{ agent.agent_id }}/capabilities"
                           class="mt-3 flex items-center gap-2">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                        <input type="text" name="capabilities"
+                        <input type="text" name="capabilities" list="cullis-capabilities"
                                value="{{ agent.capabilities | join(', ') }}"
-                               placeholder="llm.chat, mcp.tools.list, custom.read"
+                               placeholder="llm.chat, mcp.tools.list"
                                class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">
                         <button type="submit"
                                 class="px-3 py-1.5 rounded text-xs font-medium bg-info-400/10 text-info-400 border border-info-400/30 hover:bg-info-400/20 transition-colors">
                             Update
                         </button>
                     </form>
+                    {% include "_capabilities_datalist.html" %}
+                    <p class="text-[10px] text-gray-600 mt-2">
+                        Set-replacement, not delta. See the <a href="https://cullis.io/docs/reference/capabilities" target="_blank" rel="noopener" class="text-info-400 underline">capabilities catalog</a> for what each token unlocks.
+                    </p>
                     {% if request.query_params.get('error') %}
                     <p class="text-[10px] text-red-400 mt-1">{{ request.query_params.get('error') }}</p>
                     {% endif %}

--- a/mcp_proxy/dashboard/templates/agent_detail.html
+++ b/mcp_proxy/dashboard/templates/agent_detail.html
@@ -83,6 +83,21 @@
                         <span class="text-xs text-gray-600">none</span>
                         {% endif %}
                     </div>
+                    <form method="post" action="/proxy/agents/{{ agent.agent_id }}/capabilities"
+                          class="mt-3 flex items-center gap-2">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                        <input type="text" name="capabilities"
+                               value="{{ agent.capabilities | join(', ') }}"
+                               placeholder="llm.chat, mcp.tools.list, custom.read"
+                               class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">
+                        <button type="submit"
+                                class="px-3 py-1.5 rounded text-xs font-medium bg-info-400/10 text-info-400 border border-info-400/30 hover:bg-info-400/20 transition-colors">
+                            Update
+                        </button>
+                    </form>
+                    {% if request.query_params.get('error') %}
+                    <p class="text-[10px] text-red-400 mt-1">{{ request.query_params.get('error') }}</p>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -104,7 +104,7 @@
             </div>
             <div>
                 <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Capabilities</label>
-                <input type="text" name="capabilities" list="cullis-capabilities"
+                <input type="text" name="capabilities"
                        placeholder="llm.chat, mcp.tools.list"
                        class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
                 {% include "_capabilities_datalist.html" %}

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -104,10 +104,13 @@
             </div>
             <div>
                 <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Capabilities</label>
-                <input type="text" name="capabilities"
-                       placeholder="erp.read, salesforce.query, http.get"
+                <input type="text" name="capabilities" list="cullis-capabilities"
+                       placeholder="llm.chat, mcp.tools.list"
                        class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
-                <p class="text-[10px] text-gray-600 mt-1">Comma-separated capability tokens. Must match tool requirements.</p>
+                {% include "_capabilities_datalist.html" %}
+                <p class="text-[10px] text-gray-600 mt-1">
+                    Comma-separated. Standard: <code class="text-info-400">llm.chat</code>, <code class="text-info-400">mcp.tools.list</code>, <code class="text-info-400">mcp.tools.call</code>, <code class="text-info-400">http.get</code>. Custom tokens (per-tool) also accepted. See the <a href="https://cullis.io/docs/reference/capabilities" target="_blank" rel="noopener" class="text-info-400 underline">capabilities catalog</a> for what each one unlocks.
+                </p>
             </div>
             {% if has_ca is defined and has_ca %}
             <p class="text-[10px] text-gray-500 flex items-center gap-1.5">

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -206,6 +206,53 @@ document.addEventListener('click', function(ev) {
         }, 1500);
     });
 });
+
+// Append-only handler for the capability suggestion chips.
+// Each chip carries ``data-cap-add="<token>"``. Clicking it locates
+// the nearest ``<input name="capabilities">`` (same form preferred,
+// then nearest preceding input on the page as a fallback) and
+// appends the token to the comma-separated list, skipping duplicates.
+// Replaces the HTML5 ``<datalist>`` UX which clobbered the existing
+// value when the operator picked a suggestion.
+document.addEventListener('click', function(ev) {
+    var btn = ev.target.closest('[data-cap-add]');
+    if (!btn) return;
+    ev.preventDefault();
+    var token = btn.getAttribute('data-cap-add');
+    if (!token) return;
+    var form = btn.closest('form');
+    var input = form ? form.querySelector('input[name="capabilities"]') : null;
+    if (!input) {
+        // Fallback: walk back from the chip group to the nearest
+        // preceding capabilities input on the page.
+        var group = btn.closest('[data-cap-suggestions]');
+        var probe = group ? group.previousElementSibling : null;
+        while (probe) {
+            var found = probe.querySelector
+                ? probe.querySelector('input[name="capabilities"]')
+                : null;
+            if (found) { input = found; break; }
+            if (probe.tagName === 'INPUT' && probe.name === 'capabilities') {
+                input = probe; break;
+            }
+            probe = probe.previousElementSibling;
+        }
+    }
+    if (!input) return;
+    var current = input.value
+        .split(',').map(function(s) { return s.trim(); })
+        .filter(Boolean);
+    if (current.indexOf(token) === -1) {
+        current.push(token);
+        input.value = current.join(', ');
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.focus();
+    } else {
+        // Already present, just flash feedback.
+        btn.classList.add('opacity-50');
+        setTimeout(function() { btn.classList.remove('opacity-50'); }, 600);
+    }
+});
 </script>
 </body>
 </html>

--- a/mcp_proxy/dashboard/templates/enrollments.html
+++ b/mcp_proxy/dashboard/templates/enrollments.html
@@ -105,8 +105,8 @@
                                 </div>
                                 <div>
                                     <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Capabilities</label>
-                                    <input type="text" name="capabilities"
-                                           placeholder="procurement.read, erp.query"
+                                    <input type="text" name="capabilities" list="cullis-capabilities"
+                                           placeholder="llm.chat, mcp.tools.list"
                                            class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
                                 </div>
                                 <div>
@@ -116,7 +116,8 @@
                                            class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
                                 </div>
                             </div>
-                            <p class="text-[10px] text-gray-600">Comma-separated. Assigned values are authoritative &mdash; requester input is informational only.</p>
+                            <p class="text-[10px] text-gray-600">Comma-separated. Assigned values are authoritative; requester input is informational only. See the <a href="https://cullis.io/docs/reference/capabilities" target="_blank" rel="noopener" class="text-info-400 underline">capabilities catalog</a>.</p>
+                            {% include "_capabilities_datalist.html" %}
                             <div class="flex items-center gap-2 pt-1">
                                 <button type="submit"
                                         class="px-4 py-1.5 text-[11px] font-semibold rounded transition-all"

--- a/mcp_proxy/dashboard/templates/enrollments.html
+++ b/mcp_proxy/dashboard/templates/enrollments.html
@@ -105,7 +105,7 @@
                                 </div>
                                 <div>
                                     <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Capabilities</label>
-                                    <input type="text" name="capabilities" list="cullis-capabilities"
+                                    <input type="text" name="capabilities"
                                            placeholder="llm.chat, mcp.tools.list"
                                            class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
                                 </div>

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -175,7 +175,7 @@
             <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/capabilities"
                   class="flex items-center gap-2">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                <input type="text" name="capabilities" list="cullis-capabilities"
+                <input type="text" name="capabilities"
                        value="{{ user.capabilities | join(', ') }}"
                        placeholder="llm.chat, mcp.tools.list"
                        class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -158,6 +158,34 @@
             </div>
         </div>
 
+        <!-- Capabilities (v0.6.4) -->
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-1">Capabilities</h3>
+            <p class="text-[11px] text-gray-500 mb-4">
+                Capability tokens the Mastio gates on (e.g. <code class="font-mono text-info-400">llm.chat</code>, <code class="font-mono text-info-400">mcp.tools.list</code>). Empty list = zero-trust default-deny. New token takes effect on the user's next sign-in.
+            </p>
+            <div class="flex flex-wrap gap-1 mb-3">
+                {% for cap in user.capabilities %}
+                <span class="px-1.5 py-0.5 rounded text-[10px] font-mono bg-info-400/10 text-info-400">{{ cap }}</span>
+                {% endfor %}
+                {% if not user.capabilities %}
+                <span class="text-xs text-gray-600 italic">none granted</span>
+                {% endif %}
+            </div>
+            <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/capabilities"
+                  class="flex items-center gap-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="text" name="capabilities"
+                       value="{{ user.capabilities | join(', ') }}"
+                       placeholder="llm.chat, mcp.tools.list"
+                       class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">
+                <button type="submit"
+                        class="px-3 py-1.5 rounded text-xs font-medium bg-info-400/10 text-info-400 border border-info-400/30 hover:bg-info-400/20 transition-colors">
+                    Update
+                </button>
+            </form>
+        </div>
+
     </div>
 
     <!-- TAB 2: Activity -->

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -175,7 +175,7 @@
             <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/capabilities"
                   class="flex items-center gap-2">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                <input type="text" name="capabilities"
+                <input type="text" name="capabilities" list="cullis-capabilities"
                        value="{{ user.capabilities | join(', ') }}"
                        placeholder="llm.chat, mcp.tools.list"
                        class="flex-1 bg-surface-950 border border-gray-700/60 rounded px-3 py-1.5 text-xs text-white placeholder-gray-600 font-mono transition-all">
@@ -184,6 +184,10 @@
                     Update
                 </button>
             </form>
+            {% include "_capabilities_datalist.html" %}
+            <p class="text-[10px] text-gray-600 mt-2">
+                Set-replacement, not delta. See the <a href="https://cullis.io/docs/reference/capabilities" target="_blank" rel="noopener" class="text-info-400 underline">capabilities catalog</a> for what each token unlocks.
+            </p>
         </div>
 
     </div>

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -75,7 +75,7 @@
             </div>
             <div>
                 <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Capabilities</label>
-                <input type="text" name="capabilities" list="cullis-capabilities"
+                <input type="text" name="capabilities"
                        placeholder="llm.chat, mcp.tools.list"
                        class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
                 {% include "_capabilities_datalist.html" %}

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -75,10 +75,13 @@
             </div>
             <div>
                 <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Capabilities</label>
-                <input type="text" name="capabilities"
+                <input type="text" name="capabilities" list="cullis-capabilities"
                        placeholder="llm.chat, mcp.tools.list"
                        class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
-                <p class="text-[10px] text-gray-600 mt-1">Comma-separated capability tokens. Empty = zero-trust default-deny. Edit later from the user detail page.</p>
+                {% include "_capabilities_datalist.html" %}
+                <p class="text-[10px] text-gray-600 mt-1">
+                    Comma-separated. Empty = zero-trust default-deny. Edit later from the user detail page. See the <a href="https://cullis.io/docs/reference/capabilities" target="_blank" rel="noopener" class="text-info-400 underline">capabilities catalog</a>.
+                </p>
             </div>
             {% if frontdesk_enabled %}
             <div class="grid grid-cols-2 gap-4">

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -73,6 +73,13 @@
                     <p class="text-[10px] text-gray-600 mt-1">Optional label. Falls back to user name.</p>
                 </div>
             </div>
+            <div>
+                <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Capabilities</label>
+                <input type="text" name="capabilities"
+                       placeholder="llm.chat, mcp.tools.list"
+                       class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+                <p class="text-[10px] text-gray-600 mt-1">Comma-separated capability tokens. Empty = zero-trust default-deny. Edit later from the user detail page.</p>
+            </div>
             {% if frontdesk_enabled %}
             <div class="grid grid-cols-2 gap-4">
                 <div>

--- a/mcp_proxy/dashboard/users_routes.py
+++ b/mcp_proxy/dashboard/users_routes.py
@@ -202,6 +202,7 @@ async def _build_user_view() -> tuple[list[dict], bool]:
     merged: list[dict] = []
     seen_user_names: set[str] = set()
 
+    from mcp_proxy.admin._capabilities import decode_capabilities as _dec_caps
     for row in mastio_rows:
         user_name = row.get("user_name") or ""
         seen_user_names.add(user_name)
@@ -214,6 +215,7 @@ async def _build_user_view() -> tuple[list[dict], bool]:
             "surface": row.get("surface"),
             "cert_thumbprint": row.get("cert_thumbprint"),
             "pubkey_thumbprint": row.get("pubkey_thumbprint"),
+            "capabilities": _dec_caps(row.get("capabilities")),
             "created_at": row.get("created_at"),
             "last_active_at": row.get("last_active_at"),
             "in_frontdesk": user_name in fd_users,
@@ -238,6 +240,7 @@ async def _build_user_view() -> tuple[list[dict], bool]:
             "surface": "frontdesk",
             "cert_thumbprint": None,
             "pubkey_thumbprint": None,
+            "capabilities": [],
             "created_at": fd.get("created_at"),
             "last_active_at": None,
             "in_frontdesk": True,
@@ -322,9 +325,17 @@ async def users_create(request: Request):
     form = await request.form()
     user_name = (form.get("user_name") or "").strip()
     display_name = (form.get("display_name") or "").strip()
+    capabilities_raw = str(form.get("capabilities", "")).strip()
     if not user_name:
         return RedirectResponse(
             "/proxy/users?error=user_name+is+required",
+            status_code=303,
+        )
+    capabilities, cap_err = _parse_capabilities_form(capabilities_raw)
+    if cap_err is not None:
+        from urllib.parse import quote as _q
+        return RedirectResponse(
+            f"/proxy/users?error={_q(cap_err)}",
             status_code=303,
         )
 
@@ -361,20 +372,22 @@ async def users_create(request: Request):
                         f"/proxy/users?error=User+{user_name}+already+exists",
                         status_code=303,
                     )
+                import json as _json
                 await conn.execute(
                     text(
                         """
                         INSERT INTO local_user_principals
                         (principal_id, user_name, display_name, reach,
-                         surface, created_at)
+                         surface, capabilities, created_at)
                         VALUES (:pid, :uname, :dname, 'intra', 'registry',
-                                datetime('now'))
+                                :caps, datetime('now'))
                         """
                     ),
                     {
                         "pid": principal_id,
                         "uname": user_name,
                         "dname": display_name,
+                        "caps": _json.dumps(capabilities),
                     },
                 )
             await log_audit(
@@ -485,16 +498,24 @@ async def users_create(request: Request):
         org_id = await get_config("org_id") or ""
         if org_id:
             principal_id = f"{org_id}::user::{user_name}"
+            import json as _json
             async with get_db() as conn:
                 await conn.execute(
                     text(
                         """
                         INSERT OR IGNORE INTO local_user_principals
-                        (principal_id, user_name, display_name, reach, surface, created_at)
-                        VALUES (:pid, :uname, :dname, 'intra', 'frontdesk', datetime('now'))
+                        (principal_id, user_name, display_name, reach,
+                         surface, capabilities, created_at)
+                        VALUES (:pid, :uname, :dname, 'intra', 'frontdesk',
+                                :caps, datetime('now'))
                         """
                     ),
-                    {"pid": principal_id, "uname": user_name, "dname": display_name},
+                    {
+                        "pid": principal_id,
+                        "uname": user_name,
+                        "dname": display_name,
+                        "caps": _json.dumps(capabilities),
+                    },
                 )
     except Exception as exc:  # noqa: BLE001, pre-seed is best-effort
         _log.warning("users_create: mastio pre-seed failed: %s", exc)
@@ -599,6 +620,86 @@ async def user_detail_page(principal_id: str, request: Request):
         new_api_token_label=new_api_token_label,
         api_token_error=api_token_error,
     ))
+
+
+_CAPABILITY_RE = __import__("re").compile(r"^[a-z_][a-z0-9_.]{0,63}$")
+_MAX_CAP_ITEMS = 64
+
+
+def _parse_capabilities_form(raw: str) -> tuple[list[str], str | None]:
+    items = [c.strip() for c in raw.split(",") if c.strip()]
+    if len(items) > _MAX_CAP_ITEMS:
+        return [], f"too many capabilities (max {_MAX_CAP_ITEMS})"
+    for c in items:
+        if not _CAPABILITY_RE.match(c):
+            return (
+                [],
+                f"invalid capability {c!r}: must match [a-z_][a-z0-9_.]{{0,63}}",
+            )
+    return items, None
+
+
+@router.post("/users/{principal_id:path}/capabilities")
+async def users_set_capabilities(principal_id: str, request: Request):
+    """Replace the user principal's capability set from the dashboard.
+
+    Symmetric to ``POST /proxy/agents/{id}/capabilities``. Writes to
+    ``local_user_principals.capabilities`` (added in migration 0045).
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=csrf",
+            status_code=303,
+        )
+
+    form = await request.form()
+    capabilities_raw = str(form.get("capabilities", "")).strip()
+    capabilities, err = _parse_capabilities_form(capabilities_raw)
+    if err is not None:
+        from urllib.parse import quote
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error={quote(err)}",
+            status_code=303,
+        )
+
+    from mcp_proxy.db import get_db, log_audit
+    from sqlalchemy import text as _text
+    import json as _json
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            _text(
+                "SELECT 1 FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )).first()
+        if row is None:
+            return RedirectResponse(
+                f"/proxy/users?error=user+not+found",
+                status_code=303,
+            )
+        await conn.execute(
+            _text(
+                "UPDATE local_user_principals "
+                "   SET capabilities = :caps "
+                " WHERE principal_id = :pid"
+            ),
+            {"caps": _json.dumps(capabilities), "pid": principal_id},
+        )
+
+    await log_audit(
+        agent_id=principal_id,
+        action="user.capabilities_set",
+        status="success",
+        detail=f"source=dashboard capabilities={capabilities}",
+    )
+
+    return RedirectResponse(
+        f"/proxy/users/{principal_id}", status_code=303,
+    )
 
 
 @router.post("/users/{principal_id:path}/reset-password")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -873,7 +873,7 @@ async def list_user_principals() -> list[dict]:
             text(
                 "SELECT principal_id, user_name, display_name, reach, "
                 "       surface, cert_thumbprint, pubkey_thumbprint, "
-                "       created_at, last_active_at "
+                "       capabilities, created_at, last_active_at "
                 "  FROM local_user_principals "
                 " ORDER BY created_at DESC"
             )

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -923,6 +923,54 @@ async def get_user_principal_pubkey_thumbprint(
         return (True, row["pubkey_thumbprint"])
 
 
+async def get_principal_capabilities(
+    principal_id: str, principal_type: str,
+) -> list[str]:
+    """Return the capability list for a typed principal.
+
+    Used by ``mcp_proxy.auth.local_agent_dep`` when minting the
+    ``TokenPayload.scope`` for the user / workload short-circuit (#23
+    follow-up — v0.6.4). Returns an empty list when:
+
+      * principal_type is not ``"user"`` or ``"workload"`` (callers
+        for agents should read ``internal_agents.capabilities`` via
+        :func:`get_agent` instead);
+      * the principal row does not exist;
+      * the stored value is malformed JSON.
+
+    The empty-list contract is the zero-trust default: a user /
+    workload with no row, or a row pre-migration-0045, denies on
+    every capability gate. Operators grant capabilities explicitly
+    via ``POST /v1/admin/users`` / ``POST /v1/admin/workloads``.
+    """
+    if principal_type == "user":
+        table = "local_user_principals"
+    elif principal_type == "workload":
+        table = "local_workload_principals"
+    else:
+        return []
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(f"SELECT capabilities FROM {table} WHERE principal_id = :pid"),  # noqa: S608 — table whitelisted above
+            {"pid": principal_id},
+        )
+        row = result.mappings().first()
+    if row is None:
+        return []
+    raw = row["capabilities"]
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [c for c in raw if isinstance(c, str)]
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(loaded, list):
+        return []
+    return [c for c in loaded if isinstance(c, str)]
+
+
 async def get_workload_principal_pubkey_thumbprint(
     principal_id: str,
 ) -> tuple[bool, str | None]:

--- a/mcp_proxy/egress/anthropic_messages_router.py
+++ b/mcp_proxy/egress/anthropic_messages_router.py
@@ -295,7 +295,10 @@ async def anthropic_messages(
     if agent.scope_providers:
         try:
             req_provider = parse_provider_from_model(req.model)
-        except Exception:  # noqa: BLE001 — parse failure → deny
+        except Exception as exc:  # noqa: BLE001 — parse failure → deny
+            _log.warning(
+                "parse_provider_from_model failed for %r: %s", req.model, exc,
+            )
             req_provider = None
         if req_provider is None or req_provider not in agent.scope_providers:
             await log_audit(

--- a/mcp_proxy/egress/anthropic_messages_router.py
+++ b/mcp_proxy/egress/anthropic_messages_router.py
@@ -37,6 +37,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from mcp_proxy.auth.builtin_capabilities import LLM_CHAT
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
@@ -265,7 +266,7 @@ async def anthropic_messages(
     # gate nor scope_providers was actually applied here. Any agent
     # could egress via the Anthropic shape regardless of its
     # capabilities. Fixed alongside #22 (audit 2026-05-28 BLOCKER B1).
-    if "llm.chat" not in (agent.capabilities or []):
+    if LLM_CHAT not in (agent.capabilities or []):
         await log_audit(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
@@ -278,7 +279,7 @@ async def anthropic_messages(
                 "model": req.model,
                 "trace_id": trace_id,
                 "reason": "capability_missing",
-                "required_capability": "llm.chat",
+                "required_capability": LLM_CHAT,
             },
         )
         raise HTTPException(
@@ -286,7 +287,7 @@ async def anthropic_messages(
             detail={
                 "reason": "capability_missing",
                 "trace_id": trace_id,
-                "required_capability": "llm.chat",
+                "required_capability": LLM_CHAT,
             },
         )
 

--- a/mcp_proxy/egress/anthropic_messages_router.py
+++ b/mcp_proxy/egress/anthropic_messages_router.py
@@ -41,6 +41,7 @@ from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
 from mcp_proxy.egress.ai_gateway import GatewayError, dispatch
+from mcp_proxy.egress.provider_catalog import parse_provider_from_model
 from mcp_proxy.egress.schemas import (
     ChatCompletionRequest,
     ChatMessage,
@@ -257,6 +258,71 @@ async def anthropic_messages(
     """
     settings = get_settings()
     trace_id = f"trace_{uuid.uuid4().hex[:16]}"
+
+    # Capability gate (#22) — symmetric to ``/v1/chat/completions``.
+    # The docstring above promises "Same security gates as
+    # ``/v1/chat/completions``" but pre-v0.6.4 neither the capability
+    # gate nor scope_providers was actually applied here. Any agent
+    # could egress via the Anthropic shape regardless of its
+    # capabilities. Fixed alongside #22 (audit 2026-05-28 BLOCKER B1).
+    if "llm.chat" not in (agent.capabilities or []):
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="denied",
+            details={
+                "event": "llm.chat_completion",
+                "surface": "anthropic_messages",
+                "principal_id": agent.agent_id,
+                "principal_type": agent.principal_type,
+                "model": req.model,
+                "trace_id": trace_id,
+                "reason": "capability_missing",
+                "required_capability": "llm.chat",
+            },
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "reason": "capability_missing",
+                "trace_id": trace_id,
+                "required_capability": "llm.chat",
+            },
+        )
+
+    # scope_providers gate — also previously documented but not
+    # enforced on this router. Mirrors the llm_chat_router behaviour.
+    if agent.scope_providers:
+        try:
+            req_provider = parse_provider_from_model(req.model)
+        except Exception:  # noqa: BLE001 — parse failure → deny
+            req_provider = None
+        if req_provider is None or req_provider not in agent.scope_providers:
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_llm_chat",
+                status="denied",
+                details={
+                    "event": "llm.chat_completion",
+                    "surface": "anthropic_messages",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "reason": "token_scope_provider_mismatch",
+                    "requested_provider": req_provider,
+                    "scope_providers": agent.scope_providers,
+                },
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "reason": "token_scope_provider_mismatch",
+                    "trace_id": trace_id,
+                    "requested_provider": req_provider,
+                    "allowed_providers": agent.scope_providers,
+                },
+            )
 
     if req.stream:
         raise HTTPException(

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -28,6 +28,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from mcp_proxy.auth.builtin_capabilities import LLM_CHAT
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.auth.rate_limit import get_token_sum_limiter
 from mcp_proxy.config import get_settings
@@ -72,7 +73,7 @@ async def chat_completions(
     # passed. From v0.6.4 the capability is the first gate after
     # auth: the agent envelope MUST carry ``llm.chat`` or the request
     # is denied before any provider dispatch.
-    if "llm.chat" not in (agent.capabilities or []):
+    if LLM_CHAT not in (agent.capabilities or []):
         await log_audit(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
@@ -84,7 +85,7 @@ async def chat_completions(
                 "model": req.model,
                 "trace_id": trace_id,
                 "reason": "capability_missing",
-                "required_capability": "llm.chat",
+                "required_capability": LLM_CHAT,
             },
         )
         raise HTTPException(
@@ -92,7 +93,7 @@ async def chat_completions(
             detail={
                 "reason": "capability_missing",
                 "trace_id": trace_id,
-                "required_capability": "llm.chat",
+                "required_capability": LLM_CHAT,
             },
         )
 

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -65,6 +65,37 @@ async def chat_completions(
     settings = get_settings()
     trace_id = f"trace_{uuid.uuid4().hex[:16]}"
 
+    # Capability gate (#22) — fail-closed on missing ``llm.chat``.
+    # Phase 1 left this check decorative on the chat path; an agent
+    # enrolled without ``llm.chat`` in its capabilities could still
+    # reach the LLM provider as long as it was bound and DPoP+mTLS
+    # passed. From v0.6.4 the capability is the first gate after
+    # auth: the agent envelope MUST carry ``llm.chat`` or the request
+    # is denied before any provider dispatch.
+    if "llm.chat" not in (agent.capabilities or []):
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="denied",
+            details={
+                "event": "llm.chat_completion",
+                "principal_id": agent.agent_id,
+                "principal_type": agent.principal_type,
+                "model": req.model,
+                "trace_id": trace_id,
+                "reason": "capability_missing",
+                "required_capability": "llm.chat",
+            },
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "reason": "capability_missing",
+                "trace_id": trace_id,
+                "required_capability": "llm.chat",
+            },
+        )
+
     # Wave A PR3 (audit 2026-05-11 Tema A) — enforce ``scope_providers``
     # on culk_-authed callers. Pre-fix this field was stored at mint
     # time and never read; a token "anthropic only" worked on every

--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -60,6 +60,7 @@ ERR_RESOURCE_UNREACHABLE = -32001
 ERR_RESOURCE_AUTH_FAILED = -32002
 ERR_RESOURCE_ERROR = -32003
 ERR_TOOL_NOT_FOUND = -32004
+ERR_CAPABILITY_MISSING = -32005
 
 
 def _rpc_error(req_id: Any, code: int, message: str, data: Any = None) -> dict:
@@ -95,16 +96,43 @@ async def _handle_initialize(req_id: Any) -> dict:
 
 
 async def _handle_tools_list(req_id: Any, agent: TokenPayload) -> dict:
+    agent_caps = set(agent.scope or [])
+
+    # Capability gate (#23) — fail-loud on missing ``mcp.tools.list``.
+    # Phase 1 left tools/list ungated at the method level; an agent
+    # without the discovery capability could still enumerate every
+    # tool it was bound to. From v0.6.4 the JSON-RPC method itself
+    # requires the capability, symmetric to ``llm.chat`` on the chat
+    # endpoint. Per-tool binding + ``required_capability`` filters
+    # still apply downstream.
+    if "mcp.tools.list" not in agent_caps:
+        await append_local_audit(
+            event_type="mcp_tools_list",
+            result="denied",
+            agent_id=agent.agent_id,
+            org_id=agent.org,
+            details={
+                "principal_id": agent.agent_id,
+                "principal_type": agent.principal_type,
+                "reason": "capability_missing",
+                "required_capability": "mcp.tools.list",
+            },
+        )
+        return _rpc_error(
+            req_id, ERR_CAPABILITY_MISSING,
+            "capability_missing: mcp.tools.list",
+            data={"required_capability": "mcp.tools.list"},
+        )
+
     bound = await _bound_resource_ids(
         agent.agent_id, agent.principal_type,
     )
-    agent_caps = set(agent.scope or [])
 
     tools_out: list[dict] = []
     for td in tool_registry.list_tools():
         if td.is_mcp_resource:
-            # MCP resource: binding is the only gate (capability stays
-            # informational in Phase 1; binding is the auth decision).
+            # MCP resource: binding remains the per-tool gate after
+            # the method-level capability check above.
             if td.resource_id not in bound:
                 continue
         else:

--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -31,6 +31,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
+from mcp_proxy.auth.builtin_capabilities import MCP_TOOLS_LIST
 from mcp_proxy.auth.dependencies import get_authenticated_agent
 from mcp_proxy.local.audit import append_local_audit
 from mcp_proxy.models import (
@@ -105,7 +106,7 @@ async def _handle_tools_list(req_id: Any, agent: TokenPayload) -> dict:
     # requires the capability, symmetric to ``llm.chat`` on the chat
     # endpoint. Per-tool binding + ``required_capability`` filters
     # still apply downstream.
-    if "mcp.tools.list" not in agent_caps:
+    if MCP_TOOLS_LIST not in agent_caps:
         await append_local_audit(
             event_type="mcp_tools_list",
             result="denied",
@@ -115,13 +116,13 @@ async def _handle_tools_list(req_id: Any, agent: TokenPayload) -> dict:
                 "principal_id": agent.agent_id,
                 "principal_type": agent.principal_type,
                 "reason": "capability_missing",
-                "required_capability": "mcp.tools.list",
+                "required_capability": MCP_TOOLS_LIST,
             },
         )
         return _rpc_error(
             req_id, ERR_CAPABILITY_MISSING,
-            "capability_missing: mcp.tools.list",
-            data={"required_capability": "mcp.tools.list"},
+            f"capability_missing: {MCP_TOOLS_LIST}",
+            data={"required_capability": MCP_TOOLS_LIST},
         )
 
     bound = await _bound_resource_ids(

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -75,7 +75,7 @@ server {
     # earlier shipped regex missed it and the catch-all below would
     # strip the client cert, surfacing as ``client_cert_not_verified``
     # at the Mastio. Sister-file: add new mTLS routes here, not below.
-    location ~ ^/v1/(egress|agents|audit|llm|chat|guardian)(/.*)?$ {
+    location ~ ^/v1/(egress|agents|audit|llm|chat|guardian|messages)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }

--- a/site/src/content/docs/reference/capabilities.md
+++ b/site/src/content/docs/reference/capabilities.md
@@ -1,0 +1,157 @@
+---
+title: "Capabilities catalog"
+description: "What every capability token does, which endpoint it gates, and how to grant or revoke it."
+category: "Reference"
+order: 40
+updated: "2026-05-28"
+---
+
+# Capabilities catalog
+
+**Who this is for**: an operator deciding which capabilities to grant to an agent, a user, or a workload — and the dev curious to know what `mcp.tools.list` actually unlocks before they paste it into the dashboard.
+
+A **capability** is a short lowercase token (e.g. `llm.chat`, `mcp.tools.list`) attached to a principal. The Mastio checks it as the first gate after DPoP+mTLS authentication, before any provider dispatch or tool execution. Missing capability is fail-closed: HTTP `403` on the LLM path, JSON-RPC `-32005` on the MCP path, and a `denied` row on the audit chain.
+
+The principal carries its capability set in one of three places, depending on its type:
+
+| Principal type | Stored in | Granted via |
+|---|---|---|
+| Agent (`<org>::<name>`) | `internal_agents.capabilities` (JSON array) | `POST /v1/admin/agents` at enrollment; `PATCH /v1/admin/agents/{id}/capabilities` to edit; dashboard *Agent detail → Capabilities* form |
+| User (`<org>::user::<name>`) | `local_user_principals.capabilities` | `POST /v1/admin/users`; `PATCH /v1/admin/users/{principal_id}/capabilities`; dashboard *User detail → Capabilities* card |
+| Workload (`<org>::workload::<name>`) | `local_workload_principals.capabilities` | `POST /v1/admin/workloads`; `PATCH /v1/admin/workloads/{principal_id}/capabilities` (admin API only in v0.6.4 — dashboard tab planned for v0.7) |
+
+Capability tokens follow the shape `^[a-z_][a-z0-9_.]{0,63}$` (max 64 chars, max 64 entries per principal) — validation is enforced server-side at both the admin API and the dashboard form, so a typo at create time is a 422 not a silent breakage at the gate.
+
+Zero-trust default: a newly enrolled principal with an empty `capabilities` list is denied on every gated endpoint. The admin must grant capabilities explicitly. There is no "default-allow" fallback path.
+
+## Built-in (shipped with the Mastio)
+
+These four are recognised by the Mastio out of the box. They appear in the dashboard datalist as autocomplete suggestions.
+
+### `llm.chat`
+
+**What**: permits the principal to issue chat completions through the Mastio's AI gateway.
+
+**Endpoints gated**:
+
+- `POST /v1/chat/completions` (OpenAI shape)
+- `POST /v1/llm/chat` (same handler, legacy alias)
+- `POST /v1/messages` (Anthropic shape)
+
+**Without it**: HTTP `403` with `{"reason": "capability_missing", "required_capability": "llm.chat"}` and a denied audit row (`action=egress_llm_chat status=denied`). Streaming path hits the same gate.
+
+**Typical grant**: every agent that talks to an LLM. Workloads usually don't have it (they're infra, not chat clients). Users get it if you let them use the Mastio as a chat backend (LibreChat, Cherry Studio, Cursor).
+
+### `mcp.tools.list`
+
+**What**: permits the principal to enumerate the MCP tools the Mastio aggregates (built-in + registered MCP resources visible to the principal via bindings).
+
+**Endpoint gated**:
+
+- `POST /v1/mcp` with JSON-RPC method `tools/list`
+
+**Without it**: JSON-RPC error `-32005` `"capability_missing: mcp.tools.list"`, with `data.required_capability="mcp.tools.list"`, and a denied local-audit row (`event_type=mcp_tools_list result=denied`).
+
+**Typical grant**: every agent or user that needs discovery before invoking a tool. Not granting it does NOT hide a tool the principal is already bound to — it just refuses the listing method. Per-tool execution remains gated by binding + per-tool `required_capability` regardless.
+
+### `mcp.tools.call`
+
+**What**: permits invocation of MCP tools via JSON-RPC.
+
+**Endpoint gated**:
+
+- `POST /v1/mcp` with JSON-RPC method `tools/call`
+
+**Notes**: in Phase 1 (v0.6.x) the per-tool `required_capability` (declared by the MCP resource at registration) is the load-bearing check on this method, and `mcp.tools.call` is treated as informational unless a tool registers it as its `required_capability`. The method-level gate lands in v0.7 once the dashboard exposes per-tool capability assignment. Granting it today is forward-compatible — no behaviour change in v0.6.x, automatic enforcement in v0.7.
+
+### `http.get`
+
+**What**: permits the principal to use the Mastio's generic HTTP-GET egress for ad-hoc resource fetches.
+
+**Endpoint gated**: `POST /v1/mcp` `tools/call` for the built-in `http.get` tool.
+
+**Notes**: enforced today via the built-in tool's `required_capability`. Useful for sandbox agents that need to read public docs through the Mastio's egress trail (so the call is audited like every other action).
+
+## Custom (registered by MCP tools)
+
+When an MCP resource is registered via `POST /v1/admin/mcp-resources` with a `required_capability` field, that capability becomes a recognised token on this Mastio. The Mastio does NOT mint these centrally — they are defined by the tool author. Examples from the reference integrations:
+
+- `erp.read` — read-only access to an ERP-backed MCP resource
+- `salesforce.query` — Salesforce read via the published Salesforce MCP tool
+- `kyc.screen` — KYC screening tool (Cullis demo, `cullis-mcp-kyc`)
+- `pitchbook.search` — pitch-book search tool (Cullis demo, `cullis-mcp-pitchbook`)
+
+These do not appear in the dashboard datalist by default — they appear once the tool is registered on this Mastio, because the Mastio reads the registry at boot and adds them to the autocomplete list.
+
+## Operator-defined
+
+You can grant a principal an arbitrary token that no built-in path or registered tool requires today. The Mastio stores it verbatim and surfaces it in audit rows but does not enforce anything else. This is intentional: operator-defined capabilities are a forward-compatibility hook for Rego policies that gate on the presence/absence of a string (e.g. `if "compliance.signed_off" in agent.capabilities`).
+
+In v0.7 the dashboard will expose a *Capabilities → Manage vocabulary* page that lets the admin define operator-specific capabilities, attach descriptions, and link them to Rego rules. Today the workflow is: pick a name following the same shape constraint, grant it to a principal, write your Rego rule that consumes it.
+
+## Granting and rotating
+
+### Via the dashboard
+
+Agent: */proxy/agents → click the agent row → Capabilities section* on the detail page → textbox lists current tokens (precompiled, comma-separated), Update button replaces the set. The autocomplete datalist suggests the four built-ins as you type.
+
+User: */proxy/users → click the user row → Capabilities card* (under Authentication on the Overview tab) → same form shape.
+
+Workload: admin API only in v0.6.4 (`PATCH /v1/admin/workloads/{id}/capabilities`). Dashboard *Workloads* tab planned for v0.7.
+
+### Via the admin API
+
+```bash
+# Grant a fresh set (replace, not delta)
+curl -k -X PATCH https://mastio.example/v1/admin/agents/acme::alice/capabilities \
+  -H "X-Admin-Secret: $MCP_PROXY_ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"capabilities": ["llm.chat", "mcp.tools.list", "erp.read"]}'
+```
+
+The endpoint is **idempotent set-replacement, not delta apply**. Pass the full list each call. The Mastio bumps `federation_revision` for federated agents so the Phase 3 publisher will propagate the change on its next pass.
+
+Same shape for users (`/v1/admin/users/{principal_id}/capabilities`) and workloads (`/v1/admin/workloads/{principal_id}/capabilities`).
+
+### Audit
+
+Every grant emits one row on the Mastio audit chain. Search by action:
+
+- `agent.capabilities_set` / `agent.capabilities_patched` (dashboard / admin API)
+- `user.capabilities_set` / `user.capabilities_patched`
+- `workload.capabilities_patched`
+
+The detail payload carries the full new list verbatim — replay-friendly. Append-only triggers prevent retro-editing the row.
+
+## Removing a capability
+
+There is no "remove this one token" endpoint. The semantics are: read the current list, drop the entries you want gone, PATCH the rest.
+
+```bash
+# Read
+curl -k https://mastio.example/v1/admin/agents \
+  -H "X-Admin-Secret: $MCP_PROXY_ADMIN_SECRET" | \
+  jq '.[] | select(.agent_id == "acme::alice") | .capabilities'
+# → ["llm.chat", "mcp.tools.list", "erp.read"]
+
+# Drop erp.read
+curl -k -X PATCH https://mastio.example/v1/admin/agents/acme::alice/capabilities \
+  -H "X-Admin-Secret: $MCP_PROXY_ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"capabilities": ["llm.chat", "mcp.tools.list"]}'
+```
+
+The denied audit row at the next attempt confirms the revoke landed.
+
+## Limits
+
+- Max 64 capability tokens per principal (Pydantic constraint, enforced at the admin API and dashboard form).
+- Max 64 characters per token.
+- Shape `^[a-z_][a-z0-9_.]{0,63}$` — lowercase identifier with optional dotted segments.
+- The list field is stored as a JSON string (`TEXT`) on SQLite + Postgres; no indexed search on capability membership in v0.6.x. If you need "list every agent with `erp.read`", pull the full table and filter in the operator script. A reverse index is on the v0.7 backlog if customer usage demands it.
+
+## Migration notes
+
+Pre-v0.6.4 typed principals (users + workloads) had no `capabilities` column. Migration `0045_principal_capabilities` adds the column on both tables with `server_default '[]'`. Existing rows are backfilled to zero-trust default-deny — the admin grants explicitly. There is no automated "open it up to keep things working" path. This is the breaking change called out in the v0.6.4 CHANGELOG.
+
+For agents enrolled with empty `capabilities` before v0.6.4, the same applies: they will start receiving `403`/`-32005` on the gated endpoints. Either re-enroll with the right set, or `PATCH .../capabilities` directly. The audit row at the first denied call is the operational signal.

--- a/test/smoke/lib/_agent.sh
+++ b/test/smoke/lib/_agent.sh
@@ -22,15 +22,20 @@ fi
 # Enroll an agent via POST /v1/admin/agents. Args:
 #   $1  agent_name (e.g. "alice")
 #   $2  display_name (optional, defaults to agent_name)
+#   $3  capabilities JSON array (optional, defaults to the standard
+#       smoke set: ["llm.chat","mcp.tools.list"]). Pass "[]" for the
+#       negative scenarios that exercise the capability gate.
 #
 # Side effects: writes state/agents/<name>/cert.pem +
 # state/agents/<name>/key.pem with the minted material. Echoes the
 # fully-qualified agent_id (<org>::<name>) on stdout.
 agent_enroll() {
     local name="$1" display="${2:-$1}"
+    local capabilities="${3:-[\"llm.chat\",\"mcp.tools.list\"]}"
     local body resp agent_dir agent_id
 
-    body=$(printf '{"agent_name":"%s","display_name":"%s","capabilities":[]}' "$name" "$display")
+    body=$(printf '{"agent_name":"%s","display_name":"%s","capabilities":%s}' \
+        "$name" "$display" "$capabilities")
     resp="$(curl_admin POST "/v1/admin/agents" "$body")" \
         || die "agent enrollment failed (HTTP $(smoke_status)): $resp"
 

--- a/test/smoke/scenarios/20_enroll_agent.sh
+++ b/test/smoke/scenarios/20_enroll_agent.sh
@@ -40,6 +40,26 @@ for name in alice bob; do
 done
 log_pass "alice + bob enrolled, cert+key on disk"
 
+# ── Verify capabilities round-trip (#22 / #23 gate inputs) ──────────────────
+# agent_enroll defaults to ["llm.chat","mcp.tools.list"]; the GET back
+# must echo the same set or downstream chat + tools/list scenarios will
+# fail capability_missing at runtime.
+resp="$(curl_admin GET "/v1/admin/agents" '')"
+alice_block="$(printf '%s' "$resp" | python3 -c "
+import sys, json
+rows = json.loads(sys.stdin.read())
+for r in rows:
+    if r['agent_id'] == '$alice_id':
+        print(json.dumps(r['capabilities']))
+        break
+" 2>/dev/null)"
+[[ -n "$alice_block" ]] || die "alice_id $alice_id not in /v1/admin/agents listing: $resp"
+echo "$alice_block" | grep -q 'llm.chat' \
+    || die "alice missing llm.chat: $alice_block"
+echo "$alice_block" | grep -q 'mcp.tools.list' \
+    || die "alice missing mcp.tools.list: $alice_block"
+log_pass "alice capabilities persisted: $alice_block"
+
 # ── Negative: duplicate enrollment returns 409 ──────────────────────────────
 body='{"agent_name":"alice","display_name":"dup","capabilities":[]}'
 resp="$(curl_admin_raw POST '/v1/admin/agents' "$body")"

--- a/test/smoke/scenarios/41_chat_capability_denied.sh
+++ b/test/smoke/scenarios/41_chat_capability_denied.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 41_chat_capability_denied — negative gate for #22 (Mastio v0.6.4)
+# =============================================================================
+#
+# Enrolls a third agent with an empty capabilities list, runs the same
+# OpenAI-compatible chat completion alice does in 40, and asserts the
+# Mastio fails closed at the capability gate before reaching the AI
+# gateway:
+#
+#   * HTTP 403 with detail.reason == "capability_missing"
+#   * detail.required_capability == "llm.chat"
+#   * No mock-gateway call (we know because the stub would have echoed
+#     "smoke-mock-ok"; we never see that string)
+#
+# This is the defense-in-depth signal the HN narrative leans on: the
+# capability isn't decorative, it's the first gate after DPoP+mTLS auth.
+# =============================================================================
+set -euo pipefail
+
+SCENARIO_TAG="41_chat_capability_denied"
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# shellcheck source=../lib/_agent.sh
+source "$SMOKE_LIB_DIR/_agent.sh"
+
+# ── Enroll cap-less agent ───────────────────────────────────────────────────
+nocap_id="$(agent_enroll nocap "No-Capability (smoke #41)" '[]')"
+cert="$(agent_cert_path nocap)"
+key="$(agent_key_path nocap)"
+[[ -s "$cert" && -s "$key" ]] || die "nocap cert/key missing"
+log_pass "enrolled $nocap_id with capabilities=[]"
+
+base="$(smoke_mastio_url)"
+body='{"model":"anthropic/claude-haiku-4-5","messages":[{"role":"user","content":"should be denied"}]}'
+
+resp_file="$(mktemp)"
+trap 'rm -f "$resp_file"' EXIT
+
+status="$(curl -sk \
+    --cert "$cert" --key "$key" \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$body" \
+    -o "$resp_file" -w '%{http_code}' \
+    "$base/v1/chat/completions" || echo 000)"
+
+resp="$(cat "$resp_file")"
+
+case "$status" in
+    403)
+        echo "$resp" | grep -q 'capability_missing' \
+            || die "expected reason=capability_missing, got: $resp"
+        echo "$resp" | grep -q 'llm.chat' \
+            || die "expected required_capability=llm.chat, got: $resp"
+        log_pass "cap-less agent denied at capability gate (HTTP 403, llm.chat)"
+        ;;
+    200)
+        die "FAIL CLOSED VIOLATION — cap-less agent reached the gateway: $resp"
+        ;;
+    *)
+        die "unexpected HTTP $status from cap-less chat call: $resp"
+        ;;
+esac
+
+# ── Streaming branch must hit the same gate ─────────────────────────────────
+stream_body='{"model":"anthropic/claude-haiku-4-5","stream":true,"messages":[{"role":"user","content":"stream-deny"}]}'
+status="$(curl -sk \
+    --cert "$cert" --key "$key" \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$stream_body" \
+    -o "$resp_file" -w '%{http_code}' \
+    "$base/v1/chat/completions" || echo 000)"
+case "$status" in
+    403) log_pass "cap-less agent denied on streaming path too (HTTP 403)" ;;
+    *)   die "streaming chat returned HTTP $status (expected 403): $(cat "$resp_file")" ;;
+esac

--- a/test/smoke/scenarios/42_anthropic_capability_denied.sh
+++ b/test/smoke/scenarios/42_anthropic_capability_denied.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 42_anthropic_capability_denied — negative gate for #22 / B1 (v0.6.4)
+# =============================================================================
+#
+# Mirror of 41_chat_capability_denied for the Anthropic Messages API
+# surface (POST /v1/messages). Pre-v0.6.4 the docstring claimed "Same
+# security gates as /v1/chat/completions" but neither the capability
+# gate nor scope_providers was actually applied; an agent without
+# llm.chat could egress via the Anthropic shape unimpeded.
+#
+# Asserts:
+#   * cap-less agent receives HTTP 403 with reason=capability_missing
+#     and required_capability=llm.chat on POST /v1/messages.
+#   * No body content from the upstream stub (which would echo
+#     "smoke-mock-ok") — proves dispatch never ran.
+#
+# Reuses the ``nocap`` agent created by 41 to avoid re-enrolling.
+# =============================================================================
+set -euo pipefail
+
+SCENARIO_TAG="42_anthropic_capability_denied"
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# shellcheck source=../lib/_agent.sh
+source "$SMOKE_LIB_DIR/_agent.sh"
+
+cert="$(agent_cert_path nocap)"
+key="$(agent_key_path nocap)"
+[[ -s "$cert" && -s "$key" ]] \
+    || die "nocap cert/key missing — scenario 41 must run before 42"
+
+base="$(smoke_mastio_url)"
+body='{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"should be denied"}],"max_tokens":16}'
+
+resp_file="$(mktemp)"
+trap 'rm -f "$resp_file"' EXIT
+
+status="$(curl -sk \
+    --cert "$cert" --key "$key" \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d "$body" \
+    -o "$resp_file" -w '%{http_code}' \
+    "$base/v1/messages" || echo 000)"
+
+resp="$(cat "$resp_file")"
+
+case "$status" in
+    403)
+        echo "$resp" | grep -q 'capability_missing' \
+            || die "expected reason=capability_missing on /v1/messages: $resp"
+        echo "$resp" | grep -q 'llm.chat' \
+            || die "expected required_capability=llm.chat: $resp"
+        log_pass "cap-less agent denied at /v1/messages (HTTP 403, llm.chat)"
+        ;;
+    200)
+        die "FAIL CLOSED VIOLATION — cap-less agent reached anthropic dispatch: $resp"
+        ;;
+    *)
+        die "unexpected HTTP $status from /v1/messages: $resp"
+        ;;
+esac


### PR DESCRIPTION
## Summary

Capability enforcement story end-to-end, from gate to admin UX to operator docs.

**#22** — `/v1/chat/completions`, `/v1/llm/chat`, and `/v1/messages` (Anthropic shape) all require `llm.chat`. Missing → 403 `capability_missing` + audit denied. Stream branch hits the same gate.

**#23** — `POST /v1/mcp tools/list` requires `mcp.tools.list`. Missing → JSON-RPC error `-32005` + local audit denied.

**#21** — Edit capabilities post-enrollment. New `PATCH /v1/admin/{agents,users,workloads}/{id}/capabilities` admin endpoints + dashboard forms on agent_detail, user_detail, plus capability input on user create.

**Security review (2-pass cloud)** — closed B1 (Anthropic shape bypassed gates), M1 (typed principals broke on tools/list — added migration 0045 with `capabilities` column on `local_user_principals` + `local_workload_principals`, db helper, dashboard handler wiring), MAJOR (Pydantic shape validation), MINOR (dedup decode helper, top-level import, log triage).

**Discoverability** — `site/src/content/docs/reference/capabilities.md` catalog page (built-in + custom + operator-defined, forward-compatible shape), dashboard capability suggestion chips on all 5 forms with append-only JS handler (HTML5 datalist was clobbering the comma-separated value on selection).

**Refactor** — built-in tokens (`llm.chat`, `mcp.tools.list`, `mcp.tools.call`, `http.get`) now live in `mcp_proxy/auth/builtin_capabilities.py` as a single source of truth. Routers import constants; dashboard template iterates `builtin_capabilities` injected via `_ctx`. Adding a fifth built-in is a 1-file PR.

## Test plan

- [x] `pytest tests/test_capability_enforcement.py` — 13/13
- [x] `pytest tests/test_capability_patch_endpoints.py` — 9/9
- [x] `pytest -n auto --dist=loadfile` full suite — 113/113
- [x] `./test/smoke/smoke.sh` — 13/13 (added scenarios 41 + 42 for negative gates)
- [x] Bundle dogfood locale (`packaging/mastio-bundle/deploy.sh` with `0.6.4-dev` image) — migration 0045 applied at boot, gate enforcement live (chat 403, anthropic 403, mcp -32005), PATCH cap live (agents + users + workloads), dashboard chip-pill UX works, capabilities catalog page renders, link wired.
- [x] DCO Signed-off-by on all 6 commits, no `Co-Authored-By`.

## Breaking change

Principals (agents, users, workloads) created before v0.6.4 with empty `capabilities` will start receiving `403 capability_missing` on chat endpoints and `-32005 capability_missing` on `tools/list`. Migration 0045 adds the column to typed principals with `server_default '[]'` — zero-trust default, no auto-backfill.

Op grants explicitly via:

- Agents: `POST /v1/admin/agents` with `"capabilities": ["llm.chat", "mcp.tools.list"]`
- Users: `POST /v1/admin/users` with `"capabilities": [...]`
- Workloads: `POST /v1/admin/workloads` with `"capabilities": [...]`
- Edit any of the above: `PATCH /v1/admin/{type}/{id}/capabilities` (idempotent set-replacement)
- Direct DB: `UPDATE internal_agents SET capabilities = '["llm.chat","mcp.tools.list"]'`
- Dashboard: agent detail page → Capabilities form (Update); user detail page → Capabilities card → Update

## Commits

1. `c198a8b6` fix(security): enforce llm.chat + mcp.tools.list capability gates (#22, #23)
2. `89c7052c` fix(security): close B1 + M1 from review — /v1/messages gate + typed principal capability storage
3. `3ab35f90` chore(security): close review MAJOR + MINOR — capability shape validation, dedup helper
4. `7d157474` feat(admin): edit capabilities post-enrollment (#21) — PATCH endpoints + dashboard forms
5. `a9e47830` docs(capabilities): catalog + dashboard autocomplete + help links
6. `fbeddd3a` refactor(capabilities): centralise built-in tokens + chip-pill UX + JS append handler

## Out of scope (post-HN)

- Smoke harness extension for `/v1/auth/token` + `/v1/mcp tools/list` end-to-end (needs DPoP+JWT helper)
- Catalog page autogenerated from `builtin_capabilities.BUILTIN_CAPABILITIES` (v0.7)
- Capability registry table (custom + operator-defined vocabularies surfaced in dashboard, v0.7)
- Dashboard workloads tab (admin API only today; v0.7)