### PR TITLE
fix(observability): keep app loggers alive across in-process alembic upgrade

### DIFF
--- a/mcp_proxy/alembic/env.py
+++ b/mcp_proxy/alembic/env.py
@@ -16,7 +16,15 @@ from alembic import context
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # ``disable_existing_loggers=False`` is load-bearing: init_db() runs the
+    # alembic upgrade in-process during the app lifespan (mcp_proxy/db.py,
+    # main.py: configure_json_logging -> ... -> init_db). The fileConfig
+    # default (True) would disable every already-created ``mcp_proxy.*``
+    # logger that is not named in alembic.ini, silently suppressing all
+    # application logs (denied reasons, decode failures, rate-limit warnings)
+    # for the lifetime of the worker. The audit chain (DB-backed) is
+    # unaffected; only the operator/SIEM log stream was being muted.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # DSN override: PROXY_DB_URL wins over alembic.ini value.
 database_url = os.environ.get("PROXY_DB_URL")


### PR DESCRIPTION
## Problem

`init_db()` runs `alembic upgrade head` **in-process** during the app
lifespan (`main.py`: `configure_json_logging()` at import → lifespan →
`init_db()`). Alembic's `env.py` called `fileConfig(config_file_name)`
with the default `disable_existing_loggers=True`, and `alembic.ini` lists
only `root,sqlalchemy,alembic`. So every already-created `mcp_proxy.*`
logger was disabled the moment migrations ran at boot.

**Impact**: after boot, all application logs (`denied` reasons, Rego
decode/eval failures, rate-limit warnings, egress errors) were silently
suppressed for the lifetime of the worker. The DB-backed audit chain is
**unaffected** (it does not go through `logging`); only the operator/SIEM
log stream was muted. SEV: medium (observability, not integrity).

## Empirical proof

```
before fix → after init_db: mcp_proxy.policy.disabled = True
after  fix → after init_db: mcp_proxy.policy.disabled = False
```

## Fix

One line in `mcp_proxy/alembic/env.py`: pass
`disable_existing_loggers=False` to `fileConfig`. Canonical Alembic
recommendation, harmless in production (out-of-process `alembic` CLI runs
are unchanged).

## How it was found

First full `pytest` run during the test-suite repatriation work.
`test/unit/test_policy_helper.py::test_malformed_base64_returns_none_and_logs`
(and its sibling `test_rego_eval_error_returns_none_and_logs`) were **red
in suite, green isolated** — the classic logging-pollution signature. The
polluter is any test that triggers an in-process alembic upgrade before
them (e.g. `test_cosmetic_batch_d10_a2_a4_a5_b1.py`). Latent since #908
added the Rego engine; invisible because CI runs only syntax+metadata, and
smoke checks for present output, not absent logs.

## Verification

- Minimal repro (polluter + target): red → green
- Full local suite: **319 passed, 5 skipped**
- Smoke `./test/smoke/smoke.sh` as pre-merge gate (alembic touched): running

🤖 Generated with [Claude Code](https://claude.com/claude-code)