### PR TITLE
fix(deps): pin anthropic + openai for cullis_native default backend

### DIFF
--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -21,10 +21,23 @@ authlib>=1.3.0
 # the import path in mcp_proxy.redis.pool to resolve (audit F-B-12).
 redis>=5.0.0
 # ADR-039 — LiteLLM is no longer a runtime dependency of the Mastio
-# image. The default AI gateway backend ``cullis_native`` uses the
-# Anthropic / OpenAI / httpx-Ollama native adapters. Operators who
-# still pin ``MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`` (for
-# Gemini / Bedrock / Vertex) install the package out-of-band with the
+# image. The default AI gateway backend ``cullis_native`` dispatches
+# through per-provider SDK adapters: the Anthropic and OpenAI adapters
+# import ``anthropic.AsyncAnthropic`` / ``openai.AsyncOpenAI`` lazily
+# at dispatch and raise GatewayError(503, "provider_sdk_missing") when
+# the package is absent. Because ``cullis_native`` is the default, both
+# SDKs are hard runtime deps of the image — without them a fresh bundle
+# 503s ``provider_sdk_missing`` on the very first chat completion. This
+# is invisible to smoke (scenario 40 runs the ``portkey`` backend against
+# a mock gateway, never cullis_native) and to unit tests (the dev venv
+# happens to have both SDKs); only the bundle dogfood 2026-05-30 hit it.
+# The Ollama and Portkey adapters use raw httpx and need no SDK. Floors
+# match the versions validated against the native adapters (PR-I client
+# cache); major caps guard against a breaking SDK bump.
+anthropic>=0.101.0,<1.0
+openai>=2.24.0,<3.0
+# Operators who still pin ``MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded``
+# (for Gemini / Bedrock / Vertex) install LiteLLM out-of-band with the
 # defensive floor PR #987 set against the April-May 2026 CVE cluster:
 #
 #   pip install 'litellm>=1.83.7,<2.0'


### PR DESCRIPTION
## Problem

A fresh Mastio bundle on the **default** AI gateway backend (`cullis_native`) returns **503 `provider_sdk_missing` on the very first chat completion**. The native Anthropic/OpenAI adapters import `AsyncAnthropic` / `AsyncOpenAI` lazily at dispatch, but neither SDK is installed in the image.

### Root cause

ADR-039 flipped the default backend to `cullis_native` (PR-E #992) and dropped litellm from the runtime image (PR-F #994), but never added the per-provider SDKs the native adapters require. `git log -S anthropic -- mcp_proxy/requirements-proxy.txt` is empty: anthropic/openai were never pinned.

### Why it slipped CI

- **Unit tests** pass because the dev venv happens to carry both SDKs.
- **Smoke** scenario 40 runs the `portkey` backend against a mock gateway, never exercising `cullis_native`.

Only the bundle dogfood on 2026-05-30 hit it (real chat 503 → 200 once the SDKs were installed).

## Fix

Pin `anthropic` + `openai` as hard runtime deps in `requirements-proxy.txt` (they are the default backend's adapters). Ollama and Portkey adapters use raw httpx and need no SDK. Floors match the versions validated against the native adapters (PR-I client cache); major caps guard against a breaking SDK bump.

## Validation

- Rebuilt the dev image → `anthropic 0.105.2`, `openai 2.38.0` present.
- Bundle dogfood: enroll cap-less agent → chat 403 `capability_missing`; PATCH-grant `llm.chat` → real chat **HTTP 200** (was 503 before the fix).
- `./test/smoke/smoke.sh` full: **13/13 PASS** on this branch.

## Follow-up (not in this PR)

Smoke does not cover the default `cullis_native` path. A scenario pointing `AsyncOpenAI`/`AsyncAnthropic` `base_url` at the mock gateway would close the gap so CI catches a missing/broken native adapter dep in the future.