### PR TITLE
fix(sdk): vanilla provider drop-in works from the documented zip layout

### DIFF
--- a/cullis_sdk/README.md
+++ b/cullis_sdk/README.md
@@ -76,11 +76,12 @@ If your agent code already uses `anthropic.Anthropic` or `openai.OpenAI` directl
 import anthropic
 from cullis_sdk.providers_compat import cullis_httpx_client
 
-# cullis_httpx_client reads agent.crt + agent.key + ca-chain.pem + dpop.jwk
-# from the directory you point at (same layout the admin-minted
-# identity-bundle.zip unpacks to). It wires mTLS, DPoP signing, and
-# the nonce-retry challenge so the vanilla provider SDK does not need
-# to know any of that.
+# cullis_httpx_client reads agent.crt + agent.key (+ optional ca-chain.pem)
+# from the directory you point at (the layout the admin-minted
+# identity-bundle.zip unpacks to). It generates + persists a dpop.jwk
+# there on first use if absent. It wires mTLS, DPoP signing, and the
+# nonce-retry challenge so the vanilla provider SDK does not need to
+# know any of that.
 http = cullis_httpx_client(identity_dir="/etc/cullis/agent")
 
 # Hand the httpx client to the vanilla Anthropic SDK. Streaming, tool
@@ -88,8 +89,11 @@ http = cullis_httpx_client(identity_dir="/etc/cullis/agent")
 # API directly. Every request flows through Mastio and lands in the
 # audit chain. The Mastio holds the upstream Anthropic key; the agent
 # host never sees it, hence ``api_key="unused"``.
+#
+# NB base_url has NO trailing /v1: the Anthropic SDK appends /v1/messages
+# itself. (The OpenAI SDK does NOT, so its base_url keeps /v1 — see below.)
 client = anthropic.Anthropic(
-    base_url="https://mastio.acme.local:9443/v1",
+    base_url="https://mastio.acme.local:9443",
     api_key="unused",
     http_client=http,
 )
@@ -101,7 +105,7 @@ msg = client.messages.create(
 )
 ```
 
-Same pattern with `openai.OpenAI(base_url="https://mastio.acme.local:9443/v1", api_key="unused", http_client=cullis_httpx_client(identity_dir="..."))`. See `docs/quickstart/provider-sdk-drop-in.md` on the site.
+Same pattern with `openai.OpenAI(base_url="https://mastio.acme.local:9443/v1", api_key="unused", http_client=cullis_httpx_client(identity_dir="..."))` — note the OpenAI base_url keeps the `/v1` suffix (the OpenAI SDK does not prepend it, unlike Anthropic). See `docs/quickstart/provider-sdk-drop-in.md` on the site.
 
 ---
 

--- a/cullis_sdk/providers_compat.py
+++ b/cullis_sdk/providers_compat.py
@@ -164,21 +164,27 @@ class _DpopTransport(httpx.BaseTransport):
 def _resolve_identity_files(
     identity_dir: str | pathlib.Path,
 ) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path | None, pathlib.Path]:
-    """Locate the four identity files inside ``identity_dir``.
+    """Locate the identity files inside ``identity_dir``.
 
-    Returns ``(cert, key, ca_chain_or_None, dpop_jwk)``. ``ca_chain`` is
-    optional: a customer running against a Mastio with a publicly
-    trusted TLS cert can omit it and rely on the system trust store.
-    The other three are mandatory and raise ``FileNotFoundError``.
+    Returns ``(cert, key, ca_chain_or_None, dpop_jwk_path)``. Only
+    ``agent.crt`` and ``agent.key`` are mandatory — they are the
+    credential (ADR-014) and cannot be regenerated client-side.
+    ``ca-chain.pem`` is optional (a Mastio with a publicly trusted TLS
+    cert lets the client rely on the system trust store). ``dpop.jwk``
+    is the returned *path* and may not exist yet: the caller generates +
+    persists it on first use, the same contract as
+    ``CullisClient.from_identity_dir`` and the identity-bundle.zip NB.
+    RFC 9449 keeps the DPoP key client-side, so the admin-minted bundle
+    does not ship one.
     """
     base = pathlib.Path(identity_dir).expanduser().resolve()
 
     if not base.is_dir():
         raise FileNotFoundError(
             f"identity_dir {base} is not a directory; expected the "
-            f"layout written by enrol_via_dashboard_approval / "
-            f"from_enrollment (agent.crt + agent.key + dpop.jwk "
-            f"+ optional ca-chain.pem)"
+            f"layout written by enrol_via_dashboard_approval / the "
+            f"admin-minted identity-bundle.zip (agent.crt + agent.key "
+            f"+ optional ca-chain.pem; dpop.jwk generated on first use)"
         )
 
     cert = base / "agent.crt"
@@ -186,12 +192,13 @@ def _resolve_identity_files(
     ca = base / "ca-chain.pem"
     dpop = base / "dpop.jwk"
 
-    missing = [p.name for p in (cert, key, dpop) if not p.exists()]
+    missing = [p.name for p in (cert, key) if not p.exists()]
     if missing:
         raise FileNotFoundError(
             f"identity_dir {base} missing {', '.join(missing)}; "
-            f"required layout: agent.crt + agent.key + dpop.jwk "
-            f"(and optional ca-chain.pem for Mastio Intermediate trust)"
+            f"required layout: agent.crt + agent.key "
+            f"(plus optional ca-chain.pem for Mastio Intermediate trust; "
+            f"dpop.jwk is generated on first use if absent)"
         )
 
     return cert, key, (ca if ca.exists() else None), dpop
@@ -226,7 +233,15 @@ def cullis_httpx_client(
         by this helper and cannot be overridden via this dict.
     """
     cert, key, ca, dpop_path = _resolve_identity_files(identity_dir)
-    dpop_key = DpopKey.load(dpop_path)
+    # Generate + persist the DPoP key on first use if the bundle did not
+    # ship one (it never does — RFC 9449 keeps the key client-side, and
+    # the identity-bundle.zip NB documents "generated on first use").
+    # Mirrors CullisClient.from_identity_dir; previously this helper hard
+    # -required dpop.jwk and FileNotFound'd the documented zip → drop-in
+    # flow. The Mastio TOFU-accepts the proof under egress_dpop_mode
+    # ``optional`` (the default); once the operator flips to ``required``
+    # the jkt must be registered at enrollment, same as any agent.
+    dpop_key = DpopKey.load(dpop_path) if dpop_path.exists() else DpopKey.generate(path=dpop_path)
 
     # Build an explicit ``ssl.SSLContext`` with the client cert chain
     # loaded into it. We avoid httpx's legacy ``cert=(crt, key)`` +

--- a/site/src/content/docs/quickstart/provider-sdk-drop-in.md
+++ b/site/src/content/docs/quickstart/provider-sdk-drop-in.md
@@ -18,11 +18,13 @@ For a **greenfield agent** (new code, no provider SDK in flight), the recommende
 
 ## Prerequisites
 
-- An enrolled agent with the four-file identity layout on disk (`agent.crt`, `agent.key`, `ca-chain.pem`, `dpop.jwk`). If you don't have that yet, do [SDK quickstart](sdk) first.
+- An enrolled agent with the identity layout on disk (`agent.crt` + `agent.key`, plus optional `ca-chain.pem`). The helper generates and persists `dpop.jwk` in that directory on first use, so the admin-minted `identity-bundle.zip` does not need to ship one. If you don't have an identity yet, do [SDK quickstart](sdk) first.
 - The matching provider key configured on the Mastio side: e.g. `MCP_PROXY_ANTHROPIC_API_KEY=sk-ant-...` in `proxy.env` followed by `./deploy.sh --pull`. The agent never holds the key.
-- The Mastio reachable on the URL the agent will pass as `base_url` (typically `https://<mastio>:9443/v1`).
+- The Mastio reachable on the URL the agent passes as `base_url`. For the Anthropic SDK use the Mastio **root** (`https://<mastio>:9443`); for the OpenAI SDK keep the `/v1` suffix (`https://<mastio>:9443/v1`). See each section below.
 
 ## Anthropic SDK (uses Mastio `/v1/messages`)
+
+> **`base_url` has no `/v1` suffix for the Anthropic SDK.** The Anthropic SDK appends `/v1/messages` itself, so passing `.../9443/v1` produces `/v1/v1/messages` and the Mastio returns `404 Not Found`. Point `base_url` at the Mastio root. (The OpenAI SDK is the opposite — it keeps `/v1`; see the next section.)
 
 ```python
 import anthropic
@@ -31,7 +33,7 @@ from cullis_sdk.providers_compat import cullis_httpx_client
 http_client = cullis_httpx_client(identity_dir="~/.cullis/scenario-b")
 
 client = anthropic.Anthropic(
-    base_url="https://mastio.myorg.example.com:9443/v1",
+    base_url="https://mastio.myorg.example.com:9443",   # NO /v1 — SDK adds /v1/messages
     api_key="unused",            # Mastio ignores; mTLS + DPoP are the real auth
     http_client=http_client,
 )
@@ -78,7 +80,7 @@ from cullis_sdk.providers_compat import cullis_httpx_client
 
 llm = ChatAnthropic(
     model="claude-sonnet-4-6",
-    base_url="https://mastio.myorg.example.com:9443/v1",
+    base_url="https://mastio.myorg.example.com:9443",   # NO /v1 — Anthropic SDK adds /v1/messages
     anthropic_api_key="unused",
     http_client=cullis_httpx_client(identity_dir="~/.cullis/scenario-b"),
 )
@@ -91,7 +93,7 @@ When the framework does not surface `http_client`, two options:
 
 ## What the helper does under the hood
 
-1. Loads the four identity files from `identity_dir` (auto-discovery: `agent.crt`, `agent.key`, `ca-chain.pem` optional, `dpop.jwk`).
+1. Loads the identity files from `identity_dir` (auto-discovery: `agent.crt` + `agent.key` required, `ca-chain.pem` optional; `dpop.jwk` is loaded if present, otherwise generated + persisted there on first use).
 2. Builds an `httpx.HTTPTransport` with `cert=(agent.crt, agent.key)` and `verify=ca-chain.pem` (or system trust if the bundle is omitted).
 3. Wraps it in a `_DpopTransport` that, on every outbound request:
    - Computes a DPoP JWT for `(method, htu)` signed by the persistent EC P-256 key from `dpop.jwk` and attaches it as the `DPoP:` header.

--- a/test/unit/test_providers_compat.py
+++ b/test/unit/test_providers_compat.py
@@ -3,10 +3,11 @@
 Covered:
 
 1. ``_resolve_identity_files`` raises clearly when the directory is missing.
-2. ``_resolve_identity_files`` raises clearly when ``dpop.jwk`` is missing
-   (the file with no auto-recovery — agent.crt / agent.key the operator
-   can re-mint, but dpop.jwk is client-generated and irreplaceable from
-   the server side).
+2. ``_resolve_identity_files`` raises clearly when ``agent.crt`` / ``agent.key``
+   are missing (the credential, ADR-014). ``dpop.jwk`` is NOT mandatory:
+   it is client-generated (RFC 9449) and the admin-minted bundle never
+   ships it, so ``cullis_httpx_client`` generates + persists it on first
+   use instead of raising — the same contract as ``from_identity_dir``.
 3. ``cullis_httpx_client`` returns a usable ``httpx.Client`` with a
    ``_DpopTransport`` wrapping the inner transport.
 4. ``_DpopTransport`` attaches a DPoP header to outbound requests.
@@ -83,17 +84,34 @@ def test_resolve_identity_files_missing_dir(tmp_path: Path) -> None:
     assert "not a directory" in str(exc.value)
 
 
-def test_resolve_identity_files_missing_dpop_jwk(tmp_path: Path) -> None:
+def test_resolve_identity_files_missing_cert_raises(tmp_path: Path) -> None:
+    # agent.crt / agent.key ARE mandatory (the credential, ADR-014) —
+    # missing them must still fail loud with an operator-facing hint that
+    # names the file and documents the required layout. A bare KeyError /
+    # OSError without that hint sends the customer grepping the source.
     _write_identity_dir(tmp_path)
-    (tmp_path / "dpop.jwk").unlink()
+    (tmp_path / "agent.crt").unlink()
 
     with pytest.raises(FileNotFoundError) as exc:
         _resolve_identity_files(tmp_path)
-    # The operator-facing error names the missing file specifically and
-    # documents the required layout. A bare ``KeyError`` or ``OSError``
-    # without that hint sends the customer grepping the source.
-    assert "dpop.jwk" in str(exc.value)
+    assert "agent.crt" in str(exc.value)
     assert "required layout" in str(exc.value)
+
+
+def test_cullis_httpx_client_generates_dpop_on_first_use(tmp_path: Path) -> None:
+    # dpop.jwk is client-generated (RFC 9449); the admin-minted bundle
+    # never ships it. The helper must generate + persist it on first use,
+    # not raise — otherwise the documented "download zip → drop-in" flow
+    # FileNotFound's (regression caught by the 2026-05-30 cold-reader).
+    _write_identity_dir(tmp_path)
+    (tmp_path / "dpop.jwk").unlink()
+    assert not (tmp_path / "dpop.jwk").exists()
+
+    client = cullis_httpx_client(identity_dir=tmp_path)
+    try:
+        assert (tmp_path / "dpop.jwk").exists()  # generated on first use
+    finally:
+        client.close()
 
 
 def test_resolve_identity_files_optional_ca_chain(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

The README "download `identity-bundle.zip` → vanilla Anthropic/OpenAI drop-in" quickstart did not actually run. Two bugs, both surfaced by the 2026-05-30 cold-reader of the literal README snippets.

### 1. `cullis_httpx_client` hard-required `dpop.jwk`

It raised `FileNotFoundError` when `dpop.jwk` was absent. But the admin-minted `identity-bundle.zip` **never ships one** (RFC 9449 keeps the DPoP key client-side; the README NB itself says it is generated on first use), and `CullisClient.from_identity_dir` already generates it via `DpopKey.load_or_generate`. So a reader following the documented flow crashed on the drop-in.

**Fix:** the helper now loads `dpop.jwk` if present, else generates + persists it in the identity dir on first use — matching `from_identity_dir`. Only `agent.crt` / `agent.key` stay mandatory. The Mastio accepts the proof under `egress_dpop_mode=optional` (the default) with no separate jkt-registration step.

### 2. Anthropic `base_url` had a spurious `/v1`

The README + site quickstart showed `anthropic.Anthropic(base_url=".../9443/v1")`. The Anthropic SDK appends `/v1/messages` itself → `/v1/v1/messages` → Mastio `404`. Point the Anthropic `base_url` at the Mastio **root**; the OpenAI SDK keeps `/v1` (it does not prepend). Documented the asymmetry inline.

## Validation

- `test/unit/test_providers_compat.py`: replaced the test that asserted the old (buggy) "missing dpop.jwk raises" contract with `test_cullis_httpx_client_generates_dpop_on_first_use` + `test_resolve_identity_files_missing_cert_raises` (cert/key stay mandatory). 13/13 pass.
- End-to-end against the live bundle: identity dir with only `agent.crt` + `agent.key` + `ca-chain.pem` (no `dpop.jwk`), no jkt registration, `base_url` without `/v1` → real Anthropic chat returns **200**.

## Context

Part of the v0.6.4 HN-release hardening. Independent of the AI-gateway backend (this is the ADR-038 client-side passthrough helper). Sibling to #1005 (native provider SDK pins).