### PR TITLE
fix(pki): bind org_id to the winning Org CA pair (close D-9 multi-worker split-brain)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -477,30 +477,16 @@ class AgentManager:
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
             derived = hashlib.sha256(pubkey_der).hexdigest()[:16]
-            # D-9 multi-worker race: every uvicorn worker runs lifespan
-            # in parallel and would otherwise upsert its own derived
-            # org_id (one per candidate key), then sign an intermediate
-            # whose CN says one thing while a sibling worker exports a
-            # cert with a different CN. Atomically claim the org_id row
-            # — winner stamps it, losers adopt the winning value before
-            # building the cert subject. Mirrors the Intermediate CA
-            # winner-election pattern in ``_mint_mastio_ca``.
-            from mcp_proxy.db import set_config_if_absent
-            wrote_org_id = await set_config_if_absent("org_id", derived)
-            if wrote_org_id:
-                self._org_id = derived
-                logger.info(
-                    "Derived deterministic org_id=%s from Org CA public key",
-                    derived,
-                )
-            else:
-                winner_org_id = await get_config("org_id")
-                self._org_id = winner_org_id or self._org_id
-                logger.info(
-                    "Org CA derive race lost — adopted winner org_id=%s "
-                    "(this worker's candidate=%s discarded)",
-                    self._org_id, derived,
-                )
+            # Each worker uses its OWN candidate org_id for the cert
+            # subject CN below. The AUTHORITATIVE org_id is NOT claimed
+            # here: claiming the ``org_id`` row as a race independent of
+            # the Org CA key/cert pair let one worker win ``org_id`` while
+            # a *different* worker won the pair (``_persist_org_ca``),
+            # persisting an org_id that did not derive from the persisted
+            # cert — the D-9 split-brain. org_id is instead derived from
+            # the WINNING pair after the election (below), so org_id, key,
+            # and cert all come from the same worker.
+            self._org_id = derived
 
         subject = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} CA"),
@@ -598,6 +584,31 @@ class AgentManager:
                     "Org CA generate race lost — adopted winning pair (CN=%s)",
                     ca_cert.subject.rfc4514_string(),
                 )
+
+        # Authoritative org_id — bind it to the WINNING Org CA pair, not
+        # to each worker's own candidate. ``ca_cert`` here is the persisted
+        # winning cert for winner and loser alike (the loser adopted it
+        # above), so deriving org_id from its pubkey guarantees the
+        # persisted org_id always derives from the persisted cert — closing
+        # the D-9 split-brain where org_id and the pair were won by
+        # different workers. ``set_config_if_absent`` is idempotent here:
+        # every worker computes the SAME value from the SAME winning cert,
+        # so the write order does not matter.
+        if derive_org_id:
+            from mcp_proxy.db import set_config_if_absent
+            winning_pubkey_der = ca_cert.public_key().public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            authoritative_org_id = hashlib.sha256(
+                winning_pubkey_der,
+            ).hexdigest()[:16]
+            await set_config_if_absent("org_id", authoritative_org_id)
+            self._org_id = authoritative_org_id
+            logger.info(
+                "Org CA org_id=%s bound to persisted winning pair (CN=%s)",
+                authoritative_org_id, ca_cert.subject.rfc4514_string(),
+            )
 
         # Three-tier PKI hardening — cache only the cert at steady state
         # when the encrypted KMS path is active (the unseal helper can


### PR DESCRIPTION
## Problem

`AgentManager.generate_org_ca` made **two independent atomic claims** at multi-worker boot:
1. the deterministic `org_id` row (`set_config_if_absent("org_id", derived)`), and
2. the Org CA key/cert pair (`_persist_org_ca`).

Every uvicorn worker runs lifespan in parallel, so **worker A could win the `org_id` row while worker B won the cert/key pair**. The loser branch adopted the winning pair but never re-bound `org_id` — leaving a persisted `org_id` (derived from A's key) that does **not** derive from the persisted cert (B's key). That is a split-brain: `org_id` is the SPIFFE trust-domain component and is expected to derive from the root pubkey.

This is the ~40-60% flake in `test_pki_bootstrap_concurrent::test_concurrent_generate_org_ca_persisted_key_matches_cert` (it was intermittently blocking every PR's CI) and the original D-9 dogfood symptom.

## Fix

Stop claiming `org_id` independently. Each worker still uses its own candidate `org_id` for its candidate cert CN, but the **authoritative `org_id` is derived from the winning pair** after `_persist_org_ca` elects it. `ca_cert` at that point is the persisted winning cert for winner and loser alike (the loser already adopted it), so deriving `org_id` from its pubkey guarantees the persisted `org_id` always derives from the persisted cert. `set_config_if_absent` stays idempotent: every worker computes the same value from the same winning cert, so write order is irrelevant.

Same winner-election pattern already used for the pair itself and for `mastio_keys` mint serialisation (#997). No new concurrency primitive.

## Validation

- `test_pki_bootstrap_concurrent` now passes **12/12** locally (was flaky ~40-60%).
- Green: `test_proxy_deterministic_org_id`, `test_pki_bootstrap`, `test_mastio_org_ca_self_check`, `test_proxy_local_issuer`, `test_proxy_cli_migrate_org_ca`, `test_updates_org_ca_pathlen_fix`, `test_spiffe_resource_parsing` (81 tests total across the PKI/org_id suites).

## Context

Single-worker deploys (the default bundle, `MASTIO_WORKERS=1`) never hit the race, but multi-worker production can. Unblocks the v0.6.4 HN-release pipeline (the flake was failing CI on unrelated PRs).