### PR TITLE
feat(dashboard): label provider native-support vs requires-litellm

### DIFF
--- a/mcp_proxy/dashboard/ai_providers.py
+++ b/mcp_proxy/dashboard/ai_providers.py
@@ -85,6 +85,7 @@ def _provider_view(provider: str, row: dict | None) -> dict:
         ],
         "static_models": list(spec.static_models),
         "dynamic_models": spec.dynamic_models,
+        "native_supported": spec.native_supported,
         "configured": row is not None,
         "enabled": bool(row["enabled"]) if row else False,
         "creds_masked": mask_creds(provider, row["creds"] or {}) if row else {},

--- a/mcp_proxy/dashboard/templates/ai_providers.html
+++ b/mcp_proxy/dashboard/templates/ai_providers.html
@@ -48,8 +48,16 @@
                         {% else %}
                         <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-gray-800/40 text-gray-500 border border-gray-700/40">not configured</span>
                         {% endif %}
+                        {% if p.native_supported %}
+                        <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-accent-400/10 text-accent-400 border border-accent-400/20" title="Dispatched natively by the default cullis_native backend.">native</span>
+                        {% else %}
+                        <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20" title="No native adapter yet. Set MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded (and pip install litellm) to use this provider; otherwise calls return 501.">requires litellm</span>
+                        {% endif %}
                     </div>
                     <p class="text-[10px] text-gray-600 mt-0.5 font-mono">{{ p.provider }}</p>
+                    {% if not p.native_supported %}
+                    <p class="text-[10px] text-amber-400/70 mt-1">Not natively supported yet — requires the <span class="font-mono">litellm_embedded</span> backend.</p>
+                    {% endif %}
                 </div>
                 {% if p.docs_url %}
                 <a href="{{ p.docs_url }}" target="_blank" rel="noopener"

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -57,6 +57,15 @@ class ProviderSpec:
     dynamic_models: bool = False
     default_model_for_route: str | None = None
     docs_url: str = ""
+    # ADR-039: the default ``cullis_native`` backend dispatches through
+    # per-provider native adapters. anthropic / openai / ollama have one;
+    # gemini / bedrock / vertex do NOT yet and 501 at dispatch unless the
+    # operator pins ``MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded``. This
+    # flag drives an honest "native vs requires-litellm" label in the
+    # provider-config UI so an operator knows before configuring rather
+    # than from a runtime 501. MVP posture: surface the gap, don't hide
+    # the provider.
+    native_supported: bool = True
 
 
 # Curated chat-completion model lists. Operators can still call any
@@ -123,6 +132,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
         ),
         static_models=GEMINI_MODELS,
         docs_url="https://ai.google.dev/gemini-api/docs/api-key",
+        native_supported=False,
     ),
     "bedrock": ProviderSpec(
         provider="bedrock",
@@ -137,6 +147,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
         ),
         static_models=BEDROCK_MODELS,
         docs_url="https://docs.aws.amazon.com/bedrock/",
+        native_supported=False,
     ),
     "vertex": ProviderSpec(
         provider="vertex",
@@ -154,6 +165,7 @@ PROVIDERS: dict[str, ProviderSpec] = {
         ),
         static_models=VERTEX_MODELS,
         docs_url="https://cloud.google.com/vertex-ai/docs",
+        native_supported=False,
     ),
     "ollama": ProviderSpec(
         provider="ollama",


### PR DESCRIPTION
## Why

The default `cullis_native` backend (ADR-039) has native adapters only for **anthropic / openai / ollama**. **gemini / bedrock / vertex** `501` at dispatch (`provider_native_not_implemented`) unless the operator pins `MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded`. The AI-providers config UI offered all six identically, so an operator could configure Gemini and only discover the gap from a runtime 501.

## What

- `native_supported: bool` on `ProviderSpec` (single source of truth; gemini/bedrock/vertex = `False`).
- Surfaced in `_provider_view` and rendered as an honest badge in `ai_providers.html`: **native** for the supported three, **requires litellm** + a one-line note for the rest.
- MVP posture: **surface the gap, don't hide the provider** — the operator decides. No filtering, no dispatch behaviour change (the runtime 501 + its `pin litellm_embedded` hint stays as the backstop).

## Validation

- `PROVIDERS` flag map asserted: `{anthropic:True, openai:True, gemini:False, bedrock:False, vertex:False, ollama:True}`.
- `ai_providers.html` Jinja parse OK; provider/gateway unit tests green.

Part of the v0.6.4 HN-release hardening (Finding A from the 2026-05-30 cold-reader / litellm-drop blast-radius review).