### PR TITLE
test(smoke): run default cullis_native backend + land capability unit tests

### DIFF
--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -53,7 +53,7 @@ Pre-PR ritual:
 | 10 | `10_admin_bootstrap.sh`       | seeded admin password works, Org CA + `org_id` materialised, `X-Admin-Secret` gate |
 | 20 | `20_enroll_agent.sh`          | `POST /v1/admin/agents` mints 2 agent certs; duplicate → 409; wrong secret → 403 |
 | 30 | `30_policy_rego.sh`           | `/v1/data/cullis/policy/session` default-allow; unknown OPA path → `{"result": null}`; Rego dashboard route mounted |
-| 40 | `40_chat_completion.sh`       | mTLS → `/v1/chat/completions` → mock AI gateway round-trip; no-cert → 401 at nginx |
+| 40 | `40_agent_llm_inference.sh`   | autonomous agent (`pitch-book-builder`) governed LLM inference via default `cullis_native` → native Anthropic dispatch → mock; 503 `provider_sdk_missing` hard-fails (#1005 guard); no-cert → 401 at nginx |
 | 50 | `50_mcp_tool_call.sh`         | mTLS-authed `/v1/egress/peers` and `/agents/{id}/public-key`; foreign cert → 401 |
 | 60 | `60_audit_chain.sh`           | `audit_log` non-empty, every row has `chain_seq`/`row_hash`, in-process `/proxy/audit/verify` returns `ok: true` |
 | 70 | `70_tsa_anchor.sh`            | audit anchor watcher fires within 90 s, persisted token carries `T1\|` magic + sane shape |

--- a/test/smoke/compose.yml
+++ b/test/smoke/compose.yml
@@ -133,10 +133,14 @@ services:
       MCP_PROXY_AUDIT_MERKLE_MIN_BATCH:         ${MCP_PROXY_AUDIT_MERKLE_MIN_BATCH:-2}
       MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS:  ${MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS:-15}
       MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED:       ${MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED:-true}
-      # AI gateway — point at the mock OpenAI-compatible endpoint on
-      # mock-tsa:2561. The Portkey backend respects ai_gateway_url
-      # (litellm_embedded uses provider SDKs directly).
-      MCP_PROXY_AI_GATEWAY_BACKEND:     ${MCP_PROXY_AI_GATEWAY_BACKEND:-portkey}
+      # AI gateway — default to the PRODUCT DEFAULT backend
+      # ``cullis_native`` (native provider SDKs) so the smoke covers the
+      # path bundles actually ship with. cullis_native ignores
+      # ai_gateway_url; the chat scenario seeds the per-provider
+      # api_base (→ mock-tsa:2561) into ai_provider_credentials instead.
+      # The legacy ``portkey`` backend is the one that respects
+      # ai_gateway_url; left here for the env override path only.
+      MCP_PROXY_AI_GATEWAY_BACKEND:     ${MCP_PROXY_AI_GATEWAY_BACKEND:-cullis_native}
       MCP_PROXY_AI_GATEWAY_URL:         ${MCP_PROXY_AI_GATEWAY_URL:-http://mock-tsa:2561}
       MCP_PROXY_ANTHROPIC_API_KEY:      ${MCP_PROXY_ANTHROPIC_API_KEY:-smoke-fake-anthropic-key}
       MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S: ${MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S:-5}

--- a/test/smoke/env.smoke
+++ b/test/smoke/env.smoke
@@ -94,7 +94,7 @@ MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED=true
 # Native dispatch does NOT use MCP_PROXY_AI_GATEWAY_URL (that's a
 # portkey-only knob). The base_url that points the SDK at the in-stack
 # mock is seeded per-provider into ai_provider_credentials by the chat
-# scenario (40_chat_completion) via admin_seed_ai_provider_creds, which
+# scenario (40_agent_llm_inference) via admin_seed_ai_provider_creds, which
 # writes ``api_base=http://mock-tsa:2561``. The mock answers the
 # Anthropic Messages shape on POST /v1/messages.
 MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native

--- a/test/smoke/env.smoke
+++ b/test/smoke/env.smoke
@@ -83,14 +83,21 @@ MCP_PROXY_AUDIT_MERKLE_INTERVAL_SECONDS=15
 MCP_PROXY_AUDIT_MERKLE_TSA_ENABLED=true
 
 # ── AI gateway (mocked) ─────────────────────────────────────────────────────
-# Point LiteLLM at a mock OpenAI-compatible endpoint we stand up via
-# the mock-tsa container's second port (it doubles as a tiny HTTP
-# server with a /v1/chat/completions stub). The actual LiteLLM call is
-# made by mcp_proxy/egress/ai_gateway.py — but litellm_embedded talks
-# to provider SDKs, not a URL. For the smoke we use the ``portkey``
-# backend (which DOES respect ai_gateway_url) so the chat scenario can
-# hit a deterministic, offline endpoint.
-MCP_PROXY_AI_GATEWAY_BACKEND=portkey
+# Run the PRODUCT DEFAULT backend ``cullis_native`` so the smoke
+# exercises the path real bundles ship with — not the deprecated
+# ``portkey`` legacy backend. cullis_native dispatches via the native
+# provider SDK (anthropic.AsyncAnthropic), which makes this scenario
+# the regression guard for packaging gaps like #1005 (anthropic/openai
+# missing from requirements → 503 provider_sdk_missing on every chat,
+# invisible to the old portkey-only smoke).
+#
+# Native dispatch does NOT use MCP_PROXY_AI_GATEWAY_URL (that's a
+# portkey-only knob). The base_url that points the SDK at the in-stack
+# mock is seeded per-provider into ai_provider_credentials by the chat
+# scenario (40_chat_completion) via admin_seed_ai_provider_creds, which
+# writes ``api_base=http://mock-tsa:2561``. The mock answers the
+# Anthropic Messages shape on POST /v1/messages.
+MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native
 MCP_PROXY_AI_GATEWAY_URL=http://mock-tsa:2561
 MCP_PROXY_ANTHROPIC_API_KEY=smoke-fake-anthropic-key
 MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S=5

--- a/test/smoke/lib/_admin.sh
+++ b/test/smoke/lib/_admin.sh
@@ -79,6 +79,47 @@ except Exception as exc:
     printf '%s' "$val"
 }
 
+# Seed an AI provider credentials row so the cullis_native backend
+# dispatches to a deterministic, offline upstream instead of the real
+# provider API. ``api_base`` points the native SDK (AsyncAnthropic /
+# AsyncOpenAI) at the in-stack mock-tsa:2561 endpoint.
+#
+# Why in-container Python instead of the dashboard form: the dispatcher
+# reads ``ai_provider_credentials`` directly, and the creds_json is
+# Fernet-wrapped at rest with the per-install master key the running
+# Mastio minted into proxy_config at first boot. Writing through the
+# app's own ``upsert_ai_provider_creds`` (which calls encrypt_at_rest)
+# guarantees the row round-trips with that exact key — same pattern as
+# admin_read_org_id running python in-container. PROXY_SKIP_MIGRATIONS=1
+# keeps this a metadata.create_all no-op (the DB is already migrated by
+# the running app) so the seed never contends on the alembic lock.
+admin_seed_ai_provider_creds() {
+    local provider="$1" api_base="$2" api_key="${3:-smoke-fake-anthropic-key}"
+    smoke_compose exec -T \
+        -e SEED_PROVIDER="$provider" \
+        -e SEED_API_BASE="$api_base" \
+        -e SEED_API_KEY="$api_key" \
+        -e PROXY_SKIP_MIGRATIONS=1 \
+        mcp-proxy python3 -c "
+import asyncio, os, sys
+from mcp_proxy.db import init_db, upsert_ai_provider_creds
+async def _seed():
+    await init_db(os.environ['MCP_PROXY_DATABASE_URL'])
+    await upsert_ai_provider_creds(
+        os.environ['SEED_PROVIDER'],
+        {'api_key': os.environ['SEED_API_KEY'],
+         'api_base': os.environ['SEED_API_BASE']},
+        updated_by='smoke',
+    )
+try:
+    asyncio.run(_seed())
+    print('ok')
+except Exception as exc:  # noqa: BLE001
+    print(f'seed-error: {exc}', file=sys.stderr)
+    sys.exit(1)
+" 2>&1
+}
+
 # Verify the admin password seed was honoured. The Mastio writes the
 # bcrypt hash on first boot if MCP_PROXY_INITIAL_ADMIN_PASSWORD is
 # set; we hit /proxy/login with the seeded password and expect a 303

--- a/test/smoke/mock-tsa/Dockerfile
+++ b/test/smoke/mock-tsa/Dockerfile
@@ -6,9 +6,11 @@
 #   :2560  — RFC 3161 TSA (signs TimeStampReq with a self-issued CA
 #            baked into the image, returns a TimeStampResp the
 #            real audit_anchor_watcher accepts).
-#   :2561  — OpenAI-compatible /v1/chat/completions stub. Returns a
-#            fixed completion so 40_chat_completion can assert a
-#            deterministic shape end-to-end.
+#   :2561  — LLM upstream stub. Serves both the OpenAI-compatible
+#            /v1/chat/completions and the Anthropic /v1/messages shapes
+#            (the default cullis_native backend dispatches the latter).
+#            Returns a fixed completion so 40_agent_llm_inference can
+#            assert a deterministic shape end-to-end.
 #
 # No external network, no real CA, no public TSA. The whole point is
 # that smoke runs in an air-gapped container build.

--- a/test/smoke/mock-tsa/server.py
+++ b/test/smoke/mock-tsa/server.py
@@ -278,7 +278,9 @@ async def _handle_chat(
         if method == "POST" and path in (
             "/v1/chat/completions", "/chat/completions",
         ):
-            # Parse the request just enough to echo the model name back.
+            # OpenAI-compatible shape — served for the legacy ``portkey``
+            # backend and the native OpenAI adapter (AsyncOpenAI posts
+            # here). Parse just enough to echo the model name back.
             try:
                 req = json.loads(body or b"{}")
                 model = req.get("model", "unknown")
@@ -302,6 +304,33 @@ async def _handle_chat(
                     "completion_tokens": 1,
                     "total_tokens": 2,
                 },
+            }
+            writer.write(_http_response(
+                "200 OK", json.dumps(payload).encode(),
+                b"application/json",
+            ))
+            return
+        if method == "POST" and path in ("/v1/messages", "/messages"):
+            # Anthropic Messages shape — served for the PRODUCT DEFAULT
+            # cullis_native backend. anthropic.AsyncAnthropic posts here
+            # (base_url + /v1/messages); the response must satisfy the
+            # SDK's Message model so AnthropicAdapter.translate_response
+            # can map it to the OpenAI shape the scenario asserts on
+            # (choices[0].message.content == "smoke-mock-ok").
+            try:
+                req = json.loads(body or b"{}")
+                model = req.get("model", "unknown")
+            except Exception:  # noqa: BLE001
+                model = "unknown"
+            payload = {
+                "id": "msg_smoke_" + secrets.token_hex(6),
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [{"type": "text", "text": "smoke-mock-ok"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
             }
             writer.write(_http_response(
                 "200 OK", json.dumps(payload).encode(),

--- a/test/smoke/scenarios/40_agent_llm_inference.sh
+++ b/test/smoke/scenarios/40_agent_llm_inference.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # =============================================================================
-# 40_chat_completion — agent → Mastio → AI gateway (mocked) round trip
+# 40_agent_llm_inference — autonomous agent → Mastio → AI gateway (mocked)
 # =============================================================================
 #
-# Posts an OpenAI-compatible chat completion to /v1/chat/completions
-# with alice's client cert. The smoke runs the PRODUCT DEFAULT backend
+# Cullis governs autonomous backend agents, not human chat. The actor
+# here is `pitch-book-builder` (one of the demo agents on the site,
+# alongside portfolio-rebalancer and kyc-screener): it makes a governed,
+# audited LLM inference call as part of its own work — not a person
+# typing into a chatbot. The OpenAI-compatible /v1/chat/completions
+# wire shape is just the SDK contract; the identity is an mTLS+DPoP
+# agent cert and every call lands in the audit chain.
+#
+# The smoke runs the PRODUCT DEFAULT backend
 # MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native, so the Mastio dispatches
 # through the native anthropic.AsyncAnthropic SDK (NOT the deprecated
 # portkey path). We seed an ai_provider_credentials row whose api_base
@@ -17,6 +24,7 @@
 # could never surface. End-to-end signal:
 #
 #   * mTLS handshake succeeds (nginx 401 gate passes)
+#   * the agent's identity clears the DPoP + llm.chat capability gate
 #   * cullis_native dispatch loads the native SDK + reaches the mock
 #   * Anthropic Messages response → OpenAI shape (choices[0].message…)
 #   * Audit row written (verified in 60_audit_chain)
@@ -27,16 +35,20 @@
 # =============================================================================
 set -euo pipefail
 
-SCENARIO_TAG="40_chat_completion"
+SCENARIO_TAG="40_agent_llm_inference"
 SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
 # shellcheck source=../lib/_agent.sh
 source "$SMOKE_LIB_DIR/_agent.sh"
 # shellcheck source=../lib/_admin.sh
 source "$SMOKE_LIB_DIR/_admin.sh"
 
-cert="$(agent_cert_path alice)"
-key="$(agent_key_path alice)"
-[[ -s "$cert" && -s "$key" ]] || die "alice cert/key missing — run 20_enroll_agent first"
+# Enroll the autonomous agent that performs the governed inference. Own
+# enrollment (like 41/42's nocap) so the actor reads as a real agent
+# doing its job, not the generic alice/bob test plumbing.
+agent_enroll pitch-book-builder "Pitch-Book Builder (autonomous agent, smoke #40)" '["llm.chat"]' >/dev/null
+cert="$(agent_cert_path pitch-book-builder)"
+key="$(agent_key_path pitch-book-builder)"
+[[ -s "$cert" && -s "$key" ]] || die "pitch-book-builder cert/key missing — enrollment failed"
 
 base="$(smoke_mastio_url)"
 
@@ -51,11 +63,13 @@ else
     die "failed to seed anthropic provider creds — cullis_native cannot reach the mock"
 fi
 
-# ── Happy path: mTLS chat completion ────────────────────────────────────────
+# ── Happy path: the agent's governed LLM inference call ─────────────────────
 # Use a recognised provider/model so parse_provider_from_model() in the
 # Mastio doesn't reject the request before reaching the gateway. The
-# stub doesn't care about the model name — it echoes whatever arrives.
-body='{"model":"anthropic/claude-haiku-4-5","messages":[{"role":"user","content":"smoke ping"}]}'
+# stub doesn't care about the model name or the prompt — it echoes a
+# fixed completion — but the prompt reads as the agent's actual task so
+# the scenario stays true to what Cullis governs: autonomous agent work.
+body='{"model":"anthropic/claude-haiku-4-5","messages":[{"role":"user","content":"Draft the executive summary for the Q3 pitch book."}]}'
 resp_file="$(mktemp)"
 trap 'rm -f "$resp_file"' EXIT
 
@@ -79,13 +93,13 @@ except Exception as exc:
     print(f'parse-error:{exc}')
 " 2>/dev/null)"
         if [[ "$content" == "smoke-mock-ok" ]]; then
-            log_pass "chat completion → 200, content='smoke-mock-ok' (mock gateway reachable)"
+            log_pass "pitch-book-builder governed inference → 200, content='smoke-mock-ok' (native dispatch reached mock)"
         else
             die "unexpected content from mock gateway: '$content' (full: $resp)"
         fi
         ;;
     401|403)
-        die "Mastio rejected mTLS chat call (HTTP $status). cert path: $cert. Response: $(cat "$resp_file")"
+        die "Mastio rejected the agent's mTLS inference call (HTTP $status). cert path: $cert. Response: $(cat "$resp_file")"
         ;;
     503)
         # Hard fail: under cullis_native with creds seeded + the mock

--- a/test/smoke/scenarios/40_chat_completion.sh
+++ b/test/smoke/scenarios/40_chat_completion.sh
@@ -4,14 +4,21 @@
 # =============================================================================
 #
 # Posts an OpenAI-compatible chat completion to /v1/chat/completions
-# with alice's client cert. The Mastio dispatches via the configured
-# AI gateway (env.smoke pins MCP_PROXY_AI_GATEWAY_BACKEND=portkey +
-# ai_gateway_url=http://mock-tsa:2561), so the upstream is our in-stack
-# stub. Stub returns a fixed completion. End-to-end signal:
+# with alice's client cert. The smoke runs the PRODUCT DEFAULT backend
+# MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native, so the Mastio dispatches
+# through the native anthropic.AsyncAnthropic SDK (NOT the deprecated
+# portkey path). We seed an ai_provider_credentials row whose api_base
+# points the SDK at the in-stack mock (mock-tsa:2561, /v1/messages
+# Anthropic shape) so the call stays offline + deterministic.
+#
+# This is the regression guard for packaging gaps like #1005: if the
+# image ships without the anthropic SDK, the native adapter returns
+# 503 provider_sdk_missing here — a failure the old portkey-only smoke
+# could never surface. End-to-end signal:
 #
 #   * mTLS handshake succeeds (nginx 401 gate passes)
-#   * Mastio dispatcher reaches the configured gateway URL
-#   * Response shape is OpenAI-compatible (choices[0].message.content)
+#   * cullis_native dispatch loads the native SDK + reaches the mock
+#   * Anthropic Messages response → OpenAI shape (choices[0].message…)
 #   * Audit row written (verified in 60_audit_chain)
 #
 # Asserts:
@@ -24,12 +31,25 @@ SCENARIO_TAG="40_chat_completion"
 SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
 # shellcheck source=../lib/_agent.sh
 source "$SMOKE_LIB_DIR/_agent.sh"
+# shellcheck source=../lib/_admin.sh
+source "$SMOKE_LIB_DIR/_admin.sh"
 
 cert="$(agent_cert_path alice)"
 key="$(agent_key_path alice)"
 [[ -s "$cert" && -s "$key" ]] || die "alice cert/key missing — run 20_enroll_agent first"
 
 base="$(smoke_mastio_url)"
+
+# ── Seed the native anthropic provider creds → mock upstream ─────────────────
+# cullis_native resolves the base_url from ai_provider_credentials, not
+# from MCP_PROXY_AI_GATEWAY_URL. Point it at the mock so the SDK call
+# stays in-stack. Without this row the native adapter would fall back to
+# settings.anthropic_api_key with no base_url and dial api.anthropic.com.
+if admin_seed_ai_provider_creds anthropic "http://mock-tsa:2561" >/dev/null; then
+    log_pass "seeded anthropic provider creds (api_base → mock-tsa:2561)"
+else
+    die "failed to seed anthropic provider creds — cullis_native cannot reach the mock"
+fi
 
 # ── Happy path: mTLS chat completion ────────────────────────────────────────
 # Use a recognised provider/model so parse_provider_from_model() in the
@@ -68,13 +88,13 @@ except Exception as exc:
         die "Mastio rejected mTLS chat call (HTTP $status). cert path: $cert. Response: $(cat "$resp_file")"
         ;;
     503)
-        # provider_key_missing or gateway unreachable — log + skip with
-        # warning rather than fail the run silently. The mock gateway
-        # might not be wired in older mains.
+        # Hard fail: under cullis_native with creds seeded + the mock
+        # reachable, a 503 is a real defect — and provider_sdk_missing
+        # is the #1005 packaging bug this scenario exists to catch. Do
+        # NOT skip it (the old portkey smoke skipped 503, which is how
+        # the missing anthropic/openai SDKs shipped unnoticed).
         body_text="$(cat "$resp_file")"
-        log_warn "AI gateway returned 503 (likely backend mismatch or upstream unreachable): $body_text"
-        log_skip "/v1/chat/completions returned 503 — chat path needs investigation in follow-up"
-        exit 2
+        die "/v1/chat/completions returned 503 under cullis_native: $body_text"
         ;;
     *)
         die "/v1/chat/completions returned HTTP $status: $(cat "$resp_file")"

--- a/test/unit/test_capability_enforcement.py
+++ b/test/unit/test_capability_enforcement.py
@@ -1,0 +1,471 @@
+"""Capability enforcement gates introduced in Mastio v0.6.4 (#22, #23).
+
+Validates:
+
+  * ``/v1/chat/completions`` and ``/v1/llm/chat`` require ``llm.chat`` in
+    ``InternalAgent.capabilities``; missing -> 403 + audit denied.
+  * ``POST /v1/mcp`` ``tools/list`` requires ``mcp.tools.list`` in the
+    token ``scope``; missing -> JSON-RPC error -32005 + audit denied.
+
+The router is exercised with the auth dep overridden so we never need a
+real DPoP+mTLS handshake. The LiteLLM dispatcher is patched on
+``mcp_proxy.egress.llm_chat_router.dispatch`` so we never touch the
+network. Mirrors the fixture shape used by the enterprise legacy tests
+in ``cullis-enterprise/legacy/tests/test_proxy_llm_chat_router.py``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.ai_gateway import GatewayResult
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+from mcp_proxy.egress.schemas import (
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    ChatMessage,
+)
+from mcp_proxy.egress import anthropic_messages_router as anthropic_module
+from mcp_proxy.egress.anthropic_messages_router import router as anthropic_router
+from mcp_proxy.ingress.mcp_aggregator import router as mcp_router
+from mcp_proxy.models import InternalAgent, TokenPayload
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+async def _audit_rows(action: str, status: str | None = None) -> list[dict]:
+    sql = "SELECT agent_id, action, status, detail FROM audit_log WHERE action = :a"
+    params: dict[str, object] = {"a": action}
+    if status is not None:
+        sql += " AND status = :s"
+        params["s"] = status
+    sql += " ORDER BY chain_seq ASC"
+    async with get_db() as conn:
+        result = await conn.execute(text(sql), params)
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+async def _local_audit_rows(event_type: str, result: str | None = None) -> list[dict]:
+    sql = (
+        "SELECT agent_id, event_type, result, details FROM local_audit "
+        "WHERE event_type = :e"
+    )
+    params: dict[str, object] = {"e": event_type}
+    if result is not None:
+        sql += " AND result = :r"
+        params["r"] = result
+    sql += " ORDER BY chain_seq ASC"
+    async with get_db() as conn:
+        rows = await conn.execute(text(sql), params)
+        return [dict(r._mapping) for r in rows.fetchall()]
+
+
+def _agent(capabilities: list[str]) -> InternalAgent:
+    return InternalAgent(
+        agent_id="acme::alice",
+        display_name="alice",
+        capabilities=capabilities,
+        created_at="2026-05-29T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-test",
+        reach="both",
+    )
+
+
+def _token(scope: list[str]) -> TokenPayload:
+    return TokenPayload(
+        sub="spiffe://cullis.test/acme::alice",
+        agent_id="acme::alice",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-alice",
+        scope=scope,
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+def _chat_body() -> dict:
+    return {
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 16,
+    }
+
+
+def _gateway_result() -> GatewayResult:
+    response = ChatCompletionResponse(
+        id="chatcmpl-test",
+        created=1_700_000_000,
+        model="claude-haiku-4-5",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="pong"),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(
+            prompt_tokens=12, completion_tokens=3, total_tokens=15,
+        ),
+        cullis_trace_id="trace_test",
+    )
+    return GatewayResult(
+        response=response,
+        latency_ms=42,
+        upstream_request_id="req_abc",
+        backend="litellm_embedded",
+        provider="anthropic",
+        prompt_tokens=12,
+        completion_tokens=3,
+        cost_usd=0.0001,
+    )
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "capability.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-default")
+    monkeypatch.setenv("MCP_PROXY_DPOP_JTI_SECRET", "test-dpop-jti-secret")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(llm_chat_router)
+    app.include_router(anthropic_router)
+    app.include_router(mcp_router)
+    return app
+
+
+# ── #22 — /v1/chat/completions + /v1/llm/chat require llm.chat ──────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/llm/chat"])
+async def test_chat_completion_denied_when_llm_chat_missing(
+    proxy_db, monkeypatch, path
+):
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent([])
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(side_effect=AssertionError("dispatch must not be called")),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(path, json=_chat_body())
+
+    assert r.status_code == 403, r.text
+    body = r.json()
+    assert body["detail"]["reason"] == "capability_missing"
+    assert body["detail"]["required_capability"] == "llm.chat"
+
+    rows = await _audit_rows("egress_llm_chat", "denied")
+    assert rows, "expected one denied audit row"
+    import json as _json
+    detail = _json.loads(rows[-1]["detail"])
+    assert detail["reason"] == "capability_missing"
+    assert detail["required_capability"] == "llm.chat"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_denied_when_wrong_capability(
+    proxy_db, monkeypatch
+):
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = (
+        lambda: _agent(["mcp.tools.list"])
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(side_effect=AssertionError("dispatch must not be called")),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 403
+    assert r.json()["detail"]["reason"] == "capability_missing"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_allowed_when_llm_chat_present(
+    proxy_db, monkeypatch
+):
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = (
+        lambda: _agent(["llm.chat"])
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["choices"][0]["message"]["content"] == "pong"
+
+    denied = await _audit_rows("egress_llm_chat", "denied")
+    assert not denied, "happy path must not emit a denied audit row"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_stream_denied_when_llm_chat_missing(
+    proxy_db, monkeypatch
+):
+    """Stream branch must hit the same gate; dispatch_stream never runs."""
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent([])
+    monkeypatch.setattr(
+        router_module, "dispatch_stream",
+        AsyncMock(side_effect=AssertionError("dispatch_stream must not be called")),
+    )
+
+    body = _chat_body() | {"stream": True}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=body)
+
+    assert r.status_code == 403
+    assert r.json()["detail"]["reason"] == "capability_missing"
+
+
+# ── #23 — POST /v1/mcp tools/list requires mcp.tools.list ───────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_denied_when_capability_missing(proxy_db):
+    app = _build_app()
+    app.dependency_overrides[get_authenticated_agent] = lambda: _token([])
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/mcp", json=payload)
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("error"), f"expected JSON-RPC error, got {body}"
+    assert body["error"]["code"] == -32005
+    assert "mcp.tools.list" in body["error"]["message"]
+    assert body["error"]["data"]["required_capability"] == "mcp.tools.list"
+
+    rows = await _local_audit_rows("mcp_tools_list", "denied")
+    assert rows, "expected one denied local_audit row"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_denied_when_wrong_capability(proxy_db):
+    app = _build_app()
+    app.dependency_overrides[get_authenticated_agent] = (
+        lambda: _token(["llm.chat"])
+    )
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/mcp", json=payload)
+
+    body = r.json()
+    assert body.get("error", {}).get("code") == -32005
+
+
+# ── #22 (B1) — /v1/messages Anthropic shape requires llm.chat ────────
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_denied_when_llm_chat_missing(
+    proxy_db, monkeypatch
+):
+    """B1: /v1/messages was a documented mirror of /v1/chat/completions
+    but pre-v0.6.4 did not enforce the capability gate."""
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent([])
+    monkeypatch.setattr(
+        anthropic_module, "dispatch",
+        AsyncMock(side_effect=AssertionError("dispatch must not be called")),
+    )
+
+    body = {
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 16,
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/messages", json=body)
+
+    assert r.status_code == 403, r.text
+    detail = r.json()["detail"]
+    assert detail["reason"] == "capability_missing"
+    assert detail["required_capability"] == "llm.chat"
+
+    rows = await _audit_rows("egress_llm_chat", "denied")
+    assert rows, "expected denied audit row from anthropic surface"
+    import json as _json
+    last = _json.loads(rows[-1]["detail"])
+    assert last["surface"] == "anthropic_messages"
+    assert last["reason"] == "capability_missing"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_allowed_when_llm_chat_present(
+    proxy_db, monkeypatch
+):
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = (
+        lambda: _agent(["llm.chat"])
+    )
+    monkeypatch.setattr(
+        anthropic_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    body = {
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 16,
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/messages", json=body)
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    # Anthropic shape: content is a list with text blocks
+    assert payload["content"][0]["text"] == "pong"
+
+
+# ── #23 typed principal capability storage (migration 0045) ──────────
+
+
+@pytest.mark.asyncio
+async def test_typed_user_principal_denied_when_capability_missing(proxy_db):
+    """User principal with empty capabilities (default post-migration)
+    is denied on tools/list, same as an agent."""
+    app = _build_app()
+    app.dependency_overrides[get_authenticated_agent] = lambda: TokenPayload(
+        sub="spiffe://cullis.test/acme::user::mario",
+        agent_id="acme::user::mario",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-mario",
+        scope=[],  # post-migration default — admin grants explicit caps
+        cnf={"jkt": "fake-jkt"},
+        principal_type="user",
+    )
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/mcp", json=payload)
+
+    body = r.json()
+    assert body["error"]["code"] == -32005
+    assert "mcp.tools.list" in body["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_typed_user_principal_allowed_when_capability_granted(
+    proxy_db,
+):
+    """User principal with capabilities=['mcp.tools.list'] passes the
+    method-level gate (binding remains the per-tool gate)."""
+    app = _build_app()
+    app.dependency_overrides[get_authenticated_agent] = lambda: TokenPayload(
+        sub="spiffe://cullis.test/acme::user::anna",
+        agent_id="acme::user::anna",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-anna",
+        scope=["mcp.tools.list"],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="user",
+    )
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/mcp", json=payload)
+
+    body = r.json()
+    assert "error" not in body, f"unexpected error: {body}"
+    assert isinstance(body["result"]["tools"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_principal_capabilities_round_trip(proxy_db):
+    """Migration 0045 + db helper: capabilities are persisted and read
+    back through ``get_principal_capabilities``."""
+    from mcp_proxy.db import get_principal_capabilities
+
+    # Insert a user row directly to bypass the admin API surface.
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_user_principals ("
+                "  principal_id, user_name, display_name, reach, surface, "
+                "  capabilities, created_at"
+                ") VALUES ("
+                "  :pid, 'mario', 'Mario', 'intra', NULL, :caps, '2026-05-28T00:00:00Z'"
+                ")"
+            ),
+            {
+                "pid": "acme::user::mario",
+                "caps": '["mcp.tools.list","custom.read"]',
+            },
+        )
+
+    caps = await get_principal_capabilities("acme::user::mario", "user")
+    assert set(caps) == {"mcp.tools.list", "custom.read"}
+
+    # Missing row -> []
+    caps = await get_principal_capabilities("acme::user::ghost", "user")
+    assert caps == []
+
+    # Wrong type -> []
+    caps = await get_principal_capabilities("acme::user::mario", "agent")
+    assert caps == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_allowed_when_capability_present(proxy_db):
+    """Capability passes the method-level gate; tools list may be empty
+    (no bindings seeded) but no JSON-RPC error is returned."""
+    app = _build_app()
+    app.dependency_overrides[get_authenticated_agent] = (
+        lambda: _token(["mcp.tools.list"])
+    )
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/mcp", json=payload)
+
+    body = r.json()
+    assert "error" not in body, f"unexpected JSON-RPC error: {body}"
+    assert "tools" in body["result"]
+    assert isinstance(body["result"]["tools"], list)

--- a/test/unit/test_capability_patch_endpoints.py
+++ b/test/unit/test_capability_patch_endpoints.py
@@ -1,0 +1,225 @@
+"""PATCH /v1/admin/{agents,users,workloads}/{id}/capabilities (#21).
+
+The admin PATCH surfaces let an operator rotate capabilities without
+re-enrolling. Three symmetric endpoints, same shape:
+
+  * accepts ``{"capabilities": [...]}`` with the ``Capability``
+    constraint (pattern + per-item + list-length caps);
+  * replaces the set (not delta) and bumps audit;
+  * 404 on unknown id;
+  * 422 on shape violation.
+
+Tests use SQLite + the FastAPI ``app`` directly (no nginx in front).
+The ``X-Admin-Secret`` header authenticates the admin secret check;
+the agent_manager is stubbed so create_agent can run without the
+PKI subsystem being loaded.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.admin.agents import router as agents_router
+from mcp_proxy.admin.users import router as users_router
+from mcp_proxy.admin.workloads import router as workloads_router
+from mcp_proxy.db import dispose_db, get_db, init_db
+
+
+ADMIN_SECRET = "test-admin-secret-not-default"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "patch_caps.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_DPOP_JTI_SECRET", "test-dpop-jti-secret")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(agents_router)
+    app.include_router(users_router)
+    app.include_router(workloads_router)
+    return app
+
+
+async def _seed_agent(agent_id: str, caps: list[str]) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents ("
+                "  agent_id, display_name, capabilities, is_active, "
+                "  created_at, federated, federation_revision"
+                ") VALUES (:aid, 'A', :caps, 1, '2026-05-28T00:00:00Z', 0, 0)"
+            ),
+            {"aid": agent_id, "caps": json.dumps(caps)},
+        )
+
+
+async def _seed_user(principal_id: str, caps: list[str]) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_user_principals ("
+                "  principal_id, user_name, display_name, reach, surface, "
+                "  capabilities, created_at"
+                ") VALUES (:pid, 'mario', 'Mario', 'intra', NULL, "
+                "          :caps, '2026-05-28T00:00:00Z')"
+            ),
+            {"pid": principal_id, "caps": json.dumps(caps)},
+        )
+
+
+async def _seed_workload(principal_id: str, caps: list[str]) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_workload_principals ("
+                "  principal_id, workload_name, display_name, "
+                "  image_digest, runtime_status, capabilities, created_at"
+                ") VALUES (:pid, 'ingest', 'Ingest', NULL, 'unknown', "
+                "          :caps, '2026-05-28T00:00:00Z')"
+            ),
+            {"pid": principal_id, "caps": json.dumps(caps)},
+        )
+
+
+# ── PATCH /v1/admin/agents/{id}/capabilities ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_capabilities_replaces_set(proxy_db):
+    await _seed_agent("acme::alice", ["llm.chat"])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/agents/acme::alice/capabilities",
+            json={"capabilities": ["llm.chat", "mcp.tools.list"]},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert set(body["capabilities"]) == {"llm.chat", "mcp.tools.list"}
+    assert body["federation_revision"] == 1  # bumped
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_capabilities_404_when_missing(proxy_db):
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/agents/acme::ghost/capabilities",
+            json={"capabilities": ["llm.chat"]},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_capabilities_422_on_bad_pattern(proxy_db):
+    await _seed_agent("acme::alice", [])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/agents/acme::alice/capabilities",
+            json={"capabilities": ["LLM.CHAT"]},  # uppercase
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_capabilities_422_on_too_many(proxy_db):
+    await _seed_agent("acme::alice", [])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/agents/acme::alice/capabilities",
+            json={"capabilities": [f"cap{i}" for i in range(100)]},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_capabilities_403_without_admin_secret(proxy_db):
+    await _seed_agent("acme::alice", [])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/agents/acme::alice/capabilities",
+            json={"capabilities": ["llm.chat"]},
+            headers={"X-Admin-Secret": "wrong"},
+        )
+    assert r.status_code == 403
+
+
+# ── PATCH /v1/admin/users/{id}/capabilities ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_user_capabilities_replaces_set(proxy_db):
+    await _seed_user("acme::user::mario", [])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/users/acme::user::mario/capabilities",
+            json={"capabilities": ["mcp.tools.list"]},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["capabilities"] == ["mcp.tools.list"]
+
+
+@pytest.mark.asyncio
+async def test_patch_user_capabilities_404_when_missing(proxy_db):
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/users/acme::user::ghost/capabilities",
+            json={"capabilities": []},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 404
+
+
+# ── PATCH /v1/admin/workloads/{id}/capabilities ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_workload_capabilities_replaces_set(proxy_db):
+    await _seed_workload("acme::workload::ingest", [])
+
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/workloads/acme::workload::ingest/capabilities",
+            json={"capabilities": ["mcp.tools.list", "ingest.write"]},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 200, r.text
+    assert set(r.json()["capabilities"]) == {"mcp.tools.list", "ingest.write"}
+
+
+@pytest.mark.asyncio
+async def test_patch_workload_capabilities_404_when_missing(proxy_db):
+    async with AsyncClient(transport=ASGITransport(app=_app()), base_url="http://t") as c:
+        r = await c.patch(
+            "/v1/admin/workloads/acme::workload::ghost/capabilities",
+            json={"capabilities": []},
+            headers={"X-Admin-Secret": ADMIN_SECRET},
+        )
+    assert r.status_code == 404


### PR DESCRIPTION
## Why

The smoke harness pinned the **deprecated `portkey`** AI-gateway backend against an OpenAI-shape mock and **never exercised the product default `cullis_native`** (`config.py:675`). That blind spot is exactly how #1005 shipped: `anthropic`/`openai` were missing from `requirements-proxy.txt`, so a fresh bundle `503`'d `provider_sdk_missing` on every call — invisible to unit tests (venv has the SDKs) and to a portkey-only smoke.

Separately, the capability tests for #21/#22/#23 lived in the **gitignored `tests/` dir** → never run by CI (which collects `test/unit` + `test/integration` only).

## What

**Smoke now runs `cullis_native` (the real default):**
- `env.smoke` + `compose.yml` default `MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native`. Native dispatch takes the base_url from `ai_provider_credentials`, not `MCP_PROXY_AI_GATEWAY_URL`.
- `mock-tsa` serves an **Anthropic Messages shape** on `POST /v1/messages` so native `AsyncAnthropic` dispatch stays offline + deterministic.
- `admin_seed_ai_provider_creds` seeds the anthropic row (`api_base` → mock) through the app's own `upsert_ai_provider_creds` (Fernet round-trip); `PROXY_SKIP_MIGRATIONS=1` keeps it off the alembic lock.
- The LLM scenario **hard-fails on 503** instead of skipping → a missing provider SDK can never pass unnoticed again. This is the regression guard for the #1005 class of packaging gap.

**Scenario framing = autonomous agent, not human chat:**
- Cullis governs autonomous backend agents. The old `40_chat_completion` read as "alice posts a chat completion" — the chatbot/user framing the product is *not*. Renamed `40_agent_llm_inference`; the actor is **`pitch-book-builder`** (a site demo agent, alongside portfolio-rebalancer and kyc-screener) making a governed, audited LLM inference call as part of its own work.

**Land the orphaned capability tests into the tracked path:**
- `test_capability_patch_endpoints.py` — #21 `PATCH /v1/admin/{agents,users,workloads}/{id}/capabilities` (replace-set, 404, 422, 403).
- `test_capability_enforcement.py` — #22 `llm.chat` + #23 `mcp.tools.list` router gates, B1 `/v1/messages`, typed principals.

## Validation

- `./test/smoke/smoke.sh` → **13/13 pass** on cullis_native (scenario 40 enrolls `pitch-book-builder` → native Anthropic adapter → mock `/v1/messages` → 200).
- **Negative guard test** (real image + stack): uninstalled `anthropic` from the running container + restarted the worker → the agent's inference returned `503 {"reason":"provider_sdk_missing"}` and `40_agent_llm_inference` **failed red (exit 1)**. With the old skip-on-503 it would have gone green — exactly how #1005 slipped through.
- `pytest test/unit -n auto --dist=loadfile` → **1419 passed, 2 skipped** (+22 capability tests now CI-run).
- security-review: no findings ≥8 (test-harness only; seed helper passes values as `-e` env, not interpolated into the python source; no untrusted input).

## Note / follow-up

`tests/` (gitignored) still holds orphaned adapter tests (`test_anthropic_translator.py`, `test_ollama_adapter.py`, `test_openai_adapter.py`) covering the native adapters. Worth porting next, kept out of this PR to stay tight.