### PR TITLE
fix(docs): sync SDK quickstart + deploy.sh to real agent-create contract

### DIFF
--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -7,6 +7,7 @@ source tree required.
 
 - **Docker** Engine 20.10+ with **docker compose v2** (`docker compose version`).
 - **bash** 4+, **curl**, **tar**, **gzip** — almost always already on the host.
+- **jq** — only for the SDK quickstart's `curl`-based agent provisioning (parsing the JSON enroll response). Not needed to deploy the bundle itself.
 - **openssl** is optional. When present `deploy.sh` uses `openssl rand` for the admin secrets; when absent it falls back to `/dev/urandom + base64`, so minimal NixOS / Alpine / distroless hosts work out of the box.
 
 ## Quickstart (2 commands, you already have this tarball)

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -32,7 +32,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-export COMPOSE_PROJECT_NAME="cullis-mastio"
+# Overridable so a second bundle on the same host (e.g. a cold-reader
+# dogfood alongside a live stack) can claim a distinct project name and
+# dodge the port-owner collision check. Defaults to ``cullis-mastio``.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-cullis-mastio}"
 
 GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
 BOLD=$'\033[1m'; GRAY=$'\033[90m'; RESET=$'\033[0m'
@@ -975,7 +978,10 @@ ok "Containers started"
 # ── Wait for health ─────────────────────────────────────────────────────────
 step "Waiting for services"
 
-PROXY_PORT="$(grep -E '^MCP_PROXY_PORT=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
+# ``|| true``: under ``set -euo pipefail`` a grep no-match exits 1 and
+# the pipefail propagates it, killing the script mid-report even though
+# the deploy already succeeded. These reads are informational only.
+PROXY_PORT="$(grep -E '^MCP_PROXY_PORT=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2- || true)"
 PROXY_PORT="${PROXY_PORT:-9443}"
 
 echo -n "  Mastio + nginx "
@@ -1049,7 +1055,7 @@ except Exception:
     fi
 fi
 
-PUBLIC_URL="$(grep -E '^MCP_PROXY_PROXY_PUBLIC_URL=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
+PUBLIC_URL="$(grep -E '^MCP_PROXY_PROXY_PUBLIC_URL=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2- || true)"
 PUBLIC_URL="${PUBLIC_URL:-https://localhost:${PROXY_PORT}}"
 
 # Browser-friendly URL. On Linux hosts without Docker Desktop, host.docker.internal
@@ -1074,7 +1080,11 @@ if [[ -f "$ORG_CA_HOST" ]]; then
     echo -e "                   ${GRAY}use as CULLIS_FRONTDESK_CA_BUNDLE_HOST when bringing up the Frontdesk bundle${RESET}"
 fi
 echo ""
-SEED_PWD="$(grep -E '^MCP_PROXY_INITIAL_ADMIN_PASSWORD=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
+# ``INITIAL_ADMIN_PASSWORD`` is legitimately absent when proxy.env comes
+# from ``generate-proxy-env.sh --defaults`` (the admin sets it at first
+# boot via /proxy/register). A no-match here must not abort the script:
+# ``|| true`` keeps the "Next steps" block reachable. See PROXY_PORT note.
+SEED_PWD="$(grep -E '^MCP_PROXY_INITIAL_ADMIN_PASSWORD=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2- || true)"
 
 if [[ "$MODE" == "development" ]]; then
     echo "  Next steps (development):"

--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -49,7 +49,7 @@ The agent's runtime identity is **three files**:
 - `agent-key.pem` — private key matching the cert
 - `dpop.jwk` — EC P-256 private key bound to the cert thumbprint (DPoP, [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) — a JWT that proves the request comes from the holder of the matching private key, not just a token bearer)
 
-**A note on agent IDs.** Cullis identifies agents as `<org-id>::<agent-name>` (e.g. `orga::kyc-screener`). When you call the **raw HTTP admin API** you pass the full `agent_id`. When you call the **SDK** you pass only `agent_name` — the SDK derives the org from the admin token and prepends it. The two paths show both styles below.
+**A note on agent IDs.** Cullis identifies agents as `<org-id>::<agent-name>` (e.g. `orga::kyc-screener`). Both the **raw HTTP admin API** and the **SDK** take only the short `agent_name` — the Mastio scopes it to its own `org_id` and returns the full `agent_id` in the response. You never pass the `<org>::` prefix yourself.
 
 **A note on `capabilities`.** Free-form strings. There is no closed vocabulary. The convention is `<area>.<verb>` (e.g. `kyc.read`, `kyc.submit`, `portfolio.place_order`) but Mastio does not validate the syntax at enrollment. What matters is that the strings here **match exactly** the capabilities required by the MCP tools the agent will call — Mastio's capability gate compares them literally when a tool is dispatched. Each MCP tool declares its required capability in its server manifest; ask the team that operates the MCP server for the list, or list them at runtime with `client.list_mcp_tools()`.
 
@@ -62,22 +62,34 @@ Pick one of the three provisioning paths depending on whether your org already h
 If your org doesn't have a Certificate Authority yet, let Mastio mint everything from its org-scoped CA. Run this once from an operator script:
 
 ```bash
-# One-off, from your operator workstation or a CI/CD provisioning step
-curl -X POST https://mastio.acme.corp/v1/admin/agents/create \
+# One-off, from your operator workstation or a CI/CD provisioning step.
+# Self-signed Org CA (the bundle default)? Add --cacert ./certs/org-ca.pem
+# to the curl, or -k to skip verification (dev only).
+curl -X POST https://mastio.acme.corp/v1/admin/agents \
   -H "X-Admin-Secret: $MASTIO_ADMIN_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
-        "agent_id": "orga::kyc-screener",
+        "agent_name": "kyc-screener",
         "display_name": "KYC Screener",
         "capabilities": ["kyc.read", "kyc.submit"]
       }' \
   > kyc-screener.json
 
-# The response carries cert_pem + key_pem + dpop_jwk. Persist to disk:
-jq -r .cert_pem  kyc-screener.json > /etc/cullis/agents/kyc/cert.pem
-jq -r .key_pem   kyc-screener.json > /etc/cullis/agents/kyc/agent-key.pem
-jq -r .dpop_jwk  kyc-screener.json > /etc/cullis/agents/kyc/dpop.jwk
+# The response carries cert_pem (leaf), cert_chain_pem (leaf + Mastio
+# Intermediate), and private_key_pem (the freshly minted key). Persist
+# to disk. Write the fullchain into cert.pem so strict TLS clients can
+# build leaf -> Intermediate -> Org Root; the `// .cert_pem` fallback
+# covers legacy single-tier deployments where cert_chain_pem is null.
+jq -r '.cert_chain_pem // .cert_pem' kyc-screener.json > /etc/cullis/agents/kyc/cert.pem
+jq -r '.private_key_pem'             kyc-screener.json > /etc/cullis/agents/kyc/agent-key.pem
 chmod 0600 /etc/cullis/agents/kyc/*
+
+# No dpop.jwk here — the curl mint path doesn't produce one (unlike the
+# SDK enroll_via_* helpers in paths b/c below, which persist it). While
+# the Mastio's egress_dpop_mode is `optional` (the bundle default) the
+# agent authenticates with mTLS alone, so omit dpop_key_path at runtime.
+# For DPoP binding, enroll via the SDK or register a public JWK via
+# POST /v1/admin/agents/<agent_id>/dpop-jwk.
 ```
 
 Mastio pins the cert thumbprint in its DB. From this moment any TLS handshake presenting that exact cert authenticates as `orga::kyc-screener`.


### PR DESCRIPTION
## Contesto

Cold-reader dogfood (2026-05-30) del bundle staged `0.6.4-dev`: il sistema funziona, ma chi copia-incolla il quickstart SDK si blocca a ogni passo. Causa = **doc drift**: `sdk.md` è scritto sul contratto legacy `app/`, mai ri-sincronizzato col `mcp_proxy` pubblico dopo il rimpatrio. NON una regressione runtime.

Ogni finding verificato contro il sorgente prima della fix.

## Fix

**`sdk.md` — path "Mastio mints the cert" (curl)**
- Endpoint: `POST /v1/admin/agents` (non `/v1/admin/agents/create`, che non esiste → 404). Verificato: `mcp_proxy/admin/agents.py:53,144` (`prefix="/v1/admin/agents"`, `@router.post("")`).
- Body: `agent_name` (non `agent_id`, che dà 422 "Field required"). Verificato: `AgentCreateRequest.agent_name` required, `agents.py:73`. Corretta anche la prosa sugli agent ID.
- Response: `cert_pem` (leaf) + `cert_chain_pem` (leaf‖Intermediate) + `private_key_pem`. **Non esistono** `key_pem` né `dpop_jwk` — il doc precedente scriveva `null` su disco rompendo l'identità. Verificato: `AgentCreateResponse`, `agents.py:89-103`.
- `dpop.jwk`: lo genera l'SDK al primo login (`_enrollment.py:472-485`), non la response. Documentato.
- Scrittura `cert_chain_pem // cert_pem` in `cert.pem` per i client TLS strict (ADR-033 three-tier PKI); l'SDK accetta un cert pre-assemblato (`_enrollment.py:307-315`).

**`deploy.sh` — exit 1 spurio (F1)**
- Tre `grep` informativi (`PROXY_PORT`, `PUBLIC_URL`, `SEED_PWD`) sotto `set -euo pipefail`: un no-match esce 1, pipefail propaga, lo script muore DOPO "deployed" ma PRIMA del blocco "Next steps". `INITIAL_ADMIN_PASSWORD` è legittimamente assente con `generate-proxy-env.sh --defaults`. Guardati con `|| true`. Riprodotto empiricamente.

**`deploy.sh` — COMPOSE_PROJECT_NAME (F6)**
- Reso overridabile via env (default invariato `cullis-mastio`) così un secondo bundle sullo stesso host evita il port-owner collision check. Testato: default preservato, override onorato.

**Docs minori (F5/F7)**
- `jq` aggiunto ai prerequisiti (README + nota nel quickstart).
- Documentato `--cacert ./certs/org-ca.pem` / `-k` per l'Org CA self-signed di default.

## Test
- `bash -n deploy.sh` OK.
- F1 e F6 riprodotti/verificati empiricamente in shell isolata.
- Solo docs + script bundle: nessun test runtime impattato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)