### PR TITLE
fix(docs): point ca_chain_path at certs/org-ca.pem, not nginx-certs

### DIFF
--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -160,7 +160,7 @@ client = CullisClient.from_identity_dir(
 client.login_via_proxy_with_local_key()
 ```
 
-**Where does `ca_chain_path` come from?** It's the Org CA cert that signs Mastio's own TLS cert. Operators export it from the Mastio dashboard (PKI → Export CA Certificate) or fetch it from the bundle's `nginx-certs/org-ca.crt`. Distribute it alongside the three identity files. If you set `verify_tls=False` you don't need it, but that's for local dogfood only.
+**Where does `ca_chain_path` come from?** It's the Org CA cert that signs Mastio's own TLS cert. Operators export it from the Mastio dashboard (PKI → Export CA Certificate) or fetch it from the bundle's `certs/org-ca.pem` — the user-readable copy `deploy.sh` writes for exactly this (its "Next steps" banner points there too). The sibling `nginx-certs/org-ca.crt` holds the same cert but is owned by the in-container runtime UID and is not readable as your shell user. Distribute the file alongside the three identity files. If you set `verify_tls=False` you don't need it, but that's for local dogfood only.
 
 **Two-line mental model**:
 


### PR DESCRIPTION
## Contesto

Cold-reader install end-to-end su mastio-demo (VM, 2026-05-30), seguendo il quickstart SDK letteralmente dopo il merge di #1010. Tutto verde — deploy (exit 0, F1 ok), mint `POST /v1/admin/agents`, persist, `from_identity_dir` + `login` → COLD-READ AUTH PASS (`10c15c961a0228c4::kyc-screener`, token cached) — tranne un intoppo a metà.

## Finding

Lo step di recupero dell'Org CA falliva:
```
cp: cannot stat 'nginx-certs/org-ca.crt': Permission denied
```

`nginx-certs/` è di proprietà dell'UID runtime in-container (10001), non leggibile dall'utente shell. Lo stesso Org CA è in `certs/org-ca.pem`, di proprietà dell'utente e leggibile. `deploy.sh` usa `certs/org-ca.pem` come `ORG_CA_HOST` canonico (riga 1007) e il banner "Next steps" punta già lì (riga 1079). Il quickstart citava la fonte sbagliata.

## Fix

Riscrive la nota "Where does \`ca_chain_path\` come from?" per puntare a `certs/org-ca.pem` (user-readable) e spiega che `nginx-certs/org-ca.crt` è la stessa cert ma non leggibile come shell user.

## Verifica

Dopo aver usato `certs/org-ca.pem`, il login SDK è passato verde sulla VM. Solo docs, nessun impatto runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)