### PR TITLE
fix(egress): strip provider/ routing prefix for native adapters

### DIFF
--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -37,6 +37,7 @@ from mcp_proxy.egress.adapters import DispatchContext, resolve_adapter
 from mcp_proxy.egress.provider_catalog import (
     PROVIDERS,
     parse_provider_from_model,
+    strip_provider_prefix,
 )
 from mcp_proxy.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
 
@@ -185,6 +186,27 @@ async def _resolve_provider_creds(
     return provider, dict(row["creds"] or {})
 
 
+def _normalize_model_for_backend(
+    req: ChatCompletionRequest,
+    backend: str,
+    provider: str,
+) -> ChatCompletionRequest:
+    """Strip the ``provider/`` routing prefix for native adapters.
+
+    Only the ``cullis_native`` backend talks to provider APIs directly, so
+    only it needs the bare model id (``claude-...`` rather than
+    ``anthropic/claude-...``). ``litellm_embedded`` and ``portkey`` route on
+    the prefix themselves and must keep it. Returns ``req`` unchanged when
+    there is nothing to strip, so the common bare-id path allocates nothing.
+    """
+    if backend != "cullis_native":
+        return req
+    bare = strip_provider_prefix(req.model, provider)
+    if bare == req.model:
+        return req
+    return req.model_copy(update={"model": bare})
+
+
 async def dispatch(
     *,
     req: ChatCompletionRequest,
@@ -200,6 +222,7 @@ async def dispatch(
     # (``litellm_embedded`` / ``portkey``) ignore the ``provider`` arg.
     provider, creds = await _resolve_provider_creds(req.model, settings)
     adapter = resolve_adapter(backend, provider)
+    req = _normalize_model_for_backend(req, backend, provider)
     ctx = DispatchContext(
         agent_id=agent_id,
         org_id=org_id,
@@ -234,6 +257,7 @@ async def dispatch_stream(
     backend = settings.ai_gateway_backend.lower()
     provider, creds = await _resolve_provider_creds(req.model, settings)
     adapter = resolve_adapter(backend, provider)
+    req = _normalize_model_for_backend(req, backend, provider)
     ctx = DispatchContext(
         agent_id=agent_id,
         org_id=org_id,

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -308,6 +308,29 @@ def parse_provider_from_model(model: str) -> str:
     return "anthropic"
 
 
+def strip_provider_prefix(model: str, provider: str) -> str:
+    """Drop the ``provider/`` routing prefix before the upstream call.
+
+    The prefix in ids like ``anthropic/claude-...`` or ``openai/gpt-...``
+    exists only so :func:`parse_provider_from_model` can route the request
+    at the right provider. The upstream provider API never understands it:
+    the Anthropic Messages API 404s on ``anthropic/claude-...`` and only
+    knows the bare ``claude-...``. LiteLLM used to strip this for us; after
+    the native-adapter switch (ADR-039) the gateway must do it itself, or
+    the documented ``provider/model`` ids fail at dispatch.
+
+    Only a prefix that maps to the *already resolved* ``provider`` is
+    stripped, so a bare id that merely happens to contain a slash is left
+    untouched. Idempotent: a bare id (heuristic-routed) returns unchanged.
+    """
+    m = model.strip()
+    lower = m.lower()
+    for prefix, prov in _PROVIDER_PREFIXES:
+        if prov == provider and lower.startswith(prefix):
+            return m[len(prefix):]
+    return m
+
+
 # ── litellm kwargs translation ───────────────────────────────────────
 
 

--- a/test/unit/test_provider_prefix_strip.py
+++ b/test/unit/test_provider_prefix_strip.py
@@ -1,0 +1,92 @@
+"""The native gateway strips the ``provider/`` routing prefix before the
+upstream call (ADR-039 regression: dropping LiteLLM removed the implicit
+prefix normalization it did for free).
+
+Symptom that motivated this: an agent that sends the *documented*
+``model="anthropic/claude-haiku-4-5-20251001"`` got a bare ``HTTP 404`` on
+``/v1/llm/chat``. The Anthropic Messages API only knows ``claude-...``; the
+``anthropic/`` prefix exists solely so ``parse_provider_from_model`` can
+route the call. LiteLLM used to strip it — the native adapters must now do
+it themselves.
+
+Two layers covered:
+
+1. ``strip_provider_prefix`` (pure): strips a prefix only when it maps to
+   the already-resolved provider; leaves bare ids and unrelated slashes
+   alone; idempotent.
+2. ``_normalize_model_for_backend``: strips for ``cullis_native`` only.
+   ``litellm_embedded`` / ``portkey`` route on the prefix themselves and
+   must keep it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.egress.ai_gateway import _normalize_model_for_backend
+from mcp_proxy.egress.provider_catalog import strip_provider_prefix
+from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+
+# ── strip_provider_prefix (pure) ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model,provider,expected",
+    [
+        # The bug: prefixed id resolved to its provider → strip.
+        ("anthropic/claude-haiku-4-5-20251001", "anthropic", "claude-haiku-4-5-20251001"),
+        ("openai/gpt-4o", "openai", "gpt-4o"),
+        ("ollama/llama3.1:8b", "ollama", "llama3.1:8b"),
+        ("ollama_chat/llama3.1:8b", "ollama", "llama3.1:8b"),
+        # Bare ids (heuristic-routed) pass through untouched.
+        ("claude-haiku-4-5-20251001", "anthropic", "claude-haiku-4-5-20251001"),
+        ("gpt-4o", "openai", "gpt-4o"),
+        # A slash that is NOT the resolved provider's prefix is preserved
+        # (e.g. an OpenAI-compatible model id that legitimately has a path).
+        ("anthropic/claude-3", "openai", "anthropic/claude-3"),
+    ],
+)
+def test_strip_provider_prefix(model: str, provider: str, expected: str) -> None:
+    assert strip_provider_prefix(model, provider) == expected
+
+
+def test_strip_provider_prefix_idempotent() -> None:
+    once = strip_provider_prefix("anthropic/claude-haiku-4-5-20251001", "anthropic")
+    assert strip_provider_prefix(once, "anthropic") == once
+
+
+# ── _normalize_model_for_backend (backend gate) ──────────────────────
+
+
+def _req(model: str) -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model=model, messages=[{"role": "user", "content": "hi"}]
+    )
+
+
+def test_normalize_strips_under_cullis_native() -> None:
+    req = _req("anthropic/claude-haiku-4-5-20251001")
+    out = _normalize_model_for_backend(req, "cullis_native", "anthropic")
+    assert out.model == "claude-haiku-4-5-20251001"
+
+
+def test_normalize_keeps_prefix_for_litellm_embedded() -> None:
+    """LiteLLM routes on the ``provider/`` prefix; stripping it would break
+    that backend, so the prefix must survive."""
+    req = _req("anthropic/claude-haiku-4-5-20251001")
+    out = _normalize_model_for_backend(req, "litellm_embedded", "anthropic")
+    assert out.model == "anthropic/claude-haiku-4-5-20251001"
+
+
+def test_normalize_keeps_prefix_for_portkey() -> None:
+    req = _req("openai/gpt-4o")
+    out = _normalize_model_for_backend(req, "portkey", "openai")
+    assert out.model == "openai/gpt-4o"
+
+
+def test_normalize_noop_returns_same_instance() -> None:
+    """A bare id has nothing to strip; the common path must not allocate a
+    copy."""
+    req = _req("claude-haiku-4-5-20251001")
+    out = _normalize_model_for_backend(req, "cullis_native", "anthropic")
+    assert out is req


### PR DESCRIPTION
## Problema

Con il backend \`cullis_native\` (ADR-039, drop di LiteLLM) il gateway passava il model id raw all'API del provider upstream. Un id **documentato** come \`anthropic/claude-haiku-4-5-20251001\` arrivava all'Anthropic Messages API, che conosce solo il bare \`claude-...\` e 404a sul prefisso \`anthropic/\`. Il client riceveva un nudo \`HTTP 404\` su \`/v1/llm/chat\`, col vero motivo solo nei log proxy (\`agent_trust.egress\`, \`provider_not_found\`).

LiteLLM strippava questo prefisso per noi; nei native adapter solo Ollama aveva il proprio strip (\`_strip_ollama_prefix\`). Anthropic e OpenAI erano rimasti scoperti, asimmetrici.

## Fix

- \`strip_provider_prefix(model, provider)\` in \`provider_catalog.py\`: toglie il prefisso \`provider/\` solo se mappa al provider **gia risolto** (un id bare con slash casuale resta intatto), idempotente.
- \`_normalize_model_for_backend()\` in \`ai_gateway.py\`, applicata in \`dispatch\`/\`dispatch_stream\`, **gattata su \`cullis_native\`**. Il prefisso e load-bearing per il routing di \`litellm_embedded\`/\`portkey\`, quindi quei backend lo mantengono. Provider + adapter + creds vengono risolti sul model id prefissato **prima** dello strip (che gira su un \`model_copy\`), quindi routing e authz \`scope_providers\` non sono toccati.

## Test

\`test/unit/test_provider_prefix_strip.py\` (12 casi): strip puro, gate per backend, no-op che non rialloca. Nessuna regressione su \`test_chat_completion_kwargs\`, \`test_anthropic_messages_router\`, \`test_proxy_routing\`.

## Validazione live (dogfood)

Before/after sul native stack 9443, stessa identita agent, audit chain:
- id prefissato pre-fix -> \`egress_llm_chat\` **error** (il 404)
- id prefissato post-fix -> \`egress_llm_chat\` **success** (200 OK)
- id bare -> ancora **success** (no regressione)

Lo smoke \`40_chat_completion.sh\` gira con backend portkey e continua a passare invariato (conferma che il prefisso e preservato per i backend legacy).

## Security review

Pulita, nessun finding HIGH/MEDIUM. Lo strip non altera la decisione di routing (provider risolto prima), non bypassa l'authz \`scope_providers\` (valutata sull'id non strippato), nessun SSRF via model id.