### PR TITLE
fix(egress): surface a caller-safe hint on gateway errors

### DIFF
--- a/mcp_proxy/egress/adapters/__init__.py
+++ b/mcp_proxy/egress/adapters/__init__.py
@@ -73,15 +73,17 @@ def resolve_adapter(backend: str, provider: str | None = None) -> ProviderAdapte
         # customer asks; fall through to the explicit "no native
         # adapter" error so the dashboard surface gives a clear pointer
         # rather than a generic 501.
+        native_msg = (
+            f"The cullis_native backend has no adapter for provider "
+            f"{provider!r} yet. Pin "
+            f"MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded to keep "
+            f"using LiteLLM for this provider."
+        )
         raise GatewayError(
             501,
             f"provider_native_not_implemented:{provider or 'unknown'}",
-            detail=(
-                f"The cullis_native backend has no adapter for provider "
-                f"{provider!r} yet. Pin "
-                f"MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded to keep "
-                f"using LiteLLM for this provider."
-            ),
+            detail=native_msg,
+            hint=native_msg,
         )
     raise GatewayError(
         501,

--- a/mcp_proxy/egress/adapters/anthropic.py
+++ b/mcp_proxy/egress/adapters/anthropic.py
@@ -71,13 +71,16 @@ _STOP_REASON_MAP: dict[str, str] = {
 }
 
 
-def _map_anthropic_exception(exc: Exception) -> "GatewayError":
-    from mcp_proxy.egress.ai_gateway import GatewayError, scrub_secrets
+def _map_anthropic_exception(
+    exc: Exception, *, model: str | None = None
+) -> "GatewayError":
+    from mcp_proxy.egress.ai_gateway import GatewayError, caller_hint, scrub_secrets
 
     cls = type(exc).__name__
     status, reason = _ANTHROPIC_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
     detail = scrub_secrets((str(exc) or cls)[:512])
-    return GatewayError(status, reason, detail=detail)
+    hint = caller_hint(reason, model=model, provider="anthropic")
+    return GatewayError(status, reason, detail=detail, hint=hint)
 
 
 # ── request translation: OpenAI → Anthropic ───────────────────────────
@@ -741,7 +744,7 @@ class AnthropicAdapter:
         try:
             message = await client.messages.create(**anthropic_kwargs)
         except Exception as exc:
-            gw_err = _map_anthropic_exception(exc)
+            gw_err = _map_anthropic_exception(exc, model=request_model)
             _log.warning(
                 "anthropic_native error agent=%s model=%s reason=%s detail=%s",
                 ctx.agent_id, request_model, gw_err.reason, gw_err.detail,
@@ -857,7 +860,7 @@ class AnthropicAdapter:
                 dispatch_obj.completion_tokens = acc.completion_tokens
                 yield final_chunk
             except Exception as exc:
-                raise _map_anthropic_exception(exc) from exc
+                raise _map_anthropic_exception(exc, model=request_model) from exc
             finally:
                 dispatch_obj.latency_ms = int(
                     (time.perf_counter() - dispatch_obj.started_at) * 1000

--- a/mcp_proxy/egress/adapters/openai.py
+++ b/mcp_proxy/egress/adapters/openai.py
@@ -61,13 +61,16 @@ _OPENAI_ERROR_MAP: dict[str, tuple[int, str]] = {
 }
 
 
-def _map_openai_exception(exc: Exception) -> "GatewayError":
-    from mcp_proxy.egress.ai_gateway import GatewayError, scrub_secrets
+def _map_openai_exception(
+    exc: Exception, *, model: str | None = None
+) -> "GatewayError":
+    from mcp_proxy.egress.ai_gateway import GatewayError, caller_hint, scrub_secrets
 
     cls = type(exc).__name__
     status, reason = _OPENAI_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
     detail = scrub_secrets((str(exc) or cls)[:512])
-    return GatewayError(status, reason, detail=detail)
+    hint = caller_hint(reason, model=model, provider="openai")
+    return GatewayError(status, reason, detail=detail, hint=hint)
 
 
 # ── client cache ──────────────────────────────────────────────────────
@@ -195,7 +198,7 @@ class OpenAIAdapter:
                 extra_headers=_cullis_headers(ctx),
             )
         except Exception as exc:
-            gw_err = _map_openai_exception(exc)
+            gw_err = _map_openai_exception(exc, model=model)
             _log.warning(
                 "openai_native error agent=%s model=%s reason=%s detail=%s",
                 ctx.agent_id, model, gw_err.reason, gw_err.detail,
@@ -289,7 +292,7 @@ class OpenAIAdapter:
                     extra_headers=_cullis_headers(ctx),
                 )
             except Exception as exc:
-                raise _map_openai_exception(exc) from exc
+                raise _map_openai_exception(exc, model=model) from exc
 
             try:
                 async for chunk in stream:
@@ -322,7 +325,7 @@ class OpenAIAdapter:
                             }
                     yield payload
             except Exception as exc:
-                raise _map_openai_exception(exc) from exc
+                raise _map_openai_exception(exc, model=model) from exc
             finally:
                 dispatch_obj.latency_ms = int(
                     (time.perf_counter() - dispatch_obj.started_at) * 1000

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -128,15 +128,80 @@ class StreamingDispatch:
 class GatewayError(Exception):
     """Raised on any non-recoverable failure talking to the gateway.
 
-    `status_code` is the HTTP code Mastio should return to its own
-    caller; `reason` is a short tag suitable for the audit row.
+    ``status_code`` is the HTTP code Mastio should return to its own
+    caller; ``reason`` is a short tag suitable for the audit row.
+
+    Two human-readable fields with deliberately different trust levels:
+
+    - ``detail`` is diagnostic. It may carry scrubbed-but-still-noisy
+      upstream chatter (``str(exc)`` of an httpx / SDK / pydantic error),
+      so it is for the audit row and operator logs only. The router never
+      puts it on the wire (audit H-IO-2).
+    - ``hint`` is a caller-facing, self-authored one-liner that contains
+      no exception text — only values Mastio already knows (the model id,
+      provider, status family) plus an actionable next step. Safe to
+      surface in the HTTP / SSE error response. ``None`` when the bare
+      ``reason`` tag already says everything useful.
     """
 
-    def __init__(self, status_code: int, reason: str, *, detail: str | None = None):
+    def __init__(
+        self,
+        status_code: int,
+        reason: str,
+        *,
+        detail: str | None = None,
+        hint: str | None = None,
+    ):
         super().__init__(detail or reason)
         self.status_code = status_code
         self.reason = reason
         self.detail = detail
+        self.hint = hint
+
+
+# Reasons whose failure the caller can act on, mapped to a safe,
+# self-authored explanation. Keyed by the ``reason`` tag the adapters
+# emit. Anything not listed falls back to ``None`` (the reason tag is
+# enough). NOTHING here interpolates ``str(exc)`` — only the model id and
+# provider, which the caller already supplied / can see.
+def caller_hint(
+    reason: str,
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+) -> str | None:
+    """Build a caller-safe hint for an upstream-mapped failure ``reason``.
+
+    Used by the native adapters when translating a provider SDK exception
+    into a :class:`GatewayError`, so the router can tell the agent *why*
+    the call failed (e.g. a bad model id) instead of a bare 404.
+    """
+    m = repr(model) if model else "the requested model"
+    p = repr(provider) if provider else "the provider"
+    if reason == "provider_not_found":
+        return (
+            f"{m} was not recognised by provider {p} (upstream 404). "
+            "Verify the model id is spelled correctly and supported by "
+            "that provider; use the bare id (e.g. 'claude-haiku-4-5-20251001'), "
+            "not a 'provider/model' form."
+        )
+    if reason == "provider_auth_failed":
+        return (
+            f"Provider {p} rejected the configured credentials (upstream 401). "
+            "Check the API key under Settings → AI Providers in the Mastio "
+            "dashboard."
+        )
+    if reason == "provider_permission_denied":
+        return (
+            f"Provider {p} denied access for {m} (upstream 403). The "
+            "configured key may lack access to this model."
+        )
+    if reason == "provider_bad_request":
+        return (
+            f"Provider {p} rejected the request as malformed (upstream 400). "
+            "Check the request parameters."
+        )
+    return None
 
 
 async def _resolve_provider_creds(
@@ -167,21 +232,14 @@ async def _resolve_provider_creds(
     if row is None:
         if provider == "anthropic" and settings.anthropic_api_key:
             return provider, {"api_key": settings.anthropic_api_key}
-        raise GatewayError(
-            503,
-            "provider_not_configured",
-            detail=(
-                f"Provider {provider!r} is not configured. "
-                "Add credentials in the Mastio dashboard "
-                "(Settings → AI Providers)."
-            ),
+        msg = (
+            f"Provider {provider!r} is not configured. "
+            "Add credentials in the Mastio dashboard (Settings → AI Providers)."
         )
+        raise GatewayError(503, "provider_not_configured", detail=msg, hint=msg)
     if not row["enabled"]:
-        raise GatewayError(
-            503,
-            "provider_disabled",
-            detail=f"Provider {provider!r} is configured but disabled.",
-        )
+        msg = f"Provider {provider!r} is configured but disabled."
+        raise GatewayError(503, "provider_disabled", detail=msg, hint=msg)
     return provider, dict(row["creds"] or {})
 
 

--- a/mcp_proxy/egress/anthropic_messages_router.py
+++ b/mcp_proxy/egress/anthropic_messages_router.py
@@ -369,9 +369,14 @@ async def anthropic_messages(
                 "upstream_detail": exc.detail,
             },
         )
+        err_detail = {"reason": exc.reason, "trace_id": trace_id}
+        if exc.hint:
+            # Caller-safe, self-authored explanation (no str(exc)); see
+            # GatewayError.hint. Tells the agent why the call failed.
+            err_detail["hint"] = exc.hint
         raise HTTPException(
             status_code=exc.status_code,
-            detail={"reason": exc.reason, "trace_id": trace_id},
+            detail=err_detail,
         ) from exc
 
     latency_ms = int((time.perf_counter() - started) * 1000)

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -56,6 +56,21 @@ def _token_bucket_key(agent: InternalAgent) -> str:
     return f"principal:{agent.agent_id}:llm_tokens"
 
 
+def _gateway_error_detail(exc: GatewayError, trace_id: str) -> dict:
+    """Build the JSON error body for a caught :class:`GatewayError`.
+
+    Surfaces ``exc.hint`` — a caller-safe, self-authored explanation —
+    when the adapter set one, so the agent learns *why* the call failed
+    (e.g. an unrecognised model id) instead of a bare status code. Never
+    includes ``exc.detail``, which may carry upstream chatter and stays
+    in the audit row only (audit H-IO-2).
+    """
+    detail: dict = {"reason": exc.reason, "trace_id": trace_id}
+    if exc.hint:
+        detail["hint"] = exc.hint
+    return detail
+
+
 @router.post("/v1/chat/completions")
 @router.post("/v1/llm/chat")
 async def chat_completions(
@@ -204,7 +219,7 @@ async def chat_completions(
         )
         raise HTTPException(
             status_code=exc.status_code,
-            detail={"reason": exc.reason, "trace_id": trace_id},
+            detail=_gateway_error_detail(exc, trace_id),
         ) from exc
 
     latency_ms = int((time.perf_counter() - started) * 1000)
@@ -289,7 +304,7 @@ async def _handle_stream(
         )
         raise HTTPException(
             status_code=exc.status_code,
-            detail={"reason": exc.reason, "trace_id": trace_id},
+            detail=_gateway_error_detail(exc, trace_id),
         ) from exc
 
     # P1 Cullis Chat SSE backend — tool_call event emission.
@@ -414,11 +429,13 @@ async def _handle_stream(
             # provider chatter (timeouts, auth-key fragments, schema
             # mismatch text) back to the SSE consumer. Keep it in the
             # audit row below for ops triage; on the wire emit only the
-            # stable reason tag + trace id.
+            # stable reason tag + trace id, plus ``exc.hint`` when set —
+            # the hint is a self-authored, caller-safe line (no str(exc)),
+            # so it is fine on the wire and tells the consumer why.
             err_frame = {
                 "error": {
                     "type": exc.reason,
-                    "message": exc.reason,
+                    "message": exc.hint or exc.reason,
                     "trace_id": trace_id,
                 },
             }

--- a/test/unit/test_gateway_error_hint.py
+++ b/test/unit/test_gateway_error_hint.py
@@ -1,0 +1,110 @@
+"""Caller-facing ``hint`` on GatewayError surfaces *why* an egress call
+failed instead of a bare status code.
+
+Motivation: an agent that sent a non-existent model id got a naked
+``HTTP 404`` on ``/v1/llm/chat``. The real reason (model id not
+recognised) lived only in the proxy logs — ``_map_anthropic_exception``
+mapped it to ``provider_not_found`` and the router dropped the detail.
+
+The fix adds ``GatewayError.hint``: a self-authored, caller-safe line
+(never ``str(exc)``) that the router puts on the wire. ``detail`` stays
+audit/log-only because it may echo upstream chatter (audit H-IO-2).
+
+Covered:
+1. ``caller_hint`` maps the caller-actionable reasons and names the model.
+2. ``caller_hint`` returns None for reasons where the tag suffices.
+3. ``_map_anthropic_exception`` / ``_map_openai_exception`` attach the hint
+   for a NotFound-shaped exception and keep ``detail`` separate.
+4. ``_gateway_error_detail`` (router body builder) includes ``hint`` only
+   when set, and never leaks ``detail``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.egress.ai_gateway import GatewayError, caller_hint
+from mcp_proxy.egress.adapters.anthropic import _map_anthropic_exception
+from mcp_proxy.egress.adapters.openai import _map_openai_exception
+from mcp_proxy.egress.llm_chat_router import _gateway_error_detail
+
+
+# ── caller_hint (pure) ───────────────────────────────────────────────
+
+
+def test_caller_hint_not_found_names_model_and_provider() -> None:
+    hint = caller_hint("provider_not_found", model="claude-foo", provider="anthropic")
+    assert hint is not None
+    assert "claude-foo" in hint
+    assert "anthropic" in hint
+    assert "404" in hint
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["provider_auth_failed", "provider_permission_denied", "provider_bad_request"],
+)
+def test_caller_hint_set_for_actionable_reasons(reason: str) -> None:
+    assert caller_hint(reason, model="m", provider="openai") is not None
+
+
+def test_caller_hint_none_for_opaque_reasons() -> None:
+    # A 502/timeout/unknown class is not something the caller can fix by
+    # changing the request; the bare reason tag is enough.
+    assert caller_hint("provider_timeout") is None
+    assert caller_hint("provider_unknown_error") is None
+
+
+def test_caller_hint_handles_missing_model() -> None:
+    hint = caller_hint("provider_not_found", provider="anthropic")
+    assert hint is not None
+    assert "the requested model" in hint
+
+
+# ── adapter exception mappers attach the hint ────────────────────────
+
+
+class _FakeNotFoundError(Exception):
+    """Name matches the Anthropic/OpenAI SDK NotFoundError the mappers key on."""
+
+
+_FakeNotFoundError.__name__ = "NotFoundError"
+
+
+def test_anthropic_mapper_attaches_hint_for_not_found() -> None:
+    exc = _FakeNotFoundError("Error code: 404 - model: claude-foo not found")
+    gw = _map_anthropic_exception(exc, model="claude-foo")
+    assert gw.status_code == 404
+    assert gw.reason == "provider_not_found"
+    assert gw.hint is not None and "claude-foo" in gw.hint
+    # detail keeps the (scrubbed) upstream string; hint must not be it.
+    assert gw.hint != gw.detail
+
+
+def test_openai_mapper_attaches_hint_for_not_found() -> None:
+    exc = _FakeNotFoundError("Error code: 404 - model gpt-foo does not exist")
+    gw = _map_openai_exception(exc, model="gpt-foo")
+    assert gw.reason == "provider_not_found"
+    assert gw.hint is not None and "gpt-foo" in gw.hint
+
+
+# ── router error-body builder ────────────────────────────────────────
+
+
+def test_gateway_error_detail_includes_hint_when_set() -> None:
+    exc = GatewayError(404, "provider_not_found", detail="raw upstream chatter",
+                       hint="Model 'x' was not recognised.")
+    body = _gateway_error_detail(exc, "trace-123")
+    assert body == {
+        "reason": "provider_not_found",
+        "trace_id": "trace-123",
+        "hint": "Model 'x' was not recognised.",
+    }
+    # The raw diagnostic detail must never reach the wire body.
+    assert "raw upstream chatter" not in str(body)
+
+
+def test_gateway_error_detail_omits_hint_when_absent() -> None:
+    exc = GatewayError(502, "provider_timeout", detail="upstream timed out")
+    body = _gateway_error_detail(exc, "trace-9")
+    assert body == {"reason": "provider_timeout", "trace_id": "trace-9"}
+    assert "hint" not in body


### PR DESCRIPTION
## Problema

Un agente che manda un model id non riconosciuto riceveva un nudo \`HTTP 404\` su \`/v1/llm/chat\`. \`_map_anthropic_exception\` mappava l'errore a \`provider_not_found\`, ma il router costruiva il body come \`{reason, trace_id}\` e **scartava \`exc.detail\`**, quindi il chiamante non scopriva mai che il problema era il model id (visibile solo nei log proxy). Questo e l'asse (b) lasciato in sospeso dalla PR #1012 (asse a = strip del prefisso \`provider/\`).

## Fix

Aggiunto \`GatewayError.hint\`: una riga **self-authored e caller-safe** che non interpola mai \`str(exc)\` — solo il model id, il provider e la famiglia di status che il chiamante ha gia fornito.

- I native adapter lo settano via \`caller_hint()\` per i reason azionabili: \`provider_not_found\` (404), \`provider_auth_failed\` (401), \`provider_permission_denied\` (403), \`provider_bad_request\` (400).
- Gli errori hand-written gia user-facing (\`provider_not_configured\`, \`provider_disabled\`, \`provider_native_not_implemented\`) settano \`hint\` al loro testo esistente, che prima era invisibile al chiamante.
- Il router espone \`exc.hint\` nel body HTTP (\`_gateway_error_detail\`) e nel frame SSE mid-stream (\`exc.hint or exc.reason\`). Stesso pattern nel \`/v1/messages\` router.

\`exc.detail\` resta **solo** audit/log (puo contenere chatter upstream scrubbato), quindi la postura H-IO-2 (niente chatter grezzo sul wire) e preservata.

## Test

\`test/unit/test_gateway_error_hint.py\` (10 casi): mapping di \`caller_hint\`, None per reason opachi, mapper che attaccano l'hint tenendo \`detail\` separato, builder del body del router che include l'hint solo se presente e non perde mai \`detail\`. Nessuna regressione su \`test_chat_completion_kwargs\`/\`test_anthropic_messages_router\`/\`test_proxy_routing\`/\`test_executor_denied_reason_codes\` (48 passed).

## Validazione live (dogfood)

Su immagine combinata con #1012 sul native stack 9443:
- \`anthropic/claude-haiku-4-5-20251001\` (valido, prefissato) -> **200 OK** (strip, #1012)
- \`claude-does-not-exist-9\` (bare inesistente) -> **404** con body:
  \`\`\`json
  {\"detail\": {\"reason\": \"provider_not_found\", \"trace_id\": \"...\", \"hint\": \"'claude-does-not-exist-9' was not recognised by provider 'anthropic' (upstream 404). Verify the model id is spelled correctly and supported by that provider; use the bare id ...\"}}
  \`\`\`

## Security review

Pulita, nessun finding. \`hint\` e sempre self-authored, \`str(exc)\` non lo raggiunge mai, nessun path lo renderizza come HTML non-escaped, \`exc.detail\` resta log/audit-only.

## Nota

Indipendente da #1012 ma complementare. Entrambe partono da main e toccano \`mcp_proxy/egress/ai_gateway.py\` in regioni diverse (merge pulito verificato in locale).