### PR TITLE
fix(docs): document llm.chat capability in SDK quickstart

### DIFF
--- a/site/src/content/docs/quickstart/chat-completion.md
+++ b/site/src/content/docs/quickstart/chat-completion.md
@@ -13,6 +13,7 @@ updated: "2026-05-23"
 **Prerequisites**:
 
 - An enrolled agent with the three identity files on disk and a working `from_identity_dir(...)` + `login_via_proxy_with_local_key()`. If you don't have that yet, do [SDK quickstart](sdk) first — this page picks up where that one ends.
+- The agent's capabilities must include **`llm.chat`** (a reserved built-in capability). Since Mastio v0.6.4 the chat endpoints are gated on it: an agent enrolled without `llm.chat` gets `403 capability_missing` before any provider dispatch. Add it at enrollment — see the note in [SDK quickstart § capabilities](sdk).
 - A provider key configured on the Mastio side: `MCP_PROXY_ANTHROPIC_API_KEY` in `proxy.env` for Anthropic upstream, or a reachable Ollama daemon for local models. Without that, every call returns `503 provider_key_missing`.
 
 ## 1. The minimal call

--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -53,6 +53,8 @@ The agent's runtime identity is **three files**:
 
 **A note on `capabilities`.** Free-form strings. There is no closed vocabulary. The convention is `<area>.<verb>` (e.g. `kyc.read`, `kyc.submit`, `portfolio.place_order`) but Mastio does not validate the syntax at enrollment. What matters is that the strings here **match exactly** the capabilities required by the MCP tools the agent will call — Mastio's capability gate compares them literally when a tool is dispatched. Each MCP tool declares its required capability in its server manifest; ask the team that operates the MCP server for the list, or list them at runtime with `client.list_mcp_tools()`.
 
+**Reserved built-in capabilities.** A few capability strings are *not* free-form: Mastio matches them literally to gate its own built-in endpoints. The one you almost always need is **`llm.chat`**, required by every chat completion (`/v1/chat/completions`, `/v1/llm/chat`, `/v1/messages`) since Mastio v0.6.4 — an agent enrolled **without** it is denied `403 capability_missing` before any provider dispatch, so the [Chat completion](chat-completion) page will not work for it. The others are `mcp.tools.list` (MCP tool discovery), `mcp.tools.call` (MCP tool invocation), and `http.get` (the built-in HTTP-GET egress tool). **Include `llm.chat` in any agent that will make LLM calls** — the examples below do.
+
 **A note on `X-Admin-Secret`.** It's the Mastio operator secret. First-boot wizard bcrypts it into Vault; the env var (`MCP_PROXY_ADMIN_SECRET`) is consulted only when the hash is empty. Rotation is via dashboard / `proxy.env` rotate + restart. Full details: [Configuration reference](../reference/configuration) (search `MCP_PROXY_ADMIN_SECRET`) and [Runbook § Admin lockout](../operate/runbook#7-admin-lockout) for the recovery flow.
 
 Pick one of the three provisioning paths depending on whether your org already has a PKI.
@@ -71,7 +73,7 @@ curl -X POST https://mastio.acme.corp/v1/admin/agents \
   -d '{
         "agent_name": "kyc-screener",
         "display_name": "KYC Screener",
-        "capabilities": ["kyc.read", "kyc.submit"]
+        "capabilities": ["llm.chat", "kyc.read", "kyc.submit"]
       }' \
   > kyc-screener.json
 
@@ -116,7 +118,7 @@ CullisClient.enroll_via_byoca(
     display_name="KYC Screener",
     cert_pem=cert_pem,
     private_key_pem=private_key_pem,
-    capabilities=["kyc.read", "kyc.submit"],
+    capabilities=["llm.chat", "kyc.read", "kyc.submit"],
     persist_to="/etc/cullis/agents/kyc/",              # writes cert.pem + agent-key.pem + dpop.jwk
 )
 ```


### PR DESCRIPTION
## Problem

The SDK quickstart (`sdk.md`) mints agents with capabilities like `["kyc.read", "kyc.submit"]`, and the companion `chat-completion.md` then teaches `chat_completion(...)`. But since **v0.6.4 (#1002)** the chat endpoints (`/v1/chat/completions`, `/v1/llm/chat`, `/v1/messages`) are **fail-closed gated** on the reserved built-in capability **`llm.chat`** (`mcp_proxy/egress/llm_chat_router.py:91`). A reader following the docs verbatim gets **403 `capability_missing`** on their first chat completion.

## Fix (docs only)

- **`sdk.md`**: new "Reserved built-in capabilities" note explaining that `llm.chat`, `mcp.tools.list`, `mcp.tools.call`, `http.get` are matched literally to gate Mastio's own endpoints; add `llm.chat` to the path-a curl mint and path-b BYOCA enroll examples.
- **`chat-completion.md`**: add `llm.chat` to the prerequisites with a pointer back to the capabilities note.

## How it was found

Fresh-install cold-read on `mastio-demo` against image `0.6.4-dev` (built from current main): following `sdk.md` path-a to the letter produced a 403 on the first `chat_completion` until `llm.chat` was added at mint. The rest of the install (deploy / mint / persist / `pip install` / login / #1012 prefix-strip / #1013 gateway-hint) passed end-to-end against real Anthropic upstream.

Docs-only change, no code paths touched.
