### PR TITLE
fix(dashboard): label the MCP backends nav 'Backends', not 'Tools'

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -82,7 +82,7 @@
             <a href="/proxy/backends"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'backends' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
-                Tools
+                Backends
             </a>
             <a href="/proxy/policies"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'policies' %}nav-active{% else %}text-gray-500{% endif %}">

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -141,7 +141,7 @@
             </div>
             <div class="topo-arrow">───▶</div>
             <a href="/proxy/backends" class="topo-node hover:border-accent-400/40 transition-colors block">
-                <div class="topo-label">Tools</div>
+                <div class="topo-label">Backends</div>
                 <div class="topo-count">{{ backend_enabled }}</div>
                 <div class="topo-sub">{{ backend_total }} attached</div>
             </a>


### PR DESCRIPTION
## Problem

The `/proxy/backends` page is where operators register MCP servers, set a tool's `required_capability`, and manage agent↔resource bindings. But it was labelled **"Tools"** in two places (sidebar nav + overview topology card), while its URL, page title (`Backends`), and form (`New backend`) all say **Backends**.

Worse, it sat right next to the **"Tool Registry"** nav entry (`/proxy/tools`, the read-only list of invocable tools). Two adjacent entries, "Tool Registry" and "Tools", that look like the same thing but aren't, so an operator looking for where to attach a backend or define a capability lands on the wrong page or gives up.

## Fix

Rename both "Tools" labels that point at `/proxy/backends` to **"Backends"** (`base.html` nav + `overview.html` topology card). "Tool Registry" (`/proxy/tools`) is left untouched.

Now the two nav entries read **"Tool Registry"** (read: what's invocable) and **"Backends"** (write: what you attach), matching the page titles and URLs.

Two template strings, no logic change. Found while documenting where custom per-tool MCP capabilities are created in the dashboard.
