### PR TITLE
fix(security): wire egress DPoP mode to the env the server actually reads

### DIFF
--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -101,7 +101,7 @@ services:
       PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
       # F-B-11 Phase 5 — DPoP enforcement mode for /v1/egress/*
       # (off | optional | required). optional is the current default.
-      CULLIS_EGRESS_DPOP_MODE:     ${CULLIS_EGRESS_DPOP_MODE:-}
+      MCP_PROXY_EGRESS_DPOP_MODE:     ${MCP_PROXY_EGRESS_DPOP_MODE:-}
     volumes:
       - mcp_proxy_data:/data
       # Optional corporate CA mount. The env above points at a file under /certs

--- a/mcp_proxy/alembic/versions/0014_internal_agents_dpop_jkt.py
+++ b/mcp_proxy/alembic/versions/0014_internal_agents_dpop_jkt.py
@@ -11,7 +11,7 @@ keypair (RFC 7638 JWK thumbprint). Without the binding, a leaked
 surface (audit F-B-11, issue #181).
 
 Nullable on purpose — Phase 3 wires the SDK to send the JWK at
-enrollment time and Phase 6 flips ``CULLIS_EGRESS_DPOP_MODE`` to
+enrollment time and Phase 6 flips ``MCP_PROXY_EGRESS_DPOP_MODE`` to
 ``required``. Until then, legacy bearer auth keeps working for any
 row with NULL ``dpop_jkt``. See
 ``mcp_proxy/auth/dpop_api_key.get_agent_from_dpop_api_key`` for the

--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -160,7 +160,7 @@ def _resolve_mode() -> str:
     mode = (get_settings().egress_dpop_mode or "off").strip().lower()
     if mode not in _MODES:
         _log.warning(
-            "Unknown CULLIS_EGRESS_DPOP_MODE=%r — falling back to 'off'. "
+            "Unknown MCP_PROXY_EGRESS_DPOP_MODE=%r — falling back to 'off'. "
             "Valid values: off | optional | required.",
             mode,
         )
@@ -180,7 +180,7 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
       1. ADR-012 LOCAL_TOKEN short-circuit (cross-org Bearer JWT).
       2. ``get_agent_from_client_cert`` — identity from TLS-layer cert,
          pinned against ``internal_agents.cert_pem``, rate-limited.
-      3. When ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or
+      3. When ``MCP_PROXY_EGRESS_DPOP_MODE`` is ``optional`` or
          ``required``, verify a DPoP proof from the ``DPoP`` header:
          htm/htu match, jti consumed once, iat in window, jkt matches
          the agent's registered ``dpop_jkt`` (when stored).

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -57,7 +57,7 @@ class InternalAgent(Base):
     # keypair. NULL during the Phase 2–6 grace period; populated by the
     # Phase 3 enrollment flow and checked by
     # ``mcp_proxy.auth.dpop_api_key.get_agent_from_dpop_api_key`` when
-    # ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or ``required``.
+    # ``MCP_PROXY_EGRESS_DPOP_MODE`` is ``optional`` or ``required``.
     dpop_jkt = Column(Text, nullable=True)
     # ADR-011 Phase 1 — enrollment metadata. ``enrollment_method`` is one of
     # ``admin`` / ``connector`` / ``byoca`` / ``spiffe`` and records how the

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -13,7 +13,7 @@ Phase 2 wires them to the broker.
 
 Auth mirrors the rest of ``/v1/egress/*`` — mTLS client cert via
 ``get_agent_from_dpop_client_cert`` (ADR-014: cert at TLS handshake +
-DPoP proof when ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or
+DPoP proof when ``MCP_PROXY_EGRESS_DPOP_MODE`` is ``optional`` or
 ``required``). Storage reuses the existing
 ``local_messages`` queue with ``session_id=NULL`` and ``is_oneshot=1``
 (see migration 0008). Audit is written through ``append_local_audit``

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -6,7 +6,7 @@ keys, DPoP, or any cryptography directly.
 All endpoints require client-cert authentication (via
 ``get_agent_from_dpop_client_cert``, ADR-014). That dep verifies the
 cert nginx forwarded in ``X-SSL-Client-Cert`` against
-``internal_agents.cert_pem`` and, when ``CULLIS_EGRESS_DPOP_MODE`` is
+``internal_agents.cert_pem`` and, when ``MCP_PROXY_EGRESS_DPOP_MODE`` is
 ``optional`` or ``required``, additionally validates a DPoP proof from
 the ``DPoP`` header pinned to the agent's registered ``dpop_jkt``.
 """

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       PROXY_TRANSPORT_INTRA_ORG:   ${PROXY_TRANSPORT_INTRA_ORG:-}
       PROXY_EGRESS_INSPECTION_ENABLED: ${PROXY_EGRESS_INSPECTION_ENABLED:-}
       PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
-      CULLIS_EGRESS_DPOP_MODE:     ${CULLIS_EGRESS_DPOP_MODE:-}
+      MCP_PROXY_EGRESS_DPOP_MODE:     ${MCP_PROXY_EGRESS_DPOP_MODE:-}
     volumes:
       # ADR-030 — bind mount on the host so /data sits next to deploy.sh
       # (./data/mcp_proxy.db). Replaces the legacy ``mcp_proxy_data``

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -73,6 +73,21 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # uncommented value here in production.
 #MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
 
+# Egress DPoP enforcement mode (RFC 9449 key-possession proof on the
+# agent → Mastio → upstream LLM path). One of:
+#   off       — no DPoP check (cert mTLS only).
+#   optional  — accept a DPoP proof when present, but do not require it.
+#               This is the default and the quickstart posture.
+#   required  — every egress call MUST carry a valid DPoP proof bound to
+#               the agent's registered ``dpop_jkt``; cert-only requests
+#               get 401. **Set this for zero-trust / regulated deploys.**
+# NB: this is the SERVER-side enforcement knob, read only by the Mastio.
+# There is no matching SDK-side switch — the Cullis SDK signs every egress
+# request from its enrolled keypair automatically and does not read an
+# egress DPoP env var; this setting decides whether the Mastio *requires*
+# that proof.
+#MCP_PROXY_EGRESS_DPOP_MODE=required
+
 # PDP webhook URL — the broker calls this to ask the proxy for policy
 # decisions. The broker reaches the Mastio over the docker network,
 # where the in-network listener (port 9100) is still HTTP.


### PR DESCRIPTION
## Problem

The bundle compose mapped `CULLIS_EGRESS_DPOP_MODE` into the Mastio container, but the server reads `egress_dpop_mode` via Pydantic with `env_prefix=MCP_PROXY_` (`mcp_proxy/config.py`), i.e. `MCP_PROXY_EGRESS_DPOP_MODE`. `CULLIS_EGRESS_DPOP_MODE` was silently dropped (`Settings(extra="ignore")`), so an operator following the documented variable to set the egress DPoP mode to `required` got a **fail-silent no-op**: the runtime mode stayed `optional` and every cert-only egress request kept passing.

For a zero-trust / regulated deploy this disables a core security control exactly when the operator believes it is on. `CULLIS_EGRESS_DPOP_MODE` was the only server var on the wrong prefix; the other 47 are `MCP_PROXY_*`.

## Fix

No logic change, name alignment only:

- **bundle + proxy compose**: `CULLIS_EGRESS_DPOP_MODE` → `MCP_PROXY_EGRESS_DPOP_MODE`
- **server-side docstrings / log message / migration comment**: same rename so they match the variable the code reads
- **`proxy.env.example`**: document `MCP_PROXY_EGRESS_DPOP_MODE` (off|optional|required), and clarify there is no SDK-side egress-DPoP env var (the SDK signs from its enrolled keypair automatically)

## Verification

- **Live on mastio-demo**: with `CULLIS_EGRESS_DPOP_MODE=required` the runtime mode was `optional` and raw mTLS without a DPoP proof returned `200`; with `MCP_PROXY_EGRESS_DPOP_MODE=required` it returned `401 DPoP proof required`, and a client carrying a valid proof got `200`. The enforcement code was correct all along — only the wiring was wrong.
- **Security review**: clean, no findings (the diff is security-positive — it closes a fail-silent gap, no logic touched, no other consumer reads the old name).
- **Smoke**: `13/13 PASS` (sqlite, fresh image build).

## Out of scope (separate finding)

`site/src/content/docs/reference/configuration.md` still lists an SDK-side `CULLIS_EGRESS_DPOP_MODE` that the published SDK does not read — to be addressed in a follow-up doc fix.