### PR TITLE
test(smoke): operator Rego deny e2e + gateway/DPoP doc fixes

### DIFF
--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -307,6 +307,23 @@ MCP_PROXY_ANTHROPIC_API_KEY=
 #     warning at startup.
 #   ``portkey`` — Anthropic-only Portkey sidecar at
 #     ``MCP_PROXY_AI_GATEWAY_URL`` (legacy Phase-1 from ADR-017).
+#
+# NB — STOCK BUNDLE IS cullis_native ONLY. Two things gate the
+# alternatives in this Docker bundle, so uncommenting the three vars
+# below is a no-op unless you address both:
+#   1. LiteLLM is not installed in the published image (ADR-039). The
+#      ``litellm_embedded`` backend returns 503 ``litellm_not_installed``
+#      until you rebuild the image with it — see the install note in
+#      ``mcp_proxy/requirements-proxy.txt``.
+#   2. ``MCP_PROXY_AI_GATEWAY_BACKEND`` / ``_PROVIDER`` / ``_URL`` are NOT
+#      forwarded by this bundle's docker-compose.yml ``environment:``
+#      block, so a value set here never reaches the container (docker
+#      compose --env-file only substitutes ${...}; it does not inject).
+#      Add them to the ``mcp-proxy`` service ``environment:`` if you run
+#      a non-native backend. (The Helm chart already wires
+#      ``aiGatewayBackend``; the Compose bundle is deliberately
+#      cullis_native-only.)
+# ``MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S`` below IS wired and works.
 #MCP_PROXY_AI_GATEWAY_BACKEND=cullis_native
 
 # Default upstream provider when the request model id has no explicit

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -58,7 +58,7 @@ Required variables in bold. Safe defaults mean "OK for sandbox / eval"; producti
 | Variable | Default | Purpose |
 |---|---|---|
 | `MCP_PROXY_STRICT_PKI` | `false` | `true` refuses to boot on a legacy Org CA with `pathLen=0`. See [Apply updates § Remediate a legacy Org CA](../operate/apply-updates#worked-example--org-ca-pathlen0). |
-| `MCP_PROXY_EGRESS_DPOP_MODE` | `bound` | `bound` or `none`. `none` disables DPoP on egress from the Mastio — only for legacy targets that can't verify DPoP. |
+| `MCP_PROXY_EGRESS_DPOP_MODE` | `optional` | `off` / `optional` / `required`. Whether the Mastio requires an RFC 9449 DPoP key-possession proof (bound to the agent's registered `dpop_jkt`) on `/v1/egress/*`. `required` refuses cert-only requests with `401`; set it for zero-trust / regulated deploys. |
 | `MCP_PROXY_PDP_URL` | *(none)* | Policy Decision Point webhook. Set to wire an external OPA / custom PDP. |
 | `CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS` | `300` | Minimum seconds between consecutive signing-key rotations. Rate-limits accidental back-to-back rotates. |
 
@@ -69,7 +69,6 @@ Required variables in bold. Safe defaults mean "OK for sandbox / eval"; producti
 | `CULLIS_PROXY_URL` | *(none)* | Default Mastio URL when `CullisClient.from_identity_dir(...)` is called without `mastio_url`. |
 | `CULLIS_ORG_ID` | *(none)* | Default org slug for SDK constructors. |
 | `CULLIS_AGENT_ID` | *(none)* | Default agent id. |
-| `CULLIS_EGRESS_DPOP_MODE` | `bound` | Same semantics as `MCP_PROXY_EGRESS_DPOP_MODE`, read SDK-side. |
 | `CULLIS_EXTENSION_URI` | `cullis-trust/v1` | A2A extension URI the SDK advertises. Override only when interop-testing against a non-default registry. |
 
 ## Environment templates

--- a/test/smoke/scenarios/35_rego_policy_deny.sh
+++ b/test/smoke/scenarios/35_rego_policy_deny.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 35_rego_policy_deny — operator-authored Rego, loaded via the dashboard,
+#                       actually denies a live PDP decision
+# =============================================================================
+#
+# Scenario 30 proves the Rego engine is mounted and that an EMPTY policy
+# default-allows the session surface. This scenario closes the other
+# half: an operator pastes a Rego policy into the dashboard, the Mastio
+# compiles it with the bundled ``opa build`` (the real compile path —
+# only exercised here, not in the opa-mocked unit tests), persists the
+# WASM bundle, and the very next /v1/data/cullis/policy/session call is
+# decided by that bundle. This is the end-to-end "load a policy → see
+# the deny" signal the unit suite cannot give (it mocks the opa binary).
+#
+# The policy is scoped so it only denies a sentinel initiator and
+# default-allows everything else, so later scenarios (40 inference,
+# 50 mcp tool call) are unaffected even before the explicit cleanup.
+#
+# Asserts:
+#   * POST /proxy/policies/rego/save (admin session + CSRF) compiles the
+#     Rego and returns 303 (success redirect), not 400 (compile error)
+#   * /v1/data/cullis/policy/session with the sentinel initiator →
+#     result.decision=deny (the loaded Rego flipped the default-allow)
+#   * /v1/data/cullis/policy/session with a non-sentinel initiator →
+#     result.decision=allow (the Rego's default-allow still passes the
+#     traffic later scenarios depend on)
+#   * after the cleanup delete, the sentinel goes back to allow (the
+#     bundle was removed, no restart — the live-reload contract holds)
+# =============================================================================
+set -euo pipefail
+
+SCENARIO_TAG="35_rego_policy_deny"
+SMOKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# shellcheck source=../lib/_common.sh
+source "$SMOKE_LIB_DIR/_common.sh"
+
+base="$(smoke_mastio_url)"
+cookie_jar="$(mktemp)"
+body_file="$(mktemp)"
+trap 'rm -f "$cookie_jar" "$body_file"' EXIT
+
+# ── Helper: extract result.decision from a bridge response body ─────────────
+_bridge_decision() {
+    local body="$1" result
+    result="$(json_get "$body" 'result')"
+    [[ -n "$result" ]] || { printf ''; return; }
+    printf '%s' "$result" | python3 -c "
+import sys, json
+try:
+    print(json.loads(sys.stdin.read()).get('decision', ''))
+except Exception:
+    print('')
+" 2>/dev/null
+}
+
+# ── Helper: POST a session input to the bridge, echo the decision ───────────
+_session_decision() {
+    local initiator="$1" status
+    local input="{\"input\":{\"initiator_agent_id\":\"$initiator\",\"target_agent_id\":\"orga::bob\",\"initiator_org_id\":\"orga\",\"target_org_id\":\"orga\",\"session_context\":\"initiator\"}}"
+    status="$(curl -sk -X POST \
+        -H 'Content-Type: application/json' \
+        -d "$input" \
+        -o "$body_file" -w '%{http_code}' \
+        "$base/v1/data/cullis/policy/session" || echo 000)"
+    [[ "$status" -eq 200 ]] || die "bridge session returned HTTP $status (expected 200): $(cat "$body_file")"
+    _bridge_decision "$(cat "$body_file")"
+}
+
+# ── Admin login (seeded password) + capture session cookie ──────────────────
+pwd="$(grep -E '^MCP_PROXY_INITIAL_ADMIN_PASSWORD=' "$SMOKE_ROOT/env.smoke" | head -1 | cut -d= -f2-)"
+[[ -n "$pwd" ]] || die "MCP_PROXY_INITIAL_ADMIN_PASSWORD not set in env.smoke"
+
+curl -sk -c "$cookie_jar" -o /dev/null \
+    -X POST \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode "password=$pwd" \
+    "$base/proxy/login" || die "dashboard login failed"
+
+# ── Extract the CSRF token rendered into the Rego editor form ───────────────
+curl -sk -b "$cookie_jar" -o "$body_file" "$base/proxy/policies/rego" \
+    || die "GET /proxy/policies/rego failed"
+csrf="$(grep -oE 'name="csrf_token"[^>]*value="[a-f0-9]+"' "$body_file" \
+    | grep -oE 'value="[a-f0-9]+"' | head -1 | cut -d'"' -f2)"
+[[ -n "$csrf" ]] || die "could not extract csrf_token from /proxy/policies/rego (login may have failed)"
+log_pass "admin session established + CSRF token extracted"
+
+# ── Save an operator Rego: deny one sentinel initiator, allow the rest ──────
+# Rego v1 syntax (``if {``), matching site/.../operate/rego-policies.md.
+# ``default`` keeps every other principal (and the whole tool_call
+# surface) on allow so scenarios 40/50 are not disturbed.
+read -r -d '' rego_src <<'REGO' || true
+package cullis.policy
+
+default session := {"decision": "allow"}
+default tool_call := {"decision": "allow"}
+
+session := {"decision": "deny", "reason": "smoke35 sentinel deny"} if {
+    input.initiator_agent_id == "smoketest::denied"
+}
+REGO
+
+status="$(curl -sk -b "$cookie_jar" \
+    -X POST \
+    --data-urlencode "csrf_token=$csrf" \
+    --data-urlencode "rego=$rego_src" \
+    -o "$body_file" -w '%{http_code}' \
+    "$base/proxy/policies/rego/save" || echo 000)"
+case "$status" in
+    303|200) log_pass "Rego compiled + persisted via dashboard (HTTP $status)" ;;
+    400)     die "opa build rejected the Rego (HTTP 400): $(cat "$body_file" | head -c 400)" ;;
+    *)       die "/proxy/policies/rego/save returned HTTP $status: $(cat "$body_file" | head -c 400)" ;;
+esac
+
+# ── The loaded Rego denies the sentinel on a live decision ──────────────────
+decision="$(_session_decision 'smoketest::denied')"
+[[ "$decision" == "deny" ]] \
+    || die "expected sentinel session decision=deny after Rego load, got '$decision'"
+log_pass "operator Rego enforced live → sentinel session DENY"
+
+# ── …and default-allows the traffic later scenarios rely on ─────────────────
+decision="$(_session_decision 'orga::alice')"
+[[ "$decision" == "allow" ]] \
+    || die "expected non-sentinel session decision=allow (Rego default), got '$decision'"
+log_pass "non-sentinel session still ALLOW (Rego default-allow preserved)"
+
+# ── Cleanup: delete the bundle, confirm live-reload reverts to allow ────────
+status="$(curl -sk -b "$cookie_jar" \
+    -X POST \
+    --data-urlencode "csrf_token=$csrf" \
+    -o /dev/null -w '%{http_code}' \
+    "$base/proxy/policies/rego/delete" || echo 000)"
+case "$status" in
+    303|200) : ;;
+    *)       die "/proxy/policies/rego/delete returned HTTP $status" ;;
+esac
+
+decision="$(_session_decision 'smoketest::denied')"
+[[ "$decision" == "allow" ]] \
+    || die "sentinel still '$decision' after Rego delete — live-reload/cleanup broken"
+log_pass "Rego deleted → sentinel back to ALLOW (live-reload, no restart)"


### PR DESCRIPTION
Three small, related follow-ups bundled per request. No product-code logic changes (one new smoke scenario + two doc files), so no security-review needed.

## 1. `test(smoke)` — operator Rego deny, end-to-end

New scenario `35_rego_policy_deny.sh`. Scenario 30 already proves the Rego engine mounts and an *empty* policy default-allows the session surface. This closes the other half: an operator pastes a Rego policy into the dashboard, the Mastio compiles it with the bundled `opa build` (the **real** compile path — the unit suite mocks the `opa` binary, so this is only exercised in the smoke image), persists the WASM bundle, and the next `/v1/data/cullis/policy/session` call is decided by it.

The policy denies one sentinel initiator and default-allows everything else, so later scenarios are unaffected; the scenario then deletes the bundle and confirms the sentinel reverts to allow, exercising the live-reload (no restart) contract.

Validated: `./test/smoke/smoke.sh --scenario 35` → **5/5 PASS** (save 303 → sentinel deny → non-sentinel allow → post-delete allow).

## 2. `docs(bundle)` — stock image is cullis_native-only

`proxy.env.example` presented the `AI_GATEWAY_BACKEND/_PROVIDER/_URL` vars as if uncommenting them switches the gateway. In this Docker bundle it does not: LiteLLM isn't in the published image (ADR-039 → `litellm_embedded` returns 503 until rebuilt), **and** those three vars aren't in the compose `environment:` block (so a value in `proxy.env` never reaches the container). Added an explicit NB. `AI_GATEWAY_REQUEST_TIMEOUT_S` stays wired and works.

## 3. `docs(reference)` — fix `EGRESS_DPOP_MODE`, drop phantom SDK var

`configuration.md` listed `MCP_PROXY_EGRESS_DPOP_MODE` with default `bound` / values `bound|none`; the server actually defaults to `optional` with `off|optional|required` (`config.py`, `auth/dpop_client_cert._MODES`). Corrected. Also dropped the SDK-side `CULLIS_EGRESS_DPOP_MODE` row — the published SDK reads no such env (it signs each egress request from its enrolled keypair automatically). Follow-up to the out-of-scope note in #1018.