### PR TITLE
fix(security): require DPoP-strict egress in production (F-B-11)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -1186,6 +1186,40 @@ def validate_config(settings: ProxySettings) -> None:
                 )
                 raise SystemExit(1)
 
+        # F-B-11 (audit 2026-06-01). Egress DPoP enforcement mode.
+        # ``egress_dpop_mode`` defaults to ``optional`` — the quickstart
+        # posture, where a client-cert egress request that carries no DPoP
+        # proof is still accepted. In production that means a leaked or
+        # replayed agent client cert reaches the upstream LLM with no RFC
+        # 9449 key-possession proof bound to the agent's ``dpop_jkt``. A
+        # zero-trust / regulated deploy must run ``required`` (every
+        # ``/v1/egress/*`` call carries a valid proof; cert-only gets 401).
+        # The only legitimate weaker posture is the agent-enrollment
+        # migration window (rows with NULL ``dpop_jkt`` predating ADR-011
+        # Phase 3); declare it explicitly and track a sunset date, mirroring
+        # the WebAuthn opt-in above. (Phase 6 of the rollout flips this to
+        # ``required`` once every agent carries a registered jkt.)
+        egress_mode = (settings.egress_dpop_mode or "off").strip().lower()
+        if egress_mode != "required":
+            insecure_ok = (
+                os.environ.get("MCP_PROXY_EGRESS_DPOP_INSECURE_OK", "")
+                .strip()
+                .lower()
+            ) in {"1", "true", "yes"}
+            if not insecure_ok:
+                _log.critical(
+                    "MCP_PROXY_EGRESS_DPOP_MODE=%r is not permitted in "
+                    "production: cert-only egress is accepted with no RFC "
+                    "9449 key-possession proof, so a leaked or replayed "
+                    "agent cert reaches the upstream LLM unchallenged. Set "
+                    "MCP_PROXY_EGRESS_DPOP_MODE=required, or for the "
+                    "agent-enrollment migration window explicitly opt in via "
+                    "MCP_PROXY_EGRESS_DPOP_INSECURE_OK=true and track a "
+                    "sunset date (F-B-11).",
+                    egress_mode,
+                )
+                raise SystemExit(1)
+
         # F-A-202 (audit 2026-05-20). PDP webhook HMAC secret protects
         # /pdp/policy + /v1/policy/tool-call inbound calls with
         # X-ATN-Signature (audit 2026-04-30 lane 3 H3). Empty secret

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -86,6 +86,13 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # request from its enrolled keypair automatically and does not read an
 # egress DPoP env var; this setting decides whether the Mastio *requires*
 # that proof.
+#
+# PRODUCTION: with MCP_PROXY_ENVIRONMENT=production the Mastio REFUSES TO
+# BOOT unless this is ``required`` (F-B-11), so a regulated deploy cannot
+# silently run the weaker posture. The one sanctioned exception is the
+# agent-enrollment migration window (agents predating the DPoP-key
+# rollout): set MCP_PROXY_EGRESS_DPOP_INSECURE_OK=true to boot on
+# off/optional and track a sunset date.
 #MCP_PROXY_EGRESS_DPOP_MODE=required
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy

--- a/test/unit/test_audit_anchor_tsa_url_validation.py
+++ b/test/unit/test_audit_anchor_tsa_url_validation.py
@@ -50,6 +50,7 @@ def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _DB_ENC_OK)
     monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
     monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example")
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")  # F-B-11
     monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
     monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
     monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")

--- a/test/unit/test_proxy_tls_verify.py
+++ b/test/unit/test_proxy_tls_verify.py
@@ -44,6 +44,10 @@ def _prod_settings(**overrides) -> ProxySettings:
         # in TLS-focused tests comes from the TLS knob under test, not
         # from KMS.
         kms_backend="vault",
+        # F-E-03 — prod refuses secret_backend=env; pin vault so the
+        # helper genuinely passes every gate and a SystemExit isolates the
+        # knob under test. The env-backend negative test overrides this.
+        secret_backend="vault",
         # Audit F-B-10 — prod now refuses empty signing key.
         dashboard_signing_key="strong-signing-key",
         # Three-tier PKI hardening (audit 2026-05-18) — prod now
@@ -53,6 +57,7 @@ def _prod_settings(**overrides) -> ProxySettings:
         pdp_webhook_hmac_secret="strong-pdp-hmac-secret",  # F-A-202
         webauthn_enforcement="required",  # F-A-205
         webauthn_rp_id="mastio.example.com",
+        egress_dpop_mode="required",  # F-B-11
     )
     base.update(overrides)
     return ProxySettings(**base)
@@ -102,6 +107,46 @@ def test_validate_config_refuses_env_backend_in_prod():
     settings = _prod_settings(secret_backend="env", vault_verify_tls=True)
     with pytest.raises(SystemExit):
         validate_config(settings)
+
+
+# ── F-B-11 egress DPoP enforcement gate ──────────────────────────────
+
+def test_validate_config_rejects_prod_with_egress_dpop_optional():
+    """Production must not boot on the quickstart ``optional`` posture:
+    cert-only egress with no RFC 9449 proof is accepted (F-B-11)."""
+    settings = _prod_settings(egress_dpop_mode="optional")
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_validate_config_rejects_prod_with_egress_dpop_off():
+    settings = _prod_settings(egress_dpop_mode="off")
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_validate_config_allows_prod_with_egress_dpop_required():
+    # Must not raise — _prod_settings already pins required, but be explicit.
+    settings = _prod_settings(egress_dpop_mode="required")
+    validate_config(settings)
+
+
+def test_validate_config_allows_prod_weak_egress_dpop_with_explicit_optin(monkeypatch):
+    """The agent-enrollment migration window may run weaker, but only when
+    the operator consciously opts in (mirrors WEBAUTHN_WARN_INSECURE_OK)."""
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_INSECURE_OK", "true")
+    settings = _prod_settings(egress_dpop_mode="optional")
+    # Must not raise: explicit opt-in to the weaker migration-window posture.
+    validate_config(settings)
+
+
+def test_validate_config_dev_tolerates_optional_egress_dpop():
+    """Development keeps the quickstart ``optional`` default with no opt-in."""
+    settings = ProxySettings(
+        environment="development",
+        egress_dpop_mode="optional",
+    )
+    validate_config(settings)
 
 
 def test_validate_config_dev_tolerates_disabled_verify():


### PR DESCRIPTION
## Problem

`egress_dpop_mode` defaults to `optional` (the quickstart posture): a client-cert egress request that carries no DPoP proof is still accepted. In a production deploy that means a leaked or replayed agent client cert reaches the upstream LLM with **no RFC 9449 key-possession proof** bound to the agent's `dpop_jkt` — a core zero-trust control silently weaker than the operator assumes. The wiring fix (#1018) made `required` reachable; this makes production *demand* it.

## Fix

`validate_config()` now refuses to boot (`SystemExit(1)`) in `environment=production` unless `egress_dpop_mode` is `required`, mirroring the existing F-A-205 WebAuthn gate. The only sanctioned weaker posture is the **agent-enrollment migration window** (rows with NULL `dpop_jkt` predating ADR-011 Phase 3), declared explicitly via `MCP_PROXY_EGRESS_DPOP_INSECURE_OK=true` with a tracked sunset date.

- `config.py`: F-B-11 production gate. Fail-closed direction (`!= "required"` → reject), same `(x or "off").strip().lower()` normalization the runtime resolver uses, so no value passes the gate yet enforces weakly.
- `test_proxy_tls_verify.py`: pin `egress_dpop_mode` + `secret_backend` in the `_prod_settings` helper so it genuinely passes every gate and a `SystemExit` isolates the knob under test; add 5 tests (reject optional/off, allow required, allow weak+opt-in, dev tolerates optional).
- `test_audit_anchor_tsa_url_validation.py`: pin `EGRESS_DPOP_MODE=required` in the production-env helper so it still reaches the F-A-406 gate it targets.
- `proxy.env.example`: document the production refuse-to-boot + the opt-in.

## Validation

- **Unit**: the `validate_config` callers + production-mode test files pass (46 + 34).
- **Smoke**: `13/13 PASS` (dev mode — the gate is inside the `is_production` branch, so dev behaviour is unchanged).
- **Security review**: clean. Traced the bypass concern — gate and runtime apply the identical normalization to the same field, fail-closed, so no casing/whitespace value boots production weak. Security-positive (converts a silently-weak posture into fail-closed refuse-to-boot).

Part of the design-partner-pilot hardening: secure-by-default so the pilot cannot be misconfigured into an insecure egress posture.