### PR TITLE
fix(bundle): make deploy.sh --prod actually boot in production

### DIFF
--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -44,11 +44,31 @@ services:
     networks:
       - proxy_net
 
+  # DPoP JTI + login-challenge nonce store, shared across the uvicorn
+  # workers (the bundle runs 4 by default). In production the in-memory
+  # fallback is refused — cross-worker replay of login nonces / DPoP jti
+  # (audit L1-M4 / U-DD-1) — so Redis is required there; development
+  # tolerates its absence. Ephemeral: no volume, no persistence, no backup.
+  redis:
+    image: redis:7-alpine
+    container_name: cullis-mastio-redis
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    networks:
+      - proxy_net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   mcp-proxy:
     image: ghcr.io/cullis-security/cullis-mastio:${CULLIS_MASTIO_VERSION:-latest}
     depends_on:
       init-permissions:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     # ADR-014 — no host port publish. The Mastio listens on 9100 only
     # on proxy_net; the mastio-nginx sidecar below publishes 9443.
     expose:
@@ -104,6 +124,10 @@ services:
       # MCP_PROXY_DATABASE_URL stays as a backward-compat alias.
       MCP_PROXY_DATABASE_URL:      ${MCP_PROXY_DATABASE_URL:-sqlite+aiosqlite:////data/mcp_proxy.db}
       PROXY_DB_URL:                ${PROXY_DB_URL:-}
+      # DPoP JTI + login-challenge nonce store (the ``redis`` service
+      # above). Required in production (the in-memory fallback is refused
+      # for the multi-worker default); dev tolerates an empty value.
+      MCP_PROXY_REDIS_URL:         ${MCP_PROXY_REDIS_URL:-redis://redis:6379/0}
       # Shared secret for the policy-bridge integration endpoints
       # (/v1/data/cullis/policy and /v1/integrations/cloudevents).
       # Empty by default — the endpoints accept unsigned calls during

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -178,6 +178,38 @@ services:
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
       MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
       MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
+      # Production gate vars. ``validate_config(production)`` refuses to
+      # boot unless these are set, but until this block existed they were
+      # NOT forwarded into the container (docker compose --env-file only
+      # substitutes ${...}; it does not inject), so ``./deploy.sh --prod``
+      # set MCP_PROXY_ENVIRONMENT=production and then SystemExit'd on the
+      # first unsatisfiable gate — production mode was unreachable and
+      # every deploy fell back to development. Defaults below keep dev
+      # behaviour identical (local KMS, empty key, webauthn warn); the
+      # production path supplies real values via generate-proxy-env.sh
+      # --prod + the operator's Vault.
+      # KMS backend for the Org CA private key (ADR-031). ``local`` keeps
+      # it in the DB (dev/test); ``vault`` is required in production.
+      MCP_PROXY_KMS_BACKEND:       ${MCP_PROXY_KMS_BACKEND:-local}
+      MCP_PROXY_VAULT_ORG_CA_PATH: ${MCP_PROXY_VAULT_ORG_CA_PATH:-secret/data/cullis-mastio/org-ca}
+      # Pin a private CA for an HTTPS Vault fronted by a corporate root.
+      # Empty → system trust store. Path is inside the container (mount
+      # under /certs). Distinct from VAULT_VERIFY_TLS (the boolean).
+      MCP_PROXY_VAULT_CA_CERT_PATH: ${MCP_PROXY_VAULT_CA_CERT_PATH:-}
+      MCP_PROXY_VAULT_VERIFY_TLS:  ${MCP_PROXY_VAULT_VERIFY_TLS:-true}
+      # Fernet master passphrase wrapping the Org Root + Intermediate
+      # private keys in pki_key_store (>= 32 chars). Empty in dev; production
+      # refuses an empty value. generate-proxy-env.sh --prod mints one.
+      MCP_PROXY_DB_ENCRYPTION_KEY: ${MCP_PROXY_DB_ENCRYPTION_KEY:-}
+      # WebAuthn enforcement for on-behalf-of-user attribution (ADR-033).
+      # Default ``warn``; production refuses warn/off unless the operator
+      # opts in via WEBAUTHN_WARN_INSECURE_OK (single-Mastio pilots with no
+      # IdP-backed user registration) or sets enforcement=required with the
+      # RP fields below.
+      MCP_PROXY_WEBAUTHN_ENFORCEMENT:      ${MCP_PROXY_WEBAUTHN_ENFORCEMENT:-warn}
+      MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK: ${MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK:-}
+      MCP_PROXY_WEBAUTHN_RP_ID:            ${MCP_PROXY_WEBAUTHN_RP_ID:-}
+      MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN:  ${MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN:-}
       # Anthropic upstream key for the embedded AI gateway (ADR-017).
       # Empty default disables /v1/chat/completions cleanly (the rest of
       # the Mastio still works — registry, MCP, audit). Without this

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -232,6 +232,39 @@ if [[ -f "$PROJECT_DIR/VERSION" ]]; then
     fi
 fi
 
+# Production hardening secrets (--prod only). validate_config(production)
+# refuses to boot unless secret_backend=vault, kms_backend=vault and a
+# DB_ENCRYPTION_KEY are set (and webauthn is required or explicitly opted
+# out). Until the bundle compose forwarded these (added alongside this
+# change), ``./deploy.sh --prod`` set environment=production and then
+# SystemExit'd on the first gate, so production mode was unreachable.
+# WebAuthn posture for a single-Mastio pilot: explicit opt-in to the warn
+# default (no IdP-backed user registration); track a sunset date.
+if [[ "$MODE" == "prod" ]]; then
+    DB_ENC_KEY="$(gen_secret)$(gen_secret)"   # 64 chars, comfortably over the >= 32 floor
+    _prod_set() {  # strip any existing line (commented or not), append uncommented
+        sed -i.bak "/^#*[[:space:]]*${1%%=*}=/d" "$OUT"; rm -f "${OUT}.bak"
+        echo "$1" >> "$OUT"
+    }
+    _prod_set "MCP_PROXY_SECRET_BACKEND=vault"
+    _prod_set "MCP_PROXY_KMS_BACKEND=vault"
+    _prod_set "MCP_PROXY_DB_ENCRYPTION_KEY=${DB_ENC_KEY}"
+    _prod_set "MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true"
+    _prod_set "MCP_PROXY_EGRESS_DPOP_MODE=required"
+    # F-A-202 — production refuses an empty PDP webhook HMAC secret
+    # (inbound /pdp/policy + /v1/policy/tool-call would accept unsigned
+    # calls). Mint one; an operator pairing with an external broker PDP
+    # overwrites it to match the broker's POLICY_WEBHOOK_HMAC_SECRET.
+    _prod_set "MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=$(gen_secret)$(gen_secret)"
+    if [[ -n "${VAULT_ADDR:-}" && -n "${VAULT_TOKEN:-}" ]]; then
+        _prod_set "MCP_PROXY_VAULT_ADDR=${VAULT_ADDR}"
+        _prod_set "MCP_PROXY_VAULT_TOKEN=${VAULT_TOKEN}"
+        ok "Production: minted DB_ENCRYPTION_KEY, set KMS+secret backend=vault, DPoP=required, webauthn opt-in"
+    else
+        warn "Production needs a Vault: KMS_BACKEND=vault custodies the Org CA private key. Set MCP_PROXY_VAULT_ADDR + MCP_PROXY_VAULT_TOKEN in ${OUT} before ./deploy.sh --prod."
+    fi
+fi
+
 ok "Wrote ${OUT}"
 echo ""
 echo -e "  ${BOLD}MCP_PROXY_ADMIN_SECRET${RESET}            ${GRAY}${ADMIN_SECRET:0:8}…${RESET}"

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -88,6 +88,39 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # that proof.
 #MCP_PROXY_EGRESS_DPOP_MODE=required
 
+# ─── [PRODUCTION] Vault KMS + at-rest encryption + WebAuthn ───────────────────
+#
+# These are the gates ``validate_config(production)`` enforces. With
+# MCP_PROXY_ENVIRONMENT=production the Mastio refuses to boot unless they
+# are satisfied, and the compose now forwards them so a value set here
+# actually reaches the container. ``./generate-proxy-env.sh --prod`` sets
+# them for you (mints DB_ENCRYPTION_KEY, pins the Vault backends, opts the
+# WebAuthn posture). Leave them at the dev defaults for a sandbox.
+#
+# KMS backend for the Org CA private key (ADR-031, the org PKI root that
+# signs every agent cert). ``local`` keeps it in the DB (dev). Production
+# REQUIRES ``vault`` — set it with MCP_PROXY_VAULT_ADDR + _TOKEN above.
+#MCP_PROXY_KMS_BACKEND=vault
+# KV v2 path for the Org CA keypair. Default matches a dev Vault's
+# ``secret/`` mount; override for a custom KV layout.
+#MCP_PROXY_VAULT_ORG_CA_PATH=secret/data/cullis-mastio/org-ca
+# Pin a private CA for an HTTPS Vault behind a corporate root (path inside
+# the container, mount under /certs). Empty = system trust store.
+#MCP_PROXY_VAULT_CA_CERT_PATH=/certs/vault-ca.pem
+# Fernet master passphrase (>= 32 chars) wrapping the Org Root +
+# Intermediate private keys in pki_key_store. Production refuses an empty
+# value. Generate with ``openssl rand -hex 48``.
+#MCP_PROXY_DB_ENCRYPTION_KEY=
+# WebAuthn enforcement for on-behalf-of-user attribution (ADR-033).
+# Default ``warn``. Production refuses warn/off UNLESS you opt in below —
+# the sanctioned posture for a single-Mastio pilot with no IdP-backed user
+# registration. Track a sunset date and move to ``required`` (+ RP_ID +
+# EXPECTED_ORIGIN) once a real user-credential flow is in place.
+#MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true
+#MCP_PROXY_WEBAUTHN_ENFORCEMENT=required
+#MCP_PROXY_WEBAUTHN_RP_ID=mastio.myorg.example.com
+#MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN=https://mastio.myorg.example.com
+
 # PDP webhook URL — the broker calls this to ask the proxy for policy
 # decisions. The broker reaches the Mastio over the docker network,
 # where the in-network listener (port 9100) is still HTTP.


### PR DESCRIPTION
## The finding (empirically verified)

`./deploy.sh --prod` set `MCP_PROXY_ENVIRONMENT=production` (via the prod overlay) but the Mastio then **refused to boot**. `validate_config(production)` enforces a chain of refuse-to-boot gates — and most weren't reachable through the bundle:

| Production gate (SystemExit) | Forwarded by bundle compose? |
|---|---|
| `secret_backend=vault` | ✅ yes |
| `kms_backend=vault` (Org CA → Vault, ADR-031) | ❌ **no — the wall** |
| `db_encryption_key` (≥32c, pki_key_store Fernet envelope) | ❌ no, nor minted/documented |
| `webauthn` required-or-opted-out | ❌ no |

`docker compose --env-file` only substitutes `${...}`; it does not inject. So even an operator who discovered these vars and set them in `proxy.env` couldn't satisfy the gates — the value never reached the container. Proven against the published image:

```
env=production + the prod-overlay vars + secret_backend=vault
  → SystemExit: MCP_PROXY_KMS_BACKEND='local' is not supported in production
```

Net effect: production mode was **unreachable**, so every bundle deploy fell back to `development` — where every secure-by-default production gate (admin-secret, TLS-verify, DPoP-strict, audit-fail-deny, …) is skipped.

## Fix

- **docker-compose.yml**: forward the production gate vars into the `mcp-proxy` `environment:` block — `MCP_PROXY_KMS_BACKEND`, `VAULT_ORG_CA_PATH`, `VAULT_CA_CERT_PATH`, `VAULT_VERIFY_TLS`, `DB_ENCRYPTION_KEY`, and the `WEBAUTHN_*` knobs. Defaults keep dev behaviour byte-identical (local KMS, empty key, webauthn `warn`).
- **generate-proxy-env.sh --prod**: mint a `DB_ENCRYPTION_KEY`, pin `secret_backend`+`kms_backend=vault`, opt into the WebAuthn `warn` posture (single-Mastio pilot, no IdP-backed user registration; track a sunset date), set `egress_dpop_mode=required`, and carry the operator's `VAULT_ADDR`/`VAULT_TOKEN`.
- **proxy.env.example**: document the production gate vars + the Org CA Vault custody story.

## Validation

`docker run` of the image in `environment=production` with the now-forwarded vars **passes** `validate_config` (previously `SystemExit`). `generate-proxy-env.sh --prod` produces a complete, bootable production `proxy.env`.

## Known follow-ups (not this PR)

- `generate-proxy-env.sh --prod` still requires `BROKER_URL` (broker mode); a standalone-prod pilot hand-edits it. A `--standalone` prod path is a separate change.
- `MCP_PROXY_REDIS_URL` is still unforwarded while the bundle defaults to 4 workers — `validate_config` warns (F-B-12: cross-worker DPoP replay + rate-limit budget). Worth forwarding Redis next.
- Helm chart does not wire `kms_backend` either (same class).

---

**Update**: also ships a Redis service for the multi-worker security stores (commit 866a6c9d). The bundle runs 4 uvicorn workers; in production the DPoP-JTI + login-challenge nonce stores refuse the in-memory fallback (cross-worker replay) and require Redis. Without it, /v1/auth/login-challenge 500'd and no agent could authenticate — surfaced by the prod-shape dogfood. Adds redis:7-alpine (ephemeral) + forwards MCP_PROXY_REDIS_URL.