### PR TITLE
fix(security): atomic create-only CA store closes multi-worker PKI race (Vault)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -1967,11 +1967,19 @@ class AgentManager:
             )
             return wrote_key and wrote_cert
 
-        # KMS providers (Vault / AWS-KMS / Azure-KV / etc) implement
-        # their own atomic-insert semantics under
-        # ``store_intermediate_ca``; if the provider doesn't expose a
-        # winner signal we assume win-on-success and leave the
-        # race-safe behaviour to the provider plugin.
+        # KMS providers that expose an atomic create-only variant
+        # (``store_intermediate_ca_if_absent`` — Vault via KV v2 cas:0)
+        # return whether THIS worker won the boot race, so the loser
+        # adopts the winner's pair instead of minting its own Intermediate
+        # under its own root. Providers without it keep the legacy
+        # win-on-success contract (race-safety left to the plugin). Closes
+        # the D-9 multi-worker split-brain that broke agent mTLS under
+        # ``kms_backend=vault`` (the leaf chain failed ECDSA verification
+        # at the nginx boundary because each worker signed off a different
+        # Intermediate).
+        store_if_absent = getattr(provider, "store_intermediate_ca_if_absent", None)
+        if store_if_absent is not None:
+            return await store_if_absent(key_pem, cert_pem)
         await provider.store_intermediate_ca(key_pem, cert_pem)
         return True
 
@@ -2031,16 +2039,22 @@ class AgentManager:
                 await set_config("org_ca_cert", winning["cert"])
             return False
 
-        # KMS providers (Vault / AWS-KMS / Azure-KV / etc) implement
-        # their own atomic-insert semantics under ``store_org_ca``;
-        # we assume win-on-success for the encrypted path and leave
-        # the race-safe behaviour to the provider plugin. The cert is
-        # still written race-safe to proxy_config for the back-compat
-        # readers.
-        await provider.store_org_ca(key_pem, cert_pem)
+        # KMS providers that expose an atomic create-only variant
+        # (``store_org_ca_if_absent`` — Vault via KV v2 cas:0) return
+        # whether THIS worker won the boot race, so the loser adopts the
+        # winner's pair instead of signing the Intermediate (and every
+        # agent leaf) off its own root. Providers without it keep the
+        # legacy win-on-success contract. The cert is still written
+        # race-safe to proxy_config for the back-compat readers.
+        store_if_absent = getattr(provider, "store_org_ca_if_absent", None)
+        if store_if_absent is not None:
+            won = await store_if_absent(key_pem, cert_pem)
+        else:
+            await provider.store_org_ca(key_pem, cert_pem)
+            won = True
         from mcp_proxy.db import set_config_if_absent
         await set_config_if_absent("org_ca_cert", cert_pem)
-        return True
+        return won
 
     async def _mint_mastio_leaf(self, now: datetime) -> None:
         """Mint a fresh EC P-256 leaf under the existing intermediate CA.

--- a/mcp_proxy/kms/provider.py
+++ b/mcp_proxy/kms/provider.py
@@ -52,3 +52,12 @@ class KMSProvider(Protocol):
         replace any earlier value atomically.
         """
         ...
+
+    # NB: a provider MAY also implement ``store_org_ca_if_absent`` /
+    # ``store_intermediate_ca_if_absent`` (-> bool, True=won/False=lost)
+    # for an atomic create-only write that resolves the D-9 multi-worker
+    # boot race (Vault does, via KV v2 ``cas: 0``). They are intentionally
+    # NOT part of this runtime-checkable Protocol — adding ``...`` stubs
+    # here would make ``isinstance(local_provider, KMSProvider)`` in the
+    # factory fail for providers that don't implement them. ``AgentManager``
+    # probes via ``getattr`` and falls back to ``store_*`` + win-on-success.

--- a/mcp_proxy/kms/vault.py
+++ b/mcp_proxy/kms/vault.py
@@ -250,3 +250,60 @@ class VaultKMSProvider:
                 )
 
         _log.info("KMS[vault] %s stored to %s", label, path)
+
+    # ── Race-safe create-only (D-9 multi-worker boot) ───────────────────
+    # ``_store_path`` above is a read-modify-write whose first-write branch
+    # carries no ``cas`` constraint, so N uvicorn workers booting in
+    # parallel each create their own Org CA / Intermediate and last-write
+    # wins — leaving every worker with a different in-memory pair and the
+    # agent cert chain inconsistent (ECDSA verify failure at the nginx
+    # mTLS boundary). These ``*_if_absent`` variants do an atomic
+    # create-only write (KV v2 ``cas: 0`` = succeed only if the key does
+    # not yet exist) and return whether THIS worker won, so the caller can
+    # adopt the winner's pair instead of signing leaves off its own.
+
+    async def store_org_ca_if_absent(self, key_pem: str, cert_pem: str) -> bool:
+        """Create the Org CA keypair only if absent. True = won, False = lost."""
+        return await self._create_only(self._org_ca_path, key_pem, cert_pem, "Org CA")
+
+    async def store_intermediate_ca_if_absent(self, key_pem: str, cert_pem: str) -> bool:
+        """Create the Intermediate keypair only if absent. True = won, False = lost."""
+        return await self._create_only(
+            self._intermediate_ca_path, key_pem, cert_pem, "Intermediate CA",
+        )
+
+    async def _create_only(
+        self, path: str, key_pem: str, cert_pem: str, label: str,
+    ) -> bool:
+        url = f"/v1/{path}"
+        # cas:0 — Vault KV v2 writes only when the key has no current
+        # version, i.e. atomic create. A concurrent winner makes this
+        # return HTTP 400 (check-and-set mismatch) → we lost the race.
+        body = {
+            "options": {"cas": 0},
+            "data": {"key_pem": key_pem, "cert_pem": cert_pem},
+        }
+        async with self._client() as client:
+            try:
+                resp = await client.post(url, json=body)
+            except httpx.HTTPError as exc:
+                raise RuntimeError(
+                    f"Vault create-only POST failed for {path} "
+                    f"({label}): {exc}",
+                ) from exc
+        if resp.status_code in (200, 204):
+            _log.info("KMS[vault] %s create-only WON (cas=0) at %s", label, path)
+            return True
+        # 400 with a check-and-set / cas message means the key already
+        # exists (a sibling worker won) — a clean loss, not an error.
+        body_text = (resp.text or "").lower()
+        if resp.status_code == 400 and ("check-and-set" in body_text or "cas" in body_text):
+            _log.info(
+                "KMS[vault] %s create-only LOST (already exists) at %s — "
+                "caller adopts the winning pair", label, path,
+            )
+            return False
+        raise RuntimeError(
+            f"Vault returned HTTP {resp.status_code} on create-only "
+            f"{path} ({label}): {resp.text[:200]}",
+        )


### PR DESCRIPTION
## The bug (found by the prod-shape Postgres+Vault dogfood)

Under `kms_backend=vault` with the multi-worker uvicorn default (4 workers), **no agent could authenticate via mTLS** — `/v1/auth/login-challenge` returned `400 "SSL certificate error"` from nginx because the agent leaf failed ECDSA verification against its chain.

Root cause (openssl-confirmed): multiple `Mastio CA` Intermediates with the **same subject but different keys** coexisted. `VaultKMSProvider._store_path`'s first-write branch carried **no CAS constraint**, so every worker that booted while the CA was still absent wrote its own Org Root + Intermediate (last-write-wins), and `_persist_org_ca` / `_persist_intermediate_ca` then `return True` for each (the KMS path assumed the provider was race-safe). nginx trusted one worker's root, enrollment signed leaves off a different intermediate → inconsistent chain.

`kms_backend=local` was unaffected (`set_config_if_absent` is atomic), so dev + smoke never surfaced it. The faithful production-shape dogfood (Vault + Postgres + `environment=production` + multi-worker) did.

## Fix

- **`kms/vault.py`**: `store_org_ca_if_absent` / `store_intermediate_ca_if_absent` — atomic create-only writes via Vault KV v2 `cas:0` (succeed only when the key has no version). Return `True` (won) / `False` (lost on cas conflict).
- **`egress/agent_manager.py`**: `_persist_org_ca` + `_persist_intermediate_ca` probe for the `*_if_absent` variant via `getattr` on the KMS path and return its win/lose signal. The existing adopt paths (`generate_org_ca`, `_mint_mastio_ca`) make losers re-read and adopt the winner's pair. Providers without the variant keep legacy win-on-success (**unchanged** — no local/enterprise regression).
- **`kms/provider.py`**: documents the optional contract **without** adding it to the `runtime_checkable` Protocol (that would break `isinstance()` in the factory for the local provider).

## Validation

- **Prod-shape dogfood (the regression test that found the bug)**: rebuilt image, `environment=production` + `kms_backend=vault` + HTTPS Vault + Postgres + **4 workers** → agent enroll (cert from the Vault-custodied Org CA) → DPoP jkt → mTLS+DPoP login → **real Anthropic `chat_completion`** → hash-linked `egress_llm_chat` audit row in Postgres. All pass (previously `400`).
- **Security review**: clean — security-positive. Every failure mode converges on correct adoption of the trusted Vault winner or a fail-safe split-brain (broken mTLS, no auth), never on adopting attacker-influenced key material.
- **Smoke**: `13/13 PASS` (local-path / dev unchanged by the `getattr` fallback).