### PR TITLE
fix: Tier-A pilot-readiness — Postgres mint advisory lock + Helm prod-gate parity

### DIFF
--- a/deploy/helm/cullis-mastio/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-mastio/templates/proxy-configmap.yaml
@@ -73,6 +73,42 @@ data:
   MCP_PROXY_SECRET_BACKEND: "vault"
   MCP_PROXY_VAULT_ADDR: {{ .Values.vault.addr | quote }}
   MCP_PROXY_VAULT_SECRET_PREFIX: {{ .Values.vault.secretPrefix | quote }}
+  # ADR-031 — Org CA private key custodied in Vault. validate_config
+  # refuses to boot in production with kms_backend=local (the key would
+  # sit in the DB). Tied to vault.enabled so a production deploy that
+  # turns Vault on also moves the crown-jewel key there.
+  MCP_PROXY_KMS_BACKEND: "vault"
+  MCP_PROXY_VAULT_ORG_CA_PATH: {{ .Values.vault.orgCaPath | default "secret/data/cullis-mastio/org-ca" | quote }}
+  {{- if .Values.vault.caCertPath }}
+  MCP_PROXY_VAULT_CA_CERT_PATH: {{ .Values.vault.caCertPath | quote }}
+  {{- end }}
   {{- else }}
   MCP_PROXY_SECRET_BACKEND: "env"
+  {{- end }}
+
+  # DPoP JTI + login-challenge nonce store. Production refuses the
+  # in-memory fallback for multi-replica/multi-worker (cross-worker
+  # replay of login nonces), so REDIS_URL must point at a reachable
+  # Redis. K8s deploys bring their own (managed Redis or a subchart).
+  {{- if .Values.proxy.redisUrl }}
+  MCP_PROXY_REDIS_URL: {{ .Values.proxy.redisUrl | quote }}
+  {{- end }}
+
+  # Egress DPoP enforcement (F-B-11). ``required`` is the zero-trust
+  # posture; production refuses optional/off unless the operator opts
+  # into the agent-enrollment migration window via WEBAUTHN-style flag.
+  MCP_PROXY_EGRESS_DPOP_MODE: {{ .Values.proxy.egressDpopMode | default "required" | quote }}
+
+  # WebAuthn on-behalf-of-user attribution (ADR-033 / F-A-205). Default
+  # ``warn``; production refuses warn/off unless the operator opts in
+  # (single-Mastio pilots with no IdP-backed user registration).
+  MCP_PROXY_WEBAUTHN_ENFORCEMENT: {{ .Values.proxy.webauthn.enforcement | default "warn" | quote }}
+  {{- if .Values.proxy.webauthn.warnInsecureOk }}
+  MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK: "true"
+  {{- end }}
+  {{- if .Values.proxy.webauthn.rpId }}
+  MCP_PROXY_WEBAUTHN_RP_ID: {{ .Values.proxy.webauthn.rpId | quote }}
+  {{- end }}
+  {{- if .Values.proxy.webauthn.expectedOrigin }}
+  MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN: {{ .Values.proxy.webauthn.expectedOrigin | quote }}
   {{- end }}

--- a/deploy/helm/cullis-mastio/templates/proxy-secret.yaml
+++ b/deploy/helm/cullis-mastio/templates/proxy-secret.yaml
@@ -12,9 +12,15 @@ metadata:
 type: Opaque
 stringData:
   MCP_PROXY_ADMIN_SECRET: {{ .Values.secrets.adminSecret | default (randAlphaNum 48) | quote }}
-  {{- if .Values.secrets.dashboardSigningKey }}
-  MCP_PROXY_DASHBOARD_SIGNING_KEY: {{ .Values.secrets.dashboardSigningKey | quote }}
-  {{- end }}
+  # F-B-10 / Three-tier-PKI / F-A-202 — these are hard production
+  # refuse-to-boot gates. Default to a strong random (mirrors
+  # adminSecret) so a default ``helm install`` in production actually
+  # boots; ``helm.sh/resource-policy: keep`` above pins them across
+  # upgrades. The Secret is install-scoped, so every replica reads the
+  # same value (sessions + at-rest envelope stay consistent across pods).
+  MCP_PROXY_DASHBOARD_SIGNING_KEY: {{ .Values.secrets.dashboardSigningKey | default (randAlphaNum 48) | quote }}
+  MCP_PROXY_DB_ENCRYPTION_KEY: {{ .Values.secrets.dbEncryptionKey | default (randAlphaNum 48) | quote }}
+  MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET: {{ .Values.secrets.pdpWebhookHmacSecret | default (randAlphaNum 48) | quote }}
   {{- if .Values.secrets.orgSecret }}
   MCP_PROXY_ORG_SECRET: {{ .Values.secrets.orgSecret | quote }}
   {{- end }}

--- a/deploy/helm/cullis-mastio/values.yaml
+++ b/deploy/helm/cullis-mastio/values.yaml
@@ -112,6 +112,27 @@ proxy:
   # Empty = no CORS middleware (fail-safe).
   allowedOrigins: ""
 
+  # -- DPoP JTI + login-challenge nonce store URL. REQUIRED in production
+  # (multi-replica/multi-worker refuses the in-memory fallback → /v1/auth/
+  # login-challenge 500). Point at a managed Redis or an in-cluster redis,
+  # e.g. redis://cullis-redis-master.cullis.svc:6379/0
+  redisUrl: ""
+
+  # -- Egress DPoP enforcement (F-B-11). "required" is the zero-trust
+  # posture; production refuses "optional"/"off" (cert-only egress).
+  egressDpopMode: "required"
+
+  # -- WebAuthn on-behalf-of-user attribution (ADR-033 / F-A-205).
+  # Production refuses enforcement=warn/off UNLESS warnInsecureOk=true
+  # (the sanctioned posture for a single-Mastio pilot with no IdP-backed
+  # user registration — track a sunset date). Move to enforcement=required
+  # + rpId + expectedOrigin once a real user-credential flow exists.
+  webauthn:
+    enforcement: "warn"
+    warnInsecureOk: false
+    rpId: ""
+    expectedOrigin: ""
+
   # -- Verify broker TLS certificate. Disable ONLY for local dev with a
   # self-signed broker.
   brokerVerifyTls: true
@@ -410,8 +431,18 @@ secrets:
   adminSecret: ""
   # -- Persistent HMAC key for the proxy dashboard cookies. Without this
   # admin sessions are invalidated on every proxy restart because a random
-  # key is generated per-process. Pin it to survive rollouts.
+  # key is generated per-process. Pin it to survive rollouts. Empty →
+  # the chart mints a random one into the kept Secret (prod-boot safe).
   dashboardSigningKey: ""
+  # -- Fernet master passphrase (>=32 chars) wrapping the Org Root +
+  # Intermediate private keys in pki_key_store. REQUIRED in production
+  # (refuse-to-boot). Empty → chart mints a random one into the kept
+  # Secret. Pin explicitly if you manage at-rest keys externally.
+  dbEncryptionKey: ""
+  # -- Shared HMAC secret for the inbound PDP webhook (F-A-202). REQUIRED
+  # in production. Empty → chart mints a random one. Set to match the
+  # broker's POLICY_WEBHOOK_HMAC_SECRET when pairing with an external PDP.
+  pdpWebhookHmacSecret: ""
   # -- Org-level secret used by the proxy to authenticate to the broker
   # for admin/egress operations (when the broker is configured to require
   # one). Optional.
@@ -435,6 +466,14 @@ vault:
     # e.g. "https://vault.corp.example.com:8200"
   # -- KV v2 secret prefix the proxy reads tool secrets from.
   secretPrefix: "secret/data/mcp-proxy/tools"
+  # -- KV v2 path for the Org CA keypair (ADR-031). When vault.enabled,
+  # the Org CA private key is custodied here (kms_backend=vault) instead
+  # of the DB. Default matches a dev Vault's secret/ mount.
+  orgCaPath: "secret/data/cullis-mastio/org-ca"
+  # -- Pin a private CA for an HTTPS Vault fronted by a corporate root
+  # (path inside the container; mount via proxy.extraVolumes). Empty =
+  # system trust store.
+  caCertPath: ""
 
 # ---------------------------------------------------------------------------
 # Ingress — DISABLED by default after ADR-014. The nginx sidecar

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -182,6 +182,46 @@ def _release_mastio_mint_lock(fd: int) -> None:
             pass
 
 
+async def _acquire_mastio_mint_lock_pg(url: str):
+    """Postgres analogue of :func:`_acquire_mastio_mint_lock`.
+
+    The SQLite flock above only serialises the cullis#997 leaf-mint
+    critical section on SQLite; Postgres deploys previously took the
+    racy branch (every worker minting an active row → N>1 active →
+    ``current_signer()`` raises → ``/v1/auth/token`` 503). The pilot DB
+    is Postgres + multi-worker, so close it here with a session-level
+    advisory lock (mirrors the ``pg_advisory_xact_lock(hashtext(
+    'mastio-rotate'))`` used by :func:`activate_staged_and_deprecate_old`
+    and the Alembic migration lock). A dedicated engine/connection so the
+    lock auto-releases when the session is disposed even if the explicit
+    unlock is skipped. Returns ``(engine, conn)`` to release, or ``None``
+    for non-Postgres URLs (SQLite uses the flock; in-memory is
+    single-process).
+    """
+    if not (url.startswith("postgresql") or "+asyncpg" in url):
+        return None
+    eng = create_async_engine(url, **_engine_kwargs(url))
+    conn = await eng.connect()
+    await conn.execute(text("SELECT pg_advisory_lock(hashtext('mastio-mint'))"))
+    return (eng, conn)
+
+
+async def _release_mastio_mint_lock_pg(handle) -> None:
+    """Release the advisory lock + dispose the dedicated session."""
+    if handle is None:
+        return
+    eng, conn = handle
+    try:
+        try:
+            await conn.execute(
+                text("SELECT pg_advisory_unlock(hashtext('mastio-mint'))"),
+            )
+        finally:
+            await conn.close()
+    finally:
+        await eng.dispose()
+
+
 def _run_migrations_sync_under_flock(url: str, sqlite_path: str) -> None:
     """Run ``_run_migrations_sync`` under an exclusive blocking flock.
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -2096,18 +2096,28 @@ class AgentManager:
         from mcp_proxy.config import get_settings
         from mcp_proxy.db import (
             _acquire_mastio_mint_lock,
+            _acquire_mastio_mint_lock_pg,
             _release_mastio_mint_lock,
+            _release_mastio_mint_lock_pg,
             _sqlite_path,
             deprecate_mastio_keys_by_kids,
             get_mastio_keys_active,
         )
 
+        # cullis#997 — serialise the leaf mint across the N uvicorn
+        # workers. SQLite uses a sidecar flock; Postgres (the pilot DB)
+        # uses a session-level pg advisory lock. Previously the Postgres
+        # path was unlocked → N>1 active rows → /v1/auth/token 503.
+        db_url = get_settings().database_url
         lock_fd: int | None = None
-        sqlite_path = _sqlite_path(get_settings().database_url)
+        pg_mint_lock = None
+        sqlite_path = _sqlite_path(db_url)
         if sqlite_path:
             lock_fd = await asyncio.to_thread(
                 _acquire_mastio_mint_lock, sqlite_path,
             )
+        else:
+            pg_mint_lock = await _acquire_mastio_mint_lock_pg(db_url)
         try:
             existing = await get_mastio_keys_active()
             if existing:
@@ -2205,6 +2215,8 @@ class AgentManager:
                 await asyncio.to_thread(
                     _release_mastio_mint_lock, lock_fd,
                 )
+            if pg_mint_lock is not None:
+                await _release_mastio_mint_lock_pg(pg_mint_lock)
 
     def _require_active(self) -> MastioKey:
         if self._active_key is None or self._mastio_ca_cert is None:


### PR DESCRIPTION
Two production-readiness gaps surfaced after the prod-shape dogfood, both same-class as the blockers already fixed for the Docker bundle (#1021/#1022). Tier A of the scoped-pilot floor.

## 1. `fix(security)` — Postgres advisory lock for the mastio_keys leaf mint (cullis#997)

The cullis#997 single-writer guard (stops N uvicorn workers each INSERTing an active `mastio_keys` row → N>1 active → `current_signer()` raises → `/v1/auth/token` 503) was **SQLite-only** — a sidecar flock. Postgres took the racy branch (*"Postgres deploys (none in the wild today) take the racy branch"*). The **pilot DB is Postgres + multi-worker**, so the signing-key mint could still race.

Add a session-level `pg_advisory_lock(hashtext('mastio-mint'))` on a dedicated connection, mirroring the existing `pg_advisory_xact_lock(hashtext('mastio-rotate'))` + the Alembic migration lock. `_mint_mastio_leaf` now flocks on SQLite, advisory-locks on Postgres; in-memory stays single-process. SQLite behaviour unchanged.

## 2. `fix(helm)` — wire the production refuse-to-boot gates

The Helm chart defaulted `proxy.environment=production` but wired **none** of the gates `validate_config(production)` enforces (KMS_BACKEND, DB_ENCRYPTION_KEY, PDP_WEBHOOK_HMAC_SECRET, WEBAUTHN_*, REDIS_URL; DASHBOARD_SIGNING_KEY was conditional). So a default `helm install` deployed in production and the Mastio **SystemExit'd at boot** — same class as #1021 but worse (the default install fails). The Vault multi-worker CA race fix (#1022) is image-level and already inherited.

- configmap: `KMS_BACKEND=vault` + `VAULT_ORG_CA_PATH` + optional `VAULT_CA_CERT_PATH` (tied to `vault.enabled`); `REDIS_URL`, `EGRESS_DPOP_MODE` (default `required`), `WEBAUTHN_*` (default `warn` + opt-in).
- secret: `DB_ENCRYPTION_KEY` + `PDP_WEBHOOK_HMAC_SECRET` (+ `DASHBOARD_SIGNING_KEY`) default to a kept random (mirrors `adminSecret`; `resource-policy: keep` pins across upgrades; install-scoped so every replica reads the same value).
- values: `redisUrl`, `egressDpopMode`, `webauthn{}`, `vault.orgCaPath/caCertPath`, `secrets.dbEncryptionKey/pdpWebhookHmacSecret`.

## Validation

- **Smoke**: `14/14 PASS` (race fix is a no-op on the default SQLite path).
- **Security review**: clean — the lock is fail-closed in every branch (acquire-failure → 503, never an unlocked mint; released in `finally`; auto-release on session end); the Helm secret defaults mirror the shipped `adminSecret` pattern and every failure mode is fail-closed.
- **Helm**: `helm template` (default + `vault.enabled=true`) renders clean and the gates appear.

## Known limitations (honest)

- Helm is **render-validated, not boot-tested on a live cluster** (no kind/minikube here).
- `REDIS_URL` + Vault are **operator-provided** — no bundled redis subchart yet (follow-up). A multi-replica prod deploy must set `proxy.redisUrl`.