### PR TITLE
fix(security): refuse-to-boot guards for PKI material loss (DR-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ flow until the next `## ` heading.
 
 Polish on `main` accumulating for the next minor. No release tag is cut for each individual patch any more; release cadence is intentionally throttled to one minor every 2-3 weeks plus emergency-only patches, matching the practice of comparable alpha-stage open-core projects.
 
+### Security
+
+- **Refuse-to-boot guards against PKI material loss** (DR-1). A disaster-recovery drill on a faithful prod-shape stack (Vault + Postgres + 4 workers + production) found that a partial restore (Postgres data restored but Vault CA material not) made the boot mint fresh CA material and silently orphan every enrolled agent's mTLS identity (mTLS 400 for the whole fleet). Two boot-time safety nets close it: (1) the boot refuses, in production, to generate an Org Root or mint a Mastio Intermediate when CA material is absent but enrolled agents already exist, rather than orphaning the fleet (`MCP_PROXY_ALLOW_PKI_REKEY` opts into an intentional re-key; non-production warns and proceeds); (2) first-time Org CA provisioning in production is now explicit (`MCP_PROXY_ALLOW_CA_BOOTSTRAP`), while dev/test keeps zero-config auto-bootstrap. The bundle's `generate-proxy-env --prod` warns about the explicit first-boot provisioning step.
+
 ## [v0.6.4] — Capability enforcement, opaque-404 fixes, cold-reader doc hardening — 2026-06-01
 
 Minor on top of v0.6.3, accumulating two-plus weeks of polish. The headline is **real capability enforcement** on the chat and MCP-discovery surfaces (previously decorative), plus the close-out of the opaque-404 the flag-mcp demo surfaced, plus a sweep of SDK-quickstart fixes found by fresh-install cold-reads. The whole release was dogfooded end-to-end on `mastio-demo` against a fresh install (deploy / mint / `pip install` / login / live Anthropic chat / audit chain) with zero workarounds.

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -890,6 +890,29 @@ class ProxySettings(BaseSettings):
             )
         return self
 
+    def ca_bootstrap_enabled(self) -> bool:
+        """Whether the boot path may auto-generate a fresh Org CA when none
+        is loaded (standalone first-boot).
+
+        DR-1 hardening — per-environment default. In PRODUCTION the
+        first-time generation of the org's crown-jewel Org CA must be an
+        explicit operator action, never an unattended side effect of a
+        restart that found no CA (a botched restore must not silently
+        re-bootstrap a new identity). So this is False in production
+        unless the operator opts in with ``MCP_PROXY_ALLOW_CA_BOOTSTRAP``.
+        In dev/test it defaults True so zero-config standalone keeps
+        working. An explicit value (``1``/``true``/``yes`` or
+        ``0``/``false``/``no``) always wins; an unset or empty value
+        (``${FOO:-}`` compose passthrough) falls back to the
+        per-environment default.
+        """
+        raw = os.environ.get("MCP_PROXY_ALLOW_CA_BOOTSTRAP", "").strip().lower()
+        if raw in ("1", "true", "yes"):
+            return True
+        if raw in ("0", "false", "no"):
+            return False
+        return self.environment != "production"
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -857,6 +857,27 @@ async def list_agents() -> list[dict]:
         return [_agent_row_to_dict(row) for row in result.mappings().all()]
 
 
+async def count_enrolled_agents() -> int:
+    """Number of rows in ``internal_agents`` (enrolled agents, any state).
+
+    Used by the boot-time PKI bootstrap guard
+    (``AgentManager.ensure_ca_bootstrap_safe``). A non-zero count means
+    this is NOT a first boot: agents have been enrolled and hold leaf
+    certs that chain to the existing CA. If the CA material is then
+    found absent, minting a fresh one would orphan those certs, so the
+    guard refuses to boot in production. Counts all rows (not just
+    ``is_active``) so even revoked-only state is treated as "not a
+    clean first boot", and avoids a boolean predicate that differs
+    between Postgres and SQLite.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT COUNT(*) AS n FROM internal_agents")
+        )
+        row = result.mappings().first()
+        return int(row["n"]) if row else 0
+
+
 async def list_user_principals() -> list[dict]:
     """List user principals registered on this Mastio.
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -77,6 +77,22 @@ def _strict_pki_enabled() -> bool:
     return raw in ("1", "true", "yes")
 
 
+def _pki_rekey_allowed() -> bool:
+    """``MCP_PROXY_ALLOW_PKI_REKEY=1`` — operator opt-out from the boot
+    orphan guard, for an INTENTIONAL CA re-key.
+
+    When set, the boot path is allowed to generate fresh Org Root /
+    Intermediate CA material even though enrolled agents already exist.
+    Every existing agent certificate then stops authenticating and all
+    agents must re-enroll, so this must be a deliberate operator
+    decision. Default OFF. Same accept-list as :func:`_strict_pki_enabled`
+    so a stray empty / malformed value cannot surprise an operator.
+    """
+    import os
+    raw = os.environ.get("MCP_PROXY_ALLOW_PKI_REKEY", "").strip().lower()
+    return raw in ("1", "true", "yes")
+
+
 def _priv_to_pem(key) -> str:
     return key.private_bytes(
         serialization.Encoding.PEM,
@@ -1777,6 +1793,81 @@ class AgentManager:
             "Migrated legacy mastio leaf into mastio_keys (kid=%s)", kid,
         )
 
+    async def ensure_ca_bootstrap_safe(
+        self, missing_label: str, restore_hint: str,
+    ) -> None:
+        """Fail-closed guard: refuse to bootstrap fresh CA material when
+        enrolled agents already exist.
+
+        The boot path generates a self-signed Org Root
+        (``generate_org_ca``) and mints a Mastio Intermediate
+        (``_mint_mastio_ca``) when the KMS reports no material. That is
+        correct on a FIRST boot (no agents), but catastrophic on a
+        PARTIAL disaster-restore or a lost Vault: agents enrolled earlier
+        hold leaf certs that chain to a CA which is now gone, so minting a
+        fresh one orphans the whole fleet — every agent mTLS handshake
+        then fails at the nginx boundary with a 400. The two states are
+        distinguished by whether any agent is enrolled:
+
+          * 0 enrolled agents -> genuine first boot, generation is
+            correct, return.
+          * >0 + ``MCP_PROXY_ALLOW_PKI_REKEY`` -> intentional re-key,
+            loud warning, return (every agent must re-enroll).
+          * >0 + production -> refuse to boot (``SystemExit``), so a
+            botched restore stops the deploy loudly instead of orphaning
+            the fleet silently. ``SystemExit`` derives from
+            ``BaseException``, so the broad ``except Exception`` around
+            ``ensure_mastio_identity`` in ``main.py`` does NOT swallow it.
+          * >0 + non-production -> loud warning, return (keeps
+            dev/test/sandbox booting; production is where the guarantee
+            matters).
+
+        ``missing_label`` names the absent material (for the log);
+        ``restore_hint`` is the remediation pointer (which secret to
+        restore). Mirrors the refuse-to-boot pattern of
+        ``_detect_legacy_ca_pathlen_zero`` + ``MCP_PROXY_STRICT_PKI``.
+        """
+        from mcp_proxy.db import count_enrolled_agents
+        try:
+            enrolled = await count_enrolled_agents()
+        except Exception as exc:  # noqa: BLE001 — DB not ready: can't assert, don't block boot
+            logger.warning(
+                "PKI bootstrap guard: agent count failed (%s) — proceeding "
+                "without the guard", exc,
+            )
+            return
+        if enrolled == 0:
+            return
+        if _pki_rekey_allowed():
+            logger.warning(
+                "PKI re-key authorised via MCP_PROXY_ALLOW_PKI_REKEY: %s is "
+                "absent but %d enrolled agent(s) exist. Minting fresh "
+                "material — every existing agent certificate will STOP "
+                "authenticating and all agents must re-enroll.",
+                missing_label, enrolled,
+            )
+            return
+        from mcp_proxy.config import get_settings
+        if get_settings().environment == "production":
+            logger.critical(
+                "PKI INCOHERENCE — refusing to boot. %s is absent but %d "
+                "enrolled agent(s) exist. Generating fresh CA material would "
+                "orphan every existing agent certificate (mTLS would fail for "
+                "the entire fleet). This is the signature of a partial "
+                "disaster-restore: Postgres data was restored but the CA "
+                "material in the KMS was not. Remediation: %s and restart. "
+                "To re-key intentionally instead (all agents re-enroll), set "
+                "MCP_PROXY_ALLOW_PKI_REKEY=1.",
+                missing_label, enrolled, restore_hint,
+            )
+            raise SystemExit(1)
+        logger.warning(
+            "PKI INCOHERENCE (non-production): %s is absent but %d enrolled "
+            "agent(s) exist — minting fresh material anyway. In production "
+            "this refuses to boot. Remediation if unintended: %s.",
+            missing_label, enrolled, restore_hint,
+        )
+
     async def _generate_mastio_identity(self) -> None:
         """Mint whichever Mastio pieces are missing — CA and/or leaf.
 
@@ -1787,6 +1878,15 @@ class AgentManager:
         now = datetime.now(timezone.utc)
 
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
+            # PKI bootstrap guard — see ``ensure_ca_bootstrap_safe``. Refuse
+            # (in production) to mint a fresh Intermediate when enrolled
+            # agents exist but the intermediate-ca material is gone, which
+            # would orphan every agent leaf (the DR-1 partial-restore case).
+            await self.ensure_ca_bootstrap_safe(
+                "the Mastio Intermediate CA",
+                "restore the intermediate-ca secret "
+                "(e.g. Vault secret/cullis-mastio/intermediate-ca)",
+            )
             await self._mint_mastio_ca(now)
 
         if self._active_key is None:

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -314,6 +314,30 @@ async def lifespan(app: FastAPI):
     # admin then copies this value into the broker's attach-ca invite so
     # future uplinks pin the same identity across proxy restarts.
     if settings.standalone and not agent_mgr.ca_loaded:
+        # PKI bootstrap guard — refuse to mint a fresh Org Root when
+        # enrolled agents already exist (the signature of a partial
+        # disaster-restore / lost Vault). Minting a new root would orphan
+        # every agent leaf. A genuine first boot (no agents) proceeds.
+        # See ``AgentManager.ensure_ca_bootstrap_safe``.
+        await agent_mgr.ensure_ca_bootstrap_safe(
+            "the Org Root CA",
+            "restore the org-ca secret (e.g. Vault secret/cullis-mastio/org-ca)",
+        )
+        # Explicit-provisioning gate (DR-1 / F2) — in production the
+        # first-time generation of the org's crown-jewel Org CA must be an
+        # explicit operator action, never an unattended side effect of a
+        # restart that found no CA. Dev/test auto-bootstraps so zero-config
+        # standalone keeps working. See ``ProxySettings.ca_bootstrap_enabled``.
+        if not settings.ca_bootstrap_enabled():
+            _log.critical(
+                "No Org CA is loaded and CA bootstrap is disabled "
+                "(production default). First-time CA provisioning must be "
+                "explicit: set MCP_PROXY_ALLOW_CA_BOOTSTRAP=1 to mint a fresh "
+                "self-signed Org CA on this boot, or restore existing CA "
+                "material (org-ca + intermediate-ca in the KMS) and restart. "
+                "Refusing to boot."
+            )
+            raise SystemExit(1)
         derive = not org_id  # derive only when the operator didn't pick one
         await agent_mgr.generate_org_ca(derive_org_id=derive)
         if derive:

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -96,6 +96,7 @@ and [Postgres pilot](https://cullis.io/docs/operate/postgres-pilot).
 | Agent `SSL: CERTIFICATE_VERIFY_FAILED` / `hostname doesn't match` | Add the hostname to `MCP_PROXY_NGINX_SAN` (e.g. `mastio.acme.local,mastio.local,localhost`) and `./deploy.sh --pull` to re-mint the cert. |
 | `getaddrinfo failed` / `Name or service not known` | The public-URL hostname must resolve to this host's IP from the agent's machine (corporate DNS, public A record, or `/etc/hosts`). |
 | `Bind for 0.0.0.0:9443 failed: port is already allocated` | Set `MCP_PROXY_PORT=9444` in `proxy.env`, and update `MCP_PROXY_PROXY_PUBLIC_URL` to the same port. |
+| `Refusing to boot` / `CA bootstrap is disabled (production default)` | First standalone `--prod` boot only: set `MCP_PROXY_ALLOW_CA_BOOTSTRAP=1` in `proxy.env`, then `./deploy.sh --prod` to mint the initial Org CA. Remove it after the first successful boot so a partial restore can't silently re-mint the CA and orphan enrolled agents. |
 
 Full incident playbooks: [Runbook](https://cullis.io/docs/operate/runbook).
 

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -282,6 +282,11 @@ services:
       PROXY_EGRESS_INSPECTION_ENABLED: ${PROXY_EGRESS_INSPECTION_ENABLED:-}
       PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
       MCP_PROXY_EGRESS_DPOP_MODE:     ${MCP_PROXY_EGRESS_DPOP_MODE:-}
+      # DR-1 — first-boot CA provisioning gate (F2). Unset/empty in dev
+      # (auto-bootstrap); the operator sets =1 for the first standalone
+      # --prod boot to mint the Org CA, then removes it to seal so a
+      # partial restore can't re-bootstrap. See ca_bootstrap_enabled.
+      MCP_PROXY_ALLOW_CA_BOOTSTRAP:   ${MCP_PROXY_ALLOW_CA_BOOTSTRAP:-}
     volumes:
       # ADR-030 — bind mount on the host so /data sits next to deploy.sh
       # (./data/mcp_proxy.db). Replaces the legacy ``mcp_proxy_data``

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -263,6 +263,7 @@ if [[ "$MODE" == "prod" ]]; then
     else
         warn "Production needs a Vault: KMS_BACKEND=vault custodies the Org CA private key. Set MCP_PROXY_VAULT_ADDR + MCP_PROXY_VAULT_TOKEN in ${OUT} before ./deploy.sh --prod."
     fi
+    warn "First-boot CA provisioning is explicit in production (DR safety): the Org CA is the org's crown jewel, so an unattended restart that finds no CA refuses to boot rather than silently minting a new one. For the FIRST ./deploy.sh --prod set MCP_PROXY_ALLOW_CA_BOOTSTRAP=1 in ${OUT} to mint the initial Org CA, then remove it after the first successful boot so a partial restore cannot re-bootstrap a fresh identity."
 fi
 
 ok "Wrote ${OUT}"

--- a/test/unit/test_pki_bootstrap_guard.py
+++ b/test/unit/test_pki_bootstrap_guard.py
@@ -1,0 +1,133 @@
+"""DR-1 hardening — boot-time PKI safety nets.
+
+A disaster-recovery drill on a faithful prod-shape stack (Vault + Postgres
++ production + multi-worker) showed that a PARTIAL restore — Postgres data
+restored, Vault CA material not — made the boot path mint fresh CA
+material and silently orphan every enrolled agent's mTLS identity (the
+agent leaf certs chained to a CA that no longer existed). Two guards close
+that:
+
+  * ``AgentManager.ensure_ca_bootstrap_safe`` — refuses (in production) to
+    generate/mint fresh CA material when enrolled agents already exist,
+    unless ``MCP_PROXY_ALLOW_PKI_REKEY`` opts into an intentional re-key.
+  * ``ProxySettings.ca_bootstrap_enabled`` — per-environment default for
+    first-time CA provisioning: explicit in production, auto in dev.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import mcp_proxy.config as config_mod
+import mcp_proxy.db as db_mod
+from mcp_proxy.config import ProxySettings
+from mcp_proxy.egress.agent_manager import AgentManager
+
+_ROOT = "the Org Root CA"
+_HINT = "restore the org-ca secret"
+
+
+def _patch_count(monkeypatch, n: int) -> None:
+    async def _fake_count() -> int:
+        return n
+    monkeypatch.setattr(db_mod, "count_enrolled_agents", _fake_count)
+
+
+def _patch_environment(monkeypatch, environment: str) -> None:
+    monkeypatch.setattr(
+        config_mod, "get_settings",
+        lambda: SimpleNamespace(environment=environment),
+    )
+
+
+# ── ensure_ca_bootstrap_safe (the orphan guard) ─────────────────────────
+
+@pytest.mark.asyncio
+async def test_guard_first_boot_no_agents_proceeds(monkeypatch):
+    """0 enrolled agents == genuine first boot -> never blocks."""
+    _patch_count(monkeypatch, 0)
+    _patch_environment(monkeypatch, "production")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_PKI_REKEY", raising=False)
+    await AgentManager("testorg").ensure_ca_bootstrap_safe(_ROOT, _HINT)
+
+
+@pytest.mark.asyncio
+async def test_guard_agents_in_production_refuses_boot(monkeypatch):
+    """Agents enrolled + CA material gone + production -> SystemExit.
+
+    This is the DR-1 partial-restore signature: minting fresh material
+    would orphan the fleet, so the deploy must stop loudly.
+    """
+    _patch_count(monkeypatch, 3)
+    _patch_environment(monkeypatch, "production")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_PKI_REKEY", raising=False)
+    with pytest.raises(SystemExit):
+        await AgentManager("testorg").ensure_ca_bootstrap_safe(_ROOT, _HINT)
+
+
+@pytest.mark.asyncio
+async def test_guard_agents_in_dev_warns_but_proceeds(monkeypatch):
+    """Non-production: loud warning but boots (dev/test/sandbox stay up)."""
+    _patch_count(monkeypatch, 3)
+    _patch_environment(monkeypatch, "development")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_PKI_REKEY", raising=False)
+    await AgentManager("testorg").ensure_ca_bootstrap_safe(_ROOT, _HINT)
+
+
+@pytest.mark.asyncio
+async def test_guard_rekey_override_proceeds_in_production(monkeypatch):
+    """An explicit MCP_PROXY_ALLOW_PKI_REKEY re-key proceeds even in prod."""
+    _patch_count(monkeypatch, 3)
+    _patch_environment(monkeypatch, "production")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_PKI_REKEY", "1")
+    await AgentManager("testorg").ensure_ca_bootstrap_safe(_ROOT, _HINT)
+
+
+@pytest.mark.asyncio
+async def test_guard_count_failure_does_not_block_boot(monkeypatch):
+    """If the agent count can't be read (DB not ready), don't block boot."""
+    async def _boom() -> int:
+        raise RuntimeError("db not ready")
+    monkeypatch.setattr(db_mod, "count_enrolled_agents", _boom)
+    _patch_environment(monkeypatch, "production")
+    await AgentManager("testorg").ensure_ca_bootstrap_safe(_ROOT, _HINT)
+
+
+# ── ProxySettings.ca_bootstrap_enabled (the provisioning gate) ──────────
+
+def _settings(monkeypatch, environment: str) -> ProxySettings:
+    # Build cleanly in development (production triggers the admin-secret
+    # validator), then flip environment post-init — model validators only
+    # fire at construction, so ca_bootstrap_enabled reads the flipped value.
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-guard-secret")
+    s = ProxySettings()
+    s.environment = environment
+    return s
+
+
+def test_ca_bootstrap_default_dev_true(monkeypatch):
+    monkeypatch.delenv("MCP_PROXY_ALLOW_CA_BOOTSTRAP", raising=False)
+    assert _settings(monkeypatch, "development").ca_bootstrap_enabled() is True
+
+
+def test_ca_bootstrap_default_production_false(monkeypatch):
+    monkeypatch.delenv("MCP_PROXY_ALLOW_CA_BOOTSTRAP", raising=False)
+    assert _settings(monkeypatch, "production").ca_bootstrap_enabled() is False
+
+
+def test_ca_bootstrap_explicit_opt_in_wins_in_production(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ALLOW_CA_BOOTSTRAP", "1")
+    assert _settings(monkeypatch, "production").ca_bootstrap_enabled() is True
+
+
+def test_ca_bootstrap_explicit_opt_out_wins_in_dev(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ALLOW_CA_BOOTSTRAP", "false")
+    assert _settings(monkeypatch, "development").ca_bootstrap_enabled() is False
+
+
+def test_ca_bootstrap_empty_env_falls_back_to_per_environment(monkeypatch):
+    # docker-compose ${FOO:-} passthrough yields "", which is NOT an opt-in.
+    monkeypatch.setenv("MCP_PROXY_ALLOW_CA_BOOTSTRAP", "")
+    assert _settings(monkeypatch, "production").ca_bootstrap_enabled() is False


### PR DESCRIPTION
## Problem

A disaster-recovery drill on a faithful prod-shape stack (Vault + Postgres + 4 workers + `environment=production`) surfaced a real gap. A **partial restore** (Postgres data restored, Vault CA material not) made the boot **mint fresh CA material and silently orphan every enrolled agent's mTLS identity** (nginx `400 SSL certificate error` for the whole fleet). The Mastio Intermediate was regenerated with a new key, so agent leaf certs signed by the old Intermediate no longer verified. Same failure mode as the multi-worker race in #1022, here triggered by DR instead of concurrency.

## Changes

Two boot-time safety nets, purely additive (no existing check removed, no cert/CA validation weakened):

1. **Orphan guard** (`AgentManager.ensure_ca_bootstrap_safe`): refuses to boot (`SystemExit`) in production when an Org Root or Mastio Intermediate is absent but enrolled agents already exist; generating fresh material would orphan the fleet. A genuine first boot (0 agents) proceeds; an intentional re-key opts in via `MCP_PROXY_ALLOW_PKI_REKEY`; non-production warns and proceeds.
2. **Explicit prod provisioning** (`ProxySettings.ca_bootstrap_enabled`): per-environment gate. In production the first-time Org CA generation is explicit (`MCP_PROXY_ALLOW_CA_BOOTSTRAP`); dev/test keeps zero-config auto-bootstrap.

Bundle wiring: compose passthrough for the flag, a `generate-proxy-env --prod` warning mirroring the existing Vault one, and a README troubleshooting row.

## Validation

- 10 new unit tests (`test/unit/test_pki_bootstrap_guard.py`), all pass.
- Full DR drill on the prod-shape stack: provision-gate refuses without the flag; orphan guard refuses on incomplete restore **without minting**; complete restore boots and the pre-disaster agent authenticates via mTLS **without re-enroll**, Intermediate fingerprint identical to baseline.
- `smoke.sh` full: 14/14 (incl. `90_multiworker`).
- Security review: clean (additive hardening, no new attack surface; static SQL, `SystemExit` is `BaseException` so it is not swallowed by the lifespan `except Exception`).

## Note on `SystemExit` under uvicorn workers

The refuse-to-boot surfaces as the container going `unhealthy` (worker re-spawn loop), not `Exited`, because the guard runs inside the lifespan. Functionally a refuse (`deploy --wait` fails, nginx dependency unhealthy, log is `CRITICAL`), but flagged as a known limitation; a cleaner readiness-probe failure is a possible follow-up.

## Follow-up (separate PR)

DR procedure fix: `pg-backup`/`pg-restore` aligned to the bundle (they point at the legacy `atn`/`agent_trust` DB today, would not find the real DB) + Vault `intermediate-ca` in the backup set + a "known DR limitations" doc.
