### PR TITLE
docs(site): pre-HN honesty pass — copy + open-core/enterprise editions page

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -23,7 +23,7 @@ const year = new Date().getFullYear();
         <h4>Learn</h4>
         <ul>
           <li><a href="/docs">Operational docs</a></li>
-          <li><a href="/blog">Journal</a></li>
+          <li><a href="/editions">Open core &amp; enterprise</a></li>
         </ul>
       </div>
       <div>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -14,7 +14,7 @@ const isActive = (href: string) => {
     </a>
     <ul class="nav-links">
       <li><a href="/docs" class={isActive('/docs') ? 'is-active' : ''}>Docs</a></li>
-      <li><a href="/blog" class={isActive('/blog') ? 'is-active' : ''}>Blog</a></li>
+      <li><a href="/editions" class={isActive('/editions') ? 'is-active' : ''}>Open core</a></li>
       <li><a href="https://github.com/cullis-security/cullis" target="_blank" rel="noopener" class="ext">GitHub <span aria-hidden="true">↗</span></a></li>
     </ul>
   </div>

--- a/site/src/content/docs/reference/compliance-mapping.md
+++ b/site/src/content/docs/reference/compliance-mapping.md
@@ -17,7 +17,7 @@ responsibility of the deploying organization.
 | Framework | Article / clause | Cullis capability |
 |---|---|---|
 | **EU AI Act** | Art. 12 (logging), 13 (transparency), 14 (human oversight) | Tamper-evident audit chain, per-decision reasoning capture, ADR-020 4-quadrant identity |
-| **EU AI Act Annex III** | High-risk classification (credit, insurance pricing, recruitment) | Per-agent identity + per-decision audit + 4-eye approval capability |
+| **EU AI Act Annex III** | High-risk classification (credit, insurance pricing, recruitment) | Per-agent identity + per-decision audit + four-eyes approval (enterprise build) |
 | **DORA** | Art. 28 (third-party ICT) | mTLS + DPoP cryptographic identity per action, self-hosted deployer model |
 | **EIOPA** | Aug 2025 Opinion 8-axis governance | Mastio dashboard + audit export + policy decision logging across fairness, data, record, transparency, oversight, accuracy, robustness, cyber |
 | **IDD** | Art. 17 (fair treatment), Art. 20, 30 | Per-claim audit chain, exportable signed bundle for customer complaint reconstruction |

--- a/site/src/content/docs/security/threat-model.md
+++ b/site/src/content/docs/security/threat-model.md
@@ -197,7 +197,7 @@ Anything below this line assumes the above hold.
 | Tampering with the DPoP proof | Replay a captured proof from elsewhere | Redis-backed JTI cache rejects any DPoP `jti` seen in the configured window (`mcp_proxy/auth/dpop_jti_store.py`, `_DEFAULT_TTL = 300` seconds = 5 minutes; `SET NX EX` semantics). `htu` is checked literally including scheme + host + port: a middlebox that strips port 9443 fails. | Replay protection cold-starts empty; first-N requests in the window after a proxy restart have lower replay protection until the cache fills. We do not currently warm the cache from a persistent store. |
 | Repudiation by an agent | Agent claims it never made a call | Each call is signed end-to-end (DPoP) and logged to the append-only audit chain with `agent_id`, action, tool name, status, request ID, duration, and the verified DPoP `jkt` thumbprint denormalised onto the row (`local_audit.dpop_jkt`, migration `0033_audit_dpop_jkt`). The chain `previous_hash` / `entry_hash` columns lock historical records under SHA-256. | If the agent claims key compromise, the audit chain attributes the call to the agent's registry ID and to the DPoP `jkt` that was present at request time. Customers needing per-person attribution should pair Cullis with their IdP (SAML SSO or similar) so that the user principal is bound to the agent enrollment. |
 | Information disclosure of the cert + key on enrollment | Material shipped over an insecure channel | The dashboard offers the new cert + key PEMs as a one-time download with `Content-Disposition: attachment`, and writes nothing to the response body that gets cached. The operator copies the bytes onto the agent host out-of-band. | A screenshot of the download page leaks the material. We rely on operator hygiene; runbook guidance is in `operate/rotate-keys.md` and the bundle README. |
-| DoS via enrollment flood | Attacker hammers the enrollment endpoints | Both `/v1/enrollment/start` and `/v1/enrollment/{id}/status` are rate-limited per source IP (`mcp_proxy/enrollment/router.py`, calling `get_agent_rate_limiter()`). | A compromised admin token bypasses the rate limit. The 4-eyes plugin (open-core hook) can be configured to gate the enrollment approve step as a compensating control. |
+| DoS via enrollment flood | Attacker hammers the enrollment endpoints | Both `/v1/enrollment/start` and `/v1/enrollment/{id}/status` are rate-limited per source IP (`mcp_proxy/enrollment/router.py`, calling `get_agent_rate_limiter()`). | A compromised admin token bypasses the rate limit. The four-eyes plugin (enterprise build; the hook is wired in open-core) can be configured to gate the enrollment approve step as a compensating control. |
 | Elevation of privilege | Agent claims a role / capability it was not enrolled with | Roles and capabilities are stored on the registry record server-side; the agent cannot include a claim that overrides what the registry says. The PDP looks up the registry, not the proof. | A SQL-injection or registry-tampering vector would defeat this. We mitigate with parameterised queries throughout (SQLAlchemy), `/security-review` on every PR, and the audit chain providing forensic detection. |
 
 ### References
@@ -507,7 +507,11 @@ credentials are:
   **Verify chain** action and the standalone CLI catch it.
 - **4-eyes approval hook**: at configurable depth, a set of
   state-changing actions requires a second admin's signoff before
-  they take effect. The currently wired set is `policies.save`,
+  they take effect. The hook and its action constants are wired in the
+  open-core build, but the plugin that implements the approval workflow
+  (and the multi-admin / second-approver model it depends on) ships in
+  the enterprise build; open-core alone has a single admin and does not
+  gate. The currently wired set is `policies.save`,
   `pki.rotate_ca`, `mastio_key.rotate`, `vault.migrate_keys`,
   `users.delete`, `agents.delete`, `agent.enroll`,
   `license.import`. Federation peer changes (`federation.peer`) are

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const {
   title,
-  description = 'Zero-trust identity and audit for AI agents. Start air-gapped. Scale to cross-company federation without redeploy.',
+  description = 'Self-hosted cryptographic identity, policy and audit for autonomous AI agents. Per-agent identity, policy before the LLM call, tamper-evident audit.',
   theme = 'dark'
 } = Astro.props;
 ---

--- a/site/src/pages/editions.astro
+++ b/site/src/pages/editions.astro
@@ -1,0 +1,212 @@
+---
+import Layout from '../layouts/Layout.astro';
+
+// Open-core vs enterprise boundary mirrors the license feature flags in
+// mcp_proxy/dashboard/templates/settings.html (has_feature(...)). Keep this
+// list in sync with those flags — it is the source of truth, not a sales matrix.
+const openCore = [
+  {
+    name: 'Per-agent cryptographic identity',
+    detail: 'x509 leaf + SPIFFE ID per agent process, mTLS (RFC 8705) + DPoP (RFC 9449), thumbprint pinning, explicit rotation. The caller is the agent itself, not a shared service account.',
+  },
+  {
+    name: 'Policy enforcement (PDP)',
+    detail: 'Per-principal capabilities and a policy decision point that fires before the LLM API or MCP tool runs. OPA-compatible Rego bundles or a built-in rule set.',
+  },
+  {
+    name: 'Tamper-evident audit chain',
+    detail: 'Append-only, hash-chained events with Merkle batch sealing and optional RFC 3161 TSA anchoring. Verifiable externally, without trusting Cullis or your IT team.',
+  },
+  {
+    name: 'Embedded AI gateway',
+    detail: 'Native per-provider adapters (Anthropic and OpenAI SDKs, raw HTTP for Ollama on-prem). LLM-agnostic, no third-party gateway in the critical path.',
+  },
+  {
+    name: 'MCP reverse-proxy',
+    detail: 'Aggregates MCP tool servers behind the same identity, capability gate, and audit chain.',
+  },
+];
+
+// The nine license-gated plugins (settings.html has_feature flags). Implemented,
+// shipped only in the enterprise build, not yet released as a packaged product.
+const enterprise = [
+  { name: 'SAML 2.0 SSO', detail: 'Federate dashboard sign-in with a corporate IdP (Okta, Azure AD, Keycloak, OneLogin).' },
+  { name: 'SCIM 2.0 provisioning', detail: 'Automated user lifecycle (provision / deprovision / group sync) from the corporate IdP.' },
+  { name: 'Multi-admin RBAC + four-eyes', detail: 'More than one admin, with a configurable second-admin approval gate on sensitive actions (enrollment, CA rotation, license import).' },
+  { name: 'Cloud KMS (AWS / Azure / GCP)', detail: 'Custody of the org CA private key in a managed cloud KMS instead of Vault or filesystem.' },
+  { name: 'Audit archive', detail: 'Long-term retention and archival of the audit chain to an external sink.' },
+  { name: 'Audit export to Datadog', detail: 'Stream audit events to Datadog for SIEM / monitoring.' },
+  { name: 'LLM Guardian', detail: 'Inline content inspection hook on the message path (plug in a detector such as a guardrail provider).' },
+];
+---
+
+<Layout title="Cullis — Open core and enterprise" theme="light">
+  <main class="editions">
+    <div class="container narrow">
+      <header class="ed-head">
+        <p class="ed-eyebrow">Open core &amp; enterprise</p>
+        <h1>What is implemented, and where it runs.</h1>
+        <p class="ed-lead">
+          Cullis is <strong>pre-1.0 and not yet validated in production</strong>.
+          Treat everything below as an early MVP, not a finished product. The
+          open-core build is what you can pull and run today under FSL-1.1 +
+          Apache-2.0. The enterprise capabilities are implemented as
+          license-gated plugins, but the enterprise build is not yet released
+          as a packaged product. Neither side has been validated in a real
+          deployment. This page exists so the boundary is explicit instead of
+          something you have to infer from the code.
+        </p>
+      </header>
+
+      <section class="ed-block">
+        <div class="ed-block-head">
+          <h2>Open core</h2>
+          <span class="ed-tag ed-tag-core">runs from the public image, no license</span>
+        </div>
+        <ul class="ed-list">
+          {openCore.map((f) => (
+            <li>
+              <span class="ed-name">{f.name}</span>
+              <span class="ed-detail">{f.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section class="ed-block">
+        <div class="ed-block-head">
+          <h2>Enterprise build</h2>
+          <span class="ed-tag ed-tag-ent">implemented, license-gated, not yet released</span>
+        </div>
+        <ul class="ed-list">
+          {enterprise.map((f) => (
+            <li>
+              <span class="ed-name">{f.name}</span>
+              <span class="ed-detail">{f.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer class="ed-foot">
+        <p>
+          The split above mirrors the license feature flags in the code, not a
+          price list. If something here looks wrong or oversold, that is exactly
+          the feedback we want.
+        </p>
+        <a class="ed-cta" href="https://github.com/cullis-security/cullis" target="_blank" rel="noopener">Read the code on GitHub ↗</a>
+      </footer>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .editions {
+    padding: clamp(7rem, 12vh, 10rem) 0 6rem;
+    color: #0A2540;
+  }
+  .container.narrow {
+    max-width: 820px;
+    margin: 0 auto;
+    padding-left: clamp(1.25rem, 4vw, 2rem);
+    padding-right: clamp(1.25rem, 4vw, 2rem);
+  }
+  .ed-head { margin-bottom: 3.5rem; }
+  .ed-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #0891B2;
+    margin: 0 0 1rem;
+  }
+  .ed-head h1 {
+    font-size: clamp(1.9rem, 4vw, 2.7rem);
+    line-height: 1.1;
+    margin: 0 0 1.5rem;
+    color: #0A2540;
+  }
+  .ed-lead {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: #425466;
+    margin: 0;
+  }
+  .ed-block { margin-bottom: 3rem; }
+  .ed-block-head {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    flex-wrap: wrap;
+    border-bottom: 1px solid rgba(10, 37, 64, 0.12);
+    padding-bottom: 0.75rem;
+    margin-bottom: 1.5rem;
+  }
+  .ed-block-head h2 {
+    font-size: 1.4rem;
+    margin: 0;
+    color: #0A2540;
+  }
+  .ed-tag {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+  }
+  .ed-tag-core {
+    color: #0891B2;
+    background: rgba(8, 145, 178, 0.08);
+    border-color: rgba(8, 145, 178, 0.3);
+  }
+  .ed-tag-ent {
+    color: #B45309;
+    background: rgba(245, 158, 11, 0.08);
+    border-color: rgba(245, 158, 11, 0.3);
+  }
+  .ed-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1.4rem;
+  }
+  .ed-list li {
+    display: grid;
+    gap: 0.35rem;
+  }
+  .ed-name {
+    font-weight: 600;
+    font-size: 1.02rem;
+    color: #0A2540;
+  }
+  .ed-detail {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #425466;
+  }
+  .ed-foot {
+    margin-top: 4rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(10, 37, 64, 0.12);
+  }
+  .ed-foot p {
+    font-size: 0.98rem;
+    line-height: 1.7;
+    color: #425466;
+    margin: 0 0 1.5rem;
+  }
+  .ed-cta {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #0891B2;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(8, 145, 178, 0.4);
+    padding-bottom: 2px;
+  }
+  .ed-cta:hover { color: #0A2540; border-bottom-color: #0A2540; }
+</style>

--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -144,7 +144,7 @@ import Layout from '../layouts/Layout.astro';
           <em>Every agent. Every call.</em>
         </h2>
         <p class="feature-lead reveal" data-delay="2">
-          One Docker container per organization. Authority over AI agent
+          One self-hosted Docker container. Authority over AI agent
           identity. Policy enforced before the LLM call lands. An
           append-only chain of every action, externally verifiable by
           your auditor or regulator. Works underneath Claude Agent SDK,
@@ -173,10 +173,9 @@ import Layout from '../layouts/Layout.astro';
             <p>
               PDP fires before the LLM API or MCP tool. Per-principal
               scopes (this agent can read claim files, that agent
-              cannot). 4-eye approval capability. Decisions logged with
-              reason. OPA-compatible bundles or built-in DSL. Addresses
-              EU AI Act Art. 14 human oversight and Annex III high-risk
-              segregation of duties.
+              cannot). Decisions logged with reason. OPA-compatible
+              bundles or built-in DSL. Designed around EU AI Act Art. 14
+              human oversight.
             </p>
             <a class="feature-link" href="https://github.com/cullis-security/cullis#cullis-mastio">Policy model →</a>
           </li>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -134,9 +134,9 @@ import Layout from '../layouts/Layout.astro';
           <p>
             PDP fires before the LLM API or MCP tool runs. Per-principal
             scopes (this agent can read claim files, that agent cannot).
-            4-eye approval capability. OPA-compatible bundles or built-in
-            DSL. Designed around EU AI Act Art. 14 (human oversight) and Art. 26
-            (deployer obligations on high-risk systems).
+            OPA-compatible bundles or built-in DSL. Designed around EU AI Act
+            Art. 14 (human oversight) and Art. 26 (deployer obligations on
+            high-risk systems).
           </p>
           <a class="feature-link" href="https://github.com/cullis-security/cullis#cullis-mastio">Policy model →</a>
         </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -466,26 +466,28 @@ result = client.call_mcp_tool("sanctions_lookup", &#123;"full_name": "Acme Holdi
       const items = grid.querySelectorAll<HTMLElement>('[data-feature]');
       const descs = grid.querySelectorAll<HTMLElement>('[data-feature-desc]');
       const imgs = grid.querySelectorAll<HTMLImageElement>('[data-frame-img]');
+      const order = ['pki', 'agents', 'audit'];
 
+      const activate = (key: string) => {
+        items.forEach((i) => i.classList.toggle('active', i.dataset.feature === key));
+        descs.forEach((d) => d.classList.toggle('active', d.dataset.featureDesc === key));
+        imgs.forEach((img) => img.classList.toggle('active', img.dataset.frameImg === key));
+      };
+
+      // Auto-rotate until the visitor clicks a tab, then stop so they can read.
+      let paused = false;
       items.forEach((item) => {
         item.addEventListener('click', () => {
-          const key = item.dataset.feature || '';
-          items.forEach((i) => i.classList.toggle('active', i === item));
-          descs.forEach((d) => d.classList.toggle('active', d.dataset.featureDesc === key));
-          imgs.forEach((img) => img.classList.toggle('active', img.dataset.frameImg === key));
+          paused = true;
+          activate(item.dataset.feature || '');
         });
       });
 
-      let auto = true;
-      grid.addEventListener('click', () => { auto = false; }, { once: true });
       let idx = 0;
-      const order = ['pki', 'agents', 'audit'];
       setInterval(() => {
-        if (!auto) return;
+        if (paused) return;
         idx = (idx + 1) % order.length;
-        const next = grid.querySelector<HTMLElement>(`[data-feature="${order[idx]}"]`);
-        if (next) (next as HTMLElement).click();
-        auto = true;
+        activate(order[idx]);
       }, 6000);
     }
   </script>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Cullis — Governance layer for autonomous AI agents in regulated industries" theme="light">
+<Layout title="Cullis — A governance layer for autonomous AI agents in regulated industries" theme="light">
 
   <!-- Fixed page backdrop: cyan/indigo gradient blob that stays in viewport
        while the page scrolls. Sections with opaque backgrounds (gray-blue,
@@ -18,8 +18,8 @@ import Layout from '../layouts/Layout.astro';
       </div>
 
       <h1 class="hero-title reveal" data-delay="1">
-        The governance layer<br />
-        autonomous AI agents need to ship<br />
+        A governance layer for<br />
+        autonomous AI agents<br />
         in regulated industries.
       </h1>
 
@@ -124,7 +124,7 @@ import Layout from '../layouts/Layout.astro';
             x509 + SPIFFE ID per agent process. mTLS RFC 8705 and DPoP RFC
             9449. The caller authenticated at the gateway is the agent
             itself, not a shared service account. Rotation on its own
-            schedule, revocation propagates in seconds. Maps to EU AI Act
+            schedule, revocation propagates in seconds. Designed around EU AI Act
             Art. 12 and DORA Art. 28 + Art. 30 (ICT third-party risk +
             key contractual provisions).
           </p>
@@ -135,7 +135,7 @@ import Layout from '../layouts/Layout.astro';
             PDP fires before the LLM API or MCP tool runs. Per-principal
             scopes (this agent can read claim files, that agent cannot).
             4-eye approval capability. OPA-compatible bundles or built-in
-            DSL. Maps to EU AI Act Art. 14 (human oversight) and Art. 26
+            DSL. Designed around EU AI Act Art. 14 (human oversight) and Art. 26
             (deployer obligations on high-risk systems).
           </p>
           <a class="feature-link" href="https://github.com/cullis-security/cullis#cullis-mastio">Policy model →</a>
@@ -145,7 +145,7 @@ import Layout from '../layouts/Layout.astro';
             Every event (auth, enroll, message, tool call, LLM token)
             hashed and chained. Optional RFC 3161 TSA anchoring. Your
             auditor verifies the chain externally, without trusting
-            Cullis or your IT team. Maps to EU AI Act Art. 12
+            Cullis or your IT team. Designed around EU AI Act Art. 12
             (record-keeping) + Art. 15 (accuracy, robustness,
             cybersecurity) and EIOPA Opinion BoS-25-360 (6 Aug 2025).
           </p>
@@ -314,7 +314,7 @@ import Layout from '../layouts/Layout.astro';
             </div>
           </div>
           <ul class="topo-bullets">
-            <li>Zero added latency on the LLM call path. Agent uses the provider's native SDK.</li>
+            <li>No latency added to the LLM call itself in this mode. The agent uses the provider's native SDK.</li>
             <li>Mastio attests identity, evaluates policy and receives audit events out-of-band.</li>
             <li>Best when latency budget is tight, or when the provider call must remain unchanged.</li>
           </ul>
@@ -336,7 +336,7 @@ import Layout from '../layouts/Layout.astro';
   <section class="use-cases" data-section-theme="dark">
     <div class="container">
       <div class="use-cases-head">
-        <p class="eyebrow reveal">Reference scenarios · Claude for Financial Services on Cullis</p>
+        <p class="eyebrow reveal">Reference scenarios · regulated finance</p>
         <h2 class="reveal" data-delay="1">
           Four workflows regulated EU teams<br />
           are trying to graduate.
@@ -358,7 +358,7 @@ import Layout from '../layouts/Layout.astro';
           <p>
             Entity file assembly + AML escalation on the Anthropic
             template. Per-agent cert binds every screening action.
-            Maps to <strong>EU AI Act Art. 14 + Art. 12</strong>.</p>
+            Designed around <strong>EU AI Act Art. 14 + Art. 12</strong>.</p>
         </article>
 
         <article class="use-case-card">
@@ -366,7 +366,7 @@ import Layout from '../layouts/Layout.astro';
           <h3>Pitchbook + Chinese Walls</h3>
           <p>
             Cross-desk capability gate blocks MNPI leakage —
-            Industrials agent cannot read Tech docs. Maps to
+            Industrials agent cannot read Tech docs. Designed around
             <strong>MAR Art. 16 + Art. 18</strong>.</p>
         </article>
 
@@ -375,7 +375,7 @@ import Layout from '../layouts/Layout.astro';
           <h3>DORA Vendor Reporter</h3>
           <p>
             Cullis-specific. Runs on <strong>open-weight LLM on-prem
-            (Ollama)</strong> — no SaaS sees vendor risk data. Maps to
+            (Ollama)</strong> — no SaaS sees vendor risk data. Designed around
             <strong>DORA Art. 28 + Art. 30</strong>.</p>
         </article>
 
@@ -385,7 +385,7 @@ import Layout from '../layouts/Layout.astro';
           <p>
             Signal → reasoning → risk_check → place_order, every step
             hash-chained. PDP blocks orders when kill-switch on. Mock
-            OMS — not production trading. Maps to <strong>MiFID II
+            OMS — not production trading. Designed around <strong>MiFID II
             Art. 17 + RTS 6 Art. 23</strong> (pre-trade controls).
           </p>
         </article>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -41,7 +41,7 @@ import Layout from '../layouts/Layout.astro';
         <div class="screen-frame">
           <img src="/screenshots/mastio-overview.png" alt="Mastio overview dashboard, showing agent identity registry and live audit chain" loading="eager" />
         </div>
-        <div class="screen-caption">Mastio control plane · one container per organisation</div>
+        <div class="screen-caption">Mastio control plane · one self-hosted container</div>
         <p class="screen-disclaimer">Illustrative screenshots from the Cullis demo stack. Agent identities, tool calls, and audit events shown are reproducible from the public repo, not a customer deployment.</p>
       </div>
     </div>
@@ -95,7 +95,7 @@ import Layout from '../layouts/Layout.astro';
           For the agent, by the agent.
         </h2>
         <p class="showcase-lead reveal" data-delay="2">
-          One Docker container per organisation. Authority over agent identity,
+          One self-hosted Docker container. Authority over agent identity,
           policy enforced before the LLM call lands, an append-only audit
           chain externally verifiable by your auditor or regulator. Works
           underneath any agent stack — Claude Agent SDK, OpenAI Agents SDK,
@@ -325,7 +325,7 @@ import Layout from '../layouts/Layout.astro';
         <p class="topo-foot-label">Even behind a hardened enterprise gateway, three properties stay Cullis-only:</p>
         <ul class="topo-foot-list">
           <li><strong>Tamper-evident audit chain</strong><span>Hash-chained, externally verifiable end-to-end. Optional RFC 3161 TSA anchoring when a timestamp authority is configured.</span></li>
-          <li><strong>Cross-org A2A federation</strong><span>Bilateral signed envelope between Mastios in different organisations. Zero AI gateway covers this.</span></li>
+          <li><strong>Policy enforced before the call</strong><span>The PDP gates each request per-principal before the LLM or MCP tool runs. A gateway forwards; Mastio decides first.</span></li>
           <li><strong>Per-agent crypto identity</strong><span>x509 + SPIFFE + DPoP per agent. Gateways see the user; only Mastio attests the agent.</span></li>
         </ul>
       </div>


### PR DESCRIPTION
Pre-HN pass on the public site so the open-core / enterprise boundary and the early-stage maturity are explicit, and no capability is presented as shipped when it is not. Astro build green; `/editions` route builds.

## Homepage (`index.astro`)
- Headline softened ("A governance layer for ..." instead of "... agents need to ship ...").
- Anthropic reference: eyebrow "Claude for Financial Services on Cullis" → "regulated finance"; factual body paragraph kept.
- Latency claim scoped to control-plane-only mode (was "Zero added latency").
- Compliance framing: all "Maps to ..." → "Designed around ..." (7 spots).
- Four-eyes overclaim removed (it is `rbac_multi_admin`, enterprise).
- Cross-org A2A federation property replaced with "Policy enforced before the call" (open-core). Federation / Court is not in the public build.

## New page `/editions`
- Open core vs the nine license-gated enterprise plugins, mirroring `has_feature()` in `settings.html`. Framed explicitly pre-1.0 / not-yet-validated, not a price list. Replaces the empty Blog nav/footer slot.

## Single-org framing
- "one container per organisation" / "per organization" → "one self-hosted container" (hero caption, showcase lead, index-dark).
- Default meta/og description rewritten (was "scale to cross-company federation").

## Docs honesty
- `compliance-mapping.md`: EU AI Act Annex III row marks four-eyes as enterprise build.
- `threat-model.md`: four-eyes hook + action constants are open-core, but the approval plugin and multi-admin model ship in enterprise; open-core has a single admin and does not gate. Anchored at the canonical description; old "plugin (open-core hook)" wording fixed.
- `index-dark.astro` (unused variant): dropped "per organization" + four-eyes to match live.

## Deliberately left (already honest / accurate, not overclaims)
- threat-model federation refs are caveated ("this repository does not ship a cross-org anchor"; "defined but not yet wired in this repository's open-core surface").
- audit-export "reserved for future cross-org reconciliation" (explicitly future).
- rego-policies cross-org examples teach policy syntax (the PDP federation gate exists in open-core); not a capability claim.