### PR TITLE
fix(dashboard): honest meta.json notes for mTLS-only agent bundle

### DIFF
--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -527,16 +527,26 @@ async def agent_identity_bundle_download(request: Request, agent_id: str):
         "capabilities": agent.get("capabilities") or [],
         "created_at": agent.get("created_at"),
         "spiffe_id": agent.get("spiffe_id"),
-        # Operator hint: the SDK will create the dpop.jwk sibling on
-        # first use. No need to ship a stub here — keeping the bundle
-        # silent on it is the honest representation of what the
-        # Mastio actually persists.
+        # This Mastio-minted bundle is mTLS-only: it ships no dpop.jwk,
+        # and from_identity_dir does not generate one (it adopts a
+        # dpop.jwk sibling if present, otherwise runs without DPoP, see
+        # test_from_identity_dir_dpop_autodiscovery). A DPoP-bound
+        # identity comes from the SDK enroll flow, not this download, so
+        # the notes below say that instead of promising an auto-gen that
+        # never happens.
         "notes": (
             "Drop this directory at the agent host's identity dir "
             "(e.g. /etc/cullis/agent/), then point the SDK at it via "
-            "CullisClient.from_identity_dir(path). The SDK will "
-            "auto-generate dpop.jwk on first use and register the "
-            "public key with the Mastio."
+            "CullisClient.from_identity_dir(path). This is an mTLS-only "
+            "bundle: it carries the agent certificate and key but no "
+            "DPoP key, and from_identity_dir does not create one, so an "
+            "agent loaded from it authenticates by client certificate "
+            "alone. It is rejected where the Mastio requires DPoP on "
+            "egress (egress_dpop_mode=required). For a DPoP-bound "
+            "identity, enroll with "
+            "CullisClient.enroll_via_dashboard_approval instead: that "
+            "flow generates the certificate and DPoP keys on the agent "
+            "host and registers the DPoP public key with the Mastio."
         ),
     }
 

--- a/test/unit/test_agent_identity_bundle_download.py
+++ b/test/unit/test_agent_identity_bundle_download.py
@@ -174,6 +174,55 @@ async def test_admin_downloads_identity_bundle_zip_with_expected_files(
     assert meta["capabilities"] == ["chat"]
 
 
+@pytest.mark.asyncio
+async def test_bundle_meta_notes_are_honest_about_dpop(proxy_db):
+    """meta.json notes must NOT promise a DPoP auto-generation that
+    ``from_identity_dir`` never performs.
+
+    ``test_from_identity_dir_dpop_autodiscovery`` pins that a missing
+    ``dpop.jwk`` sibling leaves the runtime client DPoP-less: the SDK
+    loads a sibling if present but never generates one, and this
+    Mastio-minted bundle ships no ``dpop.jwk``. The notes must say so
+    and point at the SDK enroll flow for a DPoP-bound identity, rather
+    than claim an auto-gen that does not happen. Regression guard for
+    the misleading-notes finding (2026-06-02).
+    """
+    agent_id = "test-org::bob"
+    cert_pem = "-----BEGIN CERTIFICATE-----\nstub-cert\n-----END CERTIFICATE-----\n"
+    key_pem = "-----BEGIN PRIVATE KEY-----\nstub-key\n-----END PRIVATE KEY-----\n"
+
+    await db_create_agent(
+        agent_id=agent_id,
+        display_name="Bob",
+        capabilities=["chat"],
+        cert_pem=cert_pem,
+    )
+    await set_config(f"agent_key:{agent_id}", key_pem)
+    await set_config("org_id", "test-org")
+
+    app = _make_app()
+    async with _admin_client(app) as client:
+        resp = await client.get(f"/proxy/agents/{agent_id}/identity-bundle.zip")
+    assert resp.status_code == 200, resp.text
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    notes = json.loads(zf.read("meta.json"))["notes"].lower()
+
+    assert "auto-generate dpop" not in notes, (
+        "meta.json must not promise a DPoP auto-generation: "
+        "from_identity_dir loads a dpop.jwk sibling if present but never "
+        f"creates one. got notes: {notes!r}"
+    )
+    assert "enroll_via_dashboard_approval" in notes, (
+        "meta.json should point at the SDK enroll flow as the DPoP-bound "
+        f"path, got notes: {notes!r}"
+    )
+    assert ("mtls-only" in notes) or ("no dpop" in notes), (
+        "meta.json should flag the bundle as mTLS-only / carrying no DPoP "
+        f"key, got notes: {notes!r}"
+    )
+
+
 # ── Test 2: audit invariant ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

The dashboard identity-bundle download (`/proxy/agents/{id}/identity-bundle.zip`) ships a Mastio-minted, **mTLS-only** bundle (`agent.crt` + `agent.key` + `ca-chain.pem` + `meta.json`) with no `dpop.jwk`. The `meta.json` `notes` field claimed the SDK would *"auto-generate dpop.jwk on first use and register the public key with the Mastio"*.

## Why it's wrong

`from_identity_dir` never generates a DPoP key: it adopts a `dpop.jwk` sibling if present, otherwise runs without DPoP (pinned by `test_from_identity_dir_dpop_autodiscovery`). Registering a DPoP public key requires the admin endpoint `POST /v1/admin/agents/{id}/dpop-jwk`, which an autonomous agent cannot call. So an agent provisioned via this bundle has no DPoP and is rejected with `401` under `egress_dpop_mode=required`.

## Change

- Rewrite the `notes` (and the stale comment) to state the bundle is mTLS-only and point at `CullisClient.enroll_via_dashboard_approval` for a DPoP-bound identity, where cert + DPoP keys are generated on the agent host and the DPoP public key is registered with the Mastio.
- Add a regression test (`test_bundle_meta_notes_are_honest_about_dpop`) asserting the notes no longer promise an auto-gen and do point at the enroll flow.

Text-only change to a `meta.json` string; no logic, routing, auth, or crypto touched. Unit tests 6/6 green; security review: no findings.