### PR TITLE
fix(auth): pin leaf cert + enforce CA constraints on /v1/auth/token

### DIFF
--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -21,6 +21,7 @@ the Court, preserving behavior for every caller who hasn't opted in.
 from __future__ import annotations
 
 import base64
+import hmac
 import logging
 import time
 from typing import Any
@@ -80,9 +81,42 @@ def _load_chain(cert_bytes_list: list[bytes]) -> list[x509.Certificate]:
     return [x509.load_der_x509_certificate(b) for b in cert_bytes_list]
 
 
+def _assert_ca_issuer(cert: x509.Certificate) -> None:
+    """Reject a cert that is being used to sign another cert but is not a
+    valid CA.
+
+    Audit H1 (2026-06-02): ``_verify_chain`` previously verified only the
+    signature links, never the X.509 issuing constraints. That let any
+    enrolled agent forge a leaf carrying a *victim's* identity, sign it
+    with its own (non-CA) leaf key, and present ``[forged, attacker_leaf]``
+    — the chain walked to the Org CA and validated, so the Mastio minted a
+    LOCAL_TOKEN for the victim. Requiring ``BasicConstraints(ca=True)`` (and
+    ``keyCertSign`` when KeyUsage is present) on every issuing cert closes
+    that forgery vector at the root: a non-CA leaf can no longer act as an
+    issuer. This also protects typed principals (user/workload), which
+    carry no pinned ``cert_pem`` and so rely solely on the chain check.
+    """
+    try:
+        bc = cert.extensions.get_extension_for_class(x509.BasicConstraints).value
+    except x509.ExtensionNotFound as exc:
+        raise ValueError("issuing cert has no BasicConstraints (not a CA)") from exc
+    if not bc.ca:
+        raise ValueError("issuing cert is not a CA (BasicConstraints ca=False)")
+    try:
+        ku = cert.extensions.get_extension_for_class(x509.KeyUsage).value
+    except x509.ExtensionNotFound:
+        ku = None
+    if ku is not None and not ku.key_cert_sign:
+        raise ValueError("issuing cert KeyUsage lacks keyCertSign")
+
+
 def _verify_chain(chain: list[x509.Certificate], ca_cert: x509.Certificate) -> None:
     """Walk ``chain`` (leaf → intermediates) and verify the last link is
     signed by ``ca_cert``. Raises ValueError on any failure.
+
+    Every issuing cert (the intermediates in ``chain`` and the pinned Org
+    CA anchor) must be a valid CA — see ``_assert_ca_issuer`` for the H1
+    forgery this prevents.
     """
     if not chain:
         raise ValueError("empty chain")
@@ -92,10 +126,14 @@ def _verify_chain(chain: list[x509.Certificate], ca_cert: x509.Certificate) -> N
         if cert.not_valid_before_utc > now or cert.not_valid_after_utc < now:
             raise ValueError("certificate outside validity window")
 
-    # leaf → intermediates: each cert must be signed by its successor.
+    # leaf → intermediates: each cert must be signed by its successor, and
+    # every successor (i.e. every issuing cert) must itself be a CA.
     for i in range(len(chain) - 1):
-        _verify_sig(chain[i], chain[i + 1].public_key())
-    # last link of x5c must be signed by the pinned Org CA.
+        issuer = chain[i + 1]
+        _assert_ca_issuer(issuer)
+        _verify_sig(chain[i], issuer.public_key())
+    # last link of x5c must be signed by the pinned Org CA (also a CA).
+    _assert_ca_issuer(ca_cert)
     _verify_sig(chain[-1], ca_cert.public_key())
 
 
@@ -233,6 +271,47 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
         )
         raise _unauthorized("sub does not match client cert")
 
+    # Audit H1 (2026-06-02) — leaf-pin. The sub==cert-identity check above
+    # only proves the assertion's ``sub`` matches the identity *inside the
+    # presented leaf*; it does NOT prove the presented leaf is the cert
+    # actually enrolled for that agent. Combined with the chain walk, an
+    # enrolled agent could sign a forged leaf carrying a victim's identity
+    # with its own key and present ``[forged, attacker_leaf]`` to mint a
+    # LOCAL_TOKEN as the victim. Pin the presented leaf DER against the
+    # enrolled ``internal_agents.cert_pem``, mirroring challenge_response.py
+    # and client_cert.py. Typed principals (user/workload) rotate ~hourly
+    # and carry no pinned cert_pem; their forgery defence is the
+    # CA-constraint chain check in ``_verify_chain``.
+    from mcp_proxy.db import get_agent as _get_agent
+    record = await _get_agent(agent_id)
+    is_typed_principal = "::user::" in agent_id or "::workload::" in agent_id
+    if not is_typed_principal:
+        if record is None or not record.get("is_active", True):
+            raise _unauthorized("agent not registered or deactivated")
+        pinned_pem = record.get("cert_pem")
+        if not pinned_pem:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="agent has no pinned cert_pem on record",
+            )
+        try:
+            pinned_cert = x509.load_pem_x509_certificate(pinned_pem.encode())
+        except Exception as exc:  # noqa: BLE001 — malformed pin is a server fault
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="pinned cert_pem is malformed",
+            ) from exc
+        pinned_der = pinned_cert.public_bytes(serialization.Encoding.DER)
+        leaf_der = leaf.public_bytes(serialization.Encoding.DER)
+        if not hmac.compare_digest(pinned_der, leaf_der):
+            _log.warning(
+                "local /auth/token rejected sub=%s: leaf cert != pinned",
+                agent_id,
+            )
+            raise _unauthorized(
+                "leaf certificate does not match pinned internal_agents.cert_pem"
+            )
+
     ttl = _resolve_ttl(request)
 
     # Wave B C1 (audit 2026-05-11) — bind the issued LOCAL_TOKEN to the
@@ -269,17 +348,10 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
     # ``/v1/principals/csr`` refuses every user-cert mint. Sandbox
     # dogfood caught this — local_agent_dep.py was already fixed for
     # the Bearer LOCAL_TOKEN path, this is the JWT-mint counterpart.
-    try:
-        from mcp_proxy.db import get_agent as _get_agent
-        record = await _get_agent(agent_id)
-        if record and record.get("principal_type"):
-            extra_claims["principal_type"] = record["principal_type"]
-            extra_claims["org"] = record.get("agent_id", agent_id).split("::", 1)[0]
-    except Exception as exc:  # noqa: BLE001 — defensive
-        _log.warning(
-            "local /auth/token: principal_type lookup failed for %s: %s",
-            agent_id, exc,
-        )
+    # ``record`` was already loaded for the leaf-pin above (single lookup).
+    if record and record.get("principal_type"):
+        extra_claims["principal_type"] = record["principal_type"]
+        extra_claims["org"] = record.get("agent_id", agent_id).split("::", 1)[0]
 
     token = issuer.issue(
         agent_id=agent_id, ttl_seconds=ttl,

--- a/test/unit/test_local_token_chain_forgery.py
+++ b/test/unit/test_local_token_chain_forgery.py
@@ -1,0 +1,129 @@
+"""Audit H1 (2026-06-02) — /v1/auth/token x509 chain forgery.
+
+``_verify_chain`` previously verified only the signature links of the
+``x5c`` chain, never the issuing CA constraints. That let any enrolled
+agent forge a leaf carrying a *victim's* identity, sign it with its own
+(non-CA) leaf key, and present ``[forged, attacker_leaf]``: the chain
+walked to the pinned Org CA and validated, so ``issue_local_token`` minted
+a LOCAL_TOKEN as the victim (full impersonation — the victim's
+capabilities and bindings). The mTLS path was immune (it pins the leaf
+DER against ``internal_agents.cert_pem``); ``/v1/auth/token`` is reachable
+without mTLS and had no such pin.
+
+These tests exercise ``_verify_chain`` directly: the forgery must be
+rejected because a non-CA leaf can no longer act as an issuer, while
+legitimate 2- and 3-level chains still verify. The forgery test fails
+pre-fix (no raise).
+"""
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from mcp_proxy.auth.local_token import _verify_chain
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _name(cn: str, org: str = "acme") -> x509.Name:
+    return x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, cn),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+    ])
+
+
+def _ca(cn, *, issuer_key=None, issuer_cert=None, path_length=0):
+    """Mint a CA cert (BasicConstraints ca=True + keyCertSign). Self-signed
+    when no issuer is given, otherwise signed by the provided issuer."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = _name(cn)
+    issuer_name = issuer_cert.subject if issuer_cert is not None else subject
+    signing_key = issuer_key if issuer_key is not None else key
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_now() - datetime.timedelta(minutes=5))
+        .not_valid_after(_now() + datetime.timedelta(days=1))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length), critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(signing_key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _leaf(cn, issuer_key, issuer_cert, *, public_key=None):
+    """Mint an end-entity leaf (BasicConstraints ca=False) signed by the
+    given issuer. ``public_key`` lets a caller forge a leaf for an arbitrary
+    key (the H1 attack)."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub = public_key if public_key is not None else key.public_key()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(_name(cn))
+        .issuer_name(issuer_cert.subject)
+        .public_key(pub)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(_now() - datetime.timedelta(minutes=5))
+        .not_valid_after(_now() + datetime.timedelta(days=1))
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None), critical=True,
+        )
+        .sign(issuer_key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def test_forged_leaf_signed_by_non_ca_leaf_is_rejected():
+    """The H1 attack: an enrolled agent's own (non-CA) leaf signs a forged
+    victim leaf; [forged, attacker_leaf] must be rejected because the
+    attacker leaf is not a CA and cannot act as an issuer."""
+    ca_key, ca_cert = _ca("acme Org CA")
+    # The attacker's own legitimately-enrolled leaf: ca=False, Org-CA-signed.
+    attacker_key, attacker_cert = _leaf("acme::attacker", ca_key, ca_cert)
+    # Forge a leaf carrying the victim's identity, signed with the attacker
+    # leaf key, over a key the attacker controls.
+    victim_pub = ec.generate_private_key(ec.SECP256R1()).public_key()
+    _, forged = _leaf(
+        "acme::victim", attacker_key, attacker_cert, public_key=victim_pub,
+    )
+    with pytest.raises(ValueError):
+        _verify_chain([forged, attacker_cert], ca_cert)
+
+
+def test_direct_leaf_chain_accepted():
+    """Legitimate single-leaf chain (leaf signed directly by the Org CA)
+    still verifies."""
+    ca_key, ca_cert = _ca("acme Org CA")
+    _, leaf_cert = _leaf("acme::alice", ca_key, ca_cert)
+    _verify_chain([leaf_cert], ca_cert)  # no raise
+
+
+def test_three_level_chain_accepted():
+    """Legitimate 3-level chain (leaf ← intermediate CA ← Org root) still
+    verifies — the intermediate is a real CA, so the CA-constraint check
+    passes."""
+    root_key, root_cert = _ca("acme Org Root", path_length=1)
+    int_key, int_cert = _ca(
+        "acme Intermediate", issuer_key=root_key, issuer_cert=root_cert,
+        path_length=0,
+    )
+    _, leaf_cert = _leaf("acme::bob", int_key, int_cert)
+    _verify_chain([leaf_cert, int_cert], root_cert)  # no raise

--- a/test/unit/test_proxy_local_token.py
+++ b/test/unit/test_proxy_local_token.py
@@ -97,6 +97,16 @@ def _build_assertion(
     )
 
 
+async def _register_agent(agent_id: str, cert_pem: str) -> None:
+    """Audit H1 (2026-06-02) — /v1/auth/token now pins the presented leaf
+    against the enrolled ``internal_agents.cert_pem`` (mirrors
+    challenge_response.py). A mint's realistic precondition is an enrolled
+    agent, so seed the row with the leaf the assertion carries."""
+    from mcp_proxy.db import create_agent
+    _, name = agent_id.split("::", 1)
+    await create_agent(agent_id, name, [], cert_pem=cert_pem)
+
+
 @pytest_asyncio.fixture
 async def flag_on_proxy(tmp_path, monkeypatch):
     """Proxy app booted with ``MCP_PROXY_LOCAL_AUTH_ENABLED=1``.
@@ -152,7 +162,8 @@ async def test_local_token_issued_from_valid_assertion(flag_on_proxy):
     """Happy path — valid x5c chains to Org CA, Mastio signs a Bearer."""
     ctx = flag_on_proxy
     client = ctx["client"]
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
 
     resp = await client.post("/v1/auth/token", json={"client_assertion": assertion})
@@ -241,7 +252,8 @@ async def test_local_token_never_hits_the_court(flag_on_proxy):
     200 here is itself proof that no forward to the Court happened.
     """
     ctx = flag_on_proxy
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
     resp = await ctx["client"].post("/v1/auth/token", json={"client_assertion": assertion})
     assert resp.status_code == 200

--- a/test/unit/test_wave_b_pr7_local_token_dpop_binding.py
+++ b/test/unit/test_wave_b_pr7_local_token_dpop_binding.py
@@ -112,6 +112,17 @@ def _build_assertion(agent_id: str, leaf_key_pem: str, x5c: list[str]) -> str:
     )
 
 
+async def _register_agent(agent_id: str, cert_pem: str) -> None:
+    """Audit H1 (2026-06-02) — /v1/auth/token now pins the presented leaf
+    against the enrolled ``internal_agents.cert_pem``. Seed the agent row so
+    the mint reaches the DPoP-binding logic these tests exercise (instead of
+    being rejected at the pin). Typed-principal tests use ``::user::`` ids,
+    which skip the pin, so they need no seeding."""
+    from mcp_proxy.db import create_agent
+    _, name = agent_id.split("::", 1)
+    await create_agent(agent_id, name, [], cert_pem=cert_pem)
+
+
 def _make_dpop_keypair():
     """Generate an EC P-256 keypair + JWK suitable for DPoP proofs."""
     priv = ec.generate_private_key(ec.SECP256R1())
@@ -213,7 +224,8 @@ async def test_mint_with_dpop_header_stamps_cnf_jkt(proxy_app):
     """Happy path — SDK sends DPoP proof on /v1/auth/token, the issued
     LOCAL_TOKEN carries cnf.jkt = thumbprint of that DPoP key."""
     ctx = proxy_app
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
 
     priv, jwk = _make_dpop_keypair()
@@ -246,7 +258,8 @@ async def test_mint_without_dpop_header_falls_back_to_unbound(proxy_app):
     in flight), the mint succeeds but the token has no cnf.jkt and a
     WARN is logged. Caller behaviour preserved until the flag flips."""
     ctx = proxy_app
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
 
     resp = await ctx["client"].post(
@@ -275,7 +288,8 @@ async def test_mint_without_dpop_rejected_when_require_flag(proxy_app, monkeypat
     monkeypatch.setattr(
         get_settings(), "local_token_require_dpop", True,
     )
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
 
     resp = await ctx["client"].post(
@@ -291,7 +305,8 @@ async def test_mint_with_invalid_dpop_falls_back(proxy_app):
     (the caller may have opted out of DPoP). The require-flag closes
     this gap when needed."""
     ctx = proxy_app
-    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    leaf_key_pem, leaf_cert_pem, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    await _register_agent("acme::alice", leaf_cert_pem)
     assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
 
     priv, jwk = _make_dpop_keypair()


### PR DESCRIPTION
Security audit 2026-06-02 (H1 — the most serious finding: agent impersonation).

/v1/auth/token verified the x5c chain by signature links only and bound the assertion sub to the identity inside the presented leaf — never to the enrolled cert, and never checking issuing-CA constraints. The endpoint is reachable without mTLS (nginx catch-all strips the client cert), so any enrolled agent could sign a forged leaf carrying a victim identity with its own non-CA leaf key, present x5c=[forged, attacker_leaf] (walks to the Org CA, validates), and mint a LOCAL_TOKEN as the victim — inheriting the victim identity, capabilities and bindings. The mTLS path was immune (it pins the leaf DER); this endpoint had no pin.

Two defences mirroring challenge_response.py / client_cert.py: _verify_chain now requires every issuing cert to be a CA (BasicConstraints ca=True + keyCertSign), and issue_local_token pins the presented leaf DER against internal_agents.cert_pem (constant-time). Typed principals (user/workload, ~hourly rotation, no pinned cert) rely on the CA-constraint check.

Tests: test_local_token_chain_forgery.py (forgery rejected, legit 2-/3-level chains still verify; forgery test fails pre-fix). 6 existing mint tests seed cert_pem (realistic precondition). Smoke 14/14. Security review: fail-closed, no bypass, TLS intact. Verified live in prod-shape: mTLS+DPoP login of a legit agent still works.