### PR TITLE
fix(tools): pin MCP forwarder connect to the validated IP (SSRF rebinding)

### DIFF
--- a/mcp_proxy/tools/http_whitelist.py
+++ b/mcp_proxy/tools/http_whitelist.py
@@ -51,6 +51,7 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
         from mcp_proxy.utils.url_safety import (
             UnsafeUrlError,
             assert_safe_outbound_url,
+            pin_request_to_ip,
         )
         from mcp_proxy.config import get_settings
 
@@ -58,7 +59,9 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
             getattr(get_settings(), "policy_webhook_allow_private_ips", False)
         )
         try:
-            assert_safe_outbound_url(str(request.url), allow_private=allow_private)
+            pinned_ip = assert_safe_outbound_url(
+                str(request.url), allow_private=allow_private,
+            )
         except UnsafeUrlError as exc:
             _log.warning(
                 "WhitelistedTransport refused unsafe URL %s: %s",
@@ -67,6 +70,16 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
             raise ToolExecutionError(
                 f"Refused URL {request.url!s}: {exc}"
             ) from exc
+
+        # H8 (audit 2026-06-02): pin the connect to the IP we just
+        # validated. Without this, the check above is a check-then-connect
+        # TOCTOU — httpx would re-resolve the hostname at connect time, so a
+        # DNS-rebinding record (public IP at check, internal/IMDS IP at
+        # connect) would reach the internal target carrying the per-tool
+        # credential. Pinning forces the socket to the validated address;
+        # the Host header + sni_hostname keep TLS/routing on the real
+        # hostname.
+        pin_request_to_ip(request, pinned_ip)
 
         return await super().handle_async_request(request)
 

--- a/mcp_proxy/utils/url_safety.py
+++ b/mcp_proxy/utils/url_safety.py
@@ -39,6 +39,7 @@ __all__ = [
     "UnsafeUrlError",
     "assert_safe_outbound_url",
     "is_safe_ip",
+    "pin_request_to_ip",
 ]
 
 _log = logging.getLogger(__name__)
@@ -211,3 +212,35 @@ def assert_safe_outbound_url(
         raise UnsafeUrlError(f"hostname {hostname!r} produced no usable address")
 
     return pinned_ip
+
+
+def pin_request_to_ip(request, pinned_ip: str) -> None:
+    """Rewrite an ``httpx.Request`` to connect to ``pinned_ip`` while keeping
+    the original Host header and TLS SNI / cert hostname.
+
+    H8 (audit 2026-06-02): ``assert_safe_outbound_url`` validates a resolved
+    IP and returns it precisely so the socket connect can be pinned to that
+    address — but every caller used to discard it, letting httpx re-resolve
+    the hostname at connect time. A DNS-rebinding record that answers a
+    public IP during validation and an internal/IMDS IP at connect would
+    then slip past the guard (TOCTOU). Pinning the URL host to the
+    already-validated IP closes that window; ``sni_hostname`` (read by
+    httpcore as the TLS ``server_hostname``) and the ``Host`` header keep
+    cert verification and HTTP routing pointed at the real hostname, so TLS
+    and virtual-hosting still work.
+
+    No-op when the host is already an IP literal (nothing was resolved, so
+    there is no rebinding window) or equals the pinned IP.
+    """
+    original_host = request.url.host
+    if not original_host or original_host == pinned_ip:
+        return
+    # Preserve Host header (host[:port]) for HTTP routing — capture it from
+    # the original URL before the host is rewritten.
+    request.headers["Host"] = request.url.netloc.decode("ascii")
+    # Pin TLS verification to the original hostname: httpcore reads
+    # ``sni_hostname`` as ``server_hostname`` and validates the peer cert
+    # against it, not against the IP we connect to.
+    request.extensions = {**request.extensions, "sni_hostname": original_host}
+    # Connect to the validated IP (httpcore connects to request.url.host).
+    request.url = request.url.copy_with(host=pinned_ip)

--- a/test/unit/test_ssrf_pin.py
+++ b/test/unit/test_ssrf_pin.py
@@ -1,0 +1,93 @@
+"""H8 (audit 2026-06-02) — SSRF DNS-rebinding pin.
+
+assert_safe_outbound_url validates a resolved IP and returns it so the
+socket connect can be pinned. The WhitelistedTransport (MCP forwarder)
+used to discard it and let httpx re-resolve at connect time — a TOCTOU a
+rebinding record could exploit. These tests assert the request is pinned
+to the validated IP while Host + TLS SNI stay on the real hostname.
+"""
+import httpx
+import pytest
+
+from mcp_proxy.utils.url_safety import pin_request_to_ip
+
+
+def test_pin_rewrites_host_preserves_sni_and_host_header():
+    req = httpx.Request("GET", "https://example.com:8443/path?q=1")
+    pin_request_to_ip(req, "93.184.216.34")
+    # Socket connects to the validated IP...
+    assert req.url.host == "93.184.216.34"
+    assert req.url.port == 8443
+    # ...but HTTP routing and TLS cert verification stay on the hostname.
+    assert req.headers["Host"] == "example.com:8443"
+    assert req.extensions["sni_hostname"] == "example.com"
+
+
+def test_pin_noop_on_ip_literal():
+    req = httpx.Request("GET", "http://10.0.0.5/x")
+    pin_request_to_ip(req, "10.0.0.5")
+    assert req.url.host == "10.0.0.5"
+    # No hostname was resolved → no rebinding window → no SNI override.
+    assert "sni_hostname" not in req.extensions
+
+
+@pytest.mark.asyncio
+async def test_transport_pins_to_validated_ip(monkeypatch):
+    """The forwarder transport connects to the IP assert_safe_outbound_url
+    validated, not whatever the hostname re-resolves to at connect time."""
+    import mcp_proxy.utils.url_safety as us
+    from mcp_proxy.tools.http_whitelist import WhitelistedTransport
+
+    # Simulate validation resolving example.com to a public IP.
+    monkeypatch.setattr(
+        us, "assert_safe_outbound_url",
+        lambda url, allow_private=False: "93.184.216.34",
+    )
+
+    captured: dict = {}
+
+    async def fake_super(self, request):
+        captured["request"] = request
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx.AsyncHTTPTransport, "handle_async_request", fake_super,
+    )
+
+    transport = WhitelistedTransport(allowed_domains=["example.com"])
+    req = httpx.Request("GET", "https://example.com/v1/tools/call")
+    resp = await transport.handle_async_request(req)
+
+    assert resp.status_code == 200
+    pinned = captured["request"]
+    assert pinned.url.host == "93.184.216.34"  # connect goes to validated IP
+    assert pinned.headers["Host"] == "example.com"
+    assert pinned.extensions.get("sni_hostname") == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_transport_still_rejects_unsafe_url(monkeypatch):
+    """Pinning is additive — an unsafe URL is still refused before connect."""
+    import mcp_proxy.utils.url_safety as us
+    from mcp_proxy.tools.http_whitelist import WhitelistedTransport, ToolExecutionError
+
+    def _refuse(url, allow_private=False):
+        raise us.UnsafeUrlError("resolves to 169.254.169.254 (metadata)")
+
+    monkeypatch.setattr(us, "assert_safe_outbound_url", _refuse)
+
+    called = {"super": False}
+
+    async def fake_super(self, request):
+        called["super"] = True
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx.AsyncHTTPTransport, "handle_async_request", fake_super,
+    )
+
+    transport = WhitelistedTransport(allowed_domains=["example.com"])
+    req = httpx.Request("GET", "https://example.com/x")
+    with pytest.raises(ToolExecutionError):
+        await transport.handle_async_request(req)
+    assert called["super"] is False  # never reached the connect


### PR DESCRIPTION
Security audit 2026-06-02 (H8).

assert_safe_outbound_url resolves + validates + returns the pinned IP so the connect can target it, but WhitelistedTransport (MCP forwarder) discarded it and stock httpx re-resolved at connect time — a DNS-rebinding record (public IP at check, internal/IMDS IP at connect) slips past the guard, and the forwarder ships the per-tool credential to the internal target (check-then-connect TOCTOU).

Fix: pin_request_to_ip() rewrites the request URL host to the validated IP (httpcore connects there) while pinning sni_hostname (TLS server_hostname → cert verified against the real hostname) and the Host header (routing). No-op for IP-literal hosts. Wired into WhitelistedTransport after the safety check.

Scope: closes the HIGH vector (forwarder, per-tool credential). The egress LLM adapters (M7 OpenAI base_url, M8 Ollama) compute but discard the same IP — MEDIUM/LOW, on the demo path — tracked as a follow-up.

Tests: test_ssrf_pin.py (4). Smoke 14/14. Security review 10/10: TOCTOU closed, no cert bypass, no regression.