### PR TITLE
fix(db): redact DB password from init_db boot log

### DIFF
--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -87,6 +87,24 @@ def _normalize_url(db_url: str) -> str:
     return f"sqlite+aiosqlite:///{db_url}"
 
 
+def _redact_db_url(url: str) -> str:
+    """Return ``url`` with any embedded password masked, for safe logging.
+
+    H9 (audit 2026-06-02): a Postgres prod URL carries the DB password
+    inline (``postgresql+asyncpg://user:PASSWORD@host/db``). Logging it
+    verbatim leaks the production credential to the whole log-read audience
+    (SRE, log pipeline, support bundles), violating "mai loggare segreti".
+    Mask via SQLAlchemy's URL renderer; on any parse failure fall back to
+    the host/db tail (which never contains the password, since userinfo
+    precedes the ``@``) so redaction can never itself break boot.
+    """
+    try:
+        from sqlalchemy.engine.url import make_url
+        return make_url(url).render_as_string(hide_password=True)
+    except Exception:  # noqa: BLE001 — redaction must never break boot
+        return url.split("@", 1)[-1] if "@" in url else url
+
+
 def _sqlite_path(db_url: str) -> str | None:
     """Extract the filesystem path from a sqlite URL, or None if not SQLite."""
     for prefix in ("sqlite+aiosqlite:///", "sqlite:///"):
@@ -352,7 +370,7 @@ async def init_db(db_url: str) -> None:
             if _engine.dialect.name == "sqlite":
                 await conn.execute(text("PRAGMA journal_mode=WAL"))
             await conn.run_sync(metadata.create_all)
-        _log.info("Database initialized (no-migrations mode): %s", url)
+        _log.info("Database initialized (no-migrations mode): %s", _redact_db_url(url))
         return
 
     # M-db-2 audit fix — under N concurrent workers booting against
@@ -406,7 +424,7 @@ async def init_db(db_url: str) -> None:
         async with _engine.begin() as conn:
             await conn.execute(text("PRAGMA journal_mode=WAL"))
 
-    _log.info("Database initialized (alembic upgrade head): %s", url)
+    _log.info("Database initialized (alembic upgrade head): %s", _redact_db_url(url))
 
 
 async def dispose_db() -> None:

--- a/test/unit/test_db_url_redaction.py
+++ b/test/unit/test_db_url_redaction.py
@@ -1,0 +1,31 @@
+"""H9 (audit 2026-06-02) — the DB connection URL is logged at INFO on every
+boot (db.py init_db). In prod the URL carries the Postgres password inline,
+so logging it verbatim leaks the credential. ``_redact_db_url`` masks the
+password before it reaches the log.
+"""
+from mcp_proxy.db import _redact_db_url
+
+
+def test_postgres_password_is_masked():
+    url = "postgresql+asyncpg://cullis:s3cr3t-prod-pw@db.internal:5432/mastio"
+    out = _redact_db_url(url)
+    assert "s3cr3t-prod-pw" not in out, out
+    # user, host, db remain (only the password is hidden) — useful for ops.
+    assert "cullis" in out
+    assert "db.internal" in out
+    assert "mastio" in out
+
+
+def test_sqlite_url_unchanged_in_substance():
+    url = "sqlite+aiosqlite:///var/lib/mastio/proxy.sqlite"
+    out = _redact_db_url(url)
+    # No credential to hide; the path must survive.
+    assert "proxy.sqlite" in out
+
+
+def test_unparseable_url_falls_back_without_leaking_password():
+    # A string make_url can't parse: redaction must still not emit the
+    # password (which always precedes the '@').
+    url = "not a valid url://user:topsecret@host/db extra"
+    out = _redact_db_url(url)
+    assert "topsecret" not in out, out


### PR DESCRIPTION
Security audit 2026-06-02 (H9).

init_db logs the connection URL at INFO on every boot (no-migrations and alembic paths). In prod the URL is postgresql+asyncpg://user:PASSWORD@host/db, so the Postgres password lands verbatim in the structured logs — recoverable by the whole log-read audience (SRE, log pipeline, support bundles), violating "mai loggare segreti". The DB credential is also the at-rest encryption boundary for kms_backend=local and plaintext provider creds.

Fix: _redact_db_url() masks the password via SQLAlchemy URL renderer (hide_password=True), keeping user/host/db for ops; on any parse failure falls back to the host/db tail (userinfo precedes @) so redaction never breaks boot.

Tests: test_db_url_redaction.py (3). Verified live in prod-shape: log shows postgresql+asyncpg://cullis_mastio:***@postgres:5432/... — real password absent.