### PR TITLE
fix(integrations): fail closed on unsigned bridge requests in production

### DIFF
--- a/mcp_proxy/integrations/policy_bridge.py
+++ b/mcp_proxy/integrations/policy_bridge.py
@@ -65,19 +65,32 @@ _SIGNATURE_HEADER = "x-cullis-integration-signature"
 
 
 async def _verify_signature(request: Request, raw_body: bytes) -> None:
-    """Enforce the HMAC-SHA256 signature when the operator configured it.
+    """Enforce the HMAC-SHA256 signature on the integrations bridge.
 
-    Refuses with HTTP 401 (no body) when the secret is set but the
-    header is missing or mismatching. Accepts and logs at warning level
-    when the secret is empty — the same posture as the existing PDP
-    plane (mcp_proxy/main.py:1719) so the operator's mental model stays
-    consistent.
+    Refuses with HTTP 401 (no body) when the secret is set but the header
+    is missing or mismatching.
+
+    H10 (audit 2026-06-02): when no secret is configured the posture is
+    environment-dependent. The bridge router is mounted unconditionally,
+    so an unsigned request could inject rows into the append-only
+    ``audit_log`` (CloudEvents ingest) or probe the policy decision
+    surface. We therefore **fail closed in production** — unsigned
+    requests are rejected even without a secret — and accept unsigned only
+    outside production (sandbox / local dev ergonomics). This is a runtime
+    default-deny rather than a boot gate so it never breaks a prod deploy
+    that hasn't wired the (optional) integrations secret.
     """
-    secret = get_settings().integrations_hmac_secret
+    settings = get_settings()
+    secret = settings.integrations_hmac_secret
     if not secret:
-        # Operator chose not to enable signature verification. The
-        # warning at startup (logged once from main.py boot) suffices —
-        # avoid per-request log spam.
+        if settings.environment == "production":
+            _log.warning(
+                "policy_bridge: rejected unsigned request to %s — "
+                "integrations_hmac_secret is empty in production "
+                "(audit 2026-06-02 H10, fail-closed)",
+                request.url.path,
+            )
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
         return
     provided = request.headers.get(_SIGNATURE_HEADER, "")
     expected = hmac.new(

--- a/test/unit/test_policy_bridge.py
+++ b/test/unit/test_policy_bridge.py
@@ -62,6 +62,7 @@ def app_under_test(monkeypatch):
 
     class _FakeSettings:
         integrations_hmac_secret: str = ""
+        environment: str = "development"
 
     def _fake_get_settings():
         return _FakeSettings()
@@ -320,7 +321,8 @@ def test_cloudevents_missing_source_400(client):
 
 
 def test_hmac_unconfigured_accepts_unsigned(client):
-    """When integrations_hmac_secret is empty, signed/unsigned both accepted."""
+    """When integrations_hmac_secret is empty in NON-production, signed and
+    unsigned are both accepted (sandbox / dev ergonomics)."""
     resp = client.post(
         "/v1/data/cullis/policy/session",
         json={"input": {
@@ -330,6 +332,64 @@ def test_hmac_unconfigured_accepts_unsigned(client):
         }},
     )
     assert resp.status_code == 200
+
+
+def test_hmac_unconfigured_rejects_unsigned_in_production(
+    monkeypatch, app_under_test,
+):
+    """H10 (audit 2026-06-02) — with no secret the bridge fails CLOSED in
+    production: unsigned requests are rejected. The router is mounted
+    unconditionally, so an open bridge would let any reachable caller probe
+    the policy surface. Runtime default-deny (no boot gate), so a prod
+    deploy that didn't wire the optional secret still boots — just refuses
+    unsigned bridge traffic."""
+    class _Prod:
+        integrations_hmac_secret: str = ""
+        environment: str = "production"
+
+    monkeypatch.setattr(
+        "mcp_proxy.integrations.policy_bridge.get_settings", lambda: _Prod(),
+    )
+    app, _ = app_under_test
+    c = TestClient(app)
+    resp = c.post(
+        "/v1/data/cullis/policy/session",
+        json={"input": {
+            "initiator_agent_id": "a",
+            "target_agent_id": "b",
+            "session_context": "initiator",
+        }},
+    )
+    assert resp.status_code == 401
+
+
+def test_cloudevents_unsigned_rejected_in_production(monkeypatch, app_under_test):
+    """H10 — the CloudEvents ingest is the audit_log-injection vector; in
+    production without a secret it must reject and write no audit row."""
+    _, state = app_under_test
+
+    class _Prod:
+        integrations_hmac_secret: str = ""
+        environment: str = "production"
+
+    monkeypatch.setattr(
+        "mcp_proxy.integrations.policy_bridge.get_settings", lambda: _Prod(),
+    )
+    app, _ = app_under_test
+    c = TestClient(app)
+    resp = c.post(
+        "/v1/integrations/cloudevents",
+        headers={
+            "ce-id": "evt-attacker",
+            "ce-source": "gateway://attacker",
+            "ce-type": "io.gateway.tool.allowed",
+            "ce-specversion": "1.0",
+            "content-type": "application/json",
+        },
+        json={"agent_id": "victim::forged", "decision": "allow"},
+    )
+    assert resp.status_code == 401
+    assert state["audit_calls"] == []  # no row injected
 
 
 def test_hmac_configured_rejects_unsigned(monkeypatch, app_under_test):


### PR DESCRIPTION
Security audit 2026-06-02 (H10).

The integrations bridge router (/v1/data/cullis/policy/*, /v1/integrations/cloudevents) is mounted unconditionally, and _verify_signature accepted UNSIGNED requests whenever integrations_hmac_secret was empty (the default). In production that let any reachable caller inject arbitrary rows into the append-only audit_log via the CloudEvents ingest (audit-trail poisoning) and probe the policy decision surface. The docstring even claimed a boot warning that does not exist.

Fix: fail CLOSED in production — with no secret, reject unsigned with 401 when environment=production; accept unsigned only outside production (sandbox/dev). Chosen as a runtime default-deny rather than a validate_config boot gate on purpose: integrations_hmac_secret is not minted by generate-proxy-env.sh --prod (nor is pdp_webhook_hmac_secret), so a boot gate would break the already-fragile deploy.sh --prod (#1021). Runtime check closes the vuln regardless.

Tests: test_policy_bridge.py — env added to fake settings + two cases (session + cloudevents rejected in prod, no audit row). Smoke 14/14. Security review: fix correct, no client bypass; note: efficacy depends on environment=production being set (coupled to #1021). Verified live in prod-shape: boot OK with empty secret, both bridge endpoints → 401.