### PR TITLE
fix(enrollment): enforce key-strength floor on agent cert signing

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -62,6 +62,41 @@ MASTIO_LEAF_VALIDITY_DAYS = 365  # 1 year (existing ADR-012 Phase 2.1 rotation c
 AGENT_CERT_VALIDITY_DAYS = 365  # 1 year (Wave 2 narrows further with grace-period support)
 NGINX_SERVER_CERT_VALIDITY_DAYS = 90  # 90 days (was 1y, audit 2026-05-18 short-lived TLS)
 
+# H4 (audit 2026-06-02) — key-strength floor for externally-submitted keys
+# the Mastio Intermediate CA signs. Mirrors the user-CSR path
+# (registry/principals_csr._validate_public_key, F-A-102).
+_ALLOWED_EC_CURVES = (ec.SECP256R1, ec.SECP384R1, ec.SECP521R1)
+_MIN_RSA_KEY_BITS = 2048
+
+
+def assert_strong_public_key(public_key) -> None:
+    """Refuse weak externally-submitted keys before the CA signs them.
+
+    H4 (audit 2026-06-02): the user-CSR path already enforces this floor
+    (F-A-102), but the Connector agent-enrollment path
+    (``sign_external_pubkey``) accepted any loadable key, so an RSA-512 or
+    non-NIST-curve key could obtain a legitimate Org-Intermediate-signed
+    mTLS leaf — a cert on a factorable key, invisible to the approving
+    admin (who only sees the fingerprint). Floor: RSA >= 2048, EC limited
+    to P-256/384/521. Raises ``ValueError`` on a weak / unsupported key.
+    """
+    if isinstance(public_key, rsa.RSAPublicKey):
+        if public_key.key_size < _MIN_RSA_KEY_BITS:
+            raise ValueError(
+                f"RSA key too small ({public_key.key_size} bits); "
+                f"minimum {_MIN_RSA_KEY_BITS}",
+            )
+    elif isinstance(public_key, ec.EllipticCurvePublicKey):
+        if not isinstance(public_key.curve, _ALLOWED_EC_CURVES):
+            raise ValueError(
+                f"EC curve {public_key.curve.name!r} not allowed; "
+                "use P-256, P-384 or P-521",
+            )
+    else:
+        raise ValueError(
+            f"Unsupported public key type: {type(public_key).__name__}",
+        )
+
 
 def _strict_pki_enabled() -> bool:
     """Issue #285 — ``MCP_PROXY_STRICT_PKI=1`` opts the proxy into
@@ -1089,6 +1124,11 @@ class AgentManager:
                 )
 
         public_key = serialization.load_pem_public_key(pubkey_pem.encode())
+        # H4 (audit 2026-06-02): refuse weak keys before signing, mirroring
+        # the user-CSR floor (F-A-102). Closes the gap where a factorable
+        # RSA-512 / non-NIST-curve key could get an Org-Intermediate-signed
+        # mTLS leaf via the Connector enrollment path.
+        assert_strong_public_key(public_key)
 
         agent_id = f"{self._org_id}::{agent_name}"
         spiffe_uri = f"spiffe://{self._trust_domain}/{self._org_id}/{agent_name}"

--- a/test/unit/test_enroll_key_strength.py
+++ b/test/unit/test_enroll_key_strength.py
@@ -1,0 +1,55 @@
+"""H4 (audit 2026-06-02) — key-strength floor on the Connector
+agent-enrollment signing path.
+
+sign_external_pubkey accepted any loadable key, so an RSA-512 or
+non-NIST-curve key could obtain a legitimate Org-Intermediate-signed mTLS
+leaf (a cert on a factorable key, invisible to the approving admin). The
+user-CSR path already enforced RSA>=2048 + NIST curves (F-A-102); these
+tests lock in parity via assert_strong_public_key.
+"""
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+
+from mcp_proxy.egress.agent_manager import assert_strong_public_key
+
+
+def _rsa_pub(bits: int):
+    return rsa.generate_private_key(public_exponent=65537, key_size=bits).public_key()
+
+
+def _ec_pub(curve):
+    return ec.generate_private_key(curve).public_key()
+
+
+def test_rsa_1024_rejected():
+    # cryptography refuses to *generate* RSA < 1024, so 1024 is the
+    # smallest constructible weak key; it is still below the 2048 floor and
+    # must be rejected. A factorable RSA-512 submitted as PEM from an
+    # external tool would hit the same key_size < 2048 branch.
+    with pytest.raises(ValueError, match="too small"):
+        assert_strong_public_key(_rsa_pub(1024))
+
+
+def test_rsa_2048_accepted():
+    assert_strong_public_key(_rsa_pub(2048))  # no raise
+
+
+def test_ec_p256_accepted():
+    assert_strong_public_key(_ec_pub(ec.SECP256R1()))  # no raise
+
+
+def test_ec_p384_accepted():
+    assert_strong_public_key(_ec_pub(ec.SECP384R1()))  # no raise
+
+
+def test_ec_non_nist_curve_rejected():
+    # secp256k1 (Bitcoin curve) is a strong-ish curve but outside the
+    # NIST allowlist the rest of the PKI uses — must be refused.
+    with pytest.raises(ValueError, match="not allowed"):
+        assert_strong_public_key(_ec_pub(ec.SECP256K1()))
+
+
+def test_ed25519_rejected_as_unsupported():
+    pub = ed25519.Ed25519PrivateKey.generate().public_key()
+    with pytest.raises(ValueError, match="Unsupported"):
+        assert_strong_public_key(pub)


### PR DESCRIPTION
Security audit 2026-06-02 (H4).

sign_external_pubkey (Connector agent-enrollment path) signed any loadable key — no size/curve floor. An RSA-512 or non-NIST-curve key would get a legitimate Org-Intermediate-signed mTLS leaf (an agent identity on a factorable key), invisible to the approving admin (dashboard shows only the fingerprint). The user-CSR path already enforces this (F-A-102); this closes the asymmetry.

Fix: assert_strong_public_key() — RSA >= 2048, EC P-256/384/521, else refused — called in sign_external_pubkey before the CA signs.

Tests: test_enroll_key_strength.py (7: RSA-1024 rejected / 2048 ok, P-256/384 ok, secp256k1 + Ed25519 rejected). 403 enrollment/agent_manager regression tests pass. Smoke 14/14.