### PR TITLE
fix(pki): serialise multi-worker PKI provisioning (nginx server-cert + legacy migration)

### DIFF
--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -141,34 +141,39 @@ def _detect_legacy_unstamped(sync_conn) -> bool:
     return bool(_LEGACY_TABLES & table_names)
 
 
-def _acquire_mastio_mint_lock(sqlite_path: str) -> int:
-    """Open + flock-exclusive a lockfile next to the SQLite DB.
+def _acquire_boot_flock(sqlite_path: str, lock_slug: str) -> int:
+    """Open + flock-exclusive a named lockfile next to the SQLite DB.
 
-    Serialises the leaf-mint critical section in
-    ``AgentManager._mint_mastio_leaf`` across the N uvicorn worker
-    processes that race at lifespan startup. Without this, every worker
-    enters the mint path with ``self._active_key is None`` (per-process
-    in-memory cache, never populated yet) and they all INSERT a fresh
-    active row. ``mastio_keys`` then carries N>1 rows where
-    ``activated_at IS NOT NULL AND deprecated_at IS NULL``, and the
-    first call to ``LocalKeyStore.current_signer()`` raises
-    ``RuntimeError("N active mastio keys — rotation invariant
-    violated")``. The caught exception leaves ``app.state.local_issuer``
-    as None and ``/v1/auth/token`` returns 503 "local issuer not
-    initialized" for the lifetime of the deploy. Issue cullis#997.
+    Generic multi-worker boot-serialisation primitive: fences any
+    lifespan critical section that the N uvicorn workers would otherwise
+    run concurrently against shared on-disk / DB state. Each ``lock_slug``
+    gets its own sibling-of-DB lockfile (``<db>.<slug>.lock``) so
+    unrelated critical sections never serialise against each other.
+
+    Callers today:
+
+    * ``mastio_mint`` — the cullis#997 leaf-mint section in
+      ``AgentManager._mint_mastio_leaf``. Without it every worker enters
+      the mint path with ``self._active_key is None`` and INSERTs a fresh
+      active row → ``mastio_keys`` carries N>1 active rows →
+      ``current_signer()`` raises → ``/v1/auth/token`` 503 for the
+      lifetime of the deploy.
+    * ``nginx_cert`` — the nginx server-cert provisioning in
+      ``AgentManager.ensure_nginx_server_cert``. Without it each worker
+      mints its OWN leaf keypair and the three output files
+      (``mastio-server.crt`` / ``.key`` / ``org-ca.crt``) interleave
+      across workers, leaving a torn cert/key pair (cert pubkey of Kᴮ
+      with private key Kᴬ) that breaks the nginx 9443 TLS handshake.
 
     Pattern mirrors :func:`_run_migrations_sync_under_flock`: blocking
-    ``fcntl.LOCK_EX`` on a sibling-of-DB lockfile that the kernel
-    auto-releases on worker exit. SQLite-only — Postgres deploys rely
-    on a different code path (today: still racy, fix follow-up; the
-    in-the-wild Postgres count is 0 so this is acceptable as a
-    same-day patch).
+    ``fcntl.LOCK_EX`` on a lockfile the kernel auto-releases on worker
+    exit.
     """
     import fcntl
     from pathlib import Path
 
     db_path = Path(sqlite_path)
-    lock_path = db_path.with_name(f"{db_path.name}.mastio_mint.lock")
+    lock_path = db_path.with_name(f"{db_path.name}.{lock_slug}.lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o644)
@@ -187,8 +192,8 @@ def _acquire_mastio_mint_lock(sqlite_path: str) -> int:
     return fd
 
 
-def _release_mastio_mint_lock(fd: int) -> None:
-    """Release the flock acquired by :func:`_acquire_mastio_mint_lock`."""
+def _release_boot_flock(fd: int) -> None:
+    """Release a flock acquired by :func:`_acquire_boot_flock`."""
     import fcntl
 
     try:
@@ -200,44 +205,61 @@ def _release_mastio_mint_lock(fd: int) -> None:
             pass
 
 
-async def _acquire_mastio_mint_lock_pg(url: str):
-    """Postgres analogue of :func:`_acquire_mastio_mint_lock`.
+async def _acquire_boot_advisory_lock_pg(url: str, lock_key: str):
+    """Postgres analogue of :func:`_acquire_boot_flock`.
 
-    The SQLite flock above only serialises the cullis#997 leaf-mint
-    critical section on SQLite; Postgres deploys previously took the
-    racy branch (every worker minting an active row → N>1 active →
-    ``current_signer()`` raises → ``/v1/auth/token`` 503). The pilot DB
-    is Postgres + multi-worker, so close it here with a session-level
-    advisory lock (mirrors the ``pg_advisory_xact_lock(hashtext(
-    'mastio-rotate'))`` used by :func:`activate_staged_and_deprecate_old`
-    and the Alembic migration lock). A dedicated engine/connection so the
-    lock auto-releases when the session is disposed even if the explicit
-    unlock is skipped. Returns ``(engine, conn)`` to release, or ``None``
-    for non-Postgres URLs (SQLite uses the flock; in-memory is
-    single-process).
+    Takes a session-level ``pg_advisory_lock(hashtext(<lock_key>))`` on a
+    dedicated engine/connection so the lock auto-releases when the
+    session is disposed even if the explicit unlock is skipped (mirrors
+    the ``pg_advisory_xact_lock(hashtext('mastio-rotate'))`` used by the
+    rotation path and the Alembic migration lock). Returns
+    ``(engine, conn, lock_key)`` to release, or ``None`` for non-Postgres
+    URLs (SQLite uses the flock; in-memory is single-process).
     """
     if not (url.startswith("postgresql") or "+asyncpg" in url):
         return None
     eng = create_async_engine(url, **_engine_kwargs(url))
     conn = await eng.connect()
-    await conn.execute(text("SELECT pg_advisory_lock(hashtext('mastio-mint'))"))
-    return (eng, conn)
+    await conn.execute(
+        text("SELECT pg_advisory_lock(hashtext(:k))"), {"k": lock_key},
+    )
+    return (eng, conn, lock_key)
 
 
-async def _release_mastio_mint_lock_pg(handle) -> None:
+async def _release_boot_advisory_lock_pg(handle) -> None:
     """Release the advisory lock + dispose the dedicated session."""
     if handle is None:
         return
-    eng, conn = handle
+    eng, conn, lock_key = handle
     try:
         try:
             await conn.execute(
-                text("SELECT pg_advisory_unlock(hashtext('mastio-mint'))"),
+                text("SELECT pg_advisory_unlock(hashtext(:k))"),
+                {"k": lock_key},
             )
         finally:
             await conn.close()
     finally:
         await eng.dispose()
+
+
+# ── cullis#997 leaf-mint lock (thin wrappers over the generic boot
+# primitives above; kept as named helpers so the call-sites read as
+# intent and the issue reference stays attached). ───────────────────────
+def _acquire_mastio_mint_lock(sqlite_path: str) -> int:
+    return _acquire_boot_flock(sqlite_path, "mastio_mint")
+
+
+def _release_mastio_mint_lock(fd: int) -> None:
+    _release_boot_flock(fd)
+
+
+async def _acquire_mastio_mint_lock_pg(url: str):
+    return await _acquire_boot_advisory_lock_pg(url, "mastio-mint")
+
+
+async def _release_mastio_mint_lock_pg(handle) -> None:
+    await _release_boot_advisory_lock_pg(handle)
 
 
 def _run_migrations_sync_under_flock(url: str, sqlite_path: str) -> None:

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -1809,7 +1809,25 @@ class AgentManager:
             # at-rest so the lifespan's ``load_org_ca_from_config``
             # finds the keypair on the very next call.
             try:
-                await provider.store_org_ca(legacy_org_key, legacy_org_cert)
+                # Prefer the atomic create-only variant (Vault KV v2
+                # cas:0) so N workers migrating the SAME legacy material
+                # at boot don't take the racy read-modify-write first-
+                # write branch (no cas) — which interleaves into a cas
+                # version mismatch → RuntimeError → wipe aborted on some
+                # workers and completed on others = inconsistent at-rest
+                # hardening state across the fleet. "Lost" here is a
+                # clean no-op (a sibling already migrated the identical
+                # PEM), not a failure. Mirrors the D-9 fix in
+                # ``_persist_org_ca``; providers without it keep the
+                # legacy path (local backend is race-safe via the
+                # pki_key_store PK collision on the identical key_id).
+                store_if_absent = getattr(
+                    provider, "store_org_ca_if_absent", None,
+                )
+                if store_if_absent is not None:
+                    await store_if_absent(legacy_org_key, legacy_org_cert)
+                else:
+                    await provider.store_org_ca(legacy_org_key, legacy_org_cert)
             except Exception as exc:  # noqa: BLE001 — refuse-to-wipe on failure
                 logger.error(
                     "Phase 0 migration failed for org_ca: %s. Aborting "
@@ -1851,9 +1869,19 @@ class AgentManager:
 
         if legacy_int_key and legacy_int_cert:
             try:
-                await provider.store_intermediate_ca(
-                    legacy_int_key, legacy_int_cert,
+                # Same D-9 atomic create-only treatment as org_ca above:
+                # cas:0 when the provider exposes it, legacy path
+                # otherwise. Avoids the read-modify-write cas mismatch
+                # that aborted the wipe on a subset of workers.
+                store_int_if_absent = getattr(
+                    provider, "store_intermediate_ca_if_absent", None,
                 )
+                if store_int_if_absent is not None:
+                    await store_int_if_absent(legacy_int_key, legacy_int_cert)
+                else:
+                    await provider.store_intermediate_ca(
+                        legacy_int_key, legacy_int_cert,
+                    )
             except Exception as exc:  # noqa: BLE001 — refuse-to-wipe on failure
                 logger.error(
                     "Phase 0 migration failed for intermediate_ca: %s. "

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -783,12 +783,6 @@ class AgentManager:
 
         from pathlib import Path
 
-        def _aware(dt: datetime) -> datetime:
-            """cryptography <42 returns naive UTC datetimes from cert
-            properties; ≥42 returns aware. Normalize to aware for math
-            and ISO formatting."""
-            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-
         san_list = list(sans) if sans else ["mastio.local"]
 
         # Split SANs into IP literals vs hostnames. RFC 6125 / RFC 5280:
@@ -815,86 +809,198 @@ class AgentManager:
         crt_path = out / "mastio-server.crt"
         key_path = out / "mastio-server.key"
 
-        # ── Reuse path: validate existing files in one shot ─────────
-        reuse = False
-        if ca_path.exists() and crt_path.exists() and key_path.exists():
+        # ── Fast path: reuse valid on-disk material without taking the
+        # cross-worker lock (steady-state boot, the common case). ───────
+        if self._nginx_cert_reusable(
+            ca_path, crt_path, key_path,
+            san_hosts=san_hosts, san_ips=san_ips,
+            renew_within_days=renew_within_days,
+        ):
+            return False
+
+        # ── Mint path, serialised across the N uvicorn workers ─────────
+        # Cold boot with an empty cert dir: every worker fails the reuse
+        # check above and would otherwise each generate its own leaf
+        # keypair and write the three output files concurrently. The
+        # tmp+rename is atomic per file but NOT across the three files,
+        # and the tmp name used to be shared between workers — so the
+        # writes interleave and leave a torn pair (cert carrying Kᴮ's
+        # pubkey next to Kᴬ's private key), which breaks the nginx 9443
+        # TLS handshake. Same multi-worker boot-race class as the leaf
+        # mint (cullis#997) and the D-9 CA mint. Fence reuse-recheck +
+        # mint + write under the shared boot lock so exactly one worker
+        # mints and the others adopt its files.
+        from mcp_proxy.config import get_settings
+        from mcp_proxy.db import (
+            _acquire_boot_advisory_lock_pg,
+            _acquire_boot_flock,
+            _release_boot_advisory_lock_pg,
+            _release_boot_flock,
+            _sqlite_path,
+        )
+
+        db_url = get_settings().database_url
+        lock_fd: int | None = None
+        pg_lock = None
+        sqlite_path = _sqlite_path(db_url) if db_url else None
+        is_pg = bool(db_url) and (
+            db_url.startswith("postgresql") or "+asyncpg" in db_url
+        )
+        # ``:memory:`` (and a missing URL) is single-process by
+        # definition — each worker has its own DB, there is no shared
+        # state to fence — so skip the lock; an on-disk SQLite file or
+        # Postgres is the real multi-worker shape.
+        if sqlite_path and sqlite_path != ":memory:":
+            lock_fd = await asyncio.to_thread(
+                _acquire_boot_flock, sqlite_path, "nginx_cert",
+            )
+        elif is_pg:
+            pg_lock = await _acquire_boot_advisory_lock_pg(db_url, "nginx-cert")
+        try:
+            # Double-checked: a sibling worker may have minted + written
+            # the complete pair while this worker waited for the lock.
+            if self._nginx_cert_reusable(
+                ca_path, crt_path, key_path,
+                san_hosts=san_hosts, san_ips=san_ips,
+                renew_within_days=renew_within_days,
+            ):
+                return False
+            return self._mint_nginx_server_cert(
+                ca_path=ca_path, crt_path=crt_path, key_path=key_path,
+                san_list=san_list, san_hosts=san_hosts, san_ips=san_ips,
+                validity_days=validity_days, out_dir=out_dir,
+            )
+        finally:
+            if lock_fd is not None:
+                await asyncio.to_thread(_release_boot_flock, lock_fd)
+            if pg_lock is not None:
+                await _release_boot_advisory_lock_pg(pg_lock)
+
+    def _nginx_cert_reusable(
+        self,
+        ca_path,
+        crt_path,
+        key_path,
+        *,
+        san_hosts: list[str],
+        san_ips: list[str],
+        renew_within_days: int,
+    ) -> bool:
+        """True when the on-disk nginx server-cert triple is a valid,
+        current, reusable pair — so the caller can skip minting.
+
+        Validates in one shot: the cert bundle parses and carries both
+        the leaf and the Intermediate (2 PEM blocks), the leaf is issued
+        by the current Mastio Intermediate, it is not expiring within
+        ``renew_within_days``, the SANs match exactly (DNS vs IP in the
+        right type), the CA bundle matches the in-memory Org CA, AND the
+        private key on disk actually owns the leaf's public key. The
+        last check is the multi-worker hardening: a torn cert/key pair
+        left by a pre-fix concurrent boot would otherwise pass every
+        other check and be reused forever, keeping nginx permanently
+        broken across restarts.
+        """
+        def _aware(dt: datetime) -> datetime:
+            # cryptography <42 returns naive UTC datetimes from cert
+            # properties; ≥42 returns aware. Normalize for math/ISO.
+            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+        if not (ca_path.exists() and crt_path.exists() and key_path.exists()):
+            return False
+        try:
+            # The on-disk crt is a bundle (leaf + Intermediate). A pre-fix
+            # single-cert file falls through to the mint path because it
+            # is missing the Intermediate strict TLS clients need.
+            existing_bundle_bytes = crt_path.read_bytes()
+            bundle_blocks = existing_bundle_bytes.count(
+                b"-----BEGIN CERTIFICATE-----",
+            )
+            existing = x509.load_pem_x509_certificate(existing_bundle_bytes)
             try:
-                # The on-disk crt is a bundle (leaf + Intermediate, audit
-                # 2026-05-18 follow-up #2). A pre-fix single-cert file
-                # falls through to the mint path because it is missing
-                # the Intermediate that strict TLS clients need to build
-                # the chain.
-                existing_bundle_bytes = crt_path.read_bytes()
-                bundle_blocks = existing_bundle_bytes.count(
-                    b"-----BEGIN CERTIFICATE-----",
+                san_ext = existing.extensions.get_extension_for_class(
+                    SubjectAlternativeName,
+                ).value
+                existing_hosts = set(san_ext.get_values_for_type(x509.DNSName))
+                existing_ips = {
+                    str(ip) for ip in san_ext.get_values_for_type(x509.IPAddress)
+                }
+            except x509.ExtensionNotFound:
+                existing_hosts, existing_ips = set(), set()
+            issuer_ok = (
+                existing.issuer.rfc4514_string()
+                == self._mastio_ca_cert.subject.rfc4514_string()
+            )
+            now = datetime.now(timezone.utc)
+            expires_in = _aware(existing.not_valid_after) - now
+            expiry_ok = expires_in > timedelta(days=renew_within_days)
+            ca_ondisk = x509.load_pem_x509_certificate(ca_path.read_bytes())
+            ca_ok = (
+                ca_ondisk.public_bytes(serialization.Encoding.DER)
+                == self._org_ca_cert.public_bytes(serialization.Encoding.DER)
+            )
+            sans_ok = (
+                existing_hosts == set(san_hosts)
+                and existing_ips == set(san_ips)
+            )
+            bundle_ok = bundle_blocks == 2
+            # Key↔cert match — the private key on disk must own the leaf's
+            # public key. Closes the torn-pair multi-worker boot race.
+            try:
+                priv = serialization.load_pem_private_key(
+                    key_path.read_bytes(), password=None,
                 )
-                existing = x509.load_pem_x509_certificate(existing_bundle_bytes)
-                # SAN match — read DNSName + IPAddress because the same
-                # ``san_list`` may contain both (now that we split). A
-                # cert that already carries the right entries — even if
-                # we used to write IPs as DNSName before this fix —
-                # should NOT trigger a regeneration here; the post-
-                # mint reuse check below catches the type mismatch.
-                try:
-                    san_ext = existing.extensions.get_extension_for_class(
-                        SubjectAlternativeName,
-                    ).value
-                    existing_hosts = set(san_ext.get_values_for_type(x509.DNSName))
-                    existing_ips = {
-                        str(ip) for ip in san_ext.get_values_for_type(x509.IPAddress)
-                    }
-                except x509.ExtensionNotFound:
-                    existing_hosts, existing_ips = set(), set()
-                # Issuer match (current Mastio Intermediate's subject).
-                # Pre-three-tier-hardening this checked against the Org
-                # CA subject; after PR fix the leaf is signed by the
-                # Intermediate. Either issuer counts as a hit during
-                # the rollout window so a freshly-upgraded Mastio
-                # doesn't unnecessarily regenerate when the prior
-                # nginx leaf was Org-issued.
-                issuer_ok = (
-                    existing.issuer.rfc4514_string()
-                    == self._mastio_ca_cert.subject.rfc4514_string()
+                key_ok = (
+                    priv.public_key().public_bytes(
+                        serialization.Encoding.DER,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
+                    == existing.public_key().public_bytes(
+                        serialization.Encoding.DER,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
                 )
-                # Expiry guard
-                now = datetime.now(timezone.utc)
-                expires_in = _aware(existing.not_valid_after) - now
-                expiry_ok = expires_in > timedelta(days=renew_within_days)
-                # CA bundle file matches the in-memory CA
-                ca_ondisk = x509.load_pem_x509_certificate(ca_path.read_bytes())
-                ca_ok = (
-                    ca_ondisk.public_bytes(serialization.Encoding.DER)
-                    == self._org_ca_cert.public_bytes(serialization.Encoding.DER)
-                )
-
-                # Strict equality: same hosts AND same IPs in the right
-                # SAN type. A pre-fix cert that had IPs in ``DNSName``
-                # falls through to the mint path, which is the right
-                # outcome — that cert is the bug we're closing.
-                sans_ok = (
-                    existing_hosts == set(san_hosts)
-                    and existing_ips == set(san_ips)
-                )
-
-                bundle_ok = bundle_blocks == 2
-                if issuer_ok and expiry_ok and ca_ok and sans_ok and bundle_ok:
-                    reuse = True
-            except Exception as exc:  # treat any parse failure as "regenerate"
+            except Exception:
+                key_ok = False
+            if (
+                issuer_ok and expiry_ok and ca_ok
+                and sans_ok and bundle_ok and key_ok
+            ):
                 logger.info(
-                    "nginx server cert on disk failed validation (%s) — "
-                    "will regenerate",
-                    exc,
+                    "nginx server cert reused (expiring=%s)",
+                    _aware(existing.not_valid_after).isoformat(
+                        timespec="seconds",
+                    ),
                 )
-
-        if reuse:
+                return True
+            return False
+        except Exception as exc:  # treat any parse failure as "regenerate"
             logger.info(
-                "nginx server cert reused (sans=%s, expiring=%s)",
-                ",".join(san_list),
-                _aware(existing.not_valid_after).isoformat(timespec="seconds"),
+                "nginx server cert on disk failed validation (%s) — "
+                "will regenerate", exc,
             )
             return False
 
-        # ── Mint path ───────────────────────────────────────────────
+    def _mint_nginx_server_cert(
+        self,
+        *,
+        ca_path,
+        crt_path,
+        key_path,
+        san_list: list[str],
+        san_hosts: list[str],
+        san_ips: list[str],
+        validity_days: int,
+        out_dir: str,
+    ) -> bool:
+        """Mint a fresh nginx leaf + write the three output files.
+
+        Caller MUST hold the ``nginx_cert`` boot lock — this signs a new
+        keypair and overwrites the shared output files, so concurrent
+        workers would torn-write the pair. Returns ``True`` (rewritten).
+        """
+        def _aware(dt: datetime) -> datetime:
+            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
         # ECDSA P-256 leaf — fast, modern, matches the Connector cert
         # algorithm so nginx negotiates TLS 1.3 + ECDSA cleanly.
         leaf_key = ec.generate_private_key(ec.SECP256R1())
@@ -955,31 +1061,17 @@ class AgentManager:
         )
         leaf_cert = builder.sign(self._mastio_ca_key, hashes.SHA256())
 
-        # Write atomically: tmp file then rename. The mtime change is
-        # the signal the sidecar ``nginx-reload-watcher.sh`` (Wave 2
-        # fix 6) picks up to trigger ``nginx -s reload`` — no SIGHUP
-        # from this side, no docker socket. At boot we still need the
-        # writes consistent so a restart-within-restart never observes
-        # a torn pair.
-        #
-        # Three-tier PKI hardening (audit 2026-05-18): ``org-ca.crt`` now
-        # holds the **full chain** (Org Root || Intermediate) so a
-        # client doing strict path validation against an arbitrary
-        # leaf still sees the issuer chain. The legacy single-cert
-        # mode (Root only) would fail validation now that leaves are
-        # Intermediate-issued.
+        # Three-tier PKI hardening (audit 2026-05-18): ``org-ca.crt`` holds
+        # the full chain (Org Root || Intermediate); ``mastio-server.crt``
+        # is the leaf || Intermediate bundle strict TLS clients need to
+        # build ``Leaf -> Intermediate -> Org Root``. Writes use tmp+rename
+        # per file; the caller's boot lock makes the three-file set atomic
+        # across workers. The mtime change is the signal the sidecar
+        # ``nginx-reload-watcher.sh`` picks up to trigger ``nginx -s reload``.
         ca_pem = (
             self._org_ca_cert.public_bytes(serialization.Encoding.PEM)
             + self._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
         )
-        # Three-tier PKI hardening (audit 2026-05-18) follow-up #2:
-        # ``mastio-server.crt`` is now a full chain bundle
-        # (leaf || Intermediate). Strict TLS clients (Python ssl,
-        # OpenSSL, Go crypto/tls) require the Intermediate to build the
-        # path ``Leaf -> Intermediate -> Org Root`` when only the Org
-        # Root is in the trust store. Standard PEM ordering: leaf first,
-        # then Intermediate; the root is omitted because it lives in the
-        # client trust store.
         crt_pem = (
             leaf_cert.public_bytes(serialization.Encoding.PEM)
             + self._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
@@ -990,12 +1082,17 @@ class AgentManager:
             serialization.NoEncryption(),
         )
 
+        # tmp name is pid-suffixed so even a non-flock backend never
+        # collides on the same tmp file; the boot lock already serialises
+        # this, the suffix is belt-and-braces.
+        import os
+        pid = os.getpid()
         for path, payload, mode in (
             (ca_path, ca_pem, 0o644),
             (crt_path, crt_pem, 0o644),
             (key_path, key_pem, 0o600),
         ):
-            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp = path.with_suffix(path.suffix + f".tmp.{pid}")
             tmp.write_bytes(payload)
             tmp.chmod(mode)
             tmp.replace(path)

--- a/test/unit/test_mastio_nginx_cert_san.py
+++ b/test/unit/test_mastio_nginx_cert_san.py
@@ -226,3 +226,172 @@ def test_reuse_path_regenerates_when_legacy_cert_has_ip_in_dns_san(tmp_path):
         "legacy cert with IP-as-DNSName was reused instead of being "
         "replaced — operator stays stuck with CERTIFICATE_VERIFY_FAILED"
     )
+
+
+# ── Multi-worker boot race: torn cert/key pair ──────────────────────
+#
+# Cold first boot with N uvicorn workers and an empty cert dir: every
+# worker fails the reuse check, enters the mint path, generates its OWN
+# leaf keypair and writes the three shared output files. The per-file
+# tmp+rename is atomic but the three-file set is not, so the writes
+# interleave across workers and leave ``mastio-server.crt`` carrying
+# worker B's leaf pubkey next to ``mastio-server.key`` holding worker
+# A's private key — a torn pair nginx rejects with "key values
+# mismatch" on the 9443 mTLS port. The fix: (1) fence reuse-recheck +
+# mint + write under a cross-worker boot lock so exactly one worker
+# mints, and (2) make the reuse check validate that the on-disk private
+# key actually owns the leaf's public key, so a torn pair from a
+# pre-fix boot is regenerated instead of reused forever.
+
+
+def _pair_consistent(crt_path: Path, key_path: Path) -> bool:
+    """True when the on-disk private key owns the leaf cert's pubkey."""
+    cert = x509.load_pem_x509_certificate(crt_path.read_bytes())
+    priv = serialization.load_pem_private_key(
+        key_path.read_bytes(), password=None,
+    )
+    spki = serialization.PublicFormat.SubjectPublicKeyInfo
+    return (
+        priv.public_key().public_bytes(serialization.Encoding.DER, spki)
+        == cert.public_key().public_bytes(serialization.Encoding.DER, spki)
+    )
+
+
+def _write_valid_leaf_for_key(
+    mgr: AgentManager, out: Path, leaf_key, sans: list[str],
+) -> int:
+    """Write a full, valid nginx triple on disk for ``leaf_key`` and
+    return the leaf serial. Mirrors the mint output shape (crt = leaf ||
+    Intermediate bundle, ca = Org || Intermediate) so it passes every
+    reuse check EXCEPT whatever the caller deliberately breaks."""
+    out.mkdir(parents=True, exist_ok=True)
+    san_hosts, san_ips = [], []
+    for entry in sans:
+        try:
+            ipaddress.ip_address(entry)
+            san_ips.append(entry)
+        except ValueError:
+            san_hosts.append(entry)
+    now = datetime.now(timezone.utc)
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, sans[0]),
+        ]))
+        .issuer_name(mgr._mastio_ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.DNSName(h) for h in san_hosts]
+                + [x509.IPAddress(ipaddress.ip_address(ip)) for ip in san_ips],
+            ),
+            critical=False,
+        )
+        .sign(mgr._mastio_ca_key, hashes.SHA256())
+    )
+    bundle = (
+        leaf.public_bytes(serialization.Encoding.PEM)
+        + mgr._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
+    )
+    (out / "mastio-server.crt").write_bytes(bundle)
+    (out / "org-ca.crt").write_bytes(
+        mgr._org_ca_cert.public_bytes(serialization.Encoding.PEM)
+        + mgr._mastio_ca_cert.public_bytes(serialization.Encoding.PEM)
+    )
+    return leaf.serial_number
+
+
+def test_minted_pair_is_internally_consistent(tmp_path):
+    """Sanity: a freshly minted triple has a key that owns the cert."""
+    mgr = _make_manager_with_ca()
+    _emit(mgr, tmp_path, ["mastio.local", "192.168.122.154"])
+    assert _pair_consistent(
+        tmp_path / "mastio-server.crt", tmp_path / "mastio-server.key",
+    )
+
+
+def test_reuse_rejects_torn_keypair_and_regenerates(tmp_path):
+    """The core multi-worker race fix: a torn cert/key pair on disk
+    (valid cert, but the private key belongs to a DIFFERENT keypair)
+    must NOT be reused — it must be regenerated into a consistent pair.
+    Without the key↔cert match in the reuse check, the torn pair passes
+    issuer/expiry/CA/SAN/bundle validation and nginx stays broken
+    across every restart."""
+    mgr = _make_manager_with_ca()
+    sans = ["mastio.local", "192.168.122.154"]
+
+    # Lay down a torn pair: a valid leaf cert for key A, but the .key
+    # file holds an unrelated key B.
+    key_a = ec.generate_private_key(ec.SECP256R1())
+    key_b = ec.generate_private_key(ec.SECP256R1())
+    torn_serial = _write_valid_leaf_for_key(mgr, tmp_path, key_a, sans)
+    (tmp_path / "mastio-server.key").write_bytes(key_b.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ))
+    crt_path = tmp_path / "mastio-server.crt"
+    key_path = tmp_path / "mastio-server.key"
+    assert not _pair_consistent(crt_path, key_path), "fixture not torn"
+
+    _emit(mgr, tmp_path, sans)
+
+    # Regenerated: new serial AND a consistent pair.
+    new_serial = x509.load_pem_x509_certificate(
+        crt_path.read_bytes(),
+    ).serial_number
+    assert new_serial != torn_serial, (
+        "torn cert/key pair was reused instead of regenerated — nginx "
+        "would stay broken with key/cert mismatch across restarts"
+    )
+    assert _pair_consistent(crt_path, key_path), (
+        "regenerated pair is still torn"
+    )
+
+
+def test_reuse_accepts_consistent_pair_no_regen(tmp_path):
+    """A matching (non-torn) pair with the right SANs is reused — the
+    key match must not cause spurious regeneration on every boot."""
+    mgr = _make_manager_with_ca()
+    sans = ["mastio.local", "192.168.122.154"]
+    _emit(mgr, tmp_path, sans)
+    crt_path = tmp_path / "mastio-server.crt"
+    serial1 = x509.load_pem_x509_certificate(
+        crt_path.read_bytes(),
+    ).serial_number
+    _emit(mgr, tmp_path, sans)
+    serial2 = x509.load_pem_x509_certificate(
+        crt_path.read_bytes(),
+    ).serial_number
+    assert serial1 == serial2, "consistent pair was needlessly regenerated"
+
+
+def test_concurrent_emits_converge_to_consistent_pair(tmp_path):
+    """N workers provisioning into the same dir concurrently must leave
+    a single consistent pair (the double-checked-lock + adopt contract).
+    In-process asyncio can't reproduce the cross-process interleave the
+    flock/advisory lock guards against, but it pins the convergence
+    contract and the recheck-adopt path."""
+    mgr = _make_manager_with_ca()
+    sans = ["mastio.local", "10.1.2.3"]
+
+    async def _run():
+        await asyncio.gather(*[
+            mgr.ensure_nginx_server_cert(
+                out_dir=tmp_path, sans=sans,
+                validity_days=30, renew_within_days=7,
+            )
+            for _ in range(4)
+        ])
+
+    asyncio.run(_run())
+    crt_path = tmp_path / "mastio-server.crt"
+    key_path = tmp_path / "mastio-server.key"
+    assert _pair_consistent(crt_path, key_path), (
+        "concurrent provisioning left a torn pair"
+    )
+    dns, ips = _read_sans(crt_path)
+    assert dns == {"mastio.local"} and ips == {"10.1.2.3"}

--- a/test/unit/test_wipe_legacy_pki_race.py
+++ b/test/unit/test_wipe_legacy_pki_race.py
@@ -1,0 +1,115 @@
+"""Multi-worker boot race in the Phase 0 legacy-PKI migration.
+
+``AgentManager.wipe_legacy_pki_if_present`` runs at boot in EVERY uvicorn
+worker (``main.py`` lifespan). Before the fix it migrated the legacy
+plaintext Org CA / Intermediate rows into the KMS via the non-atomic
+``store_org_ca`` / ``store_intermediate_ca`` (Vault read-modify-write
+whose first-write branch carries no ``cas`` constraint). With N workers
+migrating concurrently the interleaved read-modify-write hits a Vault
+cas version mismatch → ``RuntimeError`` → the wipe is aborted on a subset
+of workers and completed on others, leaving inconsistent at-rest
+hardening state across the fleet.
+
+The fix routes the migration through the atomic create-only variants
+(``store_org_ca_if_absent`` / ``store_intermediate_ca_if_absent``,
+Vault KV v2 ``cas:0``) when the provider exposes them — the same D-9
+treatment already applied to the mint path in ``_persist_*`` (#1022).
+Providers without the create-only variant (the local dev backend) keep
+the legacy path, which is race-safe incidentally via the
+``pki_key_store`` primary-key collision on the identical derived key id.
+
+These tests pin that the create-only path is preferred when available
+and that the legacy path is the fallback otherwise.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp_proxy.egress.agent_manager as am
+import mcp_proxy.kms as kms
+import mcp_proxy.kms.pki_at_rest as pki_at_rest
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+class _FakeProvider:
+    """Records which store-path each migration call took."""
+
+    def __init__(self, name: str, *, with_if_absent: bool) -> None:
+        self.name = name
+        self.calls: list[str] = []
+        if with_if_absent:
+            self.store_org_ca_if_absent = self._record(
+                "store_org_ca_if_absent", ret=True,
+            )
+            self.store_intermediate_ca_if_absent = self._record(
+                "store_intermediate_ca_if_absent", ret=True,
+            )
+
+    def _record(self, label: str, *, ret):
+        async def _call(*_a, **_k):
+            self.calls.append(label)
+            return ret
+        return _call
+
+    async def store_org_ca(self, *_a, **_k) -> None:
+        self.calls.append("store_org_ca")
+
+    async def store_intermediate_ca(self, *_a, **_k) -> None:
+        self.calls.append("store_intermediate_ca")
+
+
+def _wire(monkeypatch, provider: _FakeProvider) -> None:
+    legacy = {
+        "org_ca_key": "ORG-KEY-PEM",
+        "org_ca_cert": "ORG-CERT-PEM",
+        "mastio_ca_key": "INT-KEY-PEM",
+        "mastio_ca_cert": "INT-CERT-PEM",
+    }
+
+    async def _get_config(key):
+        return legacy.get(key)
+
+    async def _noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(am, "get_config", _get_config)
+    monkeypatch.setattr(am, "archive_legacy_pki", _noop)
+    monkeypatch.setattr(am, "delete_proxy_config", _noop)
+    monkeypatch.setattr(am, "log_audit", _noop)
+    monkeypatch.setattr(
+        pki_at_rest, "pki_master_key_configured", lambda: True,
+    )
+    monkeypatch.setattr(kms, "get_kms_provider", lambda: provider)
+
+
+def test_wipe_prefers_cas_create_only_when_available(monkeypatch):
+    """Vault-class provider (exposes ``*_if_absent``): the migration must
+    take the atomic create-only path, never the racy read-modify-write."""
+    provider = _FakeProvider("vault", with_if_absent=True)
+    _wire(monkeypatch, provider)
+
+    mgr = AgentManager.__new__(AgentManager)
+    wiped = asyncio.run(mgr.wipe_legacy_pki_if_present())
+
+    assert wiped is True
+    assert "store_org_ca_if_absent" in provider.calls
+    assert "store_intermediate_ca_if_absent" in provider.calls
+    assert "store_org_ca" not in provider.calls, (
+        "racy non-cas read-modify-write was used despite a create-only "
+        "variant being available"
+    )
+    assert "store_intermediate_ca" not in provider.calls
+
+
+def test_wipe_falls_back_to_legacy_store_without_cas(monkeypatch):
+    """Local-class provider (no ``*_if_absent``): the migration keeps the
+    legacy store path (race-safe via the pki_key_store PK collision)."""
+    provider = _FakeProvider("local", with_if_absent=False)
+    _wire(monkeypatch, provider)
+
+    mgr = AgentManager.__new__(AgentManager)
+    wiped = asyncio.run(mgr.wipe_legacy_pki_if_present())
+
+    assert wiped is True
+    assert "store_org_ca" in provider.calls
+    assert "store_intermediate_ca" in provider.calls


### PR DESCRIPTION
Multi-worker boot-race audit (2026-06-02). Two PKI provisioning races, same class as #997 (leaf mint) and #1022 (Vault Intermediate CA) — every uvicorn worker ran the provisioning with no cross-worker mutual exclusion.

**nginx server-cert torn pair (showstopper):** ensure_nginx_server_cert ran in every worker with no lock; on a cold boot all N workers minted their own leaf keypair and wrote the three shared files concurrently. Per-file tmp+rename is atomic but the three-file set is not, leaving a torn cert/key pair (cert pubkey of worker B next to worker A private key) that breaks the nginx 9443 mTLS handshake. The reuse check never validated key↔cert match, so the torn pair survived every restart. Fix: generalise the #997 boot lock (flock / pg advisory) with a lock-slug, fence reuse-recheck+mint+write under the nginx_cert lock (double-checked locking, losers adopt the winner files), validate the on-disk key owns the leaf pubkey in the reuse check (pre-fix torn pairs regenerate), pid-suffix tmp filenames.

**Phase-0 legacy-PKI migration (medium):** wipe_legacy_pki_if_present migrated legacy plaintext Org CA / Intermediate rows via the non-atomic store_*_ca (Vault read-modify-write, first-write without cas). Concurrent workers interleave into a cas mismatch → RuntimeError → wipe aborted on some workers, completed on others, leaving inconsistent at-rest state. Fix: route through the atomic create-only variants (store_*_if_absent, KV v2 cas:0), mirroring the D-9 fix; local backend stays race-safe via the pki_key_store PK collision.

Tests: torn-pair regeneration, pair consistency, concurrent convergence (test_mastio_nginx_cert_san.py), legacy-PKI migration race (test_wipe_legacy_pki_race.py). Rebased on main on top of the 6 security-audit fixes (#1031–#1036); smoke full 14/14 incl. 90_multiworker@4-worker + 80_audit_verify.