### PR TITLE
fix(egress): pin LLM adapter connects to validated IP (SSRF rebinding, M7/M8)

### DIFF
--- a/mcp_proxy/egress/adapters/_ssrf_transport.py
+++ b/mcp_proxy/egress/adapters/_ssrf_transport.py
@@ -1,0 +1,48 @@
+"""SSRF-pinned httpx transport for the egress LLM adapters.
+
+M7/M8 follow-up to H8 (audit 2026-06-02). The OpenAI (base_url) and
+Ollama (api_base) adapters reach an operator-configured provider URL.
+H8 fixed the MCP forwarder by pinning the connect to the IP that
+``assert_safe_outbound_url`` validated; the LLM adapters validated (Ollama)
+or didn't (OpenAI) and in both cases let httpx re-resolve the hostname at
+connect time — the same DNS-rebinding TOCTOU, here with the provider API
+key on the wire.
+
+This transport closes it for both adapters: it validates every outbound
+request against the SSRF guard and pins the socket to the validated IP,
+while ``pin_request_to_ip`` keeps the Host header + TLS SNI on the real
+hostname (so api.openai.com / a real Ollama host still verify normally).
+``allow_private`` follows ``policy_webhook_allow_private_ips`` so dev /
+sandbox stacks reaching a daemon on the compose network keep working.
+"""
+from __future__ import annotations
+
+import httpx
+
+from mcp_proxy.utils.url_safety import (
+    assert_safe_outbound_url,
+    pin_request_to_ip,
+)
+
+
+class SSRFPinnedTransport(httpx.AsyncHTTPTransport):
+    """httpx transport that validates the outbound URL and pins the
+    connect to the validated IP (defends against DNS rebinding)."""
+
+    def __init__(self, *, allow_private: bool = False, **kwargs) -> None:
+        self._allow_private = allow_private
+        super().__init__(**kwargs)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        # Raises UnsafeUrlError (a ValueError) on a blocked/unresolvable
+        # host — fail closed; the adapter surfaces it as a gateway error.
+        pinned_ip = assert_safe_outbound_url(
+            str(request.url), allow_private=self._allow_private,
+        )
+        pin_request_to_ip(request, pinned_ip)
+        return await super().handle_async_request(request)
+
+
+def allow_private_from_settings(settings) -> bool:
+    """Mirror the knob the rest of the SSRF surface uses."""
+    return bool(getattr(settings, "policy_webhook_allow_private_ips", False))

--- a/mcp_proxy/egress/adapters/ollama.py
+++ b/mcp_proxy/egress/adapters/ollama.py
@@ -171,7 +171,19 @@ def _get_http_client(api_base: str, timeout: float) -> httpx.AsyncClient:
     client = _HTTP_CLIENT_CACHE.get(key)
     if client is not None:
         return client
-    client = httpx.AsyncClient(timeout=timeout)
+    # M7/M8 (audit 2026-06-02): pin the connect to the IP the SSRF guard
+    # validated, closing the DNS-rebinding TOCTOU. _safe_api_base already
+    # validates the base once; the transport re-validates + pins on every
+    # request (handles a base that resolves differently at connect time).
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.egress.adapters._ssrf_transport import (
+        SSRFPinnedTransport,
+        allow_private_from_settings,
+    )
+    transport = SSRFPinnedTransport(
+        allow_private=allow_private_from_settings(get_settings()),
+    )
+    client = httpx.AsyncClient(timeout=timeout, transport=transport)
     _HTTP_CLIENT_CACHE[key] = client
     return client
 

--- a/mcp_proxy/egress/adapters/openai.py
+++ b/mcp_proxy/egress/adapters/openai.py
@@ -140,6 +140,21 @@ def _client(creds: dict[str, str], settings: "Settings") -> Any:
     timeout = getattr(settings, "ai_gateway_request_timeout_s", None)
     if timeout:
         kwargs["timeout"] = float(timeout)
+    # M7 (audit 2026-06-02): give the SDK an httpx client whose transport
+    # validates the outbound URL against the SSRF guard and pins the
+    # connect to the validated IP. Without this, an operator-set (or
+    # DB-row-injected) base_url could be DNS-rebound to an internal/IMDS
+    # address at connect time with the provider API key on the wire.
+    import httpx as _httpx
+    from mcp_proxy.egress.adapters._ssrf_transport import (
+        SSRFPinnedTransport,
+        allow_private_from_settings,
+    )
+    kwargs["http_client"] = _httpx.AsyncClient(
+        transport=SSRFPinnedTransport(
+            allow_private=allow_private_from_settings(settings),
+        ),
+    )
     client = AsyncOpenAI(**kwargs)
     _CLIENT_CACHE[fingerprint] = client
     return client

--- a/test/unit/test_ssrf_pin_adapters.py
+++ b/test/unit/test_ssrf_pin_adapters.py
@@ -1,0 +1,92 @@
+"""M7/M8 (audit 2026-06-02) — SSRF rebinding pin on the egress LLM adapters.
+
+H8 fixed the MCP forwarder; M7 (OpenAI base_url) and M8 (Ollama api_base)
+computed-but-discarded the validated IP and let httpx re-resolve at connect
+time. SSRFPinnedTransport closes it for both: validate + pin, Host/SNI on
+the real hostname. These tests assert the transport pins and that both
+adapters install it.
+"""
+import httpx
+import pytest
+
+from mcp_proxy.egress.adapters._ssrf_transport import SSRFPinnedTransport
+from mcp_proxy.utils.url_safety import UnsafeUrlError
+
+
+@pytest.mark.asyncio
+async def test_transport_pins_to_validated_ip(monkeypatch):
+    monkeypatch.setattr(
+        "mcp_proxy.egress.adapters._ssrf_transport.assert_safe_outbound_url",
+        lambda url, allow_private=False: "93.184.216.34",
+    )
+    captured: dict = {}
+
+    async def fake_super(self, request):
+        captured["request"] = request
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx.AsyncHTTPTransport, "handle_async_request", fake_super,
+    )
+    t = SSRFPinnedTransport(allow_private=False)
+    req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    resp = await t.handle_async_request(req)
+
+    assert resp.status_code == 200
+    pinned = captured["request"]
+    assert pinned.url.host == "93.184.216.34"          # connect → validated IP
+    assert pinned.headers["Host"] == "api.openai.com"  # routing → hostname
+    assert pinned.extensions.get("sni_hostname") == "api.openai.com"  # TLS → hostname
+
+
+@pytest.mark.asyncio
+async def test_transport_refuses_unsafe_before_connect(monkeypatch):
+    def _refuse(url, allow_private=False):
+        raise UnsafeUrlError("resolves to 169.254.169.254 (metadata)")
+
+    monkeypatch.setattr(
+        "mcp_proxy.egress.adapters._ssrf_transport.assert_safe_outbound_url", _refuse,
+    )
+    reached = {"super": False}
+
+    async def fake_super(self, request):
+        reached["super"] = True
+        return httpx.Response(200)
+
+    monkeypatch.setattr(
+        httpx.AsyncHTTPTransport, "handle_async_request", fake_super,
+    )
+    t = SSRFPinnedTransport(allow_private=False)
+    with pytest.raises(UnsafeUrlError):
+        await t.handle_async_request(httpx.Request("POST", "https://evil.example/x"))
+    assert reached["super"] is False  # never connected
+
+
+def test_ollama_client_installs_pinned_transport():
+    from mcp_proxy.egress.adapters import ollama
+    # Fresh cache key so we build a new client.
+    client = ollama._get_http_client("http://ollama.local:11434", 30.0)
+    assert isinstance(client._transport, SSRFPinnedTransport)
+
+
+def test_openai_client_installs_pinned_transport(monkeypatch):
+    import openai
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.egress.adapters import openai as openai_adapter
+
+    captured: dict = {}
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(openai, "AsyncOpenAI", _FakeOpenAI)
+    # Avoid cache hits from other tests.
+    openai_adapter._CLIENT_CACHE.clear()
+
+    openai_adapter._client(
+        {"api_key": "sk-test", "base_url": "https://api.openai.com/v1"},
+        get_settings(),
+    )
+    assert "http_client" in captured
+    assert isinstance(captured["http_client"]._transport, SSRFPinnedTransport)


### PR DESCRIPTION
Follow-up to H8 (#1033). H8 pinned the MCP forwarder; the egress LLM adapters had the same DNS-rebinding TOCTOU, here with the provider API key on the wire.

**M7 (OpenAI):** base_url passed straight to AsyncOpenAI, no runtime SSRF check. **M8 (Ollama):** _safe_api_base validated api_base but discarded the pinned IP and let httpx re-resolve the hostname at connect. A base_url DNS-rebound to an internal/IMDS address at connect would receive the key.

Fix: SSRFPinnedTransport (egress/adapters/_ssrf_transport.py) — an httpx transport that validates every outbound request against the SSRF guard and pins the connect to the validated IP, keeping Host + sni_hostname on the real hostname (api.openai.com / a real Ollama host still verify normally). allow_private follows policy_webhook_allow_private_ips so dev/sandbox stacks on the compose network keep working. Wired into the Ollama cached httpx client and the OpenAI SDK via http_client=.

Scope: OpenAI + Ollama (M7/M8). The Anthropic adapter is intentionally untouched (it is the path the smoke exercises against the in-cluster mock).

Tests: test_ssrf_pin_adapters.py (transport pins to validated IP / refuses unsafe before connect; both adapters install it). Smoke full 14/14 (dispatch path intact). M7/M8 unit-covered (smoke uses Anthropic, not OpenAI/Ollama).