### PR TITLE
fix(audit): verify the audit_log admin chain in the dashboard integrity check (C1)

### DIFF
--- a/mcp_proxy/dashboard/audit_routes.py
+++ b/mcp_proxy/dashboard/audit_routes.py
@@ -648,29 +648,69 @@ def _canonical_for_row(entry: dict, previous_hash: str | None) -> str:
     return canonical_str
 
 
-@router.post("/audit/verify")
-async def verify_chain(request: Request) -> JSONResponse:
-    """Run the same chain check as ``cullis-audit-verify.py``, in-process.
+async def _verify_both_audit_chains() -> dict:
+    """Verify BOTH hash chains the Mastio maintains, return a verdict dict.
 
-    Returns 200 with a JSON verdict regardless of pass/fail — the
-    front-end inspects ``ok`` and renders a green or red banner. Real
-    failures use HTTP 200 + ``ok: false`` rather than HTTP 4xx/5xx so
-    the operator can read the failure detail without their browser
-    showing an error page.
+    Two independent append-only chains exist (different tables, different
+    canonical forms, independent ``chain_seq`` numbering):
+
+      * ``audit_log`` — the *admin* stream: ``auth.*``, ``enroll.*``,
+        ``agent.cert.rotate``, ``policy.*``. The highest-value security
+        events. Walked by :func:`mcp_proxy.db.verify_audit_chain`
+        (``action``/``row_hash``/``prev_hash`` schema, v1/v2 dispatch
+        binding ``dpop_jkt`` + ``on_behalf_of_user_id``).
+      * ``local_audit`` — the *traffic* stream: oneshot, MCP tool
+        execute, session send. Walked inline below, per org
+        (``event_type``/``entry_hash``/``previous_hash`` schema).
+
+    C1 (public security audit 2026-06-02): this surface only ever
+    walked ``local_audit``, so a tamper to an ``audit_log`` row — e.g.
+    flipping an ``enroll.deny`` to ``enroll.approve``, rewriting an
+    ``agent.cert.rotate``, or deleting the ``auth.login`` that preceded
+    an exfil — passed the operator's "Verify chain integrity" check
+    with a green verdict (false-green). ``ok`` is now the AND of both
+    chains, and the admin chain is checked first so an admin-stream
+    tamper surfaces even when the traffic stream is also broken.
+
+    Returns the raw verdict dict (the route wraps it in a 200 JSON
+    response regardless of pass/fail). Kept byte-compatible with the
+    front-end banner renderer in ``templates/audit.html``.
     """
     import hashlib
     from collections import defaultdict
 
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return JSONResponse({"ok": False, "error": "auth_required"}, status_code=401)
-    if not await verify_csrf(request, session):
-        return JSONResponse({"ok": False, "error": "csrf_invalid"}, status_code=403)
-
-    from mcp_proxy.db import get_db
     from sqlalchemy import text
 
+    from mcp_proxy.db import get_db, verify_audit_chain
+
+    # ── 1. Admin chain (audit_log). Authoritative walker lives in
+    #       mcp_proxy.db; reuse it rather than re-implement the v2
+    #       (dpop_jkt + on_behalf_of_user_id) hash dispatch here. ──────
+    admin_ok, admin_broken_seq, admin_reason = await verify_audit_chain()
+    if not admin_ok:
+        # ``verify_audit_chain`` returns only (ok, seq, reason); map the
+        # reason onto the same kind taxonomy the banner uses. A row_hash
+        # mismatch is content tamper; a gap / prev_hash break / non-
+        # genesis head is a linkage break.
+        kind = (
+            "mismatch"
+            if (admin_reason or "").startswith("row_hash mismatch")
+            else "break"
+        )
+        return {
+            "ok": False,
+            "failure": {
+                "kind": kind,
+                "scope": "audit_log",
+                "chain_seq": admin_broken_seq,
+                "reason": admin_reason,
+            },
+        }
+
     async with get_db() as db:
+        admin_chain_rows = (await db.execute(text(
+            "SELECT COUNT(*) FROM audit_log WHERE chain_seq IS NOT NULL"
+        ))).scalar() or 0
         result = await db.execute(text(
             "SELECT id, timestamp, agent_id, event_type, details, "
             "previous_hash, entry_hash, session_id, org_id, result, "
@@ -679,9 +719,9 @@ async def verify_chain(request: Request) -> JSONResponse:
         ))
         entries = [dict(r) for r in result.mappings().all()]
 
-    # Per-org chain check (mirrors verify_chains in the CLI). Legacy
-    # global-chain rows (chain_seq IS NULL) are still validated first
-    # so their tail becomes the seed for the per-org chain.
+    # ── 2. Traffic chain (local_audit), per org. Legacy global-chain
+    #       rows (chain_seq IS NULL) are validated first so their tail
+    #       becomes the seed for the per-org chain. ─────────────────────
     agents_seen: set[str] = set()
     orgs_seen: set[str] = set()
     for e in entries:
@@ -699,7 +739,7 @@ async def verify_chain(request: Request) -> JSONResponse:
         expected = _canonical_for_row(e, legacy_prev)
         computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
         if computed != e["entry_hash"]:
-            return JSONResponse({
+            return {
                 "ok": False,
                 "failure": {
                     "kind": "mismatch",
@@ -711,9 +751,9 @@ async def verify_chain(request: Request) -> JSONResponse:
                     "expected_hash": computed,
                     "observed_hash": e["entry_hash"],
                 },
-            })
+            }
         if e.get("previous_hash") != legacy_prev:
-            return JSONResponse({
+            return {
                 "ok": False,
                 "failure": {
                     "kind": "break",
@@ -723,7 +763,7 @@ async def verify_chain(request: Request) -> JSONResponse:
                     "declared_prev": e.get("previous_hash"),
                     "expected_prev": legacy_prev,
                 },
-            })
+            }
         legacy_prev = e["entry_hash"]
         legacy_n += 1
 
@@ -745,7 +785,7 @@ async def verify_chain(request: Request) -> JSONResponse:
             expected = _canonical_for_row(e, expected_prev)
             computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
             if computed != e["entry_hash"]:
-                return JSONResponse({
+                return {
                     "ok": False,
                     "failure": {
                         "kind": "mismatch",
@@ -759,9 +799,9 @@ async def verify_chain(request: Request) -> JSONResponse:
                         "expected_hash": computed,
                         "observed_hash": e["entry_hash"],
                     },
-                })
+                }
             if e.get("previous_hash") != expected_prev:
-                return JSONResponse({
+                return {
                     "ok": False,
                     "failure": {
                         "kind": "break",
@@ -773,15 +813,41 @@ async def verify_chain(request: Request) -> JSONResponse:
                         "declared_prev": e.get("previous_hash"),
                         "expected_prev": expected_prev,
                     },
-                })
+                }
             expected_prev = e["entry_hash"]
             per_org_n += 1
 
-    return JSONResponse({
+    return {
         "ok": True,
         "entries": len(entries),
         "agents": len(agents_seen),
         "orgs": len(orgs_seen),
+        "admin_chain_rows": admin_chain_rows,
         "legacy_chain_rows": legacy_n,
         "per_org_chain_rows": per_org_n,
-    })
+    }
+
+
+@router.post("/audit/verify")
+async def verify_chain(request: Request) -> JSONResponse:
+    """Verify both in-process hash chains and return a JSON verdict.
+
+    Covers the ``audit_log`` admin chain (auth / enrollment / cert
+    rotation / policy) AND the ``local_audit`` traffic chain — the
+    operator's "is my chain healthy today" story. The auditor's
+    "without trusting Cullis" story stays the offline
+    ``cullis-audit-verify.py`` over an NDJSON export.
+
+    Returns 200 with a JSON verdict regardless of pass/fail — the
+    front-end inspects ``ok`` and renders a green or red banner. Real
+    failures use HTTP 200 + ``ok: false`` rather than HTTP 4xx/5xx so
+    the operator can read the failure detail without their browser
+    showing an error page.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return JSONResponse({"ok": False, "error": "auth_required"}, status_code=401)
+    if not await verify_csrf(request, session):
+        return JSONResponse({"ok": False, "error": "csrf_invalid"}, status_code=403)
+
+    return JSONResponse(await _verify_both_audit_chains())

--- a/mcp_proxy/dashboard/templates/audit.html
+++ b/mcp_proxy/dashboard/templates/audit.html
@@ -468,28 +468,31 @@
                   '<div class="flex-1 min-w-0">' +
                     '<p class="text-sm font-semibold text-emerald-400 uppercase tracking-wider">Chain verified</p>' +
                     '<p class="text-[12px] text-gray-300 mt-1 font-mono" ' +
-                      'title="Hash-chained rows actually verified end-to-end. ' +
-                      'Smaller than the header Events counter because admin-only rows ' +
-                      'with no chain participation are excluded, and the badge in the ' +
-                      'sidebar is a rolling 1-hour count.">' +
-                      escapeHtml(data.entries) + ' chained entries verified · ' +
+                      'title="Hash-chained rows actually verified end-to-end across ' +
+                      'both the admin chain (audit_log: auth, enrollment, cert ' +
+                      'rotation, policy) and the traffic chain (local_audit). ' +
+                      'Smaller than the header Events counter because the badge in ' +
+                      'the sidebar is a rolling 1-hour count.">' +
+                      escapeHtml(data.admin_chain_rows) + ' admin · ' +
+                      escapeHtml(data.entries) + ' traffic entries · ' +
                       escapeHtml(data.agents) + ' agent' + (data.agents === 1 ? '' : 's') + ' · ' +
                       escapeHtml(data.orgs) + ' org' + (data.orgs === 1 ? '' : 's') + ' · ' +
                       escapeHtml(data.legacy_chain_rows) + ' legacy · ' +
                       escapeHtml(data.per_org_chain_rows) + ' per-org chain rows' +
                     '</p>' +
                     '<p class="text-[11px] text-gray-500 mt-1.5 leading-relaxed">' +
-                      'Every entry_hash matches the SHA-256 of its canonical row. No previous_hash → next entry_hash break detected. Bundle intact end-to-end.' +
+                      'Both chains verified: every row_hash / entry_hash matches the SHA-256 of its canonical row, and no prev_hash → row_hash break was detected. Admin and traffic streams intact end-to-end.' +
                     '</p>' +
                   '</div>' +
                 '</div>';
         } else if (data && data.failure) {
             var f = data.failure;
             var rows = [];
-            rows.push(['scope', f.scope]);
+            rows.push(['scope', f.scope === 'audit_log' ? 'audit_log (admin)' : f.scope]);
             if (f.org_id) rows.push(['org', f.org_id]);
             if (f.chain_seq != null) rows.push(['chain_seq', f.chain_seq]);
-            rows.push(['id', f.id]);
+            if (f.reason) rows.push(['reason', f.reason]);
+            if (f.id != null) rows.push(['id', f.id]);
             if (f.timestamp) rows.push(['timestamp', f.timestamp]);
             if (f.event_type) rows.push(['event_type', f.event_type]);
             if (f.agent_id) rows.push(['agent_id', f.agent_id]);
@@ -501,8 +504,8 @@
                 return '<div class="flex gap-3"><span class="text-[10px] text-gray-600 uppercase tracking-wider w-32 flex-shrink-0">' + escapeHtml(p[0]) + '</span><code class="text-[11px] text-red-300 break-all">' + escapeHtml(p[1]) + '</code></div>';
             }).join('');
             var kindLabel = f.kind === 'break'
-                ? "The row's previous_hash does not point at the prior row's entry_hash. A row was deleted, reordered, or the linkage was rewritten."
-                : "The row's content does not produce the entry_hash it carries. A field on this row was altered after the chain was written.";
+                ? "A row's prev-hash link does not point at the prior row's hash. A row was deleted, reordered, or the linkage was rewritten."
+                : "A row's content does not produce the hash it carries. A field on this row was altered after the chain was written.";
             verifyBanner.innerHTML =
                 '<div class="border border-red-500/40 bg-red-500/10 rounded-lg p-4 flex items-start gap-3">' +
                   '<svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M6 18L18 6M6 6l12 12"/></svg>' +

--- a/test/unit/test_audit_verify_covers_admin_chain.py
+++ b/test/unit/test_audit_verify_covers_admin_chain.py
@@ -1,0 +1,220 @@
+"""C1 (public security audit 2026-06-02) — the dashboard "Verify chain
+integrity" button must cover BOTH audit chains, not just ``local_audit``.
+
+The Mastio keeps two independent append-only hash chains:
+
+  * ``audit_log`` — the *admin* stream: ``auth.*``, ``enroll.*``,
+    ``agent.cert.rotate``, ``policy.*`` (schema ``action`` / ``row_hash``
+    / ``prev_hash``). The highest-value security events.
+  * ``local_audit`` — the *traffic* stream: oneshot, MCP tool execute,
+    session send (schema ``event_type`` / ``entry_hash`` /
+    ``previous_hash``).
+
+Before the fix, ``POST /proxy/audit/verify`` only walked
+``local_audit``. An operator who tampered an ``audit_log`` row — e.g.
+flipped an ``enroll.deny`` to ``enroll.approve``, rewrote an
+``agent.cert.rotate``, or deleted the ``auth.login`` that preceded an
+exfil — clicked "Verify chain integrity" and got a GREEN verdict. The
+admin chain has its own authoritative walker (``db.verify_audit_chain``,
+exercised by smoke 80) but no operator-clickable surface invoked it.
+
+These tests pin the post-fix contract of
+``_verify_both_audit_chains``: ``ok`` is the AND of both chains, an
+``audit_log`` tamper is reported with ``scope == "audit_log"``, and the
+pre-existing ``local_audit`` coverage is preserved.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.dashboard.audit_routes import _verify_both_audit_chains
+from mcp_proxy.db import dispose_db, get_db, init_db, log_audit
+from mcp_proxy.local.audit import append_local_audit
+
+
+@pytest_asyncio.fixture
+async def both_chains_db(monkeypatch, tmp_path):
+    """Fresh DB with the FULL migration chain applied.
+
+    Unlike ``audit_test_env`` (which skips migrations and builds from
+    ``metadata.create_all``), this runs the alembic chain so the
+    ``local_audit`` table carries every migration-added column
+    (``hash_format`` etc.) that ``append_local_audit`` writes. The
+    batched audit chain is disabled so ``log_audit`` lands each admin
+    row synchronously, and a non-default admin secret keeps
+    ``ProxySettings`` from refusing to construct (F-A-507).
+    """
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv(
+        "MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default",
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    db_file = tmp_path / "both_chains.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    yield url
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+async def _seed_admin_chain() -> None:
+    """Two ``audit_log`` rows: an auth event and an enrollment decision."""
+    await log_audit(
+        agent_id="acme::alice",
+        action="auth.login",
+        status="success",
+        request_id="login-1",
+    )
+    await log_audit(
+        agent_id="acme::bob",
+        action="enroll.approve",
+        status="success",
+        request_id="enroll-1",
+    )
+
+
+async def _drop_append_only_triggers(db) -> None:
+    """Model an attacker who bypassed the DB-level append-only guard.
+
+    ``audit_log`` and ``local_audit`` carry append-only triggers
+    (F-A-402 / CRIT-3) that refuse UPDATE/DELETE, so the tamper here
+    drops them first — standing in for the real bypass routes: a direct
+    SQLite-file edit, a DBA dropping the trigger, a Postgres superuser,
+    or a doctored backup restore. The hash chain is the independent
+    second line of defence, and verifying it is exactly what this
+    surface is for.
+    """
+    for trig in (
+        "audit_log_no_update", "audit_log_no_delete",
+        "local_audit_no_update", "local_audit_no_delete",
+    ):
+        await db.execute(text(f"DROP TRIGGER IF EXISTS {trig}"))
+
+
+async def _seed_traffic_chain() -> None:
+    """Two ``local_audit`` rows on one org's per-org chain."""
+    await append_local_audit(
+        event_type="session_opened", org_id="acme", agent_id="acme::alice",
+    )
+    await append_local_audit(
+        event_type="tool_execute", org_id="acme", agent_id="acme::alice",
+        details={"tool": "payments.transfer"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_clean_both_chains_verifies_ok(both_chains_db):
+    """Clean admin + traffic chains → ok:true, with the admin chain row
+    count surfaced so the operator sees audit_log was actually covered."""
+    await _seed_admin_chain()
+    await _seed_traffic_chain()
+
+    verdict = await _verify_both_audit_chains()
+
+    assert verdict["ok"] is True
+    # The admin chain (audit_log) is now part of the verdict — the field
+    # the front-end renders as "N admin" rows.
+    assert verdict["admin_chain_rows"] == 2
+    assert verdict["per_org_chain_rows"] == 2
+    assert verdict["entries"] == 2
+
+
+@pytest.mark.asyncio
+async def test_tampered_audit_log_row_is_detected(both_chains_db):
+    """THE C1 REGRESSION. Tamper an ``audit_log`` row while leaving the
+    ``local_audit`` chain pristine. Pre-fix this returned ok:true (the
+    false-green); post-fix it must return ok:false scoped to audit_log."""
+    await _seed_admin_chain()
+    await _seed_traffic_chain()
+
+    # Attacker with DB access flips the enrollment decision from approve
+    # to deny on the chained admin row — the row_hash no longer matches.
+    async with get_db() as db:
+        await _drop_append_only_triggers(db)
+        await db.execute(text(
+            "UPDATE audit_log SET status = 'denied' WHERE request_id = :rid"
+        ), {"rid": "enroll-1"})
+
+    verdict = await _verify_both_audit_chains()
+
+    assert verdict["ok"] is False, (
+        "audit_log tamper passed verification — the false-green C1 bug is back"
+    )
+    assert verdict["failure"]["scope"] == "audit_log"
+    assert verdict["failure"]["kind"] == "mismatch"
+    assert verdict["failure"]["chain_seq"] == 2
+    assert "row_hash mismatch" in (verdict["failure"]["reason"] or "")
+
+
+@pytest.mark.asyncio
+async def test_admin_chain_break_is_detected(both_chains_db):
+    """Deleting a middle admin row breaks the chain_seq linkage — the
+    walker reports a break, not a content mismatch."""
+    # Three rows so deleting the middle one leaves a verifiable gap.
+    await _seed_admin_chain()
+    await log_audit(
+        agent_id="acme::carol",
+        action="agent.cert.rotate",
+        status="success",
+        request_id="rotate-1",
+    )
+
+    async with get_db() as db:
+        await _drop_append_only_triggers(db)
+        await db.execute(text(
+            "DELETE FROM audit_log WHERE request_id = :rid"
+        ), {"rid": "enroll-1"})  # chain_seq=2, the middle row
+
+    verdict = await _verify_both_audit_chains()
+
+    assert verdict["ok"] is False
+    assert verdict["failure"]["scope"] == "audit_log"
+    assert verdict["failure"]["kind"] == "break"
+
+
+@pytest.mark.asyncio
+async def test_tampered_local_audit_row_still_detected(both_chains_db):
+    """Pre-existing coverage preserved: a ``local_audit`` tamper with a
+    clean admin chain is still caught, scoped to the per-org chain."""
+    await _seed_admin_chain()
+    await _seed_traffic_chain()
+
+    async with get_db() as db:
+        await _drop_append_only_triggers(db)
+        await db.execute(text(
+            "UPDATE local_audit SET result = 'denied' WHERE chain_seq = 1 "
+            "AND org_id = 'acme'"
+        ))
+
+    verdict = await _verify_both_audit_chains()
+
+    assert verdict["ok"] is False
+    assert verdict["failure"]["scope"] == "per_org"
+    assert verdict["failure"]["org_id"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_admin_chain_checked_first_when_both_broken(both_chains_db):
+    """When both chains are tampered, the admin chain (higher-value
+    security events) surfaces first so it is never masked by a traffic
+    failure."""
+    await _seed_admin_chain()
+    await _seed_traffic_chain()
+
+    async with get_db() as db:
+        await _drop_append_only_triggers(db)
+        await db.execute(text(
+            "UPDATE audit_log SET status = 'denied' WHERE request_id = 'enroll-1'"
+        ))
+        await db.execute(text(
+            "UPDATE local_audit SET result = 'denied' WHERE chain_seq = 1 "
+            "AND org_id = 'acme'"
+        ))
+
+    verdict = await _verify_both_audit_chains()
+
+    assert verdict["ok"] is False
+    assert verdict["failure"]["scope"] == "audit_log"

--- a/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
+++ b/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
@@ -163,11 +163,14 @@ def test_a2_audit_template_verify_banner_clarifies_entries() -> None:
     ambiguously — operators read it as the lifetime row count of
     ``audit_log`` and were confused when it differed from the header
     Events counter (filter-scoped) and the sidebar badge (1-hour
-    rolling). The clarified copy + tooltip explains why these three
-    numbers are different.
+    rolling). C1 then split the count into the admin chain
+    (``audit_log``) and the traffic chain (``local_audit``) so both
+    streams are shown as separately verified. The tooltip still explains
+    why these numbers differ from the header / sidebar counters.
     """
     body = _AUDIT_TEMPLATE.read_text()
-    assert "chained entries verified" in body
+    assert "' admin · '" in body
+    assert "' traffic entries · '" in body
     assert "Hash-chained rows actually verified end-to-end" in body
     assert "rolling 1-hour count" in body
 


### PR DESCRIPTION
## What

The dashboard **Verify chain integrity** button (`POST /proxy/audit/verify`) only ever walked the `local_audit` traffic chain. The `audit_log` admin chain — `auth.*`, `enroll.*`, `agent.cert.rotate`, `policy.*`, the highest-value security events — has its own authoritative walker (`db.verify_audit_chain`, exercised by smoke 80) but **no operator-clickable surface invoked it**.

This was a **false-green** (C1, public security audit 2026-06-02): tampering an `audit_log` row — flipping an `enroll.deny` to `approve`, rewriting an `agent.cert.rotate`, deleting the `auth.login` that preceded an exfil — passed the operator's integrity check with a green verdict.

## Fix

- Extract the verify body into a testable `_verify_both_audit_chains()` helper; the route stays thin (login + CSRF, unchanged).
- Wire `verify_audit_chain` into the route, reusing the existing v1/v2 hash dispatch (`dpop_jkt` + `on_behalf_of_user_id` binding) instead of re-implementing it.
- Verdict `ok` is now the **AND** of both chains; the admin chain is checked first so an admin-stream tamper surfaces even when the traffic stream is also broken.
- Surface `admin_chain_rows` in the green banner and the failure `reason` in the red banner so the operator sees the admin chain was actually covered; neutralise banner prose that hard-coded `entry_hash` (correct for both `row_hash`/`entry_hash`).

## Scope note

The offline auditor path (`cullis-audit-verify.py` over an NDJSON export) still covers only the `local_audit`/Court shape. Porting it to `audit_log` needs a new export endpoint (no `audit_log` NDJSON export exists in the public repo today) and is tracked separately as the remaining piece of C1.

## Tests

- 5 new unit tests pin the post-fix contract: clean both chains, `audit_log` content tamper detected, admin chain break detected, `local_audit` tamper still caught, admin checked first when both broken. Tamper is simulated by dropping the append-only triggers to model a bypass of the DB-level guard (F-A-402) — the cryptographic chain is the independent second line of defence the verifier exists for.
- Related audit unit batch: 35/35 pass.
- `./test/smoke/smoke.sh` full: **14/14 pass**.
- `/security-review`: clean, no findings.

Note: smoke does not exercise the live HTTP verify route end-to-end (scenario 60 skips it on a pre-existing CSRF-scrape failure); the route helper is covered by the new unit tests and the underlying admin walker by smoke 80.