### PR TITLE
feat(kms): renew the Vault KMS token so it never lapses under a long-running Mastio

### DIFF
--- a/docs/operate/disaster-recovery.md
+++ b/docs/operate/disaster-recovery.md
@@ -119,6 +119,40 @@ one is clean:
   then run an explicit `alembic downgrade` expecting to keep data: it
   drops the columns / tables the newer version added.
 
+## Vault token lifecycle
+
+The Mastio authenticates to Vault with a single static token
+(`MCP_PROXY_VAULT_TOKEN`). A non-root token has a finite TTL: once it
+lapses, every CA load/store returns HTTP 403, so cert rotation **and any
+restart** start failing. To make this safe:
+
+- **Issue a periodic (or renewable) token.** A periodic token never hits
+  a max-TTL and is the recommended shape:
+
+  ```bash
+  vault token create -policy=cullis-mastio -period=24h
+  ```
+
+- **The Mastio renews it for you.** When `kms_backend=vault` and the
+  token is renewable/periodic, a leader-elected watcher calls
+  `auth/token/renew-self` at roughly half the lease, so the token never
+  lapses while the Mastio runs. No operator cron is needed. Disable with
+  `MCP_PROXY_VAULT_TOKEN_RENEWAL_ENABLED=false`.
+
+- **Boot refuses a doomed token.** In production, if you supply a
+  **non-renewable** token with a finite TTL (which Mastio cannot keep
+  alive), boot is refused with a clear log line rather than starting a
+  Mastio that will silently break at the first rotation/restart after
+  expiry. Override only if you accept manual token rotation:
+  `MCP_PROXY_VAULT_TOKEN_ALLOW_NONRENEWABLE=true`.
+
+- **Renewal has a ceiling.** A renewable non-periodic token can only be
+  renewed up to its `explicit_max_ttl`; prefer `-period` for an
+  always-on Mastio. If a renew ever fails (Vault sealed, network), the
+  watcher logs and retries on a 30 s floor and emits a
+  `kms.vault_token_renewed` audit row (`status=error`) so the failure is
+  visible before the token actually expires.
+
 ## Known limitations
 
 Stated plainly so they can go in the pilot's risk register:

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -79,6 +79,17 @@ class ProxySettings(BaseSettings):
     # broker-side pattern in ``app/kms/vault.py``.
     vault_verify_tls: bool = True
     vault_ca_cert_path: str = ""
+    # Vault KMS token lifecycle (kms_backend=vault). The provider auths
+    # with a single static token; a finite-TTL token lapses without
+    # renewal and then every CA load/store 403s. The renewal watcher
+    # keeps a renewable/periodic token alive at ~half its lease.
+    vault_token_renewal_enabled: bool = True
+    # Floor between renews so a tiny TTL can't hammer Vault.
+    vault_token_renewal_min_interval_seconds: int = 60
+    # Override the production boot refusal for a non-renewable finite
+    # token (it WILL expire and break rotation/restart — opt in only if
+    # you accept manual token rotation).
+    vault_token_allow_nonrenewable: bool = False
 
     # Tools
     tools_config_path: str = "tools.yaml"

--- a/mcp_proxy/kms/vault.py
+++ b/mcp_proxy/kms/vault.py
@@ -307,3 +307,75 @@ class VaultKMSProvider:
             f"Vault returned HTTP {resp.status_code} on create-only "
             f"{path} ({label}): {resp.text[:200]}",
         )
+
+    # ── Token lifecycle (renewal) ───────────────────────────────────────
+    # The Mastio authenticates to Vault with a single static token
+    # (``X-Vault-Token``). A non-root token has a finite TTL, and unless
+    # it is renewed it lapses — after which every load/store above starts
+    # returning HTTP 403, breaking cert rotation and any restart. These
+    # two helpers let the boot guard introspect the token and the
+    # renewal watcher keep a renewable/periodic token alive.
+
+    async def lookup_token(self) -> dict:
+        """Introspect the current token via ``auth/token/lookup-self``.
+
+        Returns the Vault ``data`` block, notably ``ttl`` (seconds of
+        life remaining), ``renewable`` (bool), ``period`` (seconds, 0
+        when not periodic) and ``expire_time`` (RFC 3339, or ``None`` for
+        a non-expiring root/unlimited token). Raises ``RuntimeError`` on
+        a transport error or any non-200 so the boot guard can decide.
+        """
+        url = "/v1/auth/token/lookup-self"
+        async with self._client() as client:
+            try:
+                resp = await client.get(url)
+            except httpx.HTTPError as exc:
+                raise RuntimeError(
+                    f"Vault token lookup-self unreachable at "
+                    f"{self._vault_addr}{url}: {exc}",
+                ) from exc
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Vault token lookup-self returned HTTP {resp.status_code}: "
+                f"{resp.text[:200]}",
+            )
+        try:
+            return resp.json()["data"]
+        except (KeyError, ValueError) as exc:
+            raise RuntimeError(
+                f"Vault token lookup-self returned malformed response: {exc}",
+            ) from exc
+
+    async def renew_token(self, increment_seconds: int | None = None) -> dict:
+        """Renew the current token via ``auth/token/renew-self``.
+
+        For a periodic token Vault resets the TTL to the token's period;
+        for a renewable non-periodic token it extends up to the token's
+        max TTL. ``increment_seconds`` is a hint Vault may clamp. Returns
+        the Vault ``auth`` block (``lease_duration`` = new TTL seconds,
+        ``renewable``). Raises ``RuntimeError`` on a transport error or a
+        non-2xx (e.g. 403 once the token is no longer renewable).
+        """
+        url = "/v1/auth/token/renew-self"
+        body: dict = {}
+        if increment_seconds is not None:
+            body["increment"] = f"{increment_seconds}s"
+        async with self._client() as client:
+            try:
+                resp = await client.post(url, json=body)
+            except httpx.HTTPError as exc:
+                raise RuntimeError(
+                    f"Vault token renew-self unreachable at "
+                    f"{self._vault_addr}{url}: {exc}",
+                ) from exc
+        if resp.status_code not in (200, 204):
+            raise RuntimeError(
+                f"Vault token renew-self returned HTTP {resp.status_code}: "
+                f"{resp.text[:200]}",
+            )
+        try:
+            return resp.json().get("auth") or {}
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Vault token renew-self returned malformed response: {exc}",
+            ) from exc

--- a/mcp_proxy/kms/vault_token.py
+++ b/mcp_proxy/kms/vault_token.py
@@ -1,0 +1,85 @@
+"""Vault token lifecycle classification + boot-time policy decision.
+
+Pure helpers (no I/O) so the boot guard and the renewal watcher share
+one interpretation of an ``auth/token/lookup-self`` response, and the
+unit tests can pin the decision matrix without a live Vault.
+
+Context (validated 2026-06-02): :class:`mcp_proxy.kms.vault.VaultKMSProvider`
+authenticates with a single static token and has no renewal. A non-root
+token therefore lapses after its TTL, and every CA load/store then
+returns HTTP 403 — breaking cert rotation and any restart. The boot
+guard turns that silent landmine into an explicit, operator-visible
+decision; the renewal watcher keeps a renewable/periodic token alive.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def classify_token(lookup_data: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a Vault ``lookup-self`` ``data`` block to what renewal needs.
+
+    Returns ``{ttl, period, renewable, expires}``:
+
+    * ``ttl`` — seconds of life remaining (0 for a non-expiring token).
+    * ``period`` — token period in seconds (0 when not periodic). A
+      periodic token renews to this value indefinitely.
+    * ``renewable`` — Vault's ``renewable`` flag.
+    * ``expires`` — True when the token has a finite life. False for a
+      root/unlimited token, which Vault reports as ``ttl == 0`` with a
+      null ``expire_time``.
+    """
+    ttl = int(lookup_data.get("ttl") or 0)
+    period = int(lookup_data.get("period") or 0)
+    renewable = bool(lookup_data.get("renewable", False))
+    expire_time = lookup_data.get("expire_time")
+    # A positive ttl OR a non-null expire_time means the token will
+    # eventually die. ttl==0 + expire_time null == non-expiring (root).
+    expires = ttl > 0 or bool(expire_time)
+    return {
+        "ttl": ttl,
+        "period": period,
+        "renewable": renewable,
+        "expires": expires,
+    }
+
+
+def boot_decision(
+    classified: dict[str, Any], *, is_production: bool,
+) -> tuple[str, str]:
+    """Decide what the boot guard does about the token's renewability.
+
+    Returns ``(level, message)`` where ``level`` is:
+
+    * ``"ok"``     — non-expiring, or renewable/periodic (the watcher
+      keeps it alive). Boot proceeds.
+    * ``"warn"``   — a finite, non-renewable token in development. Boot
+      proceeds with a loud log.
+    * ``"refuse"`` — a finite, non-renewable token in production: it
+      WILL expire and Mastio cannot renew it, breaking cert rotation and
+      restart. Boot is refused unless the operator overrides.
+    """
+    if not classified["expires"]:
+        return (
+            "ok",
+            "Vault token does not expire (root/unlimited) — no renewal needed.",
+        )
+    if classified["renewable"] or classified["period"] > 0:
+        kind = "periodic" if classified["period"] > 0 else "renewable"
+        return (
+            "ok",
+            f"Vault token is {kind} (ttl={classified['ttl']}s, "
+            f"period={classified['period']}s) — renewal watcher will keep "
+            "it alive.",
+        )
+    # Finite + non-renewable: the landmine.
+    msg = (
+        f"Vault token is non-renewable with a finite TTL ({classified['ttl']}s). "
+        "Mastio cannot renew it; when it expires, cert rotation and any "
+        "restart will fail with Vault HTTP 403. Issue a periodic token "
+        "(vault token create -period=...) or a renewable token."
+    )
+    return ("refuse" if is_production else "warn"), msg
+
+
+__all__ = ["classify_token", "boot_decision"]

--- a/mcp_proxy/lifespan/vault_token_renewal_watcher.py
+++ b/mcp_proxy/lifespan/vault_token_renewal_watcher.py
@@ -1,0 +1,199 @@
+"""Boot guard + background watcher that keep the Vault KMS token alive.
+
+When ``kms_backend=vault`` the Mastio authenticates to Vault with a
+single static token. A non-root token has a finite TTL and, without
+renewal, lapses mid-deployment — after which every CA load/store
+returns HTTP 403 and the next cert rotation or restart fails (validated
+2026-06-02: :class:`mcp_proxy.kms.vault.VaultKMSProvider` had no
+renewal, and the 60-min soak used an infinite root token so never
+exercised expiry).
+
+Two parts:
+
+* :func:`evaluate_vault_token_at_boot` — looks up the token once at
+  boot, logs/guards on renewability, and returns the classified token
+  for the loop. In production a non-renewable finite token refuses boot
+  (override ``MCP_PROXY_VAULT_TOKEN_ALLOW_NONRENEWABLE=true``).
+* :func:`vault_token_renewal_watcher_loop` — renews a renewable/periodic
+  token at ~half its lease so it never lapses.
+
+Leader-elected like the other lifespan watchers so only one worker
+renews in a multi-worker deployment.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger("mcp_proxy.lifespan.vault_token_renewal_watcher")
+
+# Never sleep longer than this between renews even when the lease is
+# large — bounds how long a token revoked out-of-band stays trusted and
+# keeps the half-life assumption conservative.
+_MAX_INTERVAL_SECONDS = 12 * 60 * 60
+# After a renew failure, retry on this floor rather than the full
+# half-life so a transient Vault blip recovers well before expiry.
+_RETRY_FLOOR_SECONDS = 30
+
+
+def _next_interval(ttl: int, period: int, min_interval: int) -> float:
+    """Seconds to sleep before the next renew: ~half the live lease,
+    clamped to ``[min_interval, _MAX_INTERVAL_SECONDS]``.
+
+    Renewing at the half-life leaves a full half-life of retry budget
+    before the token would actually expire.
+    """
+    lease = period if period > 0 else ttl
+    half = max(int(lease // 2), min_interval)
+    return float(min(half, _MAX_INTERVAL_SECONDS))
+
+
+async def evaluate_vault_token_at_boot(settings) -> dict | None:
+    """Introspect the Vault token at boot; guard, log, and return it.
+
+    Returns the classified token dict (``{ttl, period, renewable,
+    expires}``) when a renewal loop should run, else ``None`` (backend
+    not vault, provider has no token lifecycle, lookup failed, or the
+    token never expires / cannot be renewed).
+
+    Raises ``SystemExit`` in production when the token is non-renewable
+    with a finite TTL, unless ``vault_token_allow_nonrenewable`` is set —
+    such a token will expire and Mastio cannot renew it.
+    """
+    if getattr(settings, "kms_backend", "local") != "vault":
+        return None
+
+    from mcp_proxy.kms import get_kms_provider
+    from mcp_proxy.kms.vault_token import boot_decision, classify_token
+
+    provider = get_kms_provider()
+    if not hasattr(provider, "lookup_token"):
+        return None
+
+    try:
+        data = await provider.lookup_token()
+    except Exception as exc:  # noqa: BLE001 — never hard-fail boot on lookup alone
+        # The CA load right after this will surface a genuinely dead
+        # token; a lookup-self blip should not by itself stop boot.
+        logger.warning(
+            "Vault token lookup-self failed at boot: %s — renewal watcher "
+            "disabled for this boot", exc,
+        )
+        return None
+
+    classified = classify_token(data)
+    is_prod = getattr(settings, "environment", "") == "production"
+    level, message = boot_decision(classified, is_production=is_prod)
+    allow_override = bool(getattr(settings, "vault_token_allow_nonrenewable", False))
+
+    if level == "refuse":
+        if not allow_override:
+            logger.critical(
+                "Vault token policy refusing boot: %s "
+                "Set MCP_PROXY_VAULT_TOKEN_ALLOW_NONRENEWABLE=true to "
+                "override (accepting that rotation/restart will fail once "
+                "the token expires).", message,
+            )
+            raise SystemExit(1)
+        logger.warning(
+            "Vault token non-renewable but override active "
+            "(MCP_PROXY_VAULT_TOKEN_ALLOW_NONRENEWABLE=true): %s", message,
+        )
+    elif level == "warn":
+        logger.warning("Vault token: %s", message)
+    else:
+        logger.info("Vault token: %s", message)
+
+    # Only run the renewal loop for a token that can actually be renewed.
+    if classified["expires"] and (
+        classified["renewable"] or classified["period"] > 0
+    ):
+        return classified
+    return None
+
+
+async def vault_token_renewal_watcher_loop(
+    provider,
+    *,
+    initial_ttl: int,
+    period: int,
+    min_interval_seconds: int = 60,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Renew the Vault token at ~half its lease until ``stop_event``.
+
+    The first renew happens after the initial half-life (the token was
+    just looked up at boot, so it is fresh). On each success the next
+    interval is recomputed from the renewed lease; on failure the loop
+    retries on a short floor and keeps going so a transient Vault outage
+    recovers without operator action.
+    """
+    stop_event = stop_event or asyncio.Event()
+    interval = _next_interval(initial_ttl, period, min_interval_seconds)
+    logger.info(
+        "vault_token_renewal_watcher starting (initial_ttl=%ds period=%ds "
+        "first_renew_in=%.0fs)", initial_ttl, period, interval,
+    )
+
+    while not stop_event.is_set():
+        # Sleep with early-exit on shutdown so SIGTERM teardown doesn't
+        # wait out the full interval.
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            break  # stop_event fired during the sleep
+        except asyncio.TimeoutError:
+            pass
+        if stop_event.is_set():
+            break
+
+        try:
+            auth = await provider.renew_token()
+            new_ttl = int(auth.get("lease_duration") or 0)
+            renewable = bool(auth.get("renewable", True))
+            if new_ttl <= 0 or not renewable:
+                logger.warning(
+                    "vault_token_renewal: renew-self returned "
+                    "lease_duration=%ss renewable=%s — token may no longer "
+                    "be renewable; retrying on floor. Cert rotation/restart "
+                    "will fail once it expires.", new_ttl, renewable,
+                )
+                interval = float(max(min_interval_seconds, _RETRY_FLOOR_SECONDS))
+                await _audit(status="error", detail=f"lease_duration={new_ttl}")
+                continue
+            interval = _next_interval(new_ttl, period, min_interval_seconds)
+            logger.info(
+                "vault_token_renewal: renewed (new_ttl=%ds next_renew_in=%.0fs)",
+                new_ttl, interval,
+            )
+            await _audit(status="success", detail=f"new_ttl={new_ttl}")
+        except Exception as exc:  # noqa: BLE001 — long-running loop must not die
+            logger.error(
+                "vault_token_renewal: renew-self failed: %s — retrying in "
+                "%ds. If this persists the token will expire and cert "
+                "rotation / restart will fail with Vault HTTP 403.",
+                exc, _RETRY_FLOOR_SECONDS,
+            )
+            interval = float(max(min_interval_seconds, _RETRY_FLOOR_SECONDS))
+            await _audit(status="error", detail=f"error={type(exc).__name__}")
+
+    logger.info("vault_token_renewal_watcher stopped")
+
+
+async def _audit(*, status: str, detail: str) -> None:
+    """Best-effort audit row for a renewal tick. Never raises."""
+    try:
+        from mcp_proxy.db import log_audit
+        await log_audit(
+            agent_id="system",
+            action="kms.vault_token_renewed",
+            status=status,
+            detail=detail,
+        )
+    except Exception:  # noqa: BLE001 — audit is best-effort here
+        pass
+
+
+__all__ = [
+    "evaluate_vault_token_at_boot",
+    "vault_token_renewal_watcher_loop",
+]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -304,6 +304,28 @@ async def lifespan(app: FastAPI):
 
     await agent_mgr.load_org_ca_from_config()
 
+    # Vault KMS token lifecycle — introspect the static token once at
+    # boot. In production a non-renewable finite token refuses boot (it
+    # would expire and break cert rotation/restart with a Vault 403);
+    # a renewable/periodic token is handed to the renewal watcher below.
+    # SystemExit (BaseException) is intentional: it bubbles past the
+    # ``except Exception`` boot guards so the refuse is a hard stop.
+    app.state._vault_token_classified = None
+    try:
+        from mcp_proxy.lifespan.vault_token_renewal_watcher import (
+            evaluate_vault_token_at_boot,
+        )
+        app.state._vault_token_classified = await evaluate_vault_token_at_boot(
+            settings,
+        )
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 — never block boot on introspection
+        _log.warning(
+            "Vault token boot evaluation raised %s — continuing without "
+            "auto-renewal", exc,
+        )
+
     # #115 — standalone first-boot: generate a fresh self-signed Org CA when
     # no CA has been attached (no attach-ca invite ever consumed) and no
     # broker is configured. Gated on standalone=true so federation deploys
@@ -401,6 +423,52 @@ async def lifespan(app: FastAPI):
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
     _log.info("Lifespan: agent_manager + org_id wired (org_id=%s)", org_id)
+
+    # Vault KMS token renewal — when the boot guard classified a
+    # renewable/periodic token, spawn the leader-elected loop that
+    # renews it at ~half its lease so it never lapses under a
+    # long-running Mastio.
+    _vault_classified = getattr(app.state, "_vault_token_classified", None)
+    if _vault_classified and getattr(
+        settings, "vault_token_renewal_enabled", True,
+    ):
+        try:
+            from mcp_proxy.kms import get_kms_provider
+            from mcp_proxy.lifespan import get_leader as _vault_get_leader
+            from mcp_proxy.lifespan.vault_token_renewal_watcher import (
+                vault_token_renewal_watcher_loop,
+            )
+            vault_renew_leader = _vault_get_leader("vault_token_renewal_watcher")
+            if await vault_renew_leader.acquire():
+                vault_renew_stop = asyncio.Event()
+                vault_renew_task = asyncio.create_task(
+                    vault_token_renewal_watcher_loop(
+                        get_kms_provider(),
+                        initial_ttl=_vault_classified["ttl"],
+                        period=_vault_classified["period"],
+                        min_interval_seconds=(
+                            settings.vault_token_renewal_min_interval_seconds
+                        ),
+                        stop_event=vault_renew_stop,
+                    ),
+                    name="vault_token_renewal_watcher",
+                )
+                app.state.vault_token_renewal_watcher_task = vault_renew_task
+                app.state.vault_token_renewal_watcher_stop = vault_renew_stop
+                app.state.vault_token_renewal_watcher_leader = vault_renew_leader
+                _log.info(
+                    "vault_token_renewal_watcher: leader acquired, loop spawned",
+                )
+            else:
+                _log.info(
+                    "vault_token_renewal_watcher: another worker holds the "
+                    "leader lock — skipping",
+                )
+        except Exception as exc:  # noqa: BLE001 best-effort
+            _log.warning(
+                "vault_token_renewal_watcher startup failed: %s — the Vault "
+                "token will not be auto-renewed this boot", exc,
+            )
 
     # Three-tier PKI hardening (audit 2026-05-18), Phase 4 — weekly-ish
     # background watcher for the Mastio Intermediate CA expiry. Leader-
@@ -1357,6 +1425,40 @@ async def lifespan(app: FastAPI):
         except Exception as exc:  # noqa: BLE001 best-effort
             _log.debug(
                 "cert_expiry_watcher leader release failed: %s", exc,
+            )
+
+    # Stop the Vault KMS token renewal watcher.
+    vault_renew_stop = getattr(
+        app.state, "vault_token_renewal_watcher_stop", None,
+    )
+    vault_renew_task = getattr(
+        app.state, "vault_token_renewal_watcher_task", None,
+    )
+    if vault_renew_stop is not None:
+        vault_renew_stop.set()
+    if vault_renew_task is not None:
+        try:
+            await asyncio.wait_for(vault_renew_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            vault_renew_task.cancel()
+            try:
+                await vault_renew_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug(
+                "vault_token_renewal_watcher teardown loop mismatch "
+                "(xdist): %s", exc,
+            )
+    vault_renew_leader = getattr(
+        app.state, "vault_token_renewal_watcher_leader", None,
+    )
+    if vault_renew_leader is not None:
+        try:
+            await vault_renew_leader.release()
+        except Exception as exc:  # noqa: BLE001 best-effort
+            _log.debug(
+                "vault_token_renewal_watcher leader release failed: %s", exc,
             )
 
     # Wave 2 fix 7+8. Stop the agent cert grace cleanup sweep.

--- a/test/unit/test_vault_token_renewal.py
+++ b/test/unit/test_vault_token_renewal.py
@@ -1,0 +1,344 @@
+"""Vault KMS token renewal — boot guard + renewal watcher (2026-06-02).
+
+VaultKMSProvider authenticates with a single static token and had no
+renewal: a finite-TTL token lapses under a long-running Mastio and then
+every CA load/store returns HTTP 403, breaking cert rotation and any
+restart. The 60-min soak used an infinite root token so never exercised
+this. These tests pin:
+
+  * ``classify_token`` / ``boot_decision`` — the pure decision matrix.
+  * ``lookup_token`` / ``renew_token`` — the provider HTTP calls
+    (hermetic via httpx.MockTransport).
+  * ``evaluate_vault_token_at_boot`` — production refuses a non-renewable
+    finite token (override opt-in), hands a renewable token to the loop.
+  * ``vault_token_renewal_watcher_loop`` — renews once and survives a
+    renew failure without dying.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from mcp_proxy.kms.vault import VaultKMSProvider
+from mcp_proxy.kms.vault_token import boot_decision, classify_token
+from mcp_proxy.lifespan.vault_token_renewal_watcher import (
+    _next_interval,
+    evaluate_vault_token_at_boot,
+    vault_token_renewal_watcher_loop,
+)
+
+
+_VAULT_ADDR = "https://vault.example:8200"
+_TOKEN = "hvs.test-token-1234567890"
+_PATH = "secret/data/cullis-mastio/org-ca"
+
+
+def _client_patch(monkeypatch, transport: httpx.MockTransport):
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+
+
+def _make_provider() -> VaultKMSProvider:
+    return VaultKMSProvider(
+        vault_addr=_VAULT_ADDR,
+        vault_token=_TOKEN,
+        org_ca_path=_PATH,
+        verify_tls=True,
+        ca_cert_path="",
+    )
+
+
+# ── classify_token ─────────────────────────────────────────────────────
+def test_classify_root_token_does_not_expire():
+    c = classify_token({"ttl": 0, "renewable": False, "period": 0,
+                        "expire_time": None})
+    assert c["expires"] is False
+    assert c["renewable"] is False
+
+
+def test_classify_renewable_finite_token():
+    c = classify_token({"ttl": 3600, "renewable": True, "period": 0,
+                        "expire_time": "2026-06-03T00:00:00Z"})
+    assert c == {"ttl": 3600, "period": 0, "renewable": True, "expires": True}
+
+
+def test_classify_periodic_token():
+    c = classify_token({"ttl": 1800, "renewable": True, "period": 86400,
+                        "expire_time": "2026-06-03T00:00:00Z"})
+    assert c["period"] == 86400
+    assert c["expires"] is True
+
+
+def test_classify_non_renewable_finite_token():
+    c = classify_token({"ttl": 7200, "renewable": False, "period": 0,
+                        "expire_time": "2026-06-03T00:00:00Z"})
+    assert c["expires"] is True
+    assert c["renewable"] is False
+    assert c["period"] == 0
+
+
+# ── boot_decision matrix ───────────────────────────────────────────────
+def test_boot_decision_non_expiring_is_ok():
+    level, _ = boot_decision(
+        classify_token({"ttl": 0, "expire_time": None}), is_production=True,
+    )
+    assert level == "ok"
+
+
+def test_boot_decision_renewable_is_ok():
+    level, _ = boot_decision(
+        {"ttl": 3600, "period": 0, "renewable": True, "expires": True},
+        is_production=True,
+    )
+    assert level == "ok"
+
+
+def test_boot_decision_periodic_is_ok():
+    level, _ = boot_decision(
+        {"ttl": 1800, "period": 86400, "renewable": False, "expires": True},
+        is_production=True,
+    )
+    assert level == "ok"
+
+
+def test_boot_decision_nonrenewable_finite_refuses_in_production():
+    level, msg = boot_decision(
+        {"ttl": 7200, "period": 0, "renewable": False, "expires": True},
+        is_production=True,
+    )
+    assert level == "refuse"
+    assert "non-renewable" in msg
+
+
+def test_boot_decision_nonrenewable_finite_only_warns_in_dev():
+    level, _ = boot_decision(
+        {"ttl": 7200, "period": 0, "renewable": False, "expires": True},
+        is_production=False,
+    )
+    assert level == "warn"
+
+
+# ── provider HTTP calls ────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_lookup_token_parses_data_block(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/v1/auth/token/lookup-self"
+        assert request.headers["X-Vault-Token"] == _TOKEN
+        return httpx.Response(200, json={"data": {
+            "ttl": 3600, "renewable": True, "period": 0,
+            "expire_time": "2026-06-03T00:00:00Z",
+        }})
+
+    _client_patch(monkeypatch, httpx.MockTransport(handler))
+    data = await _make_provider().lookup_token()
+    assert data["ttl"] == 3600
+    assert data["renewable"] is True
+
+
+@pytest.mark.asyncio
+async def test_lookup_token_raises_on_403(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="permission denied")
+
+    _client_patch(monkeypatch, httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        await _make_provider().lookup_token()
+
+
+@pytest.mark.asyncio
+async def test_renew_token_returns_auth_block(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v1/auth/token/renew-self"
+        return httpx.Response(200, json={"auth": {
+            "lease_duration": 86400, "renewable": True,
+        }})
+
+    _client_patch(monkeypatch, httpx.MockTransport(handler))
+    auth = await _make_provider().renew_token()
+    assert auth["lease_duration"] == 86400
+
+
+@pytest.mark.asyncio
+async def test_renew_token_raises_on_403(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="lease is not renewable")
+
+    _client_patch(monkeypatch, httpx.MockTransport(handler))
+    with pytest.raises(RuntimeError):
+        await _make_provider().renew_token()
+
+
+# ── evaluate_vault_token_at_boot ───────────────────────────────────────
+class _FakeProvider:
+    def __init__(self, lookup_data):
+        self._lookup_data = lookup_data
+
+    async def lookup_token(self):
+        return self._lookup_data
+
+
+def _patch_provider(monkeypatch, lookup_data):
+    monkeypatch.setattr(
+        "mcp_proxy.kms.get_kms_provider",
+        lambda: _FakeProvider(lookup_data),
+    )
+
+
+def _settings(**over):
+    base = {
+        "kms_backend": "vault",
+        "environment": "production",
+        "vault_token_allow_nonrenewable": False,
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+async def test_boot_skips_when_backend_not_vault(monkeypatch):
+    assert await evaluate_vault_token_at_boot(
+        _settings(kms_backend="local"),
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_boot_refuses_nonrenewable_finite_in_production(monkeypatch):
+    _patch_provider(monkeypatch, {"ttl": 7200, "renewable": False,
+                                  "period": 0, "expire_time": "x"})
+    with pytest.raises(SystemExit):
+        await evaluate_vault_token_at_boot(_settings())
+
+
+@pytest.mark.asyncio
+async def test_boot_override_allows_nonrenewable_but_returns_none(monkeypatch):
+    _patch_provider(monkeypatch, {"ttl": 7200, "renewable": False,
+                                  "period": 0, "expire_time": "x"})
+    # Override active → no SystemExit, but the loop must NOT run (the
+    # token cannot be renewed).
+    result = await evaluate_vault_token_at_boot(
+        _settings(vault_token_allow_nonrenewable=True),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_boot_returns_classified_for_renewable_token(monkeypatch):
+    _patch_provider(monkeypatch, {"ttl": 3600, "renewable": True,
+                                  "period": 0, "expire_time": "x"})
+    result = await evaluate_vault_token_at_boot(_settings())
+    assert result is not None
+    assert result["ttl"] == 3600 and result["renewable"] is True
+
+
+@pytest.mark.asyncio
+async def test_boot_root_token_runs_no_loop(monkeypatch):
+    _patch_provider(monkeypatch, {"ttl": 0, "renewable": False,
+                                  "period": 0, "expire_time": None})
+    assert await evaluate_vault_token_at_boot(_settings()) is None
+
+
+@pytest.mark.asyncio
+async def test_boot_lookup_failure_does_not_block_boot(monkeypatch):
+    class _Boom:
+        async def lookup_token(self):
+            raise RuntimeError("vault sealed")
+
+    monkeypatch.setattr("mcp_proxy.kms.get_kms_provider", lambda: _Boom())
+    # A lookup blip returns None (continue without renewal), never raises.
+    assert await evaluate_vault_token_at_boot(_settings()) is None
+
+
+# ── _next_interval ─────────────────────────────────────────────────────
+def test_next_interval_uses_half_life_and_floor():
+    # period wins when present; half of 86400 = 43200, clamped to max 12h.
+    assert _next_interval(1800, 86400, 60) == 12 * 60 * 60
+    # ttl half-life above the floor.
+    assert _next_interval(3600, 0, 60) == 1800.0
+    # tiny ttl clamps up to the floor.
+    assert _next_interval(10, 0, 60) == 60.0
+
+
+# ── renewal loop ───────────────────────────────────────────────────────
+class _RecordingProvider:
+    def __init__(self, *, fail: bool = False):
+        self.calls = 0
+        self._fail = fail
+
+    async def renew_token(self, increment_seconds=None):
+        self.calls += 1
+        if self._fail:
+            raise RuntimeError("renew refused")
+        return {"lease_duration": 3600, "renewable": True}
+
+
+@pytest.mark.asyncio
+async def test_loop_renews_once_then_stops(monkeypatch):
+    monkeypatch.setattr(
+        "mcp_proxy.lifespan.vault_token_renewal_watcher._audit",
+        _noop_audit,
+    )
+    provider = _RecordingProvider()
+    stop = asyncio.Event()
+
+    # Wrap renew so the first success stops the loop deterministically.
+    orig = provider.renew_token
+
+    async def _renew_and_stop(increment_seconds=None):
+        result = await orig(increment_seconds)
+        stop.set()
+        return result
+
+    provider.renew_token = _renew_and_stop
+
+    # initial_ttl=1 + min_interval=0 → first interval 0.0 → immediate renew.
+    await asyncio.wait_for(
+        vault_token_renewal_watcher_loop(
+            provider, initial_ttl=1, period=0, min_interval_seconds=0,
+            stop_event=stop,
+        ),
+        timeout=5.0,
+    )
+    assert provider.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_renew_failure(monkeypatch):
+    monkeypatch.setattr(
+        "mcp_proxy.lifespan.vault_token_renewal_watcher._audit",
+        _noop_audit,
+    )
+    provider = _RecordingProvider(fail=True)
+    stop = asyncio.Event()
+
+    orig = provider.renew_token
+
+    async def _renew_and_stop(increment_seconds=None):
+        stop.set()  # break the loop after this attempt
+        return await orig(increment_seconds)  # raises
+
+    provider.renew_token = _renew_and_stop
+
+    # Must return (not propagate the RuntimeError) — the loop swallows
+    # renew failures and keeps going until stop_event.
+    await asyncio.wait_for(
+        vault_token_renewal_watcher_loop(
+            provider, initial_ttl=1, period=0, min_interval_seconds=0,
+            stop_event=stop,
+        ),
+        timeout=5.0,
+    )
+    assert provider.calls == 1
+
+
+async def _noop_audit(*, status: str, detail: str) -> None:
+    return None


### PR DESCRIPTION
## What

`VaultKMSProvider` authenticates to Vault with a single **static token** and had **no renewal**. A non-root token has a finite TTL: once it lapses, every CA load/store returns HTTP 403 — breaking **cert rotation AND any restart**. The 60-min soak never caught this because it ran with an infinite root token (validated 2026-06-02).

## Fix — full token lifecycle

- **`VaultKMSProvider.lookup_token` / `renew_token`** (`auth/token/lookup-self`, `renew-self`) over the existing TLS-only client.
- **`kms/vault_token.py`** — pure `classify_token` + `boot_decision` (ok / warn / refuse), so the boot guard and the watcher share one interpretation and the matrix is unit-testable without a live Vault.
- **`lifespan/vault_token_renewal_watcher.py`**:
  - `vault_token_renewal_watcher_loop` — leader-elected, renews a renewable/periodic token at **~half its lease**, retries renew failures on a 30s floor, emits a `kms.vault_token_renewed` audit row.
  - `evaluate_vault_token_at_boot` — in **production** a non-renewable finite token **refuses boot** (override `MCP_PROXY_VAULT_TOKEN_ALLOW_NONRENEWABLE=true`) instead of starting a Mastio that will silently 403 at the first rotation/restart after expiry.
- **`main.py` lifespan** — boot guard after `load_org_ca_from_config`, watcher start (gated on `kms_backend=vault` + a renewable token), shutdown teardown mirroring the other watchers.
- **`config.py`** — `vault_token_renewal_enabled`, `vault_token_renewal_min_interval_seconds`, `vault_token_allow_nonrenewable`.
- **`docs/operate/disaster-recovery.md`** — "Vault token lifecycle" section (use `-period`, Mastio renews, boot refuses doomed tokens).

The token value is **never logged or audited** (only `ttl`/`renewable`/`period` metadata).

## Result

A periodic token is kept alive indefinitely with zero operator burden; a non-renewable finite token in production fails fast with a clear message instead of becoming a latent landmine.

## Tests

- **22 unit tests**: classify/decision matrix; `lookup_token`/`renew_token` via `httpx.MockTransport`; boot refuse-in-prod / override / renewable / root / lookup-failure; renewal loop renews once + survives a renew failure without dying.
- Existing `test_kms_vault_provider.py`: 17/17 still pass.
- `./test/smoke/smoke.sh` full: **14/14** (confirms boot/shutdown integrity; the vault path is no-op under `kms_backend=local`).
- `/security-review`: clean, no findings.

## Coverage note

Smoke runs `kms_backend=local`, so the Vault path is exercised by the unit tests, not end-to-end. A prod-shape dogfood with a finite-TTL Vault token is the remaining live-validation step (the original "token Vault renewal da testare" item), now feasible.