### PR TITLE
feat(boot): refuse-to-boot via readiness gate instead of a SystemExit respawn loop

### DIFF
--- a/deploy/helm/cullis-mastio/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-mastio/templates/proxy-deployment.yaml
@@ -172,7 +172,12 @@ spec:
               command:
                 - sh
                 - -c
-                - wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/health
+                # Liveness hits /healthz (shallow) not /health: /health
+                # returns 503 in degraded boot-refusal mode, and a
+                # liveness failure there would restart-loop the sidecar
+                # for a deterministic config error. Readiness above keeps
+                # /health so the pod still goes NotReady.
+                - wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/healthz
             initialDelaySeconds: 30
             periodSeconds: 30
           {{- with .Values.nginx.resources }}

--- a/deploy/helm/cullis-mastio/values.yaml
+++ b/deploy/helm/cullis-mastio/values.yaml
@@ -251,8 +251,11 @@ proxy:
     timeoutSeconds: 3
     failureThreshold: 3
 
-  # -- Readiness probe configuration. Hits /readyz — returns 503 when the
-  # DB is unwritable or the JWKS cache is stale beyond 2x refresh.
+  # -- Readiness probe configuration. Hits /readyz — returns 503 when a
+  # fail-closed boot guard refused (degraded mode), the DB is unwritable,
+  # or the JWKS cache is stale beyond 2x refresh. Liveness stays on
+  # /healthz so a deterministic boot refusal marks the pod NotReady
+  # without a restart loop.
   readinessProbe:
     httpGet:
       path: /readyz

--- a/mcp_proxy/boot_state.py
+++ b/mcp_proxy/boot_state.py
@@ -1,0 +1,66 @@
+"""Process-wide boot-refusal flag.
+
+A fail-closed boot guard (PKI orphan / partial-restore, the explicit
+CA-provisioning gate, the Vault token policy) sets this when it refuses
+to bring the Mastio up. Two readers:
+
+* the **lifespan** reads it to enter *degraded not-ready mode* instead
+  of letting a ``SystemExit`` in the async lifespan task leave the
+  container ``Up (unhealthy)`` respawning under ``uvicorn --workers``;
+* ``/readyz`` and ``/health`` read it to return 503 with the reason,
+  while ``/healthz`` (liveness) stays 200 so the orchestrator marks the
+  replica NotReady **without** a restart loop.
+
+The refusal is deterministic — it is caused by config or PKI material,
+not a transient fault, so it will not self-heal on restart. A stable
+NotReady state is therefore the right signal (the operator fixes the
+cause and redeploys), not a crash loop that buries the root cause in
+churn.
+
+Module-level state (one interpreter == one Mastio worker process),
+mirroring the ``audit_chain`` unhealthy-flag pattern ``/readyz`` already
+reads.
+"""
+from __future__ import annotations
+
+_boot_refusal_reason: str | None = None
+
+
+def refuse_boot(reason: str) -> None:
+    """Mark this worker as having refused to boot.
+
+    ``reason`` is a short, greppable string (it lands in the 503 body
+    and the CRITICAL log). Idempotent and first-writer-wins so the
+    original cause is preserved if a later guard also trips.
+    """
+    global _boot_refusal_reason
+    if _boot_refusal_reason is None:
+        _boot_refusal_reason = reason
+
+
+def boot_refusal_reason() -> str | None:
+    """Return the refusal reason, or ``None`` when the boot is healthy."""
+    return _boot_refusal_reason
+
+
+def is_boot_refused() -> bool:
+    """True when a guard has refused this worker's boot."""
+    return _boot_refusal_reason is not None
+
+
+def reset_boot_refusal() -> None:
+    """Clear the flag.
+
+    Called at the top of the lifespan so a fresh boot starts clean, and
+    exposed for tests.
+    """
+    global _boot_refusal_reason
+    _boot_refusal_reason = None
+
+
+__all__ = [
+    "refuse_boot",
+    "boot_refusal_reason",
+    "is_boot_refused",
+    "reset_boot_refusal",
+]

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -2025,6 +2025,12 @@ class AgentManager:
                 "MCP_PROXY_ALLOW_PKI_REKEY=1.",
                 missing_label, enrolled, restore_hint,
             )
+            from mcp_proxy.boot_state import refuse_boot
+            refuse_boot(
+                f"pki_incoherence: {missing_label} absent but {enrolled} "
+                "enrolled agent(s) exist (partial disaster-restore). "
+                f"{restore_hint}, or MCP_PROXY_ALLOW_PKI_REKEY=1 to re-key.",
+            )
             raise SystemExit(1)
         logger.warning(
             "PKI INCOHERENCE (non-production): %s is absent but %d enrolled "

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -326,44 +326,85 @@ async def lifespan(app: FastAPI):
             "auto-renewal", exc,
         )
 
-    # #115 — standalone first-boot: generate a fresh self-signed Org CA when
-    # no CA has been attached (no attach-ca invite ever consumed) and no
-    # broker is configured. Gated on standalone=true so federation deploys
-    # keep the attach-ca flow unchanged.
-    #
-    # ADR-006 §2.2 — when the operator hasn't pinned an ``org_id`` via env
-    # or config, derive one deterministically from the CA public key. The
-    # admin then copies this value into the broker's attach-ca invite so
-    # future uplinks pin the same identity across proxy restarts.
-    if settings.standalone and not agent_mgr.ca_loaded:
-        # PKI bootstrap guard — refuse to mint a fresh Org Root when
-        # enrolled agents already exist (the signature of a partial
-        # disaster-restore / lost Vault). Minting a new root would orphan
-        # every agent leaf. A genuine first boot (no agents) proceeds.
-        # See ``AgentManager.ensure_ca_bootstrap_safe``.
-        await agent_mgr.ensure_ca_bootstrap_safe(
-            "the Org Root CA",
-            "restore the org-ca secret (e.g. Vault secret/cullis-mastio/org-ca)",
-        )
-        # Explicit-provisioning gate (DR-1 / F2) — in production the
-        # first-time generation of the org's crown-jewel Org CA must be an
-        # explicit operator action, never an unattended side effect of a
-        # restart that found no CA. Dev/test auto-bootstraps so zero-config
-        # standalone keeps working. See ``ProxySettings.ca_bootstrap_enabled``.
-        if not settings.ca_bootstrap_enabled():
-            _log.critical(
-                "No Org CA is loaded and CA bootstrap is disabled "
-                "(production default). First-time CA provisioning must be "
-                "explicit: set MCP_PROXY_ALLOW_CA_BOOTSTRAP=1 to mint a fresh "
-                "self-signed Org CA on this boot, or restore existing CA "
-                "material (org-ca + intermediate-ca in the KMS) and restart. "
-                "Refusing to boot."
+    # Boot-refusal guard region. A fail-closed guard here (PKI orphan /
+    # partial-restore, the explicit-provisioning gate) raises SystemExit.
+    # Under ``uvicorn --workers`` a SystemExit in the lifespan task does
+    # NOT cleanly stop the container — the supervisor leaves it
+    # ``Up (unhealthy)`` respawning, burying the cause in churn. Catch it
+    # and switch to DEGRADED not-ready mode: serve only the health
+    # endpoints (``/readyz`` + ``/health`` → 503 with the reason,
+    # ``/healthz`` stays 200 so the orchestrator marks the replica
+    # NotReady without a restart loop). The dangerous bootstrap below a
+    # raising guard never runs — the guard raised before reaching it — so
+    # fail-closed is preserved; readiness simply gates the data plane.
+    from mcp_proxy.boot_state import boot_refusal_reason, reset_boot_refusal
+    reset_boot_refusal()
+    try:
+        # #115 — standalone first-boot: generate a fresh self-signed Org CA
+        # when no CA has been attached (no attach-ca invite ever consumed)
+        # and no broker is configured. Gated on standalone=true so
+        # federation deploys keep the attach-ca flow unchanged.
+        #
+        # ADR-006 §2.2 — when the operator hasn't pinned an ``org_id`` via
+        # env or config, derive one deterministically from the CA public
+        # key. The admin then copies this value into the broker's attach-ca
+        # invite so future uplinks pin the same identity across restarts.
+        if settings.standalone and not agent_mgr.ca_loaded:
+            # PKI bootstrap guard — refuse to mint a fresh Org Root when
+            # enrolled agents already exist (the signature of a partial
+            # disaster-restore / lost Vault). Minting a new root would
+            # orphan every agent leaf. A genuine first boot (no agents)
+            # proceeds. See ``AgentManager.ensure_ca_bootstrap_safe``.
+            await agent_mgr.ensure_ca_bootstrap_safe(
+                "the Org Root CA",
+                "restore the org-ca secret (e.g. Vault secret/cullis-mastio/org-ca)",
             )
-            raise SystemExit(1)
-        derive = not org_id  # derive only when the operator didn't pick one
-        await agent_mgr.generate_org_ca(derive_org_id=derive)
-        if derive:
-            org_id = agent_mgr.org_id
+            # Explicit-provisioning gate (DR-1 / F2) — in production the
+            # first-time generation of the org's crown-jewel Org CA must be
+            # an explicit operator action, never an unattended side effect
+            # of a restart that found no CA. Dev/test auto-bootstraps so
+            # zero-config standalone keeps working. See
+            # ``ProxySettings.ca_bootstrap_enabled``.
+            if not settings.ca_bootstrap_enabled():
+                from mcp_proxy.boot_state import refuse_boot
+                refuse_boot(
+                    "ca_bootstrap_disabled: no Org CA loaded and CA bootstrap "
+                    "is disabled (production default). Set "
+                    "MCP_PROXY_ALLOW_CA_BOOTSTRAP=1 to mint, or restore "
+                    "org-ca + intermediate-ca in the KMS and redeploy.",
+                )
+                _log.critical(
+                    "No Org CA is loaded and CA bootstrap is disabled "
+                    "(production default). First-time CA provisioning must be "
+                    "explicit: set MCP_PROXY_ALLOW_CA_BOOTSTRAP=1 to mint a "
+                    "fresh self-signed Org CA on this boot, or restore "
+                    "existing CA material (org-ca + intermediate-ca in the "
+                    "KMS) and restart. Refusing to boot."
+                )
+                raise SystemExit(1)
+            derive = not org_id  # derive only when the operator didn't pick one
+            await agent_mgr.generate_org_ca(derive_org_id=derive)
+            if derive:
+                org_id = agent_mgr.org_id
+    except SystemExit as exc:
+        from mcp_proxy.boot_state import refuse_boot
+        if boot_refusal_reason() is None:
+            refuse_boot(f"boot refused (exit {getattr(exc, 'code', 1)})")
+        app.state.boot_refused = True
+        _log.critical(
+            "Boot refused — entering degraded not-ready mode (readiness "
+            "503, liveness 200) until the operator fixes the cause and "
+            "redeploys: %s", boot_refusal_reason(),
+        )
+        # Best-effort release of what startup opened before the guard so a
+        # degraded worker doesn't pin the DB pool for its (short) life.
+        try:
+            from mcp_proxy.db import dispose_db
+            await dispose_db()
+        except Exception:  # noqa: BLE001 best-effort
+            pass
+        yield
+        return
 
     # ``get_settings`` is lru_cached so mutating the shared instance
     # propagates the resolved id to every call-site (decide_route,
@@ -2562,7 +2603,15 @@ if _static_dir.is_dir():
 
 @app.get("/health", tags=["infra"])
 async def health(request: Request):
-    """Basic health check — always 200 if the process is running.
+    """Basic health check — 200 when the process booted cleanly.
+
+    Returns **503** when a fail-closed boot guard refused to bring this
+    worker up (degraded not-ready mode), so the Docker Compose
+    healthcheck and any ``/health``-based probe mark the container
+    unhealthy and ``deploy.sh ... up -d --wait`` fails loudly instead of
+    reporting a half-up Mastio that serves nothing real. Liveness
+    (``/healthz``) stays 200 so a deterministic refusal does not trigger
+    a restart loop.
 
     Surfaces operator-visible warnings in a ``warnings`` array when
     present (omitted entirely when clean so existing consumers that
@@ -2573,6 +2622,12 @@ async def health(request: Request):
         underneath. Stdlib-verifier cross-org federation silently
         401s; remediation is ``POST /pki/rotate-ca``.
     """
+    from mcp_proxy.boot_state import boot_refusal_reason
+    _refused = boot_refusal_reason()
+    if _refused is not None:
+        return JSONResponse(
+            {"status": "refused", "reason": _refused}, status_code=503,
+        )
     body: dict = {"status": "ok", "version": _mastio_version()}
     warnings: list[str] = []
     agent_mgr = getattr(request.app.state, "agent_manager", None)
@@ -2593,8 +2648,21 @@ async def healthz():
 
 @app.get("/readyz", tags=["infra"])
 async def readyz():
-    """Readiness probe — checks DB writable and JWKS cache age."""
+    """Readiness probe — checks boot refusal, DB writable and JWKS age."""
     checks: dict[str, str] = {}
+
+    # Boot-refusal gate (deterministic, won't self-heal on restart). A
+    # fail-closed guard refused this worker; report not-ready so the
+    # orchestrator keeps it out of rotation / marks the rollout NotReady
+    # while the operator fixes the cause. Checked first, before any DB
+    # work, since a refused worker may not have finished startup.
+    from mcp_proxy.boot_state import boot_refusal_reason
+    _refused = boot_refusal_reason()
+    if _refused is not None:
+        checks["boot"] = f"refused: {_refused}"
+        return JSONResponse(
+            {"status": "refused", "checks": checks}, status_code=503,
+        )
 
     # Audit F-A-404 — batched audit chain background flush exhaustion
     # sets a process-wide unhealthy flag. Fail readyz so the LB kicks

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -398,8 +398,11 @@ async def lifespan(app: FastAPI):
         )
         # Best-effort release of what startup opened before the guard so a
         # degraded worker doesn't pin the DB pool for its (short) life.
+        # ``dispose_db`` is the module-level import (top of file); a local
+        # ``from ... import`` here would shadow it into a function-local and
+        # break the happy-path shutdown ``await dispose_db()`` below with an
+        # UnboundLocalError.
         try:
-            from mcp_proxy.db import dispose_db
             await dispose_db()
         except Exception:  # noqa: BLE001 best-effort
             pass

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -31,6 +31,21 @@ import pytest
 os.environ.setdefault("MCP_PROXY_ADMIN_SECRET", "test-proxy-secret-not-default")
 
 
+@pytest.fixture(autouse=True)
+def _reset_boot_state():
+    """Keep the process-wide boot-refusal flag from leaking across tests.
+
+    Boot guards (``ensure_ca_bootstrap_safe``, the Vault token guard)
+    now call ``mcp_proxy.boot_state.refuse_boot`` before raising, so a
+    test that trips one would otherwise leave the flag set for the next
+    test and make ``/readyz`` / ``/health`` report 503 spuriously.
+    """
+    from mcp_proxy.boot_state import reset_boot_refusal
+    reset_boot_refusal()
+    yield
+    reset_boot_refusal()
+
+
 @pytest.fixture
 def audit_test_env(monkeypatch, tmp_path):
     """Initialise a fresh file-backed SQLite + audit chain for one test.

--- a/test/unit/test_boot_refusal_readiness.py
+++ b/test/unit/test_boot_refusal_readiness.py
@@ -1,0 +1,135 @@
+"""Refuse-to-boot via readiness gate (2026-06-02).
+
+A fail-closed boot guard (PKI orphan / partial-restore, the explicit
+CA-provisioning gate, the Vault token policy) raises SystemExit. Under
+``uvicorn --workers`` that left the container ``Up (unhealthy)``
+respawning instead of a clean refuse. The fix: the guard records a
+reason in ``mcp_proxy.boot_state``, the lifespan catches the SystemExit
+and serves a degraded not-ready worker, and the probes surface it:
+
+  * ``/readyz`` → 503 (not ready, kept out of rotation / rollout)
+  * ``/health`` → 503 (compose healthcheck fails, ``--wait`` fails)
+  * ``/healthz`` → 200 (liveness; no restart loop for a deterministic,
+    won't-self-heal refusal)
+
+These tests pin the flag semantics and each endpoint's behaviour, and
+that ``ensure_ca_bootstrap_safe`` records a reason before refusing.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_proxy import boot_state
+
+
+# ── boot_state flag ────────────────────────────────────────────────────
+def test_clean_by_default():
+    assert boot_state.boot_refusal_reason() is None
+    assert boot_state.is_boot_refused() is False
+
+
+def test_refuse_sets_reason():
+    boot_state.refuse_boot("pki_incoherence: x")
+    assert boot_state.is_boot_refused() is True
+    assert boot_state.boot_refusal_reason() == "pki_incoherence: x"
+
+
+def test_first_writer_wins():
+    boot_state.refuse_boot("first")
+    boot_state.refuse_boot("second")
+    assert boot_state.boot_refusal_reason() == "first"
+
+
+def test_reset_clears():
+    boot_state.refuse_boot("x")
+    boot_state.reset_boot_refusal()
+    assert boot_state.boot_refusal_reason() is None
+
+
+# ── /readyz ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_readyz_503_when_boot_refused():
+    from mcp_proxy.main import readyz
+
+    boot_state.refuse_boot("ca_bootstrap_disabled: restore the CA")
+    resp = await readyz()
+    assert resp.status_code == 503
+    import json
+    body = json.loads(bytes(resp.body))
+    assert body["status"] == "refused"
+    assert "ca_bootstrap_disabled" in body["checks"]["boot"]
+
+
+# ── /health ────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_health_503_when_boot_refused():
+    from mcp_proxy.main import health
+
+    boot_state.refuse_boot("pki_incoherence: org-ca absent")
+    # request is not touched on the refused path; pass a placeholder.
+    resp = await health(request=SimpleNamespace())
+    assert resp.status_code == 503
+    import json
+    body = json.loads(bytes(resp.body))
+    assert body["status"] == "refused"
+    assert body["reason"] == "pki_incoherence: org-ca absent"
+
+
+@pytest.mark.asyncio
+async def test_health_200_when_clean():
+    from mcp_proxy.main import health
+
+    # Clean boot — no refusal flag. The handler reads
+    # request.app.state.agent_manager, so provide a minimal stand-in.
+    req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    result = await health(request=req)
+    # Clean path returns a plain dict (FastAPI → 200), not a 503 response.
+    assert isinstance(result, dict)
+    assert result["status"] == "ok"
+
+
+# ── /healthz stays 200 (liveness must not flap on a refusal) ───────────
+@pytest.mark.asyncio
+async def test_healthz_200_even_when_boot_refused():
+    from mcp_proxy.main import healthz
+
+    boot_state.refuse_boot("anything")
+    result = await healthz()
+    # Liveness is shallow and unconditional — a deterministic boot
+    # refusal must NOT fail liveness (that would restart-loop the pod).
+    assert result == {"status": "ok"}
+
+
+# ── guard records a reason before refusing ─────────────────────────────
+@pytest.mark.asyncio
+async def test_ensure_ca_bootstrap_safe_records_reason(monkeypatch):
+    """In production with enrolled agents and missing CA, the guard sets
+    a boot-refusal reason (not just raising SystemExit) so the degraded
+    probes can name the cause."""
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+    mgr = AgentManager(org_id="acme", trust_domain="acme.example")
+
+    async def _fake_count():
+        return 3
+
+    monkeypatch.setattr(
+        "mcp_proxy.db.count_enrolled_agents", _fake_count,
+    )
+    # Force the production branch + no rekey override.
+    monkeypatch.setattr(
+        "mcp_proxy.egress.agent_manager._pki_rekey_allowed", lambda: False,
+    )
+    monkeypatch.setattr(
+        "mcp_proxy.config.get_settings",
+        lambda: SimpleNamespace(environment="production"),
+    )
+
+    with pytest.raises(SystemExit):
+        await mgr.ensure_ca_bootstrap_safe("the Org Root CA", "restore org-ca")
+
+    reason = boot_state.boot_refusal_reason()
+    assert reason is not None
+    assert "pki_incoherence" in reason


### PR DESCRIPTION
## What

A fail-closed boot guard (PKI orphan / partial-restore, the explicit CA-provisioning gate) raises `SystemExit`. Under `uvicorn --workers` a `SystemExit` in the lifespan task does **not** cleanly stop the container — the supervisor leaves it `Up (unhealthy)` respawning, burying the cause in churn. The refusal is **deterministic** (config / PKI material): it will not self-heal on restart, so a crash loop is pure noise.

This converts the in-lifespan refusal to a **stable, inspectable degraded mode** (readiness gate).

## Fix

- **`boot_state.py`** (new): process-wide refusal flag + reason (first-writer-wins).
- **`main.py` lifespan**: wrap the PKI guard region in `try/except SystemExit`; on refuse set the flag, log CRITICAL, best-effort `dispose_db`, and **yield in degraded mode**. The dangerous CA mint never runs (the guard raised before reaching it), so **fail-closed is preserved** — readiness simply gates the data plane.
- **`/health` + `/readyz`** → **503** with the reason when refused; **`/healthz`** (liveness) stays **200** so a deterministic refusal does not restart-loop the pod. Compose `--wait` fails on `/health`; K8s marks the pod NotReady on `/readyz`.
- **`agent_manager.ensure_ca_bootstrap_safe`**: records a descriptive `pki_incoherence: ...` reason before its `SystemExit`.
- **Helm**: move the nginx sidecar **liveness** probe `/health` → `/healthz` (a 503 on `/health` in degraded mode would otherwise restart-loop the sidecar). `readinessProbe` already hits `/readyz`; `startupProbe` stays on `/healthz` so a refused worker is "started" but NotReady.
- **`conftest.py`**: autouse fixture resets `boot_state` between tests.

Pre-serve config gates (`validate_config`, ~30 sites) keep their `SystemExit` — they run **before** the server binds, so a clean process exit is correct there. Only the in-lifespan class changes.

## Why degraded-serve, not hard-exit

The security guarantee is "never serve traffic in this state" — satisfied by readiness-gating (the pod gets no traffic, the dangerous bootstrap never ran). Killing the process is an *operational* choice, and for a deterministic error a stable NotReady worker is strictly more debuggable than a crash loop (stable logs, inspectable endpoint, no churn). Liveness stays green precisely to avoid the restart loop.

## Tests

- **9 unit tests**: flag semantics (set / first-writer-wins / reset), `/readyz` 503, `/health` 503 + clean 200, `/healthz` 200-even-when-refused, and that the PKI guard records a reason before refusing.
- PKI bootstrap guard + health-version suites still pass.
- `./test/smoke/smoke.sh` full: **14/14** (proxy + nginx reach `Healthy` on a clean boot; the 4-worker scenario is healthy).
- `/security-review`: clean, no findings.

## Notes

- **Interaction with #1041** (Vault token guard, not yet merged): this branch is off `main`, which doesn't have that guard. It covers the two guards present (PKI orphan + provisioning gate). When #1041 merges, its `SystemExit` should land inside this `try` (or get its own `refuse_boot` call) — a small resolve in the same lifespan region. Flagged here so the merge order is deliberate.
- The degraded-serve path itself (lifespan catches `SystemExit` → yields degraded) is simple control flow validated indirectly; a live end-to-end test would need a prod-shape boot with missing CA material (possible in a dedicated dogfood).