### PR TITLE
fix(bundle): restore the nginx reload-watcher so cert rotation/org-change hot reload works

### DIFF
--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -349,10 +349,15 @@ services:
       - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/etc/nginx/certs:ro
       # Wave 2 fix 6 — polling reload watcher script. Pairs with the
       # Mastio-side ``nginx_cert_watcher`` lifespan task: that task
-      # rewrites ``mastio-server.crt`` when expiry approaches, and the
-      # mtime change here triggers ``nginx -s reload`` without docker
-      # socket exposure or a custom image.
-      - ../nginx-reload-watcher/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
+      # rewrites ``mastio-server.crt`` when expiry approaches OR the org/CA
+      # changes, and the mtime change here triggers ``nginx -s reload``
+      # without docker socket exposure or a custom image. Shipped inside
+      # the bundle at ``nginx/reload-watcher.sh`` so it survives tarball
+      # extraction — the old ``../nginx-reload-watcher/`` sibling path did
+      # not exist after extraction, so Docker auto-created a root-owned
+      # empty dir there and the reload watcher never ran (cert rotation +
+      # org-change hot reload were silently dead, since #884).
+      - ./nginx/reload-watcher.sh:/usr/local/bin/nginx-reload-watcher.sh:ro
     command:
       - /bin/sh
       - -c

--- a/packaging/mastio-bundle/nginx/reload-watcher.sh
+++ b/packaging/mastio-bundle/nginx/reload-watcher.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# =============================================================================
+# nginx-reload-watcher — polls a TLS cert file mtime and reloads nginx on
+# change. Pairs with the Mastio-side lifespan watcher
+# (`mcp_proxy/lifespan/nginx_cert_watcher.py`) that rewrites the cert via
+# `ensure_nginx_server_cert` when expiry approaches OR the org/CA changes.
+#
+# Why polling vs inotify: the sidecar runs stock `nginx:1.27-alpine`,
+# which does not ship `inotify-tools`. Polling with `stat -c %Y` is POSIX
+# busybox-compatible, needs no package install, no docker socket mount,
+# and adds at most one poll interval of latency. For a cert that rotates
+# at most every 60-90 days, 60-second polling latency is comfortably
+# below any SLA concern.
+#
+# Trigger: mtime change on the cert file. `ensure_nginx_server_cert`
+# writes via tmpfile + rename so mtime updates atomically. Without this
+# watcher running, nginx keeps serving the OLD cert in memory after a
+# rotation / org change until the container is restarted by hand — which
+# silently breaks client verification (the served leaf no longer chains
+# to the CA the Mastio advertises at /pki/ca.crt).
+#
+# Env:
+#   NGINX_RELOAD_WATCH_FILE   path to the cert file to poll
+#                             (default: /etc/nginx/certs/mastio-server.crt)
+#   NGINX_RELOAD_POLL_SECONDS poll interval (default: 60)
+# =============================================================================
+set -eu
+CERT_FILE="${NGINX_RELOAD_WATCH_FILE:-/etc/nginx/certs/mastio-server.crt}"
+INTERVAL="${NGINX_RELOAD_POLL_SECONDS:-60}"
+last_mtime=""
+if [ -f "$CERT_FILE" ]; then
+    last_mtime=$(stat -c %Y "$CERT_FILE" 2>/dev/null || echo "")
+fi
+echo "[nginx-reload-watcher] start watch=$CERT_FILE interval=${INTERVAL}s initial_mtime=${last_mtime:-none}"
+while sleep "$INTERVAL"; do
+    if [ ! -f "$CERT_FILE" ]; then
+        continue
+    fi
+    cur_mtime=$(stat -c %Y "$CERT_FILE" 2>/dev/null || echo "")
+    if [ -z "$cur_mtime" ]; then
+        continue
+    fi
+    if [ -z "$last_mtime" ]; then
+        last_mtime="$cur_mtime"
+        echo "[nginx-reload-watcher] cert appeared, baseline mtime=$cur_mtime"
+        continue
+    fi
+    if [ "$cur_mtime" != "$last_mtime" ]; then
+        echo "[nginx-reload-watcher] cert mtime changed ($last_mtime -> $cur_mtime), reloading nginx"
+        if nginx -s reload 2>&1; then
+            echo "[nginx-reload-watcher] reload OK"
+        else
+            rc=$?
+            echo "[nginx-reload-watcher] reload FAILED (rc=$rc), will retry on next change" >&2
+        fi
+        last_mtime="$cur_mtime"
+    fi
+done


### PR DESCRIPTION
## Root cause

The Mastio re-mints the nginx server cert via `ensure_nginx_server_cert` (on expiry approach **or** org/CA change) and relies on a sidecar polling script, `nginx-reload-watcher.sh`, to run `nginx -s reload` when the cert file mtime changes (the `nginx_cert_watcher` lifespan task is the other half).

That script was **lost in the Portkey pivot (#884)**:
- `/packaging/nginx-reload-watcher/` was added to `.gitignore` and the script content removed (the path is now an empty dir).
- The bundle staging allowlist (`scripts/stage-mastio-bundle.sh`) never copied it into the tarball.
- The compose still bind-mounted `../nginx-reload-watcher/reload-watcher.sh` — a path that **does not exist after the tarball is extracted** — so Docker auto-created a root-owned **empty directory** there, the reload-watcher `CMD` failed to exec, and nginx never reloaded.

## Impact (silent since 2026-05-21)

`nginx_cert_watcher` rewrites the cert file but nginx keeps serving the **old cert in memory** until the container is restarted by hand:
- On expiry → serves an **expired leaf** → fleet-wide mTLS break.
- On an org/CA change → the served leaf no longer chains to the CA advertised at `/pki/ca.crt`, so **no client can verify the Mastio**.

Found while bringing up a multi-agent workflow on the demo VMs: agents fetch `/pki/ca.crt` (new org) and fail TLS verify against the stale leaf (old org) → `CERTIFICATE_VERIFY_FAILED`.

## Fix

Ship the script **inside the bundle** at `nginx/reload-watcher.sh` (already staged via the `nginx` allowlist entry, so it survives extraction) and point the compose bind at `./nginx/reload-watcher.sh` instead of the non-existent `../nginx-reload-watcher/` sibling.

## Validation (live, demo stack)

- reload-watcher script now mounts as an executable file and its process runs.
- Touching the cert (`mtime` change) → sidecar log: `cert mtime changed (...), reloading nginx` → `reload OK`.
- nginx then serves the current leaf, **consistent with `/pki/ca.crt`**.
- An agent enrolls over **verified TLS** (previously failed immediately with `CERTIFICATE_VERIFY_FAILED`).

Smoke does not catch this (a fresh single-org deploy never triggers a cert rotation), which is why it stayed silent.

## Follow-up (not in this PR)

The **Helm** nginx sidecar has the same gap (no reload-on-cert-change mechanism). It needs the same watcher, validated on a real cluster — flagged for a separate PR.