### PR TITLE
fix(dashboard): keep login form on error re-render + auto-login after register

### DIFF
--- a/mcp_proxy/dashboard/auth_routes.py
+++ b/mcp_proxy/dashboard/auth_routes.py
@@ -82,12 +82,23 @@ async def login_submit(request: Request):
     if not await is_admin_password_set():
         return RedirectResponse(url="/proxy/register", status_code=303)
 
+    # Resolve the same template context the GET ``login_page`` computes
+    # (oidc/password toggles + display name). Every error re-render below
+    # MUST pass these, otherwise the Jinja variables are undefined →
+    # falsy → the ``{% if password_enabled %}`` form block (and the SSO
+    # button) silently disappear, leaving the user with an error and no
+    # way to retry except the browser back button.
+    from mcp_proxy.dashboard.oidc import is_oidc_configured
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    oidc_enabled = await is_oidc_configured()
+    password_enabled = await is_local_password_login_enabled()
+    display_name = await _load_display_name()
+
     # SSO-only hardening toggle: refuse before touching bcrypt so a
     # timing side-channel can't probe the stored secret. The env
     # break-glass (``MCP_PROXY_FORCE_LOCAL_PASSWORD=1``) is honoured
     # inside ``is_local_password_login_enabled`` itself.
-    from mcp_proxy.dashboard.session import is_local_password_login_enabled
-    if not await is_local_password_login_enabled():
+    if not password_enabled:
         from mcp_proxy.db import log_audit
         await log_audit(
             agent_id="admin",
@@ -98,7 +109,12 @@ async def login_submit(request: Request):
         return templates.TemplateResponse("login.html", {
             "request": request,
             "error": "Password sign-in is disabled. Use the SSO button instead.",
+            # Keep the password form hidden on purpose (it is disabled),
+            # but still surface the SSO button + display name so the user
+            # has a way forward.
+            "oidc_enabled": oidc_enabled,
             "password_enabled": False,
+            "display_name": display_name,
         }, status_code=403)
 
     # H9 audit fix — per-IP lockout + rate-limit before bcrypt.
@@ -126,6 +142,9 @@ async def login_submit(request: Request):
                 "Too many failed attempts from this address. Try again later "
                 "or reset the admin password from the local CLI."
             ),
+            "oidc_enabled": oidc_enabled,
+            "password_enabled": password_enabled,
+            "display_name": display_name,
         }, status_code=429)
 
     if not await get_agent_rate_limiter().check(
@@ -140,6 +159,9 @@ async def login_submit(request: Request):
         return templates.TemplateResponse("login.html", {
             "request": request,
             "error": "Too many login attempts. Slow down and try again in a minute.",
+            "oidc_enabled": oidc_enabled,
+            "password_enabled": password_enabled,
+            "display_name": display_name,
         }, status_code=429)
 
     form = await request.form()
@@ -149,6 +171,9 @@ async def login_submit(request: Request):
         return templates.TemplateResponse("login.html", {
             "request": request,
             "error": "Password is required.",
+            "oidc_enabled": oidc_enabled,
+            "password_enabled": password_enabled,
+            "display_name": display_name,
         }, status_code=400)
 
     if not await verify_admin_password(password):
@@ -167,6 +192,9 @@ async def login_submit(request: Request):
         return templates.TemplateResponse("login.html", {
             "request": request,
             "error": "Invalid password.",
+            "oidc_enabled": oidc_enabled,
+            "password_enabled": password_enabled,
+            "display_name": display_name,
         }, status_code=401)
 
     await lockout_store.record_success(client_ip)
@@ -288,5 +316,10 @@ async def register_submit(request: Request):
         },
     )
 
-    # Force a clean sign-in for the very first session.
-    return RedirectResponse(url="/proxy/login", status_code=303)
+    # Auto-authenticate the very first session: the operator just proved
+    # they know the password (typed twice) — forcing an immediate re-login
+    # is pure friction and yields the exact same session they'd get by
+    # signing in right after. Mirror the ``login_submit`` success path.
+    response = RedirectResponse(url=await _post_login_redirect(), status_code=303)
+    set_session(response, role="admin")
+    return response

--- a/test/unit/test_dashboard_login_error_form_and_register_autologin.py
+++ b/test/unit/test_dashboard_login_error_form_and_register_autologin.py
@@ -1,0 +1,177 @@
+"""Dashboard auth UX fixes (2026-06-03).
+
+Two bugs surfaced by Daniele while bootstrapping the admin for the bank
+sim (org d1b4):
+
+Bug 2 — the login form vanished on every POST error re-render. The
+``login.html`` template gates the whole password ``<form>`` behind
+``{% if password_enabled %}``. The GET ``login_page`` passes
+``password_enabled``/``oidc_enabled``/``display_name`` so the form
+shows, but the POST ``login_submit`` error branches re-rendered the
+template WITHOUT them → undefined → falsy → the form block was skipped →
+the user saw the error with no field to retry (browser "back" only).
+The fix computes those three flags once at the top of ``login_submit``
+and threads them through every error ``TemplateResponse``.
+
+Bug 1 — ``register_submit`` forced a clean re-login after
+``set_admin_password`` (redirect to ``/proxy/login``). The fix
+auto-authenticates the very first session (mirror the ``login_submit``
+success path), so the operator lands on the dashboard.
+
+The tests drive the auth router via httpx's ASGITransport on the same
+event loop pytest-asyncio runs on, so the SQLAlchemy + aiosqlite engine
+stays bound to the loop that created it (mirrors
+``test_agent_identity_bundle_download``).
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard import session as session_module
+from mcp_proxy.dashboard.auth_routes import router as auth_router
+from mcp_proxy.db import dispose_db, init_db
+
+
+_ADMIN_SECRET = "test-admin-secret-login-error-form"
+_ADMIN_PASSWORD = "correct-horse-battery-staple"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """File-backed SQLite with the full schema for the auth routes.
+
+    Audit chain is forced off so ``log_audit`` writes inline (the
+    error paths audit denied/error events). Deterministic signing key
+    so the auto-login session cookie round-trips the secret
+    ``require_login`` verifies against.
+    """
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "a" * 64)
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    db_path = tmp_path / "login_error_form.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    # The auth router mounts at ``/proxy`` in production (the prefix
+    # lives on the parent include). Replicate so URLs match the browser.
+    app.include_router(auth_router, prefix="/proxy")
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ── Bug 2: error re-render keeps the password form ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_invalid_password_response_still_renders_the_form(proxy_db):
+    """A 401 (wrong password) re-renders login.html WITH the password
+    form so the user can retry inline — no browser back button.
+    """
+    from mcp_proxy.dashboard.session import set_admin_password
+
+    await set_admin_password(_ADMIN_PASSWORD)
+
+    app = _make_app()
+    async with _client(app) as client:
+        resp = await client.post(
+            "/proxy/login", data={"password": "WRONGPASS123"},
+        )
+
+    assert resp.status_code == 401, resp.text
+    body = resp.text
+    assert "Invalid password." in body
+    # The bug: before the fix the form block was skipped because
+    # password_enabled was undefined. These assertions pin its presence.
+    assert 'name="password"' in body, (
+        "password input must survive the error re-render"
+    )
+    assert 'action="/proxy/login"' in body, (
+        "the retry form must POST back to /proxy/login"
+    )
+
+
+@pytest.mark.asyncio
+async def test_password_required_response_still_renders_the_form(proxy_db):
+    """The 400 "Password is required." branch must also keep the form."""
+    from mcp_proxy.dashboard.session import set_admin_password
+
+    await set_admin_password(_ADMIN_PASSWORD)
+
+    app = _make_app()
+    async with _client(app) as client:
+        resp = await client.post("/proxy/login", data={"password": ""})
+
+    assert resp.status_code == 400, resp.text
+    body = resp.text
+    assert "Password is required." in body
+    assert 'name="password"' in body
+    assert 'action="/proxy/login"' in body
+
+
+@pytest.mark.asyncio
+async def test_get_login_page_renders_form_baseline(proxy_db):
+    """Sanity: the GET form is present (so the POST assertions above
+    are testing parity, not a template that never shows a form)."""
+    from mcp_proxy.dashboard.session import set_admin_password
+
+    await set_admin_password(_ADMIN_PASSWORD)
+
+    app = _make_app()
+    async with _client(app) as client:
+        resp = await client.get("/proxy/login")
+
+    assert resp.status_code == 200, resp.text
+    assert 'name="password"' in resp.text
+
+
+# ── Bug 1: register auto-logs-in instead of forcing re-login ────────
+
+
+@pytest.mark.asyncio
+async def test_register_auto_logs_in_and_redirects_to_dashboard(proxy_db):
+    """POST /proxy/register on a pristine Mastio (no admin yet) sets a
+    session cookie (auto-login) and redirects to the dashboard, NOT
+    back to /proxy/login.
+    """
+    from mcp_proxy.dashboard.session import is_admin_password_set
+
+    assert await is_admin_password_set() is False
+
+    app = _make_app()
+    async with _client(app) as client:
+        resp = await client.post(
+            "/proxy/register",
+            data={
+                "password": _ADMIN_PASSWORD,
+                "confirm_password": _ADMIN_PASSWORD,
+            },
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303, resp.text
+    # Not bounced back to the login form.
+    location = resp.headers.get("location", "")
+    assert location != "/proxy/login", (
+        "register must auto-login, not force a re-login"
+    )
+    assert location in ("/proxy/overview", "/proxy/setup"), location
+    # The session cookie was minted on the redirect response.
+    assert session_module._COOKIE_NAME in resp.cookies, (
+        "register must set a session cookie (auto-login)"
+    )
+    # Password was actually persisted.
+    assert await is_admin_password_set() is True


### PR DESCRIPTION
## Summary

Two dashboard auth UX defects found while bootstrapping the admin password for a demo org. Both confirmed on current `main` in `mcp_proxy/dashboard/auth_routes.py` (`templates/login.html` is correct and untouched).

### Bug 2 — login form vanishes on the error page

`login.html` wraps the whole password `<form>` inside `{% if password_enabled %}`. The GET `login_page` passes `password_enabled` / `oidc_enabled` / `display_name`, so the form renders. But **every error branch of POST `login_submit` re-rendered the template without those flags**. In Jinja an unpassed variable is undefined → falsy → the form block (and the SSO button) are skipped. Net effect: a wrong password landed the user on a page showing only "Invalid password." with no field to retry — they had to hit the browser back button.

Affected error responses: "Password is required." (400), "Invalid password." (401), per-IP lockout (429), rate-limit (429).

**Fix:** compute `oidc_enabled` / `password_enabled` / `display_name` once at the top of `login_submit` (mirroring the GET) and thread them through every error `TemplateResponse`. The SSO-only 403 path intentionally keeps `password_enabled=False` (the password form must stay hidden because password login is disabled) but now also passes `oidc_enabled` + `display_name` so the SSO button and org name remain visible.

### Bug 1 — register forced a re-login

`register_submit` redirected to `/proxy/login` after `set_admin_password` ("Force a clean sign-in"). The operator just typed the password twice; forcing an immediate re-login is pure friction and yields the exact same session they'd get by signing in right after.

**Fix:** auto-authenticate the very first session (mirror the `login_submit` success path: `set_session(response, role="admin")` + redirect to `_post_login_redirect()`), so the operator lands directly on the dashboard.

## Tests

New `test/unit/test_dashboard_login_error_form_and_register_autologin.py`, driving the auth router over httpx `ASGITransport` + in-memory SQLite (reuses the existing fixture pattern from `test_agent_identity_bundle_download`):

- wrong password (401) and empty password (400) responses contain `name="password"` and `action="/proxy/login"` (would fail before the fix)
- a baseline GET assertion so the parity tests aren't testing a form that never shows
- POST `/proxy/register` sets a session cookie and redirects to the dashboard (`/proxy/overview` or `/proxy/setup`), not `/proxy/login`

`pytest test/unit -k "login or register or auth or session or seed"` → 91 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
