### PR TITLE
fix(site): footer brand subtitle to Agent governance

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
         <img src="/cullis-mark.svg" alt="" width="40" height="40" />
         <div>
           <div class="fb-title">Cullis</div>
-          <div class="fb-sub">Agent Trust Fabric · Self-hosted</div>
+          <div class="fb-sub">Agent governance · Self-hosted</div>
         </div>
       </div>
       <p class="footer-motto">


### PR DESCRIPTION
Il footer mostrava ancora la tagline pre-pivot "Agent Trust Fabric". Allineato a "Agent governance", coerente con il resto del sito (pill hero e `<title>` della home dicono già "Agent governance").

Unica occorrenza residua di "trust fabric" nel repo, verificato con grep su `site/`, `docs/`, `branding/`, `mcp_proxy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)