### PR TITLE
fix(config): refuse to boot in production without Redis or in-memory opt-in (S-4)

### DIFF
--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -102,6 +102,13 @@ services:
       # F-B-11 Phase 5 — DPoP enforcement mode for /v1/egress/*
       # (off | optional | required). optional is the current default.
       MCP_PROXY_EGRESS_DPOP_MODE:     ${MCP_PROXY_EGRESS_DPOP_MODE:-}
+      # S-4 (prod-shape stress test 2026-06-04) — the DPoP JTI + login
+      # challenge stores require Redis in production (U-DD-1 / F-B-12);
+      # without it the proxy boots but the first agent login crashes 500.
+      # The redis service below is the default target; production refuses
+      # to boot if this is empty (validate_config S-4 gate). Single-worker
+      # deploys can opt out via MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES.
+      MCP_PROXY_REDIS_URL:            ${MCP_PROXY_REDIS_URL:-redis://redis:6379/0}
     volumes:
       - mcp_proxy_data:/data
       # Optional corporate CA mount. The env above points at a file under /certs
@@ -111,6 +118,11 @@ services:
       # ADR-014 — shared volume for nginx sidecar TLS material.
       # Mastio (this service) writes; mastio-nginx mounts ro.
       - mastio_nginx_certs:/var/lib/mastio/nginx-certs:rw
+    # S-4 — wait for Redis so the DPoP JTI / login-challenge stores have
+    # their backing store before the first authenticated request lands.
+    depends_on:
+      redis:
+        condition: service_healthy
     networks:
       - proxy_net
     restart: unless-stopped
@@ -120,6 +132,24 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+  # S-4 (prod-shape stress test 2026-06-04) — shared DPoP JTI replay cache
+  # + per-agent rate-limit budget. Required in production (the proxy
+  # refuses to boot without it unless the in-memory single-worker opt-in
+  # is set); the bundle under packaging/mastio-bundle/ ships the same
+  # service. No persistence — the JTI window is short-lived and the rate
+  # budget is best-effort, so an empty dataset on restart is correct.
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    networks:
+      - proxy_net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
   # ADR-014 — TLS terminator + mTLS gate for Connector → Mastio.
   mastio-nginx:

--- a/deploy/proxy/proxy.env.example
+++ b/deploy/proxy/proxy.env.example
@@ -161,3 +161,17 @@ MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
 # MCP_PROXY_SECRET_BACKEND=vault
 # MCP_PROXY_VAULT_ADDR=https://vault.myorg.example.com:8200
 # MCP_PROXY_VAULT_TOKEN=   # scoped token, NOT the root token
+
+# ─── Redis (DPoP JTI store + rate limit) ─────────────────────────────────────
+
+# [PRODUCTION] The DPoP JTI replay cache and the per-agent rate-limit
+# budget live in Redis. In production the proxy REFUSES TO BOOT without
+# this (the in-process fallback would let a captured DPoP proof replay
+# once per worker — RFC 9449 — and multiply the advertised rate budget).
+# The docker-compose ships a ``redis`` service; this URL targets it.
+#
+# Single-worker, low-volume deploys can run Redis-free by opting into
+# per-process in-memory stores instead:
+#   MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true
+#   MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical
+MCP_PROXY_REDIS_URL=redis://redis:6379/0

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -1316,6 +1316,31 @@ def validate_config(settings: ProxySettings) -> None:
                 )
                 raise SystemExit(1)
 
+        # S-4 (prod-shape stress test 2026-06-04) — the DPoP JTI store and
+        # the login challenge store raise at *first use* in production when
+        # Redis is absent and in-memory stores aren't explicitly allowed
+        # (dpop_jti_store.py / challenge_store.py: "requires Redis ... unless
+        # ALLOW_INMEMORY_SECURITY_STORES=true"). The F-A-502 block above only
+        # guards the allow_inmemory=true branch; the *default* (no Redis, no
+        # opt-in) booted green and crashed the first agent login with HTTP
+        # 500. Fail closed at boot instead: production needs either a shared
+        # Redis (the default, multi-worker safe) or the explicit in-memory
+        # opt-in (validated as single-worker just above).
+        if not settings.redis_url and not settings.allow_inmemory_security_stores:
+            _log.critical(
+                "MCP_PROXY_REDIS_URL is empty in production and "
+                "MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES is not set. The "
+                "DPoP JTI and login-challenge stores require Redis in "
+                "production, so the proxy would boot but the first agent "
+                "login would crash with HTTP 500. Set MCP_PROXY_REDIS_URL "
+                "(recommended, and required for multi-worker), or opt into "
+                "per-process in-memory stores with "
+                "MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true plus "
+                "MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical "
+                "(U-DD-1 / F-B-12)."
+            )
+            raise SystemExit(1)
+
         # F-A-406 (audit 2026-05-20) — refuse mock-equivalent TSA anchor
         # configuration in production. The legacy ``app/`` codebase shipped
         # ``audit_tsa_backend="mock"`` whose ``MockTsaClient`` returned an
@@ -1450,15 +1475,18 @@ def validate_config(settings: ProxySettings) -> None:
 
     # Audit F-B-12 — Mastio keeps a DPoP JTI cache and per-agent rate
     # limiter in process memory by default. Single-instance deployments
-    # (the current Mastio mainstream) work fine without Redis. Operators
-    # running Mastio multi-worker or multi-replica (HA) MUST set
-    # MCP_PROXY_REDIS_URL so the JTI store is shared — otherwise a
-    # captured DPoP proof can be replayed once per worker within the iat
-    # window, and the advertised per-agent rate budget multiplies by N.
+    # (the current Mastio mainstream) only run Redis-free when they have
+    # explicitly opted into per-process in-memory security stores
+    # (allow_inmemory_security_stores=true, validated as single-worker by
+    # the F-A-502 gate above; without that opt-in the S-4 gate already
+    # refused to boot). Surface the residual replay caveat so the operator
+    # knows to add MCP_PROXY_REDIS_URL before scaling out.
     if is_production and not settings.redis_url:
         _log.warning(
-            "MCP_PROXY_REDIS_URL is empty in production. Safe for "
-            "single-instance Mastio; set MCP_PROXY_REDIS_URL before "
+            "MCP_PROXY_REDIS_URL is empty in production — running on "
+            "per-process in-memory DPoP JTI + rate-limit stores "
+            "(MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES opt-in). Safe only "
+            "for single-worker Mastio; set MCP_PROXY_REDIS_URL before "
             "scaling to multiple workers or replicas (audit F-B-12: "
             "cross-worker DPoP replay + rate-limit budget multiplies)."
         )

--- a/test/unit/test_audit_anchor_tsa_url_validation.py
+++ b/test/unit/test_audit_anchor_tsa_url_validation.py
@@ -55,6 +55,11 @@ def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
     monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
     monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "false")
+    # S-4 (prod-shape stress test 2026-06-04) — prod refuses to boot
+    # without a shared security store (Redis) or the in-memory opt-in, so
+    # the F-A-406 gate under test is reachable. Provide Redis so the only
+    # SystemExit comes from the audit-anchor URL gate.
+    monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://localhost:6379/0")
 
 
 def _fresh_settings():

--- a/test/unit/test_proxy_tls_verify.py
+++ b/test/unit/test_proxy_tls_verify.py
@@ -58,6 +58,12 @@ def _prod_settings(**overrides) -> ProxySettings:
         webauthn_enforcement="required",  # F-A-205
         webauthn_rp_id="mastio.example.com",
         egress_dpop_mode="required",  # F-B-11
+        # S-4 (prod-shape stress test 2026-06-04) — prod now refuses to
+        # boot without a shared security store (Redis) or the explicit
+        # in-memory opt-in, because the DPoP JTI / login-challenge stores
+        # require Redis at first use. Pin a Redis URL so the SystemExit in
+        # these TLS-focused tests isolates the knob under test.
+        redis_url="redis://localhost:6379/0",
     )
     base.update(overrides)
     return ProxySettings(**base)

--- a/test/unit/test_redis_required_in_prod.py
+++ b/test/unit/test_redis_required_in_prod.py
@@ -1,0 +1,125 @@
+"""S-4 — production refuses to boot without a shared security store.
+
+Prod-shape stress test (2026-06-04) found that a ``deploy --prod`` bundle
+booted green and then crashed the *first* agent login with HTTP 500:
+``RuntimeError: DPoP JTI store requires Redis in production``. The DPoP JTI
+store and the login-challenge store both raise at first use when Redis is
+absent and in-memory stores aren't explicitly allowed
+(``mcp_proxy/auth/dpop_jti_store.py`` / ``challenge_store.py``). The boot
+validator only guarded the ``allow_inmemory=true`` branch (F-A-502); the
+*default* (no Redis, no opt-in) wasn't gated, so the failure surfaced at
+runtime instead of at boot.
+
+These tests pin the boot gate that fails closed early:
+
+  prod + no Redis + no opt-in                       → SystemExit(1)
+  prod + Redis URL                                  → ok
+  prod + in-memory opt-in + single-worker-vertical  → ok
+  development + no Redis                            → ok (dev not gated)
+"""
+from __future__ import annotations
+
+import pytest
+
+
+_ADMIN_OK = "test-admin-secret-not-the-default"
+_DB_ENC_OK = "0" * 64
+_DASHBOARD_KEY_OK = "1" * 64
+_PDP_HMAC_OK = "2" * 64
+_VAULT_ADDR_OK = "https://vault.test.example:8200"
+_VAULT_TOKEN_OK = "s.test-token"
+
+
+def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the production env vars that gate *before* the S-4 Redis gate so
+    the test reaches it. Redis / in-memory opt-in are left to each test."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", _DASHBOARD_KEY_OK)
+    monkeypatch.setenv("MCP_PROXY_SECRET_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", _VAULT_ADDR_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", _VAULT_TOKEN_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_VERIFY_TLS", "true")
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _DB_ENC_OK)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example")
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+
+
+def _fresh_settings():
+    from mcp_proxy.config import ProxySettings, get_settings
+
+    get_settings.cache_clear()
+    return ProxySettings()
+
+
+@pytest.fixture(autouse=True)
+def _require_webauthn():
+    """Production pins WEBAUTHN_ENFORCEMENT=required; skip if the optional
+    extra is missing so the webauthn gate doesn't mask the S-4 gate."""
+    pytest.importorskip("webauthn")
+    yield
+
+
+def test_production_without_redis_or_optin_refuses_to_boot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The default prod posture (no Redis, no in-memory opt-in) must
+    SystemExit at boot — otherwise the first agent login crashes 500."""
+    _production_env(monkeypatch)
+    monkeypatch.delenv("MCP_PROXY_REDIS_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "false")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_production_with_redis_url_boots(monkeypatch: pytest.MonkeyPatch):
+    """A shared Redis is the recommended, multi-worker-safe posture."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://redis:6379/0")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "false")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_production_inmemory_optin_single_worker_boots(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Single-worker deploys may run Redis-free, but only with the explicit
+    in-memory opt-in + single-worker-vertical topology (F-A-502)."""
+    _production_env(monkeypatch)
+    monkeypatch.delenv("MCP_PROXY_REDIS_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "true")
+    monkeypatch.setenv(
+        "MCP_PROXY_DEPLOYMENT_TOPOLOGY", "single-worker-vertical",
+    )
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_development_without_redis_boots(monkeypatch: pytest.MonkeyPatch):
+    """Dev mode is not gated — local stacks run Redis-free for convenience."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.delenv("MCP_PROXY_REDIS_URL", raising=False)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise


### PR DESCRIPTION
## Context

Prod-shape stress test (2026-06-04, Postgres+Vault+production) found that a `deploy --prod` bundle **booted green and then crashed the first agent login with HTTP 500**: `RuntimeError: DPoP JTI store requires Redis in production`.

The DPoP JTI store (`auth/dpop_jti_store.py`) and the login-challenge store (`auth/challenge_store.py`) both raise at *first use* when Redis is absent and in-memory stores aren't explicitly allowed. But `validate_config` only guarded the `allow_inmemory=true` branch (F-A-502) — the **default** posture (no Redis, no opt-in) wasn't gated, so the failure surfaced at runtime instead of at boot. The old `MCP_PROXY_REDIS_URL is empty ... Safe for single-instance` warning was also misleading: single-instance crashes too without the opt-in.

## Change

- **`config.py`**: production now `SystemExit`s at boot unless either a shared Redis is configured (recommended, multi-worker-safe) **or** the explicit single-worker in-memory opt-in is set (`ALLOW_INMEMORY_SECURITY_STORES=true` + `DEPLOYMENT_TOPOLOGY=single-worker-vertical`). Corrected the misleading warning.
- **`deploy/compose/docker-compose.proxy.yml`**: added the missing `redis` service + `MCP_PROXY_REDIS_URL` (`depends_on: service_healthy`) so operators satisfy the gate out-of-the-box. The `packaging/mastio-bundle` compose already shipped redis — this closes the `deploy/compose` parity gap the stress test hit.
- **`proxy.env.example`**: documents the Redis requirement + the single-worker opt-out.

## Tests

- New `test_redis_required_in_prod.py`: refuse / redis-ok / optin-ok / dev-ok.
- The two production happy-path helpers (TLS, TSA) now provide a Redis URL so the `SystemExit` isolates the knob under test.
- 59 passed across all `validate_config` + boot tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)