### PR TITLE
fix(enrollment): route identity audit events through the hash chain (S-6)

### DIFF
--- a/mcp_proxy/dashboard/enrollments_routes.py
+++ b/mcp_proxy/dashboard/enrollments_routes.py
@@ -209,6 +209,10 @@ async def enrollments_approve(request: Request, session_id: str):
             status_code=500,
         )
 
+    # S-6 — emit agent.create / agent.cert_rotated through the
+    # hash-chained log_audit after the approval transaction committed.
+    await _enrollment_service.emit_audit_events(record.get("audit_events", []))
+
     _log.info(
         "enrollment_approved via dashboard: session=%s agent=%s admin=%s",
         session_id, record.get("agent_id_assigned"), session.role,

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -138,6 +138,12 @@ async def start_enrollment(
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
 
+    # S-6 — emit the hardware-attestation audit event through the
+    # hash-chained log_audit now that the enrollment transaction has
+    # committed (a raw INSERT inside the transaction landed it with
+    # chain_seq NULL, outside the tamper-evident chain).
+    await service.emit_audit_events(started.audit_events)
+
     # B-1 dogfood fix: prefer ``settings.proxy_public_url`` (which
     # carries the operator-visible ``:9443`` of the nginx sidecar) over
     # ``request.base_url`` (which, inside the uvicorn container behind
@@ -382,6 +388,10 @@ async def admin_approve(
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
+
+    # S-6 — emit agent.create / agent.cert_rotated through the
+    # hash-chained log_audit after the approval transaction committed.
+    await service.emit_audit_events(record.get("audit_events", []))
 
     logger.info(
         "enrollment_approved",

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -11,7 +11,7 @@ import asyncio
 import hashlib
 import json
 import secrets
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -40,6 +40,13 @@ class EnrollmentError(Exception):
 class StartedEnrollment:
     session_id: str
     expires_at: datetime
+    # S-6 — audit events the caller must emit *after* the enrollment
+    # transaction commits, via :func:`emit_audit_events`. Kept out of the
+    # DB write path so they route through the hash-chained ``log_audit``
+    # (ADR-033 batched chain) instead of the raw INSERT they used to use,
+    # which landed rows with ``chain_seq`` NULL — invisible to the
+    # tamper-evident chain and absent from ``local_audit``.
+    audit_events: list[dict[str, Any]] = field(default_factory=list)
 
 
 def _now() -> datetime:
@@ -48,6 +55,37 @@ def _now() -> datetime:
 
 def _iso(ts: datetime) -> str:
     return ts.isoformat(timespec="seconds")
+
+
+async def emit_audit_events(events: list[dict[str, Any]]) -> None:
+    """Emit accumulated enrollment audit events through the hash-chained
+    ``log_audit`` surface, AFTER the enrollment DB transaction has committed.
+
+    S-6 (prod-shape stress test 2026-06-04) — ``start_enrollment`` and
+    ``approve`` used to write their audit rows with a raw ``INSERT INTO
+    audit_log`` inside the same ``conn`` transaction. Those rows landed
+    with ``chain_seq`` / ``prev_hash`` / ``row_hash`` NULL, so the events
+    that record identity creation (``agent.create``), key rotation
+    (``agent.cert_rotated``) and hardware attestation
+    (``device_attestation.verified``) bypassed the tamper-evident chain
+    entirely. Routing them through ``log_audit`` feeds the ADR-033 batched
+    chain and makes them first-class, hash-linked entries.
+
+    Must be called *after* the enrollment transaction commits: ``log_audit``
+    opens its own connection on the legacy per-row path, and doing that
+    while the enrollment ``conn`` still holds an open write transaction
+    would deadlock SQLite. Mirrors the create-then-audit pattern already
+    used by ``admin/agents.py`` and ``dashboard/agents_routes.py``.
+    """
+    from mcp_proxy.db import log_audit
+    for ev in events:
+        await log_audit(
+            agent_id=ev["agent_id"],
+            action=ev["action"],
+            status=ev.get("status", "success"),
+            detail=ev.get("detail"),
+            details=ev.get("details"),
+        )
 
 
 def _pubkey_fingerprint(pubkey_pem: str) -> str:
@@ -333,24 +371,23 @@ async def start_enrollment(
         },
     )
 
+    audit_events: list[dict[str, Any]] = []
     if attestation_json:
-        # Audit the verified hardware claim at enrollment time; the F6
-        # audit migration will extend ``audit_log`` with first-class
-        # columns; until then the JSON detail captures the same payload.
-        await conn.execute(
-            text(
-                """INSERT INTO audit_log
-                   (timestamp, agent_id, action, status, detail)
-                   VALUES (:ts, :aid, 'device_attestation.verified', 'success', :detail)"""
-            ),
-            {
-                "ts": _iso(now),
-                "aid": f"pending::{session_id}",
-                "detail": attestation_json,
-            },
-        )
+        # S-6 — audit the verified hardware claim through the hash-chained
+        # log_audit after the transaction commits, not via a raw INSERT
+        # here (which landed the row with chain_seq NULL). The caller
+        # emits this via emit_audit_events once get_db() has committed.
+        audit_events.append({
+            "agent_id": f"pending::{session_id}",
+            "action": "device_attestation.verified",
+            "detail": attestation_json,
+        })
 
-    return StartedEnrollment(session_id=session_id, expires_at=expires_at)
+    return StartedEnrollment(
+        session_id=session_id,
+        expires_at=expires_at,
+        audit_events=audit_events,
+    )
 
 
 async def _verify_tpm_attestation(
@@ -522,6 +559,12 @@ async def approve(
     # ``internal_agents.last_attestation`` and will pick up the hardware
     # half once F5 merges the two halves. Keeping the claim only on the
     # pending row for the F3 spike avoids fighting F2 over the agent row.
+    #
+    # S-6 — identity audit events are collected here and emitted *after*
+    # the caller commits this transaction (see emit_audit_events). The
+    # raw INSERT INTO audit_log they replace landed rows with chain_seq
+    # NULL, outside the tamper-evident hash chain.
+    audit_events: list[dict[str, Any]] = []
     if existing.first() is None:
         # ADR-010 D1 left ``federated`` opt-in (admin flips manually) so
         # an org could onboard local-only agents without leaking them
@@ -568,23 +611,16 @@ async def approve(
                 "ptype": record.get("principal_type") or "agent",
             },
         )
-        await conn.execute(
-            text(
-                """INSERT INTO audit_log
-                   (timestamp, agent_id, action, status, detail)
-                   VALUES (:ts, :aid, 'agent.create', 'success', :detail)"""
-            ),
-            {
-                "ts": now,
-                "aid": canonical_id,
-                "detail": json.dumps({
-                    "source": "device_code_enrollment",
-                    "session_id": session_id,
-                    "admin": admin_name,
-                    "capabilities": capabilities,
-                }),
+        audit_events.append({
+            "agent_id": canonical_id,
+            "action": "agent.create",
+            "details": {
+                "source": "device_code_enrollment",
+                "session_id": session_id,
+                "admin": admin_name,
+                "capabilities": capabilities,
             },
-        )
+        })
     else:
         # Row already exists — this is a re-enrollment of the same
         # ``agent_id`` (recovery scenario: operator wiped
@@ -663,29 +699,22 @@ async def approve(
                 "ptype": record.get("principal_type") or "agent",
             },
         )
-        await conn.execute(
-            text(
-                """INSERT INTO audit_log
-                   (timestamp, agent_id, action, status, detail)
-                   VALUES (:ts, :aid, 'agent.cert_rotated', 'success', :detail)"""
-            ),
-            {
-                "ts": now,
-                "aid": canonical_id,
-                "detail": json.dumps({
-                    "source": "device_code_enrollment",
-                    "session_id": session_id,
-                    "admin": admin_name,
-                    "reason": "re-enrollment of existing agent_id",
-                    "previous_cert_thumbprint": cert_thumbprint_hex(old_cert_pem),
-                    "new_cert_thumbprint": cert_thumbprint_hex(cert_pem),
-                    "previous_dpop_jkt": old_dpop_jkt,
-                    "new_dpop_jkt": record.get("dpop_jkt"),
-                    "grace_period_expires_at": grace_expiry,
-                    "grace_period_hours": grace_hours,
-                }),
+        audit_events.append({
+            "agent_id": canonical_id,
+            "action": "agent.cert_rotated",
+            "details": {
+                "source": "device_code_enrollment",
+                "session_id": session_id,
+                "admin": admin_name,
+                "reason": "re-enrollment of existing agent_id",
+                "previous_cert_thumbprint": cert_thumbprint_hex(old_cert_pem),
+                "new_cert_thumbprint": cert_thumbprint_hex(cert_pem),
+                "previous_dpop_jkt": old_dpop_jkt,
+                "new_dpop_jkt": record.get("dpop_jkt"),
+                "grace_period_expires_at": grace_expiry,
+                "grace_period_hours": grace_hours,
             },
-        )
+        })
 
     # ADR-021 PR4d follow-up: schedule a baseline binding on the Court so
     # the freshly enrolled agent can pass ``login_via_proxy_with_local_key``
@@ -764,7 +793,12 @@ async def approve(
             canonical_id, exc,
         )
 
-    return await get_record(conn, session_id)
+    # S-6 — hand the identity audit events back to the caller so it can
+    # emit them through the hash-chained log_audit *after* this
+    # transaction commits (see emit_audit_events).
+    result = await get_record(conn, session_id)
+    result["audit_events"] = audit_events
+    return result
 
 
 def _ambassador_mode_from_device_info(device_info: str | None) -> str | None:

--- a/test/unit/test_enrollment_tpm_flow.py
+++ b/test/unit/test_enrollment_tpm_flow.py
@@ -147,7 +147,7 @@ async def test_start_enrollment_audit_row_written_on_verified_quote(db_engine):
     quote_b64 = _build_quote_b64(issued.nonce_bytes, key)
 
     async with get_db() as conn:
-        await service.start_enrollment(
+        started = await service.start_enrollment(
             conn,
             pubkey_pem=pem,
             pop_signature=_sign_pop(key, pem),
@@ -161,15 +161,28 @@ async def test_start_enrollment_audit_row_written_on_verified_quote(db_engine):
             tpm_ek_cert_present=True,
         )
 
+    # S-6 — start_enrollment no longer writes the audit row inline (that
+    # INSERT landed with chain_seq NULL, outside the tamper-evident
+    # chain). It hands the event back; the router emits it post-commit
+    # through the hash-chained log_audit.
+    assert [e["action"] for e in started.audit_events] == [
+        "device_attestation.verified"
+    ]
+
+    await service.emit_audit_events(started.audit_events)
+
     async with get_db() as conn:
         result = await conn.execute(
             text(
-                "SELECT action FROM audit_log WHERE action = "
+                "SELECT action, chain_seq FROM audit_log WHERE action = "
                 "'device_attestation.verified'"
             )
         )
-        actions = [r[0] for r in result.all()]
-    assert actions == ["device_attestation.verified"]
+        rows = result.all()
+    assert [r[0] for r in rows] == ["device_attestation.verified"]
+    # The fix: the row is now part of the hash chain (chain_seq populated),
+    # not an orphan with chain_seq NULL.
+    assert rows[0][1] is not None, "audit row must carry a chain_seq"
 
 
 @pytest.mark.asyncio

--- a/test/unit/test_proxy_device_info.py
+++ b/test/unit/test_proxy_device_info.py
@@ -215,3 +215,61 @@ async def test_approve_without_device_info_yields_null(_proxy_db):
     row = await get_agent("testorg::bob")
     assert row is not None
     assert row["device_info"] is None
+
+
+@pytest.mark.asyncio
+async def test_approve_emits_agent_create_into_hash_chain(_proxy_db):
+    """S-6 — agent.create must land in the tamper-evident hash chain.
+
+    approve() used to write agent.create with a raw INSERT inside the
+    transaction, which left chain_seq NULL (orphaned from the chain). It
+    now returns the event in ``record['audit_events']`` and the caller
+    emits it post-commit via ``emit_audit_events`` -> hash-chained
+    log_audit. Assert the row carries a chain_seq.
+    """
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment.service import (
+        start_enrollment, approve, emit_audit_events,
+    )
+    from sqlalchemy import text
+
+    async with get_db() as conn:
+        started = await start_enrollment(
+            conn,
+            **_fresh_pop_kwargs(),
+            requester_name="carol",
+            requester_email="carol@example.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        record = await approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="testorg::carol",
+            capabilities=["llm.chat"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    # approve hands the event back rather than writing it inline.
+    assert [e["action"] for e in record["audit_events"]] == ["agent.create"]
+
+    # The router emits post-commit; do the same here.
+    await emit_audit_events(record["audit_events"])
+
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT chain_seq FROM audit_log WHERE action = 'agent.create' "
+                "AND agent_id = :aid"
+            ),
+            {"aid": "testorg::carol"},
+        )).all()
+    assert len(rows) == 1, "exactly one agent.create row expected"
+    assert rows[0][0] is not None, (
+        "agent.create must be hash-chained (chain_seq populated), not an "
+        "orphan with chain_seq NULL"
+    )


### PR DESCRIPTION
## Context

Prod-shape stress test (2026-06-04) found **42 `agent.create` rows in `audit_log` with `chain_seq` NULL** — outside the tamper-evident hash chain and absent from `local_audit`. `start_enrollment` and `approve` wrote their audit rows with a **raw `INSERT INTO audit_log` inside the enrollment transaction**, bypassing the canonical hash-chained `log_audit` (ADR-033 batched chain).

Result: the events that record identity creation (`agent.create`), key rotation (`agent.cert_rotated`) and hardware attestation (`device_attestation.verified`) were **not tamper-evident** — an attacker with DB access could rewrite their `detail` without breaking the chain.

## Change

Route them through `log_audit`, following the create-then-audit pattern already used by `admin/agents.py` and `dashboard/agents_routes.py`:

- The service **collects** the events and hands them back (`StartedEnrollment.audit_events` / `record['audit_events']`).
- The three callers (`enrollment.router` start + approve, `dashboard.enrollments_routes` approve) emit them via the new `service.emit_audit_events` **after** the enrollment transaction commits.

Post-commit emission is required: `log_audit` opens its own connection on the legacy per-row path (would **deadlock SQLite** if called inside the open write transaction), and an in-transaction write would also **race the batched chain on `chain_seq`**.

## Tests

- New `test_approve_emits_agent_create_into_hash_chain` pins `chain_seq` populated.
- The TPM-flow test now asserts the event is returned + emitted + hash-chained instead of written inline.
- 83 passed across the enrollment/attestation suite.

## Follow-up (same raw-INSERT pattern, separate paths, not in this PR)

- `mcp_proxy/registry/revoke_cert.py:159`
- `mcp_proxy/attestation/audit_events.py:145`
- `mcp_proxy/attestation/enrollment_hook.py:237`

🤖 Generated with [Claude Code](https://claude.com/claude-code)