### PR TITLE
fix(deploy): make deploy/compose --prod self-sufficient on production secrets (S-1)

### DIFF
--- a/deploy/compose/docker-compose.proxy.yml
+++ b/deploy/compose/docker-compose.proxy.yml
@@ -95,10 +95,25 @@ services:
       # SSL_CERT_FILE is honored by stdlib ssl + httpx/certifi.
       SSL_CERT_FILE:               ${MCP_PROXY_BROKER_CA_BUNDLE:-}
       REQUESTS_CA_BUNDLE:          ${MCP_PROXY_BROKER_CA_BUNDLE:-}
-      # Vault (optional)
+      # Vault (optional in dev; required in production for secret + KMS)
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
+      MCP_PROXY_KMS_BACKEND:       ${MCP_PROXY_KMS_BACKEND:-}
       MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
       MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
+      # S-1 (prod-shape stress test 2026-06-04) — production secrets the
+      # validate_config gates require. generate-proxy-env.sh --prod mints
+      # these into proxy.env, but docker compose only delivers env-file
+      # values that are mapped here. Without the mapping the proxy boots
+      # in production and SystemExits on the first gate (DB encryption key,
+      # PDP webhook HMAC, WebAuthn posture). The mastio-bundle compose
+      # already forwarded them; this closes the deploy/compose parity gap.
+      # Empty / warn defaults keep dev untouched.
+      MCP_PROXY_DB_ENCRYPTION_KEY:         ${MCP_PROXY_DB_ENCRYPTION_KEY:-}
+      MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET:   ${MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET:-}
+      MCP_PROXY_WEBAUTHN_ENFORCEMENT:      ${MCP_PROXY_WEBAUTHN_ENFORCEMENT:-warn}
+      MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK: ${MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK:-}
+      MCP_PROXY_WEBAUTHN_RP_ID:            ${MCP_PROXY_WEBAUTHN_RP_ID:-}
+      MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN:  ${MCP_PROXY_WEBAUTHN_EXPECTED_ORIGIN:-}
       # ADR-001 §10 — intra-org routing + transport. All read by
       # ``_apply_routing_overrides`` in mcp_proxy/config.py. Exposing
       # them here lets operators flip behaviour through proxy.env

--- a/deploy/proxy/proxy.env.example
+++ b/deploy/proxy/proxy.env.example
@@ -185,3 +185,21 @@ MCP_PROXY_POLICY_WEBHOOK_ALLOW_PRIVATE_IPS=1
 #   MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true
 #   MCP_PROXY_DEPLOYMENT_TOPOLOGY=single-worker-vertical
 MCP_PROXY_REDIS_URL=redis://redis:6379/0
+
+# ─── Production hardening (set automatically by --prod) ───────────────────────
+#
+# validate_config(production) refuses to boot unless these are present.
+# ``scripts/generate-proxy-env.sh --prod`` mints them; listed here so a
+# hand-edited prod env knows what the gates require. Leave them OUT of a
+# development env (vault-backed secret/KMS needs a running Vault).
+#
+#   MCP_PROXY_SECRET_BACKEND=vault
+#   MCP_PROXY_KMS_BACKEND=vault          # custodies the Org CA private key
+#   MCP_PROXY_VAULT_ADDR=https://vault.myorg.example.com:8200
+#   MCP_PROXY_VAULT_TOKEN=               # scoped token, NOT the root token
+#   MCP_PROXY_DB_ENCRYPTION_KEY=         # >= 32 chars; encrypts secrets at rest
+#   MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=   # signs inbound /pdp/policy calls
+#   MCP_PROXY_EGRESS_DPOP_MODE=required  # RFC 9449 proof on /v1/egress/*
+#   # WebAuthn: single-Mastio pilots opt into the warn posture (no IdP yet);
+#   # IdP-backed deploys set ENFORCEMENT=required + RP_ID + EXPECTED_ORIGIN.
+#   MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true

--- a/scripts/generate-proxy-env.sh
+++ b/scripts/generate-proxy-env.sh
@@ -109,6 +109,31 @@ sed -i "s|^MCP_PROXY_BROKER_URL=.*|MCP_PROXY_BROKER_URL=${BROKER}|"             
 sed -i "s|^MCP_PROXY_BROKER_JWKS_URL=.*|MCP_PROXY_BROKER_JWKS_URL=${JWKS}|"          "$OUT"
 sed -i "s|^MCP_PROXY_PROXY_PUBLIC_URL=.*|MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}|"      "$OUT"
 
+# S-1 (prod-shape stress test 2026-06-04) — production hardening secrets.
+# validate_config(production) refuses to boot unless secret/KMS backend is
+# vault and DB_ENCRYPTION_KEY + PDP_WEBHOOK_HMAC_SECRET + a WebAuthn posture
+# are set. This script previously minted only admin/signing/nonce, so
+# ``--prod`` set environment=production and then SystemExit'd on the first
+# gate — production was unreachable without hand-editing proxy.env. Mint the
+# rest (mirrors packaging/mastio-bundle/generate-proxy-env.sh). Vault addr +
+# token still come from the operator (KMS custodies the Org CA private key).
+if [[ "$MODE" == "prod" ]]; then
+    _prod_set() {  # strip any existing line (commented or not), append uncommented
+        sed -i.bak "/^#*[[:space:]]*${1%%=*}=/d" "$OUT"; rm -f "${OUT}.bak"
+        echo "$1" >> "$OUT"
+    }
+    _prod_set "MCP_PROXY_SECRET_BACKEND=vault"
+    _prod_set "MCP_PROXY_KMS_BACKEND=vault"
+    _prod_set "MCP_PROXY_DB_ENCRYPTION_KEY=$(gen_secret)$(gen_secret)"   # 64 chars, over the >=32 floor
+    _prod_set "MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=$(gen_secret)$(gen_secret)"
+    _prod_set "MCP_PROXY_EGRESS_DPOP_MODE=required"
+    # Single-Mastio pilot WebAuthn posture: explicit opt-in to the warn
+    # default (no IdP-backed user registration yet). Track a sunset date.
+    _prod_set "MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true"
+    ok "Production: minted DB_ENCRYPTION_KEY + PDP HMAC, secret/KMS backend=vault, DPoP=required, webauthn opt-in"
+    warn "Production needs a Vault: set MCP_PROXY_VAULT_ADDR + MCP_PROXY_VAULT_TOKEN in ${OUT} before deploy (KMS custodies the Org CA key)."
+fi
+
 ok "Wrote ${OUT}"
 echo ""
 echo -e "  ${BOLD}MCP_PROXY_ADMIN_SECRET${RESET}      ${GRAY}${ADMIN_SECRET:0:8}...${RESET}"


### PR DESCRIPTION
## Context

Prod-shape stress test (2026-06-04) found `deploy --prod` set `environment=production` and then **SystemExit'd at boot**: `validate_config` requires `DB_ENCRYPTION_KEY`, `PDP_WEBHOOK_HMAC_SECRET`, a WebAuthn posture and vault-backed secret/KMS, but the `deploy/compose` path **neither minted nor mapped them**. The operator couldn't satisfy the gates without hand-editing `proxy.env` — a regression of the #1021 FINDING-MASTER, on the `deploy/compose` stack (the bundle already forwarded them).

## Change (close the deploy/compose ↔ bundle parity gap)

- **`scripts/generate-proxy-env.sh --prod`** mints `DB_ENCRYPTION_KEY` (64 chars), `PDP_WEBHOOK_HMAC_SECRET`, sets secret/KMS backend = vault, `EGRESS_DPOP_MODE=required`, and the WebAuthn warn opt-in. Vault addr + token still come from the operator (KMS custodies the Org CA key).
- **`deploy/compose/docker-compose.proxy.yml`** maps those secrets + `KMS_BACKEND` + the WebAuthn knobs into the container `environment:` (compose only delivers env-file values that are mapped there — the same gap that hit Redis/nonce).
- **`proxy.env.example`** documents the production hardening block.

## Verification

`generate-proxy-env.sh --prod` emits a `proxy.env` with every gate secret populated (`SECRET_BACKEND=vault`, `KMS_BACKEND=vault`, `DB_ENCRYPTION_KEY`, `PDP_WEBHOOK_HMAC_SECRET`, `EGRESS_DPOP_MODE=required`, `WEBAUTHN_WARN_INSECURE_OK=true`, `DPOP_NONCE_SECRET`); `docker compose config` resolves the mappings. No Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)