### PR TITLE
fix(enrollment): graceful 429 + upstream-saturation handling under enroll storm (S-3)

### DIFF
--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -53,6 +53,13 @@ router = APIRouter(tags=["enrollment"])
 _ENROLLMENT_START_PER_MINUTE = 5
 _ENROLLMENT_STATUS_PER_MINUTE = 60
 
+# S-3 — when the per-IP limiter trips, hand the caller a Retry-After so a
+# fleet enroll backs off instead of hammering (and so the SDK / curl loop
+# can honour it). Sized to the limiter window: ~one slot frees per
+# 60/limit seconds, rounded up to a calm retry cadence.
+_ENROLLMENT_START_RETRY_AFTER_S = 60
+_ENROLLMENT_STATUS_RETRY_AFTER_S = 10
+
 
 def _client_ip(request: Request) -> str:
     client = request.client
@@ -113,6 +120,7 @@ async def start_enrollment(
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="enrollment rate limit exceeded",
+            headers={"Retry-After": str(_ENROLLMENT_START_RETRY_AFTER_S)},
         )
 
     try:
@@ -250,6 +258,7 @@ async def attestation_nonce(request: Request) -> dict[str, object]:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="attestation nonce rate limit exceeded",
+            headers={"Retry-After": str(_ENROLLMENT_STATUS_RETRY_AFTER_S)},
         )
     issued = await issue_nonce()
     return {
@@ -274,6 +283,7 @@ async def enrollment_status(
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="enrollment status rate limit exceeded",
+            headers={"Retry-After": str(_ENROLLMENT_STATUS_RETRY_AFTER_S)},
         )
 
     try:

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -55,6 +55,25 @@ server {
 
     client_max_body_size 4m;
 
+    # ── S-3: graceful upstream-saturation handling ──────────────────
+    # Under an enroll storm the single mcp-proxy worker pool (512M/1cpu in
+    # the prod profile) can momentarily refuse or time out connections.
+    # nginx then synthesises a bare 502/504 the caller cannot act on (the
+    # stress test saw an opaque upstream error on POST /proxy/enrollments/
+    # .../approve). Reshape nginx-generated upstream errors into a 503 +
+    # Retry-After so a fleet enroll / SDK loop backs off instead of
+    # treating it as fatal. proxy_intercept_errors stays OFF on purpose:
+    # a genuine 5xx FROM the app (a real bug) passes through untouched and
+    # stays visible — we only reshape the errors nginx itself raises when
+    # the upstream is unreachable/timed-out.
+    error_page 502 504 = @upstream_degraded;
+    location @upstream_degraded {
+        internal;
+        default_type application/json;
+        add_header Retry-After 5 always;
+        return 503 '{"detail":"Mastio upstream busy — retry shortly","retry_after_s":5}';
+    }
+
     # ──────────────────────────────────────────────────────────────────
     # mTLS-required (TLS-layer agent identity)
     # ──────────────────────────────────────────────────────────────────

--- a/test/unit/test_enrollment_rate_limit_retry_after.py
+++ b/test/unit/test_enrollment_rate_limit_retry_after.py
@@ -1,0 +1,60 @@
+"""S-3 — enrollment rate-limit 429s carry a Retry-After header.
+
+Prod-shape stress test (2026-06-04): a 40-agent fleet enroll tripped the
+per-IP limiter on /v1/enrollment/{start,status,attestation-nonce} and the
+server answered a bare 429 with no Retry-After, so the SDK / curl loop kept
+hammering instead of backing off. The fix attaches Retry-After to every
+enrollment 429 so a fleet enroll degrades gracefully.
+
+These tests force the limiter to deny and assert the header is present and
+parses as a positive integer (seconds).
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.enrollment.router import router as enrollment_router
+
+# ``mcp_proxy.enrollment`` re-exports the APIRouter as ``.router``, which
+# shadows the submodule on attribute access — so reach the real module
+# (where ``get_agent_rate_limiter`` is bound) via sys.modules to patch it.
+_router_mod = sys.modules["mcp_proxy.enrollment.router"]
+
+
+class _DenyingRateLimiter:
+    """Stand-in limiter whose check always denies, to hit the 429 path."""
+
+    async def check(self, key: str, limit: int) -> bool:  # noqa: ARG002
+        return False
+
+
+@pytest.fixture
+def client(monkeypatch) -> TestClient:
+    monkeypatch.setattr(
+        _router_mod, "get_agent_rate_limiter",
+        lambda: _DenyingRateLimiter(),
+    )
+    app = FastAPI()
+    app.include_router(enrollment_router)
+    return TestClient(app)
+
+
+def _assert_retry_after(resp) -> None:
+    assert resp.status_code == 429, resp.text
+    retry = resp.headers.get("Retry-After")
+    assert retry is not None, "429 must carry a Retry-After header (S-3)"
+    assert retry.isdigit() and int(retry) > 0, f"Retry-After not a positive int: {retry!r}"
+
+
+def test_attestation_nonce_429_has_retry_after(client: TestClient) -> None:
+    _assert_retry_after(client.get("/v1/enrollment/attestation-nonce"))
+
+
+def test_status_429_has_retry_after(client: TestClient) -> None:
+    # The limiter denies before the session is ever looked up, so an
+    # arbitrary session_id is fine — the 429 fires first.
+    _assert_retry_after(client.get("/v1/enrollment/whatever-sid/status"))


### PR DESCRIPTION
## Context

Prod-shape stress test (2026-06-04): a 40-agent fleet enroll tripped the per-IP limiter and saturated the single 512M/1cpu mcp-proxy worker. Status polls returned a **bare 429 (no Retry-After**, so the SDK/curl loop kept hammering) and `POST /proxy/enrollments/.../approve` surfaced an **opaque upstream error** the caller couldn't act on. The steady-state 40-agent loop does NOT saturate — only the concurrent enroll storm does.

## Change (two non-speculative graceful-degradation fixes)

- **`enrollment/router.py`** — the `start` / `status` / `attestation-nonce` 429s now carry a `Retry-After` header (sized to the limiter window) so a fleet enroll backs off instead of busy-looping.
- **`nginx/mastio/mastio.conf`** — map nginx-generated `502/504` (upstream unreachable / timed out under load) to a `503` + `Retry-After` via an `@upstream_degraded` named location. **`proxy_intercept_errors` stays OFF** so a genuine 5xx *from the app* still passes through and stays visible — we only reshape errors nginx itself raises when the worker is saturated.

## Tests

- `test_enrollment_rate_limit_retry_after` pins `Retry-After` on the 429s (14 passed across the enrollment suite).
- nginx config parses clean (only the test-env upstream DNS is absent).

## Honest limitation

If the approve 500 originates **inside the app** (a DB-pool / timeout exception) rather than from an unreachable upstream, pinning its exact cause needs the traceback from a live repro. This PR makes the two *expected* degradations (rate-limit + upstream saturation) graceful and recommends **paced/serial enroll** for large fleets on the 512M/1cpu profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)