### PR TITLE
fix(bundle): graceful 502/504->503 in bundle nginx (S-3 parity)

### DIFF
--- a/packaging/mastio-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-bundle/nginx/mastio/mastio.conf
@@ -72,6 +72,26 @@ server {
 
     client_max_body_size 4m;
 
+    # ── S-3: graceful upstream-saturation handling ──────────────────
+    # Under an enroll storm the single mcp-proxy worker pool (512M/1cpu in
+    # the prod profile) can momentarily refuse or time out connections.
+    # nginx then synthesises a bare 502/504 the caller cannot act on (the
+    # stress test saw an opaque upstream error on POST /proxy/enrollments/
+    # .../approve). Reshape nginx-generated upstream errors into a 503 +
+    # Retry-After so a fleet enroll / SDK loop backs off instead of
+    # treating it as fatal. proxy_intercept_errors stays OFF on purpose:
+    # a genuine 5xx FROM the app (a real bug) passes through untouched and
+    # stays visible — we only reshape the errors nginx itself raises when
+    # the upstream is unreachable/timed-out. Mirrors deploy/compose's
+    # nginx/mastio/mastio.conf (S-3 PR #1052).
+    error_page 502 504 = @upstream_degraded;
+    location @upstream_degraded {
+        internal;
+        default_type application/json;
+        add_header Retry-After 5 always;
+        return 503 '{"detail":"Mastio upstream busy — retry shortly","retry_after_s":5}';
+    }
+
     # ──────────────────────────────────────────────────────────────────
     # Forwarded-Host / Forwarded-Port propagation (D-12)
     # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Context

S-3 (#1052) added the `@upstream_degraded` reshape (nginx-generated 502/504 → 503 + Retry-After) to **`deploy/compose`'s** `nginx/mastio/mastio.conf`, but missed the **bundle's own copy** (`packaging/mastio-bundle/nginx/mastio/mastio.conf`) — which is what the prod-shape dogfood actually runs. Same bundle-vs-deploy/compose parity gap as Redis (S-4) / nonce (S-7) / secrets (S-1).

## Change

Mirror the `error_page 502 504 = @upstream_degraded` block into the bundle nginx config. `proxy_intercept_errors` stays OFF so a genuine app 5xx still surfaces.

## Validated live on mastio-demo (bundle stack)

- Rate-limit: 75× `/v1/enrollment/status` → 60×404 then **15×429, all `Retry-After: 10`**.
- Upstream saturation (mcp-proxy stopped): nginx returns **`HTTP/2 503` + `Retry-After: 5`** with body `{"detail":"Mastio upstream busy — retry shortly"}` instead of an opaque 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)