### PR TITLE
fix(resilience): 503 + Retry-After on runtime dependency loss (closes #1054)

### DIFF
--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -68,6 +68,15 @@ def _engine_kwargs(url: str) -> dict:
             pool_size=20,
             max_overflow=10,
             pool_timeout=5.0,
+            # Issue #1054 — bound each statement so a stalled Postgres (paused,
+            # network-partitioned, failing over) fails the query in bounded
+            # time instead of hanging the worker until the client read-timeout.
+            # asyncpg raises on command_timeout; SQLAlchemy wraps it as
+            # OperationalError, which the app maps to 503 + Retry-After. 15s is
+            # generous enough not to clip legitimate runtime queries (audit
+            # writes/lookups are sub-second); alembic runs on a separate sync
+            # engine and is unaffected.
+            connect_args={"command_timeout": 15},
         )
     return kwargs
 
@@ -441,7 +450,12 @@ async def init_db(db_url: str) -> None:
         # In-memory SQLite (tests). Single-process by definition.
         await asyncio.to_thread(_run_migrations_sync, url)
 
-    _engine = create_async_engine(url, echo=False, future=True)
+    # Issue #1054 — the runtime engine MUST carry the pool + statement-timeout
+    # bounds from ``_engine_kwargs`` (this post-migration assignment previously
+    # dropped them, so a stalled Postgres hung the worker unbounded). alembic
+    # already ran above on its own sync engine, so applying the bounds here is
+    # safe for migrations.
+    _engine = create_async_engine(url, **_engine_kwargs(url))
     if _engine.dialect.name == "sqlite":
         async with _engine.begin() as conn:
             await conn.execute(text("PRAGMA journal_mode=WAL"))

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -18,7 +18,13 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from redis.exceptions import RedisError as _RedisError
 from sqlalchemy import text
+from sqlalchemy.exc import (
+    InterfaceError as _SAInterfaceError,
+    OperationalError as _SAOperationalError,
+    TimeoutError as _SATimeoutError,
+)
 
 from mcp_proxy.config import get_settings, validate_config
 from mcp_proxy.db import dispose_db, get_db, init_db
@@ -1751,6 +1757,46 @@ app = FastAPI(
 # ─────────────────────────────────────────────────────────────────────────────
 # Exception handler
 # ─────────────────────────────────────────────────────────────────────────────
+
+# Issue #1054 — when a hard backing dependency drops at *runtime* the request
+# path fails closed (correct), but a bare 500 (Redis) or a hung worker
+# (Postgres) is not graceful. Reshape these into a fast 503 + Retry-After so an
+# SDK / agent loop backs off cleanly and an LB can retry, while fail-closed
+# stays fail-closed — the action is never granted, only the response *shape*
+# changes. We log the exception *class* (never str(exc), which could carry a
+# connection string) and return a generic body (no leak, H-IO-2).
+_DEPENDENCY_RETRY_AFTER_S = 5
+
+
+def _dependency_unavailable(request: Request, exc: Exception, dependency: str) -> JSONResponse:
+    _log.warning(
+        "%s unavailable on %s %s (%s) — returning 503 Service Unavailable",
+        dependency, request.method, request.url.path, exc.__class__.__name__,
+    )
+    return JSONResponse(
+        status_code=503,
+        content={"detail": f"{dependency} temporarily unavailable — retry shortly"},
+        headers={"Retry-After": str(_DEPENDENCY_RETRY_AFTER_S)},
+    )
+
+
+@app.exception_handler(_RedisError)
+async def redis_unavailable_handler(request: Request, exc: Exception) -> JSONResponse:
+    # DPoP JTI store / login-challenge store / rate limiter backing. A
+    # ConnectionError here means Redis dropped after a clean boot.
+    return _dependency_unavailable(request, exc, "Security store")
+
+
+@app.exception_handler(_SAOperationalError)
+@app.exception_handler(_SAInterfaceError)
+@app.exception_handler(_SATimeoutError)
+async def database_unavailable_handler(request: Request, exc: Exception) -> JSONResponse:
+    # OperationalError / InterfaceError: DB unreachable or connection lost.
+    # sqlalchemy TimeoutError: pool exhausted (every connection blocked on a
+    # query against a stalled DB). asyncpg command_timeout surfaces as
+    # OperationalError, so a hung query is bounded and lands here too.
+    return _dependency_unavailable(request, exc, "Database")
+
 
 @app.exception_handler(Exception)
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/test/unit/test_dependency_unavailable_503.py
+++ b/test/unit/test_dependency_unavailable_503.py
@@ -1,0 +1,84 @@
+"""Issue #1054 — hard-dependency outage at runtime returns 503 + Retry-After.
+
+When Redis or Postgres drops *after* a clean boot, the request path fails
+closed (correct), but a bare 500 (Redis) or a hung worker (Postgres) is not
+graceful. main.py reshapes the relevant exceptions into a fast 503 +
+Retry-After so an SDK / agent loop backs off and a load balancer can retry —
+without granting the action (fail-closed stays fail-closed) and without
+leaking the exception detail (H-IO-2).
+
+These tests pin:
+  1. the redis / sqlalchemy exception types are registered on the app, and
+  2. the 503 response carries Retry-After + a generic body that does NOT echo
+     the underlying exception message.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.requests import Request
+
+
+@pytest.fixture
+def main_mod(monkeypatch):
+    """Import mcp_proxy.main with the minimum env it needs to construct
+    ProxySettings (admin secret gate) and skip the migration boot path."""
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-secret-not-the-default")
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    import mcp_proxy.main as m
+    return m
+
+
+def test_dependency_exception_handlers_registered(main_mod):
+    from redis.exceptions import RedisError
+    from sqlalchemy.exc import (
+        InterfaceError,
+        OperationalError,
+        TimeoutError as SATimeoutError,
+    )
+
+    handlers = main_mod.app.exception_handlers
+    # The four runtime-dependency exception types map to a 503 handler...
+    assert RedisError in handlers
+    assert OperationalError in handlers
+    assert InterfaceError in handlers
+    assert SATimeoutError in handlers
+    # ...and the generic 500 fallback is still present for everything else.
+    assert Exception in handlers
+
+
+def _fake_request() -> Request:
+    return Request({
+        "type": "http", "method": "POST", "path": "/v1/llm/chat", "headers": [],
+    })
+
+
+def test_503_carries_retry_after_and_no_leak(main_mod):
+    """The 503 body is generic; the exception message must not leak (it could
+    carry a connection string)."""
+    secret_looking = "postgresql://user:SUPERSECRET@db:5432/x command failed"
+    resp = main_mod._dependency_unavailable(
+        _fake_request(), RuntimeError(secret_looking), "Database",
+    )
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == str(main_mod._DEPENDENCY_RETRY_AFTER_S)
+    body = json.loads(bytes(resp.body))
+    assert "temporarily unavailable" in body["detail"]
+    # H-IO-2 — the raw exception text (and any secret in it) must NOT appear.
+    assert "SUPERSECRET" not in bytes(resp.body).decode()
+    assert secret_looking not in bytes(resp.body).decode()
+
+
+def test_redis_and_db_dependency_labels(main_mod):
+    redis_resp = main_mod._dependency_unavailable(
+        _fake_request(), RuntimeError("x"), "Security store",
+    )
+    db_resp = main_mod._dependency_unavailable(
+        _fake_request(), RuntimeError("x"), "Database",
+    )
+    assert redis_resp.status_code == db_resp.status_code == 503
+    assert "Security store" in json.loads(bytes(redis_resp.body))["detail"]
+    assert "Database" in json.loads(bytes(db_resp.body))["detail"]


### PR DESCRIPTION
## Context

Closes #1054. Prod-shape resilience testing (chaos axis) found that when a hard backing dependency drops **after** a clean boot, the request path fails closed (correct) but the *shape* of the failure is not graceful:

- **Redis down** → `POST /v1/llm/chat` returns a bare **500** (DPoP JTI store raises `redis.ConnectionError`), no signal to back off.
- **Postgres down** → the request **hangs** until the client read-timeout. Root cause: the post-migration runtime engine was rebuilt **without** the `_engine_kwargs` bounds (`pool_timeout` silently dropped) and had no statement timeout, so a stalled DB blocked the worker unbounded.

## Change (response shape only — fail-closed stays fail-closed)

- **`main.py`**: map `redis.RedisError` and SQLAlchemy `OperationalError` / `InterfaceError` / `TimeoutError` to **`503` + `Retry-After`** via dedicated handlers, ahead of the generic 500 handler. Body is generic and logs the exception **class only** (never `str(exc)`, which could carry a connection string) — H-IO-2 no-leak preserved.
- **`db.py`**: the runtime engine now carries `_engine_kwargs` (restoring `pool_timeout`) and adds asyncpg `command_timeout=15`, so a stalled Postgres fails the query in bounded time → `OperationalError` → 503. alembic runs on a separate sync engine and is unaffected.

The action is never granted — only the response code changes. Mirrors the 503 + Retry-After reshape already shipped for the enroll path (PR #1052/#1053).

## Tests

`test_dependency_unavailable_503.py`: handlers registered, 503 + Retry-After, and the exception message (incl. a secret-looking connection string) does **not** leak into the body.

> Note: the one failing `@pytest.mark.postgres` test (`test_full_chain` head assertion) is a **pre-existing stale assertion** (expects `0042/0043`, chain is at `0045`) — verified unrelated to this change via stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)