### PR TITLE
fix(readyz): not-ready when Redis backing store is down (closes #1055)

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -2735,6 +2735,29 @@ async def readyz():
             {"status": "not_ready", "checks": checks}, status_code=503,
         )
 
+    # Redis backing store (issue #1055). The DPoP JTI replay cache and the
+    # login-challenge store live in Redis; when it is the configured backing
+    # (production, multi-worker) a Redis outage makes the auth path fail
+    # closed (issue #1054) while the process stays live — so readyz must
+    # report not-ready and let the LB drain this worker, then re-admit it
+    # automatically when Redis recovers. Skip when Redis isn't configured
+    # (dev, or the single-worker in-memory opt-in): there is nothing to
+    # drain to. Bounded ping so a stalled Redis doesn't hang the probe;
+    # log the exception class only (no connection-string leak).
+    from mcp_proxy.redis.pool import get_redis
+    _redis = get_redis()
+    if _redis is not None:
+        try:
+            await asyncio.wait_for(_redis.ping(), timeout=2.0)
+            checks["redis"] = "ok"
+        except Exception as exc:
+            checks["redis"] = f"error: {type(exc).__name__}"
+            return JSONResponse(
+                {"status": "not_ready", "checks": checks}, status_code=503,
+            )
+    else:
+        checks["redis"] = "not_configured"
+
     # Standalone deploys have no broker, so no JWKS to check — skip.
     if get_settings().standalone:
         checks["jwks_cache"] = "standalone"

--- a/test/unit/test_readyz_redis_check.py
+++ b/test/unit/test_readyz_redis_check.py
@@ -1,0 +1,90 @@
+"""Issue #1055 — /readyz reflects the Redis backing store.
+
+/health is liveness (process up) and stays 200 during a backing-store
+outage so a transient blip doesn't restart-loop the pod. /readyz is
+readiness: it already checked the DB; this adds the Redis check so that
+when Redis is the configured backing (production, multi-worker) a Redis
+outage — which makes the DPoP JTI / login-challenge path fail closed
+(issue #1054) — reports not-ready and lets a load balancer drain the
+worker, then re-admit it automatically when Redis recovers.
+
+  Redis configured + reachable     → ready (200), redis: ok
+  Redis configured + down          → not_ready (503), redis: error
+  Redis not configured (dev/opt-in)→ ready (200), redis: not_configured
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+async def readyz_env(tmp_path, monkeypatch):
+    """Clean-boot, healthy-chain, DB-up environment so readyz reaches the
+    Redis check (everything before it must pass)."""
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-secret-not-the-default")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy import boot_state
+    boot_state.reset_boot_refusal()
+    from mcp_proxy.audit_chain import _reset_unhealthy_for_tests
+    _reset_unhealthy_for_tests()
+
+    from mcp_proxy.db import init_db, dispose_db
+    db_file = tmp_path / "readyz.sqlite"
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+class _OkRedis:
+    async def ping(self):
+        return True
+
+
+class _DownRedis:
+    async def ping(self):
+        raise ConnectionError("connection refused")
+
+
+@pytest.mark.asyncio
+async def test_readyz_ready_when_redis_reachable(readyz_env, monkeypatch):
+    monkeypatch.setattr("mcp_proxy.redis.pool.get_redis", lambda: _OkRedis())
+    from mcp_proxy.main import readyz
+
+    result = await readyz()
+    # Clean path returns a plain dict → 200.
+    assert isinstance(result, dict)
+    assert result["status"] == "ready"
+    assert result["checks"]["redis"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_readyz_503_when_redis_down(readyz_env, monkeypatch):
+    monkeypatch.setattr("mcp_proxy.redis.pool.get_redis", lambda: _DownRedis())
+    from mcp_proxy.main import readyz
+
+    resp = await readyz()
+    assert resp.status_code == 503
+    body = json.loads(bytes(resp.body))
+    assert body["status"] == "not_ready"
+    assert "redis" in body["checks"]
+    # No leak — the class name, not the raw "connection refused" message.
+    assert "connection refused" not in json.dumps(body)
+
+
+@pytest.mark.asyncio
+async def test_readyz_ready_when_redis_not_configured(readyz_env, monkeypatch):
+    # Dev / single-worker in-memory opt-in: get_redis() returns None.
+    monkeypatch.setattr("mcp_proxy.redis.pool.get_redis", lambda: None)
+    from mcp_proxy.main import readyz
+
+    result = await readyz()
+    assert isinstance(result, dict)
+    assert result["status"] == "ready"
+    assert result["checks"]["redis"] == "not_configured"


### PR DESCRIPTION
## Context

Closes #1055. Prod-shape resilience testing found `/health` stays 200 when a backing store is down — correct, it's liveness + boot-refusal and a transient blip must not restart-loop the pod. `/readyz` already checked the DB (`SELECT 1` → 503), but **did not check Redis**, so when Redis dropped the DPoP JTI / login-challenge path failed closed (#1054) while readyz kept reporting ready — no signal for an orchestrator/LB to drain the worker.

## Change

Add a bounded Redis ping to `/readyz`:
- Redis configured + reachable → `ready`, `redis: ok`
- Redis configured + down → **`503` `not_ready`**, so the LB drains this worker and re-admits it automatically on recovery
- Redis not configured (dev, or single-worker in-memory opt-in) → `ready`, `redis: not_configured` (nothing to drain to)

The ping is wrapped in `asyncio.wait_for(2s)` so a stalled Redis can't hang the probe, and logs the exception **class only** (no connection-string leak). `/health` (liveness) is unchanged.

## Tests

`test_readyz_redis_check.py`: ready / not-ready / not-configured paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)