### PR TITLE
fix(dashboard): server-side pagination for the audit log view

### DIFF
--- a/mcp_proxy/dashboard/audit_routes.py
+++ b/mcp_proxy/dashboard/audit_routes.py
@@ -428,49 +428,95 @@ async def audit_page(request: Request):
     # use the per-table equivalent when building WHERE clauses.
     local_audit_result_for = {"success": "ok", "ok": "ok", "error": "error", "denied": "denied"}
 
+    # Build each stream's WHERE once — reused by the paginated UNION and
+    # the COUNT. The same input filter maps to different columns per
+    # table (action↔event_type, status↔result), so the bind params have
+    # distinct names; ``agent_id`` is shared (same value either side).
+    a_conds: list[str] = []
+    t_conds: list[str] = []
+    params: dict[str, object] = {}
+    if agent_filter:
+        a_conds.append("agent_id = :agent_id")
+        t_conds.append("agent_id = :agent_id")
+        params["agent_id"] = agent_filter
+    if action_filter:
+        a_conds.append("action = :action_filter")
+        t_conds.append("event_type = :action_filter")
+        params["action_filter"] = action_filter
+    if status_filter:
+        a_conds.append("status = :status_filter")
+        t_conds.append("result = :result_filter")
+        params["status_filter"] = status_filter
+        params["result_filter"] = local_audit_result_for.get(status_filter, status_filter)
+    a_where = (" WHERE " + " AND ".join(a_conds)) if a_conds else ""
+    t_where = (" WHERE " + " AND ".join(t_conds)) if t_conds else ""
+
+    want_admin = source_filter in ("", "admin")
+    want_traffic = source_filter in ("", "traffic")
+
+    # Server-side pagination (was a fixed LIMIT 500 per table → only the
+    # newest ~1000 rows were ever reachable; the rest of the archive was
+    # invisible regardless of page/filter). Project both tables onto one
+    # positional column set (every column either normalizer reads; NULL
+    # where not native to a stream) so a single UNION ALL can be ordered
+    # by timestamp and sliced with LIMIT/OFFSET across the whole archive.
+    # The per-source loops below then run unchanged — each reads only its
+    # own keys. ``duration_ms`` is cast to TEXT so the column types line
+    # up across the UNION on Postgres as well as SQLite.
+    _ADMIN_SELECT = (
+        "SELECT id, timestamp, agent_id, chain_seq, 'admin' AS source, "
+        "detail, action, status, tool_name, CAST(duration_ms AS TEXT) AS duration_ms, "
+        "request_id, row_hash, "
+        "CAST(NULL AS TEXT) AS details, CAST(NULL AS TEXT) AS event_type, "
+        "CAST(NULL AS TEXT) AS result, CAST(NULL AS TEXT) AS session_id, "
+        "CAST(NULL AS TEXT) AS org_id, CAST(NULL AS TEXT) AS entry_hash, "
+        "CAST(NULL AS TEXT) AS peer_org_id "
+        f"FROM audit_log{a_where}"
+    )
+    _TRAFFIC_SELECT = (
+        "SELECT id, timestamp, agent_id, chain_seq, 'traffic' AS source, "
+        "CAST(NULL AS TEXT) AS detail, CAST(NULL AS TEXT) AS action, "
+        "CAST(NULL AS TEXT) AS status, CAST(NULL AS TEXT) AS tool_name, "
+        "CAST(NULL AS TEXT) AS duration_ms, CAST(NULL AS TEXT) AS request_id, "
+        "CAST(NULL AS TEXT) AS row_hash, "
+        "details, event_type, result, session_id, org_id, entry_hash, peer_org_id "
+        f"FROM local_audit{t_where}"
+    )
+
+    if page < 1:
+        page = 1
+    page_offset = (page - 1) * per_page
+
     async with get_db() as db:
-        admin_rows: list[dict] = []
-        traffic_rows: list[dict] = []
+        # Totals per stream over the whole archive (drive total_pages and
+        # the stream badges, which now match the sidebar count instead of
+        # the loaded window).
+        admin_total = 0
+        traffic_total = 0
+        if want_admin:
+            r = await db.execute(text(f"SELECT COUNT(*) FROM audit_log{a_where}"), params)
+            admin_total = int(r.scalar() or 0)
+        if want_traffic:
+            r = await db.execute(text(f"SELECT COUNT(*) FROM local_audit{t_where}"), params)
+            traffic_total = int(r.scalar() or 0)
 
-        # Admin stream - legacy ``audit_log`` (auth, enroll, agent CRUD, policy...)
-        if source_filter in ("", "admin"):
-            a_conds: list[str] = []
-            a_params: dict[str, object] = {}
-            if agent_filter:
-                a_conds.append("agent_id = :agent_id")
-                a_params["agent_id"] = agent_filter
-            if action_filter:
-                a_conds.append("action = :action")
-                a_params["action"] = action_filter
-            if status_filter:
-                a_conds.append("status = :status")
-                a_params["status"] = status_filter
-            a_where = (" WHERE " + " AND ".join(a_conds)) if a_conds else ""
-            result = await db.execute(
-                text(f"SELECT * FROM audit_log{a_where} ORDER BY timestamp DESC LIMIT 500"),
-                a_params,
-            )
-            admin_rows = [dict(r) for r in result.mappings().all()]
-
-        # Traffic stream - hash-chained ``local_audit`` (oneshot, mcp, sessions)
-        if source_filter in ("", "traffic"):
-            t_conds: list[str] = []
-            t_params: dict[str, object] = {}
-            if agent_filter:
-                t_conds.append("agent_id = :agent_id")
-                t_params["agent_id"] = agent_filter
-            if action_filter:
-                t_conds.append("event_type = :event_type")
-                t_params["event_type"] = action_filter
-            if status_filter:
-                t_conds.append("result = :result")
-                t_params["result"] = local_audit_result_for.get(status_filter, status_filter)
-            t_where = (" WHERE " + " AND ".join(t_conds)) if t_conds else ""
-            result = await db.execute(
-                text(f"SELECT * FROM local_audit{t_where} ORDER BY timestamp DESC LIMIT 500"),
-                t_params,
-            )
-            traffic_rows = [dict(r) for r in result.mappings().all()]
+        # Time-ordered, paginated merge of the in-scope streams.
+        if want_admin and want_traffic:
+            union_sql = f"{_ADMIN_SELECT} UNION ALL {_TRAFFIC_SELECT}"
+        elif want_admin:
+            union_sql = _ADMIN_SELECT
+        else:
+            union_sql = _TRAFFIC_SELECT
+        page_sql = (
+            f"SELECT * FROM ({union_sql}) AS merged "
+            "ORDER BY timestamp DESC LIMIT :_limit OFFSET :_offset"
+        )
+        result = await db.execute(
+            text(page_sql), dict(params, _limit=per_page, _offset=page_offset)
+        )
+        page_rows = [dict(r) for r in result.mappings().all()]
+        admin_rows = [r for r in page_rows if r["source"] == "admin"]
+        traffic_rows = [r for r in page_rows if r["source"] == "traffic"]
 
         # Distinct actions + event_types for the filter dropdown.
         r1 = await db.execute(text("SELECT DISTINCT action FROM audit_log WHERE action IS NOT NULL"))
@@ -547,25 +593,25 @@ async def audit_page(request: Request):
         })
 
     # ISO-8601 strings sort correctly as plain strings, no parsing needed.
+    # ``unified`` already holds exactly the current page (the DB applied
+    # LIMIT/OFFSET); the sort just re-interleaves admin+traffic within it.
     unified.sort(key=lambda x: x["timestamp"] or "", reverse=True)
 
-    admin_total = sum(1 for e in unified if e["source"] == "admin")
-    traffic_total = len(unified) - admin_total
+    # Totals span the whole archive (from COUNT), so total_pages walks the
+    # entire log, not just a loaded window.
+    total = admin_total + traffic_total
+    total_pages = max(1, (total + per_page - 1) // per_page)
 
-    # ``view=grouped`` (default) → CISO-mode card view, one card per
-    # tool call. ``view=raw`` → maintainer-mode flat row table.
+    # ``view=grouped`` (default) → CISO-mode card view, one card per tool
+    # call. ``view=raw`` → maintainer-mode flat row table. Grouping now
+    # runs on the current page's rows; a tool-call's 3-row fan-out that
+    # straddles a page boundary may render as two partial cards across two
+    # pages — cosmetic, no row is lost.
     if view_mode == "grouped":
-        cards = _group_audit_events(unified)
-        total = len(cards)
-        total_pages = max(1, (total + per_page - 1) // per_page)
-        offset = (page - 1) * per_page
-        page_cards = cards[offset:offset + per_page]
+        page_cards = _group_audit_events(unified)
         entries = []  # raw-view list stays empty in grouped mode
     else:
-        total = len(unified)
-        total_pages = max(1, (total + per_page - 1) // per_page)
-        offset = (page - 1) * per_page
-        entries = unified[offset:offset + per_page]
+        entries = unified
         page_cards = []
 
     agents = await list_agents()

--- a/mcp_proxy/dashboard/audit_routes.py
+++ b/mcp_proxy/dashboard/audit_routes.py
@@ -400,6 +400,23 @@ def _group_audit_events(entries: list[dict]) -> list[dict]:
     return cards
 
 
+def _coerce_ms(value: Any) -> float | None:
+    """Coerce a ``duration_ms`` cell back to float (or None).
+
+    The paginated audit UNION casts ``duration_ms`` to TEXT so the admin
+    and traffic SELECTs line up column-type-wise on Postgres. The audit
+    template renders it with ``'%.1f' | format(...)``, which raises
+    ``TypeError: must be real number, not str`` on a TEXT value — so this
+    converts back, tolerating None / empty / non-numeric.
+    """
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @router.get("/audit", response_class=HTMLResponse)
 async def audit_page(request: Request):
     session = require_login(request)
@@ -539,7 +556,11 @@ async def audit_page(request: Request):
             "status": r.get("status"),
             "target": r.get("tool_name"),
             "tool_name": r.get("tool_name"),
-            "duration_ms": r.get("duration_ms"),
+            # ``duration_ms`` returns as TEXT from the paginated UNION (the
+            # CAST aligns admin/traffic column types for Postgres). The
+            # template formats it with ``'%.1f'``, which needs a real
+            # number, so coerce back to float here (None if absent/unparseable).
+            "duration_ms": _coerce_ms(r.get("duration_ms")),
             "request_id": r.get("request_id"),
             "endpoint_url": None,
             "session_id": None,

--- a/test/unit/test_audit_pagination_server_side.py
+++ b/test/unit/test_audit_pagination_server_side.py
@@ -51,14 +51,17 @@ async def seeded_audit_db(monkeypatch, tmp_path):
     for k in range(TOTAL):
         ts = f"2026-06-03T00:00:00.{k:06d}+00:00"
         if k % 2 == 0:
-            admin_rows.append({"ts": ts, "aid": f"acme::a{k}", "act": "auth.login", "st": "success"})
+            # ``dur`` populated so the paginated UNION's CAST(duration_ms AS
+            # TEXT) is exercised end-to-end (regression for the template's
+            # ``'%.1f'`` filter, which needs a real number not a TEXT cell).
+            admin_rows.append({"ts": ts, "aid": f"acme::a{k}", "act": "auth.login", "st": "success", "dur": 12.5})
         else:
             traffic_rows.append({"ts": ts, "aid": f"acme::t{k}", "evt": "tool_execute"})
 
     async with get_db() as db:
         await db.execute(
-            text("INSERT INTO audit_log (timestamp, agent_id, action, status) "
-                 "VALUES (:ts, :aid, :act, :st)"),
+            text("INSERT INTO audit_log (timestamp, agent_id, action, status, duration_ms) "
+                 "VALUES (:ts, :aid, :act, :st, :dur)"),
             admin_rows,
         )
         await db.execute(
@@ -135,6 +138,38 @@ async def test_page_one_interleaves_both_streams(seeded_audit_db):
     p1 = await _render("view=raw&page=1")
     sources = {e["source"] for e in p1["entries"]}
     assert sources == {"admin", "traffic"}, "merge must interleave both streams"
+
+
+def test_audit_route_maps_to_audit_page():
+    """The @router.get('/audit') decorator must decorate audit_page, not
+    a helper defined nearby — a misplaced decorator turned GET /audit into
+    a 422 ('value' field required, the _coerce_ms helper's param leaking
+    as a required query param). Direct-call tests can't catch this; assert
+    the route wiring."""
+    import mcp_proxy.dashboard.audit_routes as ar
+    routes = [r for r in ar.router.routes
+              if getattr(r, "path", None) == "/audit"
+              and "GET" in getattr(r, "methods", set())]
+    assert routes, "GET /audit route not registered"
+    assert routes[0].endpoint is ar.audit_page, \
+        "GET /audit must map to audit_page, not a helper"
+
+
+@pytest.mark.asyncio
+async def test_duration_ms_is_float_for_template(seeded_audit_db):
+    """The UNION casts duration_ms to TEXT (Postgres type-alignment); the
+    audit template renders it with ``'%.1f' | format(...)`` which raises
+    TypeError on a str. Regression for the live 500 — duration_ms must
+    reach the context as float (or None), never str."""
+    ctx = await _render("view=raw&page=1")
+    admin = [e for e in ctx["entries"] if e["source"] == "admin"]
+    assert admin, "expected admin rows on page 1"
+    for e in admin:
+        assert e["duration_ms"] is None or isinstance(e["duration_ms"], float), (
+            f"duration_ms must be float for the '%.1f' template filter, "
+            f"got {type(e['duration_ms']).__name__}={e['duration_ms']!r}"
+        )
+    assert any(e["duration_ms"] == 12.5 for e in admin), "seeded duration_ms not coerced"
 
 
 @pytest.mark.asyncio

--- a/test/unit/test_audit_pagination_server_side.py
+++ b/test/unit/test_audit_pagination_server_side.py
@@ -1,0 +1,145 @@
+"""Server-side pagination for the dashboard audit log.
+
+Before this fix ``audit_page`` loaded a fixed ``LIMIT 500`` from each of
+``audit_log`` and ``local_audit`` (the admin + traffic streams), merged
+the ≤1000 rows in memory, and paginated *that window*. So with 24k rows
+in the DB the dashboard could only ever reach the newest ~1000 — every
+page/filter combination was still capped, and the sidebar count (real
+COUNT) disagreed with the view.
+
+The fix projects both tables onto one positional column set and runs a
+single time-ordered ``UNION ALL`` sliced with ``LIMIT/OFFSET`` at the SQL
+layer, with the totals coming from ``COUNT(*)``. These tests pin:
+
+1. ``total`` equals the real row count across both tables and exceeds the
+   old 1000 cap; ``total_pages`` walks the whole archive.
+2. The page slice respects ``LIMIT/OFFSET``: page 1 and page 2 are
+   disjoint and ``per_page`` rows each.
+3. The OLDEST row is reachable on the last page (the regression — it was
+   unreachable under the fixed cap).
+4. Rows come back interleaved across streams in timestamp-DESC order.
+5. The ``source`` filter scopes the count + rows to one stream.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from starlette.datastructures import QueryParams
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+
+PER_PAGE = 50
+N_ADMIN = 600
+N_TRAFFIC = 600
+TOTAL = N_ADMIN + N_TRAFFIC  # 1200 — deliberately past the old 1000 cap
+
+
+@pytest.fixture
+async def seeded_audit_db(monkeypatch, tmp_path):
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-the-default")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    url = f"sqlite+aiosqlite:///{tmp_path / 'audit_paging.db'}"
+    await init_db(url)
+
+    # One global, strictly increasing timestamp per row, alternating
+    # streams (even index → admin, odd → traffic). The timestamp-DESC
+    # merge is then exactly the reverse of the global index, interleaved.
+    admin_rows = []
+    traffic_rows = []
+    for k in range(TOTAL):
+        ts = f"2026-06-03T00:00:00.{k:06d}+00:00"
+        if k % 2 == 0:
+            admin_rows.append({"ts": ts, "aid": f"acme::a{k}", "act": "auth.login", "st": "success"})
+        else:
+            traffic_rows.append({"ts": ts, "aid": f"acme::t{k}", "evt": "tool_execute"})
+
+    async with get_db() as db:
+        await db.execute(
+            text("INSERT INTO audit_log (timestamp, agent_id, action, status) "
+                 "VALUES (:ts, :aid, :act, :st)"),
+            admin_rows,
+        )
+        await db.execute(
+            text("INSERT INTO local_audit (timestamp, agent_id, event_type, result) "
+                 "VALUES (:ts, :aid, :evt, 'ok')"),
+            traffic_rows,
+        )
+        await db.commit()
+    yield url
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+async def _render(qs: str) -> dict:
+    """Invoke the real ``audit_page`` and capture the template context.
+
+    ``require_login`` and ``_ctx``/``TemplateResponse`` are stubbed so the
+    test exercises the query + pagination logic without an HTTP session or
+    Jinja render — the returned dict is the context the template sees.
+    """
+    import mcp_proxy.dashboard.audit_routes as ar
+
+    class _Req:
+        query_params = QueryParams(qs)
+
+    orig_login = ar.require_login
+    orig_ctx = ar._ctx
+    orig_tr = ar.templates.TemplateResponse
+    ar.require_login = lambda request: {"username": "admin"}
+    ar._ctx = lambda request, session, **kw: kw
+    ar.templates.TemplateResponse = lambda name, ctx: ctx
+    try:
+        return await ar.audit_page(_Req())
+    finally:
+        ar.require_login = orig_login
+        ar._ctx = orig_ctx
+        ar.templates.TemplateResponse = orig_tr
+
+
+@pytest.mark.asyncio
+async def test_total_spans_whole_archive_past_old_cap(seeded_audit_db):
+    ctx = await _render("view=raw&page=1")
+    assert ctx["total"] == TOTAL
+    assert ctx["total"] > 1000  # the old fixed-cap ceiling
+    assert ctx["admin_total"] == N_ADMIN
+    assert ctx["traffic_total"] == N_TRAFFIC
+    assert ctx["total_pages"] == (TOTAL + PER_PAGE - 1) // PER_PAGE  # 24
+
+
+@pytest.mark.asyncio
+async def test_pages_are_disjoint_and_full(seeded_audit_db):
+    p1 = await _render("view=raw&page=1")
+    p2 = await _render("view=raw&page=2")
+    assert len(p1["entries"]) == PER_PAGE
+    assert len(p2["entries"]) == PER_PAGE
+    ts1 = [e["timestamp"] for e in p1["entries"]]
+    ts2 = [e["timestamp"] for e in p2["entries"]]
+    assert set(ts1).isdisjoint(ts2)
+    # DESC order within and across the page boundary.
+    assert ts1 == sorted(ts1, reverse=True)
+    assert min(ts1) > max(ts2)
+
+
+@pytest.mark.asyncio
+async def test_oldest_row_reachable_on_last_page(seeded_audit_db):
+    last = await _render(f"view=raw&page={(TOTAL + PER_PAGE - 1) // PER_PAGE}")
+    oldest_ts = "2026-06-03T00:00:00.000000+00:00"
+    assert any(e["timestamp"] == oldest_ts for e in last["entries"]), \
+        "oldest row must be reachable — it was beyond the old 1000-row cap"
+
+
+@pytest.mark.asyncio
+async def test_page_one_interleaves_both_streams(seeded_audit_db):
+    p1 = await _render("view=raw&page=1")
+    sources = {e["source"] for e in p1["entries"]}
+    assert sources == {"admin", "traffic"}, "merge must interleave both streams"
+
+
+@pytest.mark.asyncio
+async def test_source_filter_scopes_count_and_rows(seeded_audit_db):
+    ctx = await _render("view=raw&page=1&source=admin")
+    assert ctx["total"] == N_ADMIN
+    assert ctx["traffic_total"] == 0
+    assert all(e["source"] == "admin" for e in ctx["entries"])


### PR DESCRIPTION
## Context

Found during the 48h soak: the audit dashboard capped the visible rows (`LIMIT 500` per table, paginated in memory), so on a 24k-row chain only the last ~1000 rows were reachable and the side badge count diverged from what the table could show.

## Change

Server-side pagination for `/proxy/audit`: SQL `LIMIT`/`OFFSET` over a `UNION ALL` of the audit tables + a real `COUNT`, so every row is reachable and the count is accurate. Also coerces the paginated `duration_ms` and fixes the `/audit` route wiring.

## Tests

`test_audit_pagination_server_side.py` (7 passed). Rebased clean on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)