### PR TITLE
feat(policy): enforce operator Rego tool_call policy on the executor path

### DIFF
--- a/mcp_proxy/policy/denied_reason_codes.py
+++ b/mcp_proxy/policy/denied_reason_codes.py
@@ -26,6 +26,11 @@ INSUFFICIENT_TIER = "insufficient_tier"
 # principal — covers REST + JSON-RPC ingress symmetrically (CRIT-2 fix).
 MISSING_BINDING = "missing_binding"
 
+# Operator's Rego policy returned decision=="deny" for this tool call.
+# Content-aware ABAC layered on top of the static capability+binding
+# gates — e.g. a rule on input.arguments (a specific customer_id/name).
+POLICY_DENIED = "policy_denied"
+
 # Catch-all for handler-side failures: timeouts, ToolExecutionError,
 # unexpected exceptions. Operator-facing detail lives in audit + logs.
 INTERNAL_ERROR = "internal_error"
@@ -35,5 +40,6 @@ ALL_CODES: frozenset[str] = frozenset({
     CAPABILITY_DENIED,
     INSUFFICIENT_TIER,
     MISSING_BINDING,
+    POLICY_DENIED,
     INTERNAL_ERROR,
 })

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -12,13 +12,14 @@ from typing import Any
 
 import httpx
 
-from mcp_proxy.db import log_audit
+from mcp_proxy.db import get_config, log_audit
 from mcp_proxy.models import TokenPayload, ToolExecuteRequest, ToolExecuteResponse
 from mcp_proxy.policy.denied_reason_codes import (
     CAPABILITY_DENIED,
     INSUFFICIENT_TIER,
     INTERNAL_ERROR,
     MISSING_BINDING,
+    POLICY_DENIED,
     TOOL_NOT_FOUND,
 )
 from mcp_proxy.policy.tier_eval import resolve_effective_tier
@@ -327,6 +328,94 @@ async def run(
                 execution_time_ms=duration_ms,
                 denied_reason_code=CAPABILITY_DENIED,
             )
+
+    # 2-rego. Operator Rego policy gate (tool_call surface).
+    #
+    # The capability gate above answers "may this principal call this
+    # CLASS of tool?". This gate lets the operator layer a content-aware
+    # ABAC rule on top — e.g. deny a specific ``customer_id`` / ``name``
+    # — through a Rego policy loaded from the dashboard. It evaluates the
+    # SAME ``cullis/policy/tool_call`` Rego (WASM) layer that the
+    # ``/v1/data/cullis/policy/tool_call`` bridge evaluates, now consulted
+    # INLINE on the agent's own tool-call path (the bridge is the external
+    # PDP-as-a-service surface; this is the internal enforcement point).
+    #
+    # PARITY CAVEAT: the bridge ALSO has a legacy ``tool_rules`` allowlist /
+    # blocklist (``blocked_tools`` / ``allowed_tools``, ADR-029) that runs
+    # as a fall-through when the Rego layer abstains. This gate consults
+    # ONLY the Rego WASM layer — it does NOT replicate that ``tool_rules``
+    # fall-through, which predates this gate (the executor never read
+    # ``tool_rules``). So a ``blocked_tools`` entry configured WITHOUT a
+    # compiled Rego is enforced on the bridge but NOT on the agent path.
+    # Follow-up: extend this gate to apply the ``tool_rules`` allowlist
+    # after a Rego ``None``, sharing the bridge's logic.
+    #
+    # Runs unconditionally (builtins + MCP resources), after the
+    # capability gate, so a principal lacking the capability still gets
+    # the more specific ``capability_denied`` first.
+    #
+    # Posture — backward compatible: ``try_rego_decision`` returns ``None``
+    # when no operator Rego is loaded, so deployments without a policy
+    # behave EXACTLY as before; only an explicit ``decision == "deny"``
+    # blocks. It also returns ``None`` on a Rego runtime error (soft
+    # fall-through, matching the session surface + the bridge), so a
+    # broken operator Rego cannot brick every previously-allowed call.
+    # Strict fail-closed on Rego eval errors is deliberate future work
+    # (see ``try_rego_decision`` docstring) and is called out for review.
+    from mcp_proxy.policy import try_rego_decision
+
+    rego_input = {
+        "agent_id": agent.agent_id,
+        "principal_type": principal_type,
+        "tool_name": tool_name,
+        "arguments": request.parameters,
+    }
+    try:
+        _rules_raw = await get_config("policy_rules")
+        _rego_rules = _json.loads(_rules_raw) if _rules_raw else {}
+        if not isinstance(_rego_rules, dict):
+            _rego_rules = {}
+    except Exception as _cfg_exc:  # noqa: BLE001
+        # Config read or JSON parse failed. Fall through to "no operator
+        # Rego" instead of breaking the call. The Rego layer is ADDITIVE
+        # over capability + binding (both still enforced below), so on a
+        # config-read error we degrade to the pre-feature posture — never
+        # to "no authorization". Catching broadly is deliberate: a narrow
+        # except would let a transient policy_rules read failure turn
+        # every tool call into an unhandled 500 (self-inflicted DoS).
+        _log.warning(
+            "policy_rules read failed (%s) — skipping Rego tool_call gate "
+            "for this call (capability + binding still enforced)",
+            type(_cfg_exc).__name__,
+        )
+        _rego_rules = {}
+    rego_decision = try_rego_decision(
+        _rego_rules, rego_input, surface="tool_call",
+    )
+    if rego_decision is not None and rego_decision.get("decision") == "deny":
+        duration_ms = _elapsed_ms(t0)
+        reason = rego_decision.get("reason") or "operator policy denied this tool call"
+        _log.warning(
+            "Rego policy denied tool '%s' for principal '%s': %s",
+            tool_name, agent.agent_id, reason,
+        )
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="tool_execute",
+            tool_name=tool_name,
+            status="denied",
+            detail=f"Rego policy deny: {reason}",
+            request_id=request_id,
+            duration_ms=duration_ms,
+        )
+        return ToolExecuteResponse(
+            request_id=request_id,
+            tool=tool_name,
+            status="error",
+            error=f"Forbidden by operator policy: {reason}",
+            execution_time_ms=duration_ms,
+            denied_reason_code=POLICY_DENIED,
+        )
 
     # 2a. Tier gate (ADR-032 Decision E / F5).
     #

--- a/test/unit/test_executor_denied_reason_codes.py
+++ b/test/unit/test_executor_denied_reason_codes.py
@@ -30,6 +30,7 @@ from mcp_proxy.policy.denied_reason_codes import (
     INSUFFICIENT_TIER,
     INTERNAL_ERROR,
     MISSING_BINDING,
+    POLICY_DENIED,
     TOOL_NOT_FOUND,
 )
 from mcp_proxy.policy.tier_matrix import TierMatrix
@@ -321,5 +322,6 @@ def test_all_codes_unique():
         CAPABILITY_DENIED,
         INSUFFICIENT_TIER,
         MISSING_BINDING,
+        POLICY_DENIED,
         INTERNAL_ERROR,
     })

--- a/test/unit/test_executor_rego_tool_call_gate.py
+++ b/test/unit/test_executor_rego_tool_call_gate.py
@@ -1,0 +1,236 @@
+"""Operator Rego policy gate on the executor's tool-call path.
+
+The executor authorises tool calls with capability + tier + binding —
+all STATIC (who you are, what device, what resource). This gate adds a
+content-aware ABAC layer: the operator loads a Rego policy
+(``cullis/policy/tool_call``) from the dashboard, and the executor now
+consults it INLINE with the call's ``arguments`` in the input, so a rule
+like "deny customer_id == CUST-00042" blocks the agent at runtime and
+lands a ``status=denied`` audit row — the same surface the
+``/v1/data/cullis/policy/tool_call`` bridge evaluates, but enforced on
+the agent's own path (the bridge is the external PDP-as-a-service view).
+
+The Rego ENGINE itself is covered by ``test_rego_engine`` + smoke
+30/35; here ``try_rego_decision`` is mocked so these tests pin the
+EXECUTOR gate behaviour:
+
+1. decision=deny → POLICY_DENIED, handler never runs, audit denied.
+2. the call's ``arguments`` reach the Rego input (the whole point — a
+   rule on customer_id/name is only possible if it sees them).
+3. no policy loaded (try_rego_decision → None) → call proceeds exactly
+   as before (backward compatible).
+4. decision=allow → call proceeds.
+5. a missing capability is denied FIRST — the Rego gate is never
+   reached (the more specific code wins, and a broken/permissive Rego
+   can't widen a capability deny).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.policy.denied_reason_codes import CAPABILITY_DENIED, POLICY_DENIED
+from mcp_proxy.policy.tier_matrix import TierMatrix
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+
+_TOOL_NAME = "get_customer_fixture"
+_TOOL_CAP = "mcp.core_banking.read"
+# A non-empty policy_rules JSON so the gate's get_config path is exercised;
+# try_rego_decision is mocked, so the contents past JSON-parse don't matter.
+_RULES_JSON = '{"rego_wasm_base64": "ZmFrZQ=="}'
+
+
+@pytest.fixture
+def clean_registry():
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+class _FakeSecrets:
+    async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
+        return {}
+
+
+def _agent(scope: list[str] | None = None) -> TokenPayload:
+    return TokenPayload(
+        sub="spiffe://cullis.test/acme::daniele",
+        agent_id="acme::daniele",
+        org="acme",
+        exp=9_999_999_999,
+        iat=0,
+        jti="jti-rego-gate",
+        scope=scope if scope is not None else [_TOOL_CAP],
+        cnf={"jkt": "fake-jkt"},
+        principal_type="agent",
+    )
+
+
+def _request(parameters: dict | None = None) -> ToolExecuteRequest:
+    return ToolExecuteRequest.model_construct(
+        tool=_TOOL_NAME,
+        parameters=parameters if parameters is not None else {},
+        request_id="rq-rego",
+    )
+
+
+def _register_tool(handler: AsyncMock | None = None) -> AsyncMock:
+    h = handler or AsyncMock(return_value={"ok": True})
+    tool_registry.register_definition(ToolDefinition(
+        name=_TOOL_NAME,
+        description="Rego gate fixture",
+        required_capability=_TOOL_CAP,
+        allowed_domains=[],
+        handler=h,
+        resource_id=None,
+    ))
+    return h
+
+
+def _tier_ok():
+    # Tier gate passes so execution reaches (or passes) the Rego gate.
+    matrix = TierMatrix(
+        version="test", default_min_tier="untrusted",
+        by_exact={}, by_prefix=(), source_path="<test>",
+    )
+    return SimpleNamespace(tier_matrix=matrix)
+
+
+@pytest.mark.asyncio
+async def test_rego_deny_blocks_call_and_audits(clean_registry):
+    handler = _register_tool()
+    rego = MagicMock(return_value={"decision": "deny", "reason": "customer off-limits"})
+    audit = AsyncMock()
+    with patch("mcp_proxy.tools.executor.resolve_effective_tier",
+               AsyncMock(return_value=("managed_attested", None))), \
+         patch("mcp_proxy.tools.executor.get_config",
+               AsyncMock(return_value=_RULES_JSON)), \
+         patch("mcp_proxy.policy.try_rego_decision", rego), \
+         patch("mcp_proxy.tools.executor.log_audit", audit):
+        resp = await executor.run(
+            request=_request({"customer_id": "CUST-00042"}),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=_tier_ok(),
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == POLICY_DENIED
+    assert "customer off-limits" in resp.error
+    handler.assert_not_awaited()  # tool must NOT run on a policy deny
+    # audit wrote a denied row for this tool
+    denied = [c for c in audit.await_args_list
+              if c.kwargs.get("status") == "denied"
+              and c.kwargs.get("tool_name") == _TOOL_NAME]
+    assert denied, "a denied audit row must be written"
+
+
+@pytest.mark.asyncio
+async def test_arguments_reach_the_rego_input(clean_registry):
+    _register_tool()
+    captured = {}
+
+    def _fake(rules, input_doc, *, surface):
+        captured["input"] = input_doc
+        captured["surface"] = surface
+        return {"decision": "deny", "reason": "x"}
+
+    with patch("mcp_proxy.tools.executor.resolve_effective_tier",
+               AsyncMock(return_value=("managed_attested", None))), \
+         patch("mcp_proxy.tools.executor.get_config",
+               AsyncMock(return_value=_RULES_JSON)), \
+         patch("mcp_proxy.policy.try_rego_decision", _fake), \
+         patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        await executor.run(
+            request=_request({"customer_id": "CUST-00042", "name": "Acme SpA"}),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=_tier_ok(),
+        )
+    assert captured["surface"] == "tool_call"
+    assert captured["input"]["arguments"] == {
+        "customer_id": "CUST-00042", "name": "Acme SpA",
+    }
+    assert captured["input"]["tool_name"] == _TOOL_NAME
+    assert captured["input"]["agent_id"] == "acme::daniele"
+
+
+@pytest.mark.asyncio
+async def test_no_policy_loaded_proceeds_as_before(clean_registry):
+    handler = _register_tool()
+    with patch("mcp_proxy.tools.executor.resolve_effective_tier",
+               AsyncMock(return_value=("managed_attested", None))), \
+         patch("mcp_proxy.tools.executor.get_config",
+               AsyncMock(return_value=None)), \
+         patch("mcp_proxy.policy.try_rego_decision", MagicMock(return_value=None)), \
+         patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_request({"customer_id": "CUST-00042"}),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=_tier_ok(),
+        )
+    assert resp.status == "success"
+    assert resp.denied_reason_code is None
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rego_allow_proceeds(clean_registry):
+    handler = _register_tool()
+    with patch("mcp_proxy.tools.executor.resolve_effective_tier",
+               AsyncMock(return_value=("managed_attested", None))), \
+         patch("mcp_proxy.tools.executor.get_config",
+               AsyncMock(return_value=_RULES_JSON)), \
+         patch("mcp_proxy.policy.try_rego_decision",
+               MagicMock(return_value={"decision": "allow"})), \
+         patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_request({"customer_id": "CUST-99999"}),
+            agent=_agent(),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=_tier_ok(),
+        )
+    assert resp.status == "success"
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capability_deny_wins_before_rego_gate(clean_registry):
+    """A principal without the capability is denied first; the Rego gate
+    is never reached, so a permissive/broken Rego can't widen it."""
+    _register_tool()
+    rego = MagicMock(return_value={"decision": "allow"})
+    with patch("mcp_proxy.tools.executor._load_principal_capabilities",
+               AsyncMock(return_value=set())), \
+         patch("mcp_proxy.policy.try_rego_decision", rego), \
+         patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_request({"customer_id": "CUST-1"}),
+            agent=_agent(scope=[]),
+            db=None,
+            secret_provider=_FakeSecrets(),
+            app_state=_tier_ok(),
+        )
+    assert resp.status == "error"
+    assert resp.denied_reason_code == CAPABILITY_DENIED
+    rego.assert_not_called()  # capability deny short-circuits before Rego


### PR DESCRIPTION
## Context

ABAC data-aware gating on the agent path: the executor previously gated only on capability + binding + tier, NOT on the operator Rego policy with the call arguments. So an operator policy like "deny tool_call when customer_id ∈ off-limits" was not enforced on the executor surface.

## Change

The executor now consults the operator Rego policy with the tool_call arguments before dispatch (deny e.g. by `customer_id`), with structured denied-reason codes. Additive — capability/binding/tier checks are unchanged; this adds the data-aware deny that was missing. Audit records the deny.

Security-reviewed previously as APPROVE-WITH-NOTES (additive, no weakening). Follow-up noted: the legacy `tool_rules` gap is not replicated here.

## Tests

`test_executor_denied_reason_codes.py` (11) + `test_executor_rego_tool_call_gate.py`. Rebased clean on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)