### PR TITLE
fix(dashboard): hide Court/federation UI in standalone mode

### DIFF
--- a/mcp_proxy/dashboard/agents_routes.py
+++ b/mcp_proxy/dashboard/agents_routes.py
@@ -104,11 +104,15 @@ async def agents_page(request: Request):
     org_status = await _refresh_org_status_from_broker()
     agents = await list_agents()
     has_ca = bool(await get_config("org_ca_cert"))
+    # Court / cross-org federation is uplink-gated: with no broker the proxy
+    # is standalone (open-core default) and the federation UI stays hidden.
+    federation_enabled = bool(await get_config("broker_url"))
 
     # Split by reach so the template can render two sections:
     # Federated (reach in {'cross','both'}) on top, Local (reach ==
     # 'intra') below. Peer-org agents live on /proxy/network now —
-    # this page is exclusively "my agents".
+    # this page is exclusively "my agents". In standalone mode the
+    # template ignores this split and lists ``agents`` in one table.
     federated_agents = [a for a in agents if a.get("reach", "both") != "intra"]
     local_agents = [a for a in agents if a.get("reach", "both") == "intra"]
 
@@ -118,6 +122,7 @@ async def agents_page(request: Request):
         agents=agents,
         federated_agents=federated_agents,
         local_agents=local_agents,
+        federation_enabled=federation_enabled,
         org_status=org_status,
         has_ca=has_ca,
         new_agent_id=None,
@@ -138,6 +143,10 @@ async def agents_create(request: Request):
     from mcp_proxy.egress.agent_manager import AgentManager
     from mcp_proxy.config import get_settings
 
+    # Court federation is uplink-gated; pass the flag through every render
+    # path so an error re-render keeps the same (standalone vs federated) UI.
+    federation_enabled = bool(await get_config("broker_url"))
+
     form = await request.form()
     agent_name = str(form.get("agent_name", "")).strip().lower().replace(" ", "_")
     display_name = str(form.get("display_name", "")).strip()
@@ -153,6 +162,7 @@ async def agents_create(request: Request):
             agents=agents,
             org_status=_org_status,
             has_ca=_has_ca,
+            federation_enabled=federation_enabled,
             error="Agent name and display name are required.",
             new_agent_id=None,
         ))
@@ -177,6 +187,7 @@ async def agents_create(request: Request):
                 agents=agents,
                 org_status=_org_status,
                 has_ca=False,
+                federation_enabled=federation_enabled,
                 error=(
                     "Org CA is not loaded — complete broker setup before "
                     "creating agents (the cert is the agent credential)."
@@ -201,6 +212,7 @@ async def agents_create(request: Request):
             agents=agents,
             org_status=_org_status,
             has_ca=_has_ca,
+            federation_enabled=federation_enabled,
             error=(
                 f"Agent name '{agent_name}' is already taken in this org. "
                 f"Pick a different name, or delete the existing agent first."
@@ -223,6 +235,7 @@ async def agents_create(request: Request):
             agents=agents,
             org_status=_org_status,
             has_ca=_has_ca,
+            federation_enabled=federation_enabled,
             error=(
                 "Failed to create the agent. Check the Mastio container "
                 "logs for the underlying cause."
@@ -252,6 +265,7 @@ async def agents_create(request: Request):
         request, session,
         active="agents",
         agents=agents,
+        federation_enabled=federation_enabled,
         org_status=org_status,
         has_ca=has_ca,
         new_agent_id=agent_id,

--- a/mcp_proxy/dashboard/core_routes.py
+++ b/mcp_proxy/dashboard/core_routes.py
@@ -385,6 +385,11 @@ async def overview_page(request: Request):
         org_id=org_id,
         display_name=display_name,
         broker_url=broker_url,
+        # Court / cross-org federation is an uplink-gated feature. With no
+        # broker uplink the proxy is standalone (open-core default), so every
+        # Court-facing element in the UI is hidden behind this flag. Flipping
+        # on a broker uplink brings the federation UI back automatically.
+        federation_enabled=bool(broker_url),
         org_status=org_status,
         local_count=local_count,
         local_active_count=local_active_count,

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -39,7 +39,8 @@
     <div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
     {% endif %}
 
-    <!-- Section tabs (in-page anchors) -->
+    {% if federation_enabled %}
+    <!-- Section tabs (in-page anchors) — federation mode only -->
     <div class="flex items-center justify-between gap-1 mb-6 border-b border-gray-800/60">
         <div class="flex items-center gap-1">
             <a href="#federated"
@@ -62,15 +63,24 @@
             Peer agents → Network
         </a>
     </div>
+    {% endif %}
 
     <!-- Header -->
     <div id="federated" class="flex items-center justify-between mb-6">
         <div>
+            {% if federation_enabled %}
             <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Federated Agents</h2>
             <p class="text-xs text-gray-600 mt-0.5">
                 {{ federated_agents | default([]) | length }} agent{% if (federated_agents | default([]) | length) != 1 %}s{% endif %}
                 exposed to other orgs via the Court registry
             </p>
+            {% else %}
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Agents</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                {{ agents | default([]) | length }} agent{% if (agents | default([]) | length) != 1 %}s{% endif %}
+                enrolled in this org
+            </p>
+            {% endif %}
         </div>
         <button onclick="document.getElementById('create-panel').classList.toggle('hidden')"
                 class="px-4 py-2 text-xs font-semibold rounded transition-all"
@@ -136,12 +146,12 @@
     </div>
 
     {#
-      Single row macro — used by both the Federated and Local tables.
-      ``reach`` controls the dropdown; we render it as a styled <select>
-      so it stays compact (one cell) while exposing the 3 states. The
-      form auto-submits on change — no separate save button needed.
+      Single row macro — used by the Federated, Local and (standalone)
+      Agents tables. ``show_reach`` adds the cross-org Reach selector;
+      it is suppressed in standalone mode where there is no Court to
+      publish to. ``cols`` keeps empty-state colspans in sync.
     #}
-    {% macro agent_row(agent, csrf_token) %}
+    {% macro agent_row(agent, csrf_token, show_reach=True) %}
     <tr class="table-row-hover transition-colors cursor-pointer"
         tabindex="0"
         onclick="window.location='/proxy/agents/{{ agent.agent_id }}'"
@@ -200,6 +210,7 @@
             </span>
             {% endif %}
         </td>
+        {% if show_reach %}
         <td class="px-5 py-4" onclick="event.stopPropagation()">
             {% set _reach = agent.reach | default('both') %}
             <form method="post" action="/proxy/agents/{{ agent.agent_id }}/reach" class="inline">
@@ -213,11 +224,12 @@
                 </select>
             </form>
         </td>
+        {% endif %}
         <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">{{ agent.created_at[:19] }}</td>
     </tr>
     {% endmacro %}
 
-    {% macro agents_thead() %}
+    {% macro agents_thead(show_reach=True) %}
     <thead>
         <tr class="border-b border-gray-800/60">
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Agent ID</th>
@@ -226,23 +238,27 @@
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Capabilities</th>
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Certificate</th>
+            {% if show_reach %}
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider" title="Who this agent can talk to: Local (same-org only), Federated (other orgs only), Both. Changes publish/unpublish on the Court.">Reach</th>
+            {% endif %}
             <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Created</th>
         </tr>
     </thead>
     {% endmacro %}
 
+    {% if federation_enabled %}
+    {% set _cols = 8 %}
     <!-- Federated agents table (reach in {cross, both}) -->
     <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-x-auto backdrop-blur-sm mb-10">
         <table class="w-full">
-            {{ agents_thead() }}
+            {{ agents_thead(show_reach=True) }}
             <tbody class="divide-y divide-gray-800/40">
                 {% for a in federated_agents %}
-                    {{ agent_row(a, csrf_token) }}
+                    {{ agent_row(a, csrf_token, show_reach=True) }}
                 {% endfor %}
                 {% if not federated_agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-10 text-center">
+                    <td colspan="{{ _cols }}" class="px-5 py-10 text-center">
                         <p class="text-sm text-gray-600">No federated agents on this proxy yet</p>
                         <p class="text-xs text-gray-700 mt-1">
                             Flip a local agent's <span class="text-gray-500">Reach</span> to
@@ -269,14 +285,14 @@
 
     <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-x-auto backdrop-blur-sm">
         <table class="w-full">
-            {{ agents_thead() }}
+            {{ agents_thead(show_reach=True) }}
             <tbody class="divide-y divide-gray-800/40">
                 {% for a in local_agents %}
-                    {{ agent_row(a, csrf_token) }}
+                    {{ agent_row(a, csrf_token, show_reach=True) }}
                 {% endfor %}
                 {% if not local_agents and not federated_agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-16 text-center">
+                    <td colspan="{{ _cols }}" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                         <p class="text-sm text-gray-600">No agents registered</p>
                         <p class="text-xs text-gray-700 mt-1">Create an agent to get started with the Mastio.</p>
@@ -284,7 +300,7 @@
                 </tr>
                 {% elif not local_agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-10 text-center">
+                    <td colspan="{{ _cols }}" class="px-5 py-10 text-center">
                         <p class="text-sm text-gray-600">No local-only agents</p>
                         <p class="text-xs text-gray-700 mt-1">
                             All of your agents are exposed cross-org. Flip an agent's Reach
@@ -296,6 +312,30 @@
             </tbody>
         </table>
     </div>
+
+    {% else %}
+    {% set _cols = 7 %}
+    <!-- Standalone mode: one table, all enrolled agents, no cross-org Reach -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-x-auto backdrop-blur-sm">
+        <table class="w-full">
+            {{ agents_thead(show_reach=False) }}
+            <tbody class="divide-y divide-gray-800/40">
+                {% for a in agents %}
+                    {{ agent_row(a, csrf_token, show_reach=False) }}
+                {% endfor %}
+                {% if not agents %}
+                <tr>
+                    <td colspan="{{ _cols }}" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                        <p class="text-sm text-gray-600">No agents registered</p>
+                        <p class="text-xs text-gray-700 mt-1">Create an agent to get started with the Mastio.</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
 
 </div>
 

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -105,7 +105,7 @@
         {% if org_id and standalone_mode %}
         <div class="mt-4 p-4 bg-surface-950/60 border border-gray-800/60 rounded">
             <div class="flex items-center justify-between gap-3 mb-2">
-                <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em]">Org ID (share with Court admin)</p>
+                <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em]">Org ID{% if federation_enabled %} (share with Court admin){% endif %}</p>
                 <button type="button"
                         data-copy="{{ org_id|e }}"
                         class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
@@ -115,8 +115,11 @@
             <code class="block text-sm text-white break-all" style="font-family: 'JetBrains Mono', monospace;">{{ org_id }}</code>
             <p class="mt-2 text-xs text-gray-500">
                 Deterministic — derived from this Mastio's Org CA public key.
+                Stable across restarts (ADR-006 §2.2).
+                {%- if federation_enabled %}
                 The Court admin pastes this into an <code>attach-ca</code> invite so
-                the uplink pins your identity across restarts (ADR-006 §2.2).
+                the uplink pins your identity.
+                {%- endif %}
             </p>
         </div>
         {% endif %}
@@ -164,7 +167,7 @@
                 <a href="/proxy/agents" class="text-[10px] text-accent-400 hover:text-accent-300 uppercase tracking-wider">Manage &rarr;</a>
             </div>
 
-            <div class="grid grid-cols-3 gap-3 mb-5">
+            <div class="grid {% if federation_enabled %}grid-cols-3{% else %}grid-cols-2{% endif %} gap-3 mb-5">
                 <div class="p-3 bg-surface-950/60 border border-gray-800/40 rounded">
                     <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Active</p>
                     <span class="text-2xl font-bold text-white" style="font-family: 'JetBrains Mono', monospace;">{{ local_active_count }}</span>
@@ -173,11 +176,13 @@
                     <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Total</p>
                     <span class="text-2xl font-bold text-gray-300" style="font-family: 'JetBrains Mono', monospace;">{{ local_count }}</span>
                 </div>
+                {% if federation_enabled %}
                 <div class="p-3 bg-surface-950/60 border border-gray-800/40 rounded">
                     <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Federated</p>
                     <span class="text-2xl font-bold text-gray-300" style="font-family: 'JetBrains Mono', monospace;">{{ federated_count }}</span>
                     <span class="text-[10px] text-gray-600 ml-1">/ {{ federated_orgs }} org{% if federated_orgs != 1 %}s{% endif %}</span>
                 </div>
+                {% endif %}
             </div>
 
             {% if recent_agents %}
@@ -252,20 +257,18 @@
 
     </div>
 
-    <!-- Broker uplink card -->
+    <!-- Broker uplink card — only when a broker uplink is configured -->
+    {% if federation_enabled %}
     <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
         <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-3">Court Uplink</p>
-        {% if broker_url %}
         <code class="text-sm text-accent-400 break-all" style="font-family: 'JetBrains Mono', monospace;">{{ broker_url }}</code>
         {% if fed_running %}
         <p class="mt-2 text-[11px] text-emerald-400">
             ● Federation sync running{% if fed_stats %} · seq {{ fed_stats.last_applied_seq }}{% endif %}
         </p>
         {% endif %}
-        {% else %}
-        <p class="text-sm text-gray-500">Standalone mode — no cross-org federation.</p>
-        {% endif %}
     </div>
+    {% endif %}
 
 </div>
 {% endblock %}


### PR DESCRIPTION
## Context

In standalone mode (no broker) the dashboard still rendered Court/federation UI elements (Overview + Agents), which is confusing for the single-product Mastio deployment where there is no Court.

## Change

Gate the Court/federation UI on `federation_enabled = bool(broker_url)` in the Overview and Agents pages, so a standalone Mastio shows no Court references. Federated deploys (broker_url set) are unchanged.

Render-validated: court=0 in standalone, federation UI intact when a broker is configured. Residual Court references in settings/mastio_key/link_broker/network are a follow-up.

## Tests

No new unit test (UI/template conditional); 30 existing dashboard/federation tests pass. Rebased clean on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)