### PR TITLE
fix(deploy): raise prod mcp-proxy memory cap from 512M to 2g

### DIFF
--- a/deploy/compose/docker-compose.proxy.prod.yml
+++ b/deploy/compose/docker-compose.proxy.prod.yml
@@ -26,14 +26,19 @@ services:
       MCP_PROXY_DASHBOARD_SIGNING_KEY:   ${MCP_PROXY_DASHBOARD_SIGNING_KEY:?MCP_PROXY_DASHBOARD_SIGNING_KEY is required in production proxy.env (run scripts/generate-proxy-env.sh --prod)}
       MCP_PROXY_BROKER_URL:              ${MCP_PROXY_BROKER_URL:?MCP_PROXY_BROKER_URL is required in production proxy.env}
       MCP_PROXY_PROXY_PUBLIC_URL:        ${MCP_PROXY_PROXY_PUBLIC_URL:?MCP_PROXY_PROXY_PUBLIC_URL is required in production proxy.env}
+    # mcp-proxy holds the audit hash-chain and per-agent crypto material in
+    # memory; the previous 512M cap OOMs around 40 concurrent agents at 4
+    # workers (roughly one MiB of headroom under that load). 2g matches the
+    # base compose and leaves room to grow. Scale memory with worker count
+    # and expected fleet size.
     deploy:
       resources:
         limits:
           cpus: "1.0"
-          memory: 512M
+          memory: 2g
         reservations:
           cpus: "0.25"
-          memory: 128M
+          memory: 256m
     logging:
       driver: "json-file"
       options:

--- a/packaging/mastio-bundle/docker-compose.prod.yml
+++ b/packaging/mastio-bundle/docker-compose.prod.yml
@@ -23,14 +23,19 @@ services:
       MCP_PROXY_ADMIN_SECRET:            ${MCP_PROXY_ADMIN_SECRET:?MCP_PROXY_ADMIN_SECRET is required in production proxy.env}
       MCP_PROXY_DASHBOARD_SIGNING_KEY:   ${MCP_PROXY_DASHBOARD_SIGNING_KEY:?MCP_PROXY_DASHBOARD_SIGNING_KEY is required in production proxy.env (run ./generate-proxy-env.sh --prod)}
       MCP_PROXY_PROXY_PUBLIC_URL:        ${MCP_PROXY_PROXY_PUBLIC_URL:?MCP_PROXY_PROXY_PUBLIC_URL is required in production proxy.env}
+    # mcp-proxy holds the audit hash-chain and per-agent crypto material in
+    # memory; the previous 512M cap OOMs around 40 concurrent agents at 4
+    # workers (roughly one MiB of headroom under that load). 2g matches the
+    # base compose and leaves room to grow. Scale memory with worker count
+    # and expected fleet size.
     deploy:
       resources:
         limits:
           cpus: "1.0"
-          memory: 512M
+          memory: 2g
         reservations:
           cpus: "0.25"
-          memory: 128M
+          memory: 256m
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Summary
- The production compose overlays capped `mcp-proxy` at **512M** while the base compose declares **2g**. The overlay wins, so every bundle/proxy prod deploy ran with the tight cap.
- Prod-shape soak measured ~511MiB resident at 40 concurrent agents on 4 workers, i.e. ~1MiB of headroom before OOM.
- Align both prod overlays (`packaging/mastio-bundle/` and `deploy/compose/`) with the base: limit **512M -> 2g**, reservation **128M -> 256m**. CPU unchanged (memory, not CPU, was the constraint).
- Inline comment documents the sizing rationale so the next operator scales memory with worker count / fleet size.

## Test plan
- [x] YAML parses; `mcp-proxy` limits/reservations confirmed `2g`/`256m` in both files
- [ ] CI: `helm-test` + smoke green