### PR TITLE
fix(audit): exclude mock anchors from the --require-anchors floor

### DIFF
--- a/scripts/cullis-audit-verify.py
+++ b/scripts/cullis-audit-verify.py
@@ -880,7 +880,7 @@ def verify_anchors(
     allow_unverified_signature: bool = False,
     max_age_days: int = 3650,
     skew_seconds: int = 300,
-) -> int:
+) -> tuple[int, int]:
     """For each anchor, recompute the expected row_hash at the anchor's
     chain_seq and cross-check against the anchor's claim + TSA token.
 
@@ -891,8 +891,15 @@ def verify_anchors(
     in that mode the anchor is downgraded to the F-A-405 pre-fix
     behaviour and a warning is emitted.
 
-    Returns count of verified anchors. Exits 3 on mismatch, 5 on
-    unverifiable token."""
+    Returns ``(verified, dispute_grade)``: total anchors that passed
+    plus the subset proven to **dispute grade** — i.e. backend label
+    ``rfc3161-verified`` (full CMS signature + chain to a trusted TSA
+    root + EKU + imprint + genTime). Forgeable ``MK|`` mock tokens and
+    the downgraded imprint-only / imprint-eku-only RFC 3161 modes count
+    toward ``verified`` but NOT toward ``dispute_grade``: an operator
+    who can rewrite the store can mint a mock token for any row, so a
+    mock anchor proves nothing against the operator. Exits 3 on
+    mismatch, 5 on unverifiable token."""
     # Map (org_id, chain_seq) -> entry.entry_hash for quick lookup.
     head_hash: dict[tuple[str, int], str] = {}
     for e in entries:
@@ -901,6 +908,7 @@ def verify_anchors(
             head_hash[(e.get("org_id") or "", seq)] = e["entry_hash"]
 
     verified = 0
+    dispute_grade = 0
     for a in anchors:
         key = (a["org_id"], a["chain_seq"])
         actual_head = head_hash.get(key)
@@ -943,7 +951,9 @@ def verify_anchors(
                   f"token backend={backend} failed verification")
             sys.exit(3)
         verified += 1
-    return verified
+        if backend == "rfc3161-verified":
+            dispute_grade += 1
+    return verified, dispute_grade
 
 
 def cross_reconcile(bundles: list[tuple[str, list[dict]]]) -> int:
@@ -1533,9 +1543,16 @@ def _load_json_file(path: str, label: str) -> dict:
     return obj
 
 
-def enforce_anchor_floor(require_anchors: bool, total_anchors: int) -> None:
-    """Reject a bundle with zero verified TSA anchors when the caller
+def enforce_anchor_floor(require_anchors: bool, dispute_grade_anchors: int) -> None:
+    """Reject a bundle with zero dispute-grade TSA anchors when the caller
     passed ``--require-anchors`` (exit 8).
+
+    ``dispute_grade_anchors`` counts only anchors verified to backend
+    ``rfc3161-verified`` (full CMS signature chained to a trusted TSA
+    root). Forgeable ``MK|`` mock tokens and the downgraded imprint-only
+    modes are deliberately excluded: an operator with write access can
+    mint a mock token for any row, so a mock anchor proves nothing
+    against the operator — the exact adversary this floor defends against.
 
     ``verify_chains`` proves the SHA-256 hash chain is internally
     consistent, but the chain is *self-asserted*: an operator with write
@@ -1552,17 +1569,18 @@ def enforce_anchor_floor(require_anchors: bool, total_anchors: int) -> None:
     anchoring leaves a trailing window of rows written since the last
     anchor. Use ``--merkle-proof`` / archive proofs for per-row coverage.
     """
-    if not require_anchors or total_anchors > 0:
+    if not require_anchors or dispute_grade_anchors > 0:
         return
     print("")
     print("✗ ANCHOR REQUIREMENT NOT MET")
     print("")
-    print("  --require-anchors was set, but the bundle carries zero verified")
-    print("  RFC 3161 TSA anchors. The hash chain is internally consistent,")
-    print("  but a self-asserted SHA-256 chain with no external timestamp can")
-    print("  be recomputed wholesale by anyone with write access to the audit")
-    print("  store. Without an anchor the bundle is tamper-evident against the")
-    print("  agent, not against the operator who holds the database.")
+    print("  --require-anchors was set, but the bundle carries zero")
+    print("  RFC 3161-verified TSA anchors (mock MK| tokens and downgraded")
+    print("  imprint-only anchors do not count). The hash chain is internally")
+    print("  consistent, but a self-asserted SHA-256 chain with no external")
+    print("  timestamp can be recomputed wholesale by anyone with write access")
+    print("  to the audit store. Without an anchor the bundle is tamper-evident")
+    print("  against the agent, not against the operator who holds the database.")
     print("")
     print("  Re-export with TSA anchoring enabled, or drop --require-anchors")
     print("  to accept chain-only (non-dispute-grade) verification.")
@@ -1697,7 +1715,9 @@ def main() -> int:
         action="store_true",
         help=(
             "Dispute-grade mode: fail (exit 8) unless the bundle carries "
-            "at least one verified RFC 3161 TSA anchor. Without this flag "
+            "at least one RFC 3161-verified TSA anchor (forgeable MK| mock "
+            "tokens and downgraded imprint-only anchors do not count). "
+            "Without this flag "
             "a chain with zero anchors still verifies (exit 0) — useful "
             "for dev/integrity-only checks, but a self-asserted SHA-256 "
             "chain with no external timestamp is tamper-evident against "
@@ -1713,13 +1733,14 @@ def main() -> int:
 
     bundles: list[tuple[str, list[dict]]] = []
     total_legacy = total_per_org = total_anchors = 0
+    total_dispute_grade = 0
     total_entries = 0
     total_orgs: set[str] = set()
     total_agents: set[str] = set()
     for path in args.bundle:
         entries, anchors = load_bundle(path)
         legacy_n, per_org_n, _agent_n = verify_chains(entries)
-        anchor_n = verify_anchors(
+        anchor_n, dispute_grade_n = verify_anchors(
             entries,
             anchors,
             trust_store_path=args.tsa_trust_store,
@@ -1730,6 +1751,7 @@ def main() -> int:
         total_legacy += legacy_n
         total_per_org += per_org_n
         total_anchors += anchor_n
+        total_dispute_grade += dispute_grade_n
         total_entries += len(entries)
         for e in entries:
             if e.get("org_id"):
@@ -1752,8 +1774,11 @@ def main() -> int:
     # is tamper-evident against the agent but not against an operator who
     # can rewrite the store and recompute every row_hash. Exits 8 under
     # --require-anchors; a no-op otherwise (chain-only verification stays
-    # exit 0 for dev / integrity-only callers).
-    enforce_anchor_floor(args.require_anchors, total_anchors)
+    # exit 0 for dev / integrity-only callers). Only RFC 3161-verified
+    # anchors clear the floor — forgeable MK| mock tokens and the
+    # downgraded imprint-only modes do not, since the operator who holds
+    # the store can mint those at will.
+    enforce_anchor_floor(args.require_anchors, total_dispute_grade)
 
     # CISO-readable PASS summary. The line breaks below are deliberate
     # so the auditor's terminal output reads like a verdict, not a CSV.
@@ -1766,6 +1791,11 @@ def main() -> int:
         f"{len(total_orgs)} org{'s' if len(total_orgs) != 1 else ''} · "
         f"{total_legacy} legacy · {total_per_org} per-org · "
         f"{total_anchors} TSA anchor{'s' if total_anchors != 1 else ''}"
+        + (
+            f" ({total_dispute_grade} dispute-grade)"
+            if total_anchors != total_dispute_grade
+            else ""
+        )
     )
     if cross_n:
         print(f"  {cross_n} cross-org peer row{'s' if cross_n != 1 else ''} reconciled")

--- a/test/unit/test_cullis_audit_verify_require_anchors.py
+++ b/test/unit/test_cullis_audit_verify_require_anchors.py
@@ -17,6 +17,7 @@ and not importable directly), mirroring the existing verifier tests.
 """
 from __future__ import annotations
 
+import base64
 import hashlib
 import importlib.util
 import json
@@ -74,6 +75,45 @@ def _valid_legacy_bundle(tmp_path) -> str:
     return str(path)
 
 
+def _mock_anchored_bundle(tmp_path) -> str:
+    """Write a one-row per-org bundle anchored with a forgeable ``MK|``
+    mock token. The chain verifies (verify_chains green) and the anchor
+    verifies (backend label ``mock``) — so the bundle carries ONE
+    verified TSA anchor but ZERO dispute-grade anchors. An operator with
+    write access can recompute the row and mint the matching mock token
+    at will, which is exactly why ``--require-anchors`` must reject this."""
+    entry = {
+        "id": 1,
+        "timestamp": "2026-06-05T00:00:00Z",
+        "event_type": "oneshot",
+        "agent_id": "acme::alice",
+        "org_id": "acme",
+        "result": "success",
+        "details": "",
+        "previous_hash": None,
+        "chain_seq": 1,
+    }
+    entry_hash = hashlib.sha256(
+        cli.canonical(entry, None).encode("utf-8")
+    ).hexdigest()
+    entry["entry_hash"] = entry_hash
+
+    # The verifier digests the anchor's row_hash (= entry_hash) and
+    # matches it against the MK| token's embedded digest.
+    digest_hex = hashlib.sha256(entry_hash.encode("ascii")).hexdigest()
+    mock_token = b"MK|" + digest_hex.encode("ascii") + b"|forged-by-operator"
+    anchor = {
+        "kind": "anchor",
+        "org_id": "acme",
+        "chain_seq": 1,
+        "row_hash": entry_hash,
+        "tsa_token_b64": base64.b64encode(mock_token).decode("ascii"),
+    }
+    path = tmp_path / "bundle.ndjson"
+    path.write_text(json.dumps(entry) + "\n" + json.dumps(anchor) + "\n")
+    return str(path)
+
+
 # ── enforce_anchor_floor (the pure gate) ────────────────────────────
 
 
@@ -122,3 +162,49 @@ def test_main_zero_anchors_fails_with_require(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "ANCHOR REQUIREMENT NOT MET" in out
     assert "CHAIN VERIFIED" not in out
+
+
+# ── mock anchors are NOT dispute-grade (the tightening) ──────────────
+
+
+def test_main_mock_anchor_passes_without_flag(tmp_path, monkeypatch, capsys):
+    """A mock-anchored bundle still verifies green by default, and the
+    summary surfaces that the lone anchor is NOT dispute-grade."""
+    path = _mock_anchored_bundle(tmp_path)
+    monkeypatch.setattr(
+        sys, "argv", ["cullis-audit-verify", "--bundle", path],
+    )
+    rc = cli.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CHAIN VERIFIED" in out
+    # One verified anchor, zero dispute-grade → breakdown is shown.
+    assert "1 TSA anchor" in out
+    assert "0 dispute-grade" in out
+
+
+def test_main_mock_anchor_fails_with_require(tmp_path, monkeypatch, capsys):
+    """THE TIGHTENING. A forgeable MK| mock anchor must NOT satisfy
+    --require-anchors: an operator who can rewrite the store can mint it,
+    so it proves nothing against the operator. Exit 8, no green verdict."""
+    path = _mock_anchored_bundle(tmp_path)
+    monkeypatch.setattr(
+        sys, "argv",
+        ["cullis-audit-verify", "--bundle", path, "--require-anchors"],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 8
+    out = capsys.readouterr().out
+    assert "ANCHOR REQUIREMENT NOT MET" in out
+    assert "CHAIN VERIFIED" not in out
+
+
+def test_verify_anchors_returns_mock_as_non_dispute_grade(tmp_path):
+    """verify_anchors counts a mock anchor toward the total but not
+    toward the dispute-grade subset (the second tuple element)."""
+    path = _mock_anchored_bundle(tmp_path)
+    entries, anchors = cli.load_bundle(path)
+    verified, dispute_grade = cli.verify_anchors(entries, anchors)
+    assert verified == 1
+    assert dispute_grade == 0


### PR DESCRIPTION
## What

Follow-up tightening of #1063 (`--require-anchors`). The dispute-grade floor must prove the chain is bound to an **external, independently-trusted timestamp**. Before this change it counted *any* verified anchor — including forgeable `MK|` mock tokens (just `sha256(row_hash)`, mintable by anyone with write access to the store) and the downgraded imprint-only RFC 3161 modes. A bundle carrying a single mock anchor cleared the floor, contradicting the flag's own help text ("at least one verified RFC 3161 TSA anchor").

## How

- `verify_anchors` now returns `(verified, dispute_grade)`. Only backend label `rfc3161-verified` (full CMS signature chained to a trusted TSA root + EKU + imprint + genTime) counts toward `dispute_grade`.
- `enforce_anchor_floor` gates on the dispute-grade subset, not the total.
- The PASS summary surfaces the breakdown: `1 TSA anchor (0 dispute-grade)`.
- Floor failure message + `--require-anchors` help now state explicitly that mock/imprint-only anchors do not count.

## Invariants preserved

- Default behaviour unchanged: a clean chain verifies green (exit 0) without the flag.
- A truly anchor-free bundle still exits 8 under `--require-anchors` (the #1063 contract).
- `enforce_anchor_floor` keeps its positional signature; the existing unit tests pass unchanged.

## Tests

3 new tests on top of the #1063 suite:
- mock-anchored bundle passes without the flag, surfacing `0 dispute-grade`
- same bundle exits 8 under `--require-anchors` (the tightening)
- `verify_anchors` reports `dispute_grade == 0` for a mock anchor

Local run: `test_cullis_audit_verify_require_anchors.py` + `test_audit_verify_tsa_signature.py` + `test_admin_audit_merkle.py` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)