### PR TITLE
fix(auth): require DPoP-bound LOCAL_TOKEN in production (F-B-14)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -1026,6 +1026,23 @@ class ProxySettings(BaseSettings):
             and _env("PROXY_LOCAL_AUTH") is None
         ):
             self.local_auth_enabled = True
+        # F-B-14 (panel 2026-06-05) — secure-by-default companion to the
+        # local_auth auto-flip above. In a standalone *production* deploy
+        # local_auth is on by default, and with ``local_token_require_dpop``
+        # false a LOCAL_TOKEN minted without a DPoP proof is accepted as a
+        # plain Bearer (the "never plain Bearer" invariant). The SDK always
+        # sends a DPoP proof at mint, so default the binding on whenever the
+        # operator hasn't explicitly chosen a posture. An explicit
+        # ``MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=false`` is left untouched and
+        # caught by the validate_config F-B-14 gate (refuse-boot unless the
+        # migration-window override is set). Dev standalone is left on the
+        # permissive default for local-iteration convenience.
+        if (
+            self.standalone
+            and self.environment == "production"
+            and _env("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP") is None
+        ):
+            self.local_token_require_dpop = True
         return self
 
 
@@ -1260,6 +1277,44 @@ def validate_config(settings: ProxySettings) -> None:
                     "MCP_PROXY_EGRESS_DPOP_INSECURE_OK=true and track a "
                     "sunset date (F-B-11).",
                     egress_mode,
+                )
+                raise SystemExit(1)
+
+        # F-B-14 (panel 2026-06-05). Ingress LOCAL_TOKEN DPoP binding.
+        # When ``local_auth_enabled`` is on, the Mastio mints in-process
+        # LOCAL_TOKENs for intra-org calls. With ``local_token_require_dpop``
+        # false (the default) a token minted without a DPoP proof carries no
+        # ``cnf.jkt`` and is accepted as a *plain Bearer* on every subsequent
+        # request (local_agent_dep.py: WARN + accept). That is the exact
+        # "never accept plain Bearer" invariant the zero-trust posture
+        # forbids: an exfiltrated LOCAL_TOKEN replays with no RFC 9449
+        # key-possession proof. The SDK already sends a DPoP proof on
+        # ``POST /v1/auth/token``, so ``required`` is satisfiable out of the
+        # box; the only legitimate weaker posture is the SDK-rollout window
+        # for in-flight legacy tokens within their TTL. Mirror the egress
+        # F-B-11 gate: refuse to boot unless the operator declares the
+        # migration window explicitly and tracks a sunset date. This gate is
+        # a no-op for the default deploy (local_auth_enabled defaults off and
+        # the local-token router is never mounted).
+        if settings.local_auth_enabled and not settings.local_token_require_dpop:
+            insecure_ok = (
+                os.environ.get("MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK", "")
+                .strip()
+                .lower()
+            ) in {"1", "true", "yes"}
+            if not insecure_ok:
+                _log.critical(
+                    "MCP_PROXY_LOCAL_AUTH_ENABLED=true with "
+                    "MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=false is not "
+                    "permitted in production: a LOCAL_TOKEN minted without a "
+                    "DPoP proof carries no cnf.jkt and is accepted as a plain "
+                    "Bearer, so an exfiltrated token replays with no RFC 9449 "
+                    "key-possession proof. Set "
+                    "MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=true (the SDK already "
+                    "sends a DPoP proof at mint), or for the SDK-rollout "
+                    "migration window explicitly opt in via "
+                    "MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK=true and track a "
+                    "sunset date (F-B-14)."
                 )
                 raise SystemExit(1)
 

--- a/test/unit/test_local_token_dpop_required_in_prod.py
+++ b/test/unit/test_local_token_dpop_required_in_prod.py
@@ -1,0 +1,223 @@
+"""F-B-14 — production refuses plain-Bearer LOCAL_TOKENs.
+
+Adversarial panel (2026-06-05) confirmed the finding: when
+``local_auth_enabled`` is on (auto-flipped on in every standalone deploy)
+and ``local_token_require_dpop`` is false (the historical default), a
+LOCAL_TOKEN minted without a DPoP proof carries no ``cnf.jkt`` and is
+accepted as a plain Bearer on every later request
+(``local_agent_dep.py``: WARN + accept). That violates the non-negotiable
+"never accept plain Bearer" invariant: an exfiltrated token replays with
+no RFC 9449 key-possession proof.
+
+The fix is two complementary pieces, mirroring the egress F-B-11 pattern:
+
+  1. Auto-flip ``local_token_require_dpop`` on in standalone *production*
+     when the operator hasn't chosen a posture explicitly (companion to
+     the existing ``local_auth_enabled`` standalone auto-flip). The SDK
+     always sends a DPoP proof at mint, so this is secure-by-default with
+     no boot break on upgrade.
+  2. A ``validate_config`` boot gate that refuses production when
+     ``local_auth_enabled`` is on but ``local_token_require_dpop`` was
+     *explicitly* set false — unless the operator declares the SDK-rollout
+     migration window via ``MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK=true``.
+
+These tests pin both pieces:
+
+  standalone prod, no explicit require_dpop      → auto-flip True
+  standalone prod, explicit require_dpop=false   → stays False (gate fires)
+  standalone dev,  no explicit require_dpop      → stays False (not gated)
+  prod + local_auth on + explicit false          → SystemExit(1)
+  prod + local_auth on + explicit false + opt-in → boots
+  prod + local_auth on + require_dpop true        → boots
+  prod + local_auth off + explicit false          → boots (gate n/a)
+"""
+from __future__ import annotations
+
+import pytest
+
+
+_ADMIN_OK = "test-admin-secret-not-the-default"
+_DB_ENC_OK = "0" * 64
+_DASHBOARD_KEY_OK = "1" * 64
+_PDP_HMAC_OK = "2" * 64
+_VAULT_ADDR_OK = "https://vault.test.example:8200"
+_VAULT_TOKEN_OK = "s.test-token"
+
+
+def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set every production gate that sits *before* and *after* F-B-14 so
+    each test reaches it cleanly. local_auth / require_dpop are left to the
+    individual test."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", _DASHBOARD_KEY_OK)
+    monkeypatch.setenv("MCP_PROXY_SECRET_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", _VAULT_ADDR_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", _VAULT_TOKEN_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_VERIFY_TLS", "true")
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _DB_ENC_OK)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example")
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+    monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://redis:6379/0")
+    # Default the override OFF; the opt-in test sets it explicitly.
+    monkeypatch.delenv("MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK", raising=False)
+
+
+def _fresh_settings():
+    from mcp_proxy.config import ProxySettings, get_settings
+
+    get_settings.cache_clear()
+    return ProxySettings()
+
+
+@pytest.fixture(autouse=True)
+def _require_webauthn():
+    """Production pins WEBAUTHN_ENFORCEMENT=required; skip if the optional
+    extra is missing so the webauthn gate doesn't mask the F-B-14 gate."""
+    pytest.importorskip("webauthn")
+    yield
+
+
+# ── standalone auto-flip (model validator) ──────────────────────────
+
+
+def test_standalone_prod_autoflips_require_dpop_on(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The default standalone prod posture must be secure: require_dpop
+    flips on when the operator hasn't chosen explicitly, so a fresh /
+    upgraded bundle never accepts a plain-Bearer LOCAL_TOKEN."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.delenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", raising=False)
+
+    settings = _fresh_settings()
+    assert settings.local_auth_enabled is True  # standalone auto-flip
+    assert settings.local_token_require_dpop is True  # F-B-14 auto-flip
+
+
+def test_empty_require_dpop_env_fails_loud_never_plain_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An EMPTY ``MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP`` (e.g. a manual
+    ``=`` in proxy.env) is rejected by pydantic bool-parsing *before* the
+    model validator runs, so it crashes the boot loudly rather than
+    silently degrading to plain Bearer. No compose passes this var, so the
+    bundle path sees it unset (→ field default → auto-flip); this test
+    pins that the empty edge can never become a silent Bearer acceptance.
+    """
+    import pydantic
+
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "")
+
+    with pytest.raises(pydantic.ValidationError):
+        _fresh_settings()
+
+
+def test_standalone_prod_explicit_false_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An explicit operator downgrade is NOT silently overridden — it is
+    preserved so the validate_config gate can catch it loudly."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "false")
+
+    settings = _fresh_settings()
+    assert settings.local_token_require_dpop is False
+
+
+def test_standalone_dev_stays_permissive(monkeypatch: pytest.MonkeyPatch):
+    """Dev standalone keeps the permissive default for local iteration —
+    only production is hardened."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.delenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", raising=False)
+
+    settings = _fresh_settings()
+    assert settings.local_token_require_dpop is False
+
+
+# ── validate_config boot gate (F-B-14) ──────────────────────────────
+
+
+def test_prod_local_auth_explicit_false_refuses_to_boot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """THE GATE. local_auth on + an explicit require_dpop=false in
+    production must SystemExit at boot — plain-Bearer LOCAL_TOKENs would
+    otherwise be accepted."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "false")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.local_auth_enabled is True
+    assert settings.local_token_require_dpop is False
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_prod_migration_window_optin_boots(monkeypatch: pytest.MonkeyPatch):
+    """The SDK-rollout migration window is reachable: explicit
+    require_dpop=false + the insecure opt-in boots (with a sunset date the
+    operator owns)."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "false")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK", "true")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_prod_require_dpop_true_boots(monkeypatch: pytest.MonkeyPatch):
+    """The secure posture (require_dpop=true) boots cleanly."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "true")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_prod_autoflip_default_boots(monkeypatch: pytest.MonkeyPatch):
+    """The default standalone prod path (no explicit require_dpop) boots:
+    the auto-flip makes it secure before the gate is reached."""
+    _production_env(monkeypatch)
+    monkeypatch.delenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", raising=False)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.local_token_require_dpop is True
+    validate_config(settings)  # must not raise
+
+
+def test_prod_local_auth_off_is_not_gated(monkeypatch: pytest.MonkeyPatch):
+    """When local_auth is explicitly off the local-token router is never
+    mounted, so require_dpop=false is irrelevant and must not block boot."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "false")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "false")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.local_auth_enabled is False
+    validate_config(settings)  # must not raise


### PR DESCRIPTION
## Finding (adversarial panel 2026-06-05, F3)

`local_auth_enabled` auto-flips **on** in every standalone deploy (config.py auto-flip, companion of the ADR-012 local-first auth). With `local_token_require_dpop` false (the historical default), a LOCAL_TOKEN minted without a DPoP proof carries no `cnf.jkt` and is accepted as a **plain Bearer** on every later request (`local_agent_dep.py`: WARN + accept). An exfiltrated token then replays with no RFC 9449 key-possession proof.

Because the standalone auto-flip enables `local_auth` by default, this was the **default standalone-production posture**, not a rare opt-in — a direct violation of the non-negotiable "never accept plain Bearer" rule.

## Fix (two pieces, mirroring egress F-B-11)

1. **Auto-flip** `local_token_require_dpop` on in standalone *production* when the operator hasn't chosen a posture explicitly (companion to the existing `local_auth` standalone auto-flip). The SDK always sends a DPoP proof at mint, so this is secure-by-default with **no boot break on upgrade**. Dev standalone keeps the permissive default for local iteration.
2. **`validate_config` boot gate**: refuse production when `local_auth_enabled` is on but `local_token_require_dpop` was *explicitly* set false — unless the operator declares the SDK-rollout migration window via `MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK=true` and tracks a sunset date.

## Blast radius

- **Default deploy** (`local_auth` off, non-standalone): gate never fires, router never mounted — no-op.
- **Standalone-prod fresh/upgrade**: auto-flip makes it secure; gate never fires; ~15-min token TTL re-mint window on upgrade for in-flight legacy tokens (SDK re-mints with DPoP automatically).
- **Explicit `require_dpop=false` in prod**: refused at boot unless the migration-window override is set — the only deliberate insecure path, made loud.

## Tests

8 new tests in `test_local_token_dpop_required_in_prod.py`: auto-flip (standalone-prod on / explicit-false preserved / dev permissive) + gate (explicit-false refuses boot / migration opt-in boots / require_dpop=true boots / auto-flip default boots / local_auth-off not gated). Targeted suite (183 config/auth/dpop/boot tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)