### PR TITLE
docs(operate): state the Vault persistence prerequisite for prod DR (T4)

### DIFF
--- a/docs/operate/disaster-recovery.md
+++ b/docs/operate/disaster-recovery.md
@@ -7,6 +7,39 @@ host bind dirs (`./data`, `./nginx-certs`) are the whole state and a
 filesystem copy is enough; this page is about the Postgres + Vault
 shape, where state is split across two systems.
 
+## Prerequisite: the production Vault must be persistent
+
+Everything below assumes the Vault custodying the CA survives a restart.
+**It only does so if Vault runs with persistent storage.** A Vault
+started in dev mode (`vault server -dev` / `-dev-tls`) keeps its entire
+KV store **in memory**: on the first container restart, upgrade, or host
+reboot, the Org CA and the Mastio Intermediate CA are gone. The Mastio
+then refuses to boot (orphan guard, DR-1) or, if CA bootstrap is left
+enabled, mints a **fresh** Intermediate that orphans every enrolled
+agent's mTLS cert. No backup script can recover from this, because there
+was never anything on disk to back up.
+
+A production Vault must therefore run with:
+
+- **Persistent storage** (`raft` integrated storage, or a `file` /
+  managed backend), never the in-memory dev backend.
+- **Auto-unseal** (a cloud KMS, an HSM, or Transit), so an unattended
+  restart does not leave Vault sealed and the Mastio unable to read the
+  CA. Manual unseal is acceptable only if an operator is always on hand
+  for every restart.
+- Its own backup of the whole store (`vault operator raft snapshot` or
+  the managed-Vault equivalent), in addition to the Mastio-scoped CA
+  export below.
+
+The `-dev-tls` overlay used in the local dogfood stack is **dev-only**
+for exactly this reason: it is convenient for a throwaway demo, but it
+loses the CA on restart and must never back a real org. The CA and the
+`DB_ENCRYPTION_KEY` are persistent for the life of the org and are never
+regenerated; a version upgrade swaps only the image and bundle files,
+never the Vault state or the CA. The Mastio integrates an
+operator-owned Vault rather than shipping its own, so this persistence
+contract is the operator's to satisfy.
+
 ## What a full backup must capture
 
 A production Mastio's state lives in **two** places, and a backup of


### PR DESCRIPTION
## Finding (adversarial panel 2026-06-05, T4)

The DR runbook (`disaster-recovery.md`) documents backup/restore order and references `vault operator raft snapshot`, but it never states the **prerequisite** that makes the whole procedure meaningful: the production Vault custodying the CA must run with **persistent storage**.

A Vault started in dev mode (`vault server -dev` / `-dev-tls`) keeps its KV store in memory and loses the Org CA + Mastio Intermediate CA on the first restart, upgrade, or reboot. At that point no backup script can recover, because nothing was ever on disk. The Mastio then either refuses to boot (orphan guard, DR-1) or mints a fresh Intermediate that orphans every enrolled agent's mTLS cert. This is the exact failure the dogfood `-dev-tls` overlay exhibits.

## Change

Docs-only. Adds a **"Prerequisite: the production Vault must be persistent"** section to `disaster-recovery.md`:
- persistent storage (raft/file, never the in-memory dev backend)
- auto-unseal for unattended restarts
- the operator's own `raft snapshot` as the authoritative backup
- names the local dogfood `-dev-tls` overlay as dev-only, with the reason
- restates that the CA and `DB_ENCRYPTION_KEY` are persistent for the org's life and a version upgrade swaps only image + bundle files

Does **not** change the bring-your-own-Vault posture or bundle a Vault: the persistence contract is the operator's to satisfy, and this just makes it explicit instead of assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)