### PR TITLE
fix(auth): encrypt the Mastio signing key at rest (F4)

### DIFF
--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1314,6 +1314,50 @@ async def deprecate_mastio_keys_by_kids(
     return updated
 
 
+def _wrap_mastio_privkey(privkey_pem: str) -> str:
+    """Encrypt the Mastio signing key for at-rest storage (F4).
+
+    ``mastio_keys.privkey_pem`` historically stored a plaintext PEM, so a
+    DB read (backup, replica, dump) yielded the LocalIssuer signing key and
+    let anyone forge LOCAL_TOKEN/JWT for any agent. Wrap it in the
+    ``enc:sec:v1:`` envelope when the at-rest master is configured. When it
+    is not (dev/sandbox), fall back to plaintext — mirroring the CA path in
+    ``mcp_proxy.kms.local`` exactly. Production requires the master, so the
+    fallback is a dev-only path.
+    """
+    from mcp_proxy.kms.pki_at_rest import encrypt_secret, pki_master_key_configured
+
+    if not pki_master_key_configured():
+        return privkey_pem
+    return encrypt_secret(privkey_pem)
+
+
+def _unwrap_mastio_privkey(value: str | None) -> str | None:
+    """Decrypt a stored ``mastio_keys.privkey_pem`` for use by callers.
+
+    Transparently returns plaintext to every reader so ``LocalKeyRecord``
+    and ``LocalIssuer`` stay unchanged. Enveloped values are decrypted;
+    legacy plaintext PEMs (pre-F4, or dev rows written without a master)
+    pass through untouched. The two are unambiguous: a PEM begins with
+    ``-----BEGIN``, the envelope with ``enc:sec:v1:``.
+    """
+    if not value:
+        return value
+    from mcp_proxy.kms.pki_at_rest import decrypt_secret, is_secret_envelope
+
+    if is_secret_envelope(value):
+        return decrypt_secret(value)
+    return value
+
+
+def _unwrap_mastio_row(row: dict) -> dict:
+    """Return a copy of a ``mastio_keys`` row with ``privkey_pem`` decrypted."""
+    if row.get("privkey_pem"):
+        row = dict(row)
+        row["privkey_pem"] = _unwrap_mastio_privkey(row["privkey_pem"])
+    return row
+
+
 async def insert_mastio_key(
     *,
     kid: str,
@@ -1346,7 +1390,7 @@ async def insert_mastio_key(
             {
                 "kid": kid,
                 "pub": pubkey_pem,
-                "priv": privkey_pem,
+                "priv": _wrap_mastio_privkey(privkey_pem),
                 "cert": cert_pem,
                 "created": created_at,
                 "activated": activated_at,
@@ -1364,7 +1408,7 @@ async def get_mastio_key_by_kid(kid: str) -> dict | None:
             {"kid": kid},
         )
         row = result.mappings().first()
-        return dict(row) if row else None
+        return _unwrap_mastio_row(dict(row)) if row else None
 
 
 async def get_mastio_keys_active() -> list[dict]:
@@ -1391,7 +1435,7 @@ async def get_mastio_keys_active() -> list[dict]:
                 """
             )
         )
-        return [dict(row) for row in result.mappings().all()]
+        return [_unwrap_mastio_row(dict(row)) for row in result.mappings().all()]
 
 
 async def swap_active_mastio_key(
@@ -1436,7 +1480,7 @@ async def swap_active_mastio_key(
             {
                 "kid": new_kid,
                 "pub": new_pubkey_pem,
-                "priv": new_privkey_pem,
+                "priv": _wrap_mastio_privkey(new_privkey_pem),
                 "cert": new_cert_pem,
                 "created": new_created_at,
                 "activated": new_activated_at,
@@ -1493,7 +1537,7 @@ async def get_mastio_keys_valid() -> list[dict]:
             ),
             {"now": datetime.now(timezone.utc).isoformat()},
         )
-        return [dict(row) for row in result.mappings().all()]
+        return [_unwrap_mastio_row(dict(row)) for row in result.mappings().all()]
 
 
 async def get_mastio_keys_staged() -> list[dict]:
@@ -1514,7 +1558,58 @@ async def get_mastio_keys_staged() -> list[dict]:
                 """
             )
         )
-        return [dict(row) for row in result.mappings().all()]
+        return [_unwrap_mastio_row(dict(row)) for row in result.mappings().all()]
+
+
+async def reencrypt_plaintext_mastio_keys() -> int:
+    """One-time at-rest backfill for F4: wrap any legacy plaintext
+    ``mastio_keys.privkey_pem`` rows in the ``enc:sec:v1:`` envelope.
+
+    A no-op when the at-rest master is not configured (dev/sandbox keeps
+    plaintext, mirroring the CA path). Idempotent: it only touches rows
+    whose ``privkey_pem`` is not already an envelope, and the UPDATE is
+    guarded by a compare-and-set on the old plaintext value so two
+    workers racing at boot cannot clobber each other (the loser's UPDATE
+    matches zero rows and is skipped). Returns the number of rows
+    re-encrypted. Call once at boot, after the keystore is reachable.
+    """
+    from mcp_proxy.kms.pki_at_rest import (
+        encrypt_secret,
+        is_secret_envelope,
+        pki_master_key_configured,
+    )
+
+    if not pki_master_key_configured():
+        return 0
+
+    rewrapped = 0
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT kid, privkey_pem FROM mastio_keys")
+        )
+        rows = [dict(r) for r in result.mappings().all()]
+        for row in rows:
+            pem = row.get("privkey_pem")
+            if not pem or is_secret_envelope(pem):
+                continue
+            upd = await conn.execute(
+                text(
+                    """
+                    UPDATE mastio_keys
+                       SET privkey_pem = :enc
+                     WHERE kid = :kid
+                       AND privkey_pem = :old
+                    """
+                ),
+                {"enc": encrypt_secret(pem), "kid": row["kid"], "old": pem},
+            )
+            rewrapped += getattr(upd, "rowcount", 0) or 0
+    if rewrapped:
+        _log.info(
+            "F4 at-rest backfill: re-encrypted %d plaintext mastio_keys "
+            "signing-key row(s) into the enc:sec:v1 envelope.", rewrapped,
+        )
+    return rewrapped
 
 
 async def delete_staged_mastio_key(kid: str) -> int:

--- a/mcp_proxy/kms/pki_at_rest.py
+++ b/mcp_proxy/kms/pki_at_rest.py
@@ -180,6 +180,67 @@ def decrypt_pki_payload(envelope: str) -> tuple[str, str]:
         ) from exc
 
 
+_SECRET_ENVELOPE_PREFIX = "enc:sec:v1:"
+
+
+def is_secret_envelope(value: str) -> bool:
+    """True when ``value`` is an :func:`encrypt_secret` envelope.
+
+    Used by callers that overload an existing plaintext column (e.g.
+    ``mastio_keys.privkey_pem``) to tell a wrapped value from a legacy
+    plaintext PEM on read. A PEM begins with ``-----BEGIN``; the
+    envelope begins with the distinct ``enc:sec:v1:`` prefix, so the
+    two are unambiguous.
+    """
+    return value.startswith(_SECRET_ENVELOPE_PREFIX)
+
+
+def encrypt_secret(plaintext: str) -> str:
+    """Wrap a single secret string in the ``enc:sec:v1:`` envelope.
+
+    The general-purpose, single-value companion to
+    :func:`encrypt_pki_payload` (which is shaped for the CA's
+    ``key_pem``+``cert_pem`` pair). Same Fernet master derived from
+    ``MCP_PROXY_DB_ENCRYPTION_KEY``; a separate prefix keeps the two
+    formats from being decoded by the wrong reader. Used for the Mastio
+    signing key (``mastio_keys.privkey_pem``) and is the seed of the
+    forthcoming general named-secret keystore.
+
+    Raises :class:`PKIKeyMissingError` when the master key is missing.
+    """
+    if not plaintext:
+        raise ValueError("encrypt_secret: plaintext must be non-empty")
+    master = derive_master_key()
+    token = Fernet(master).encrypt(plaintext.encode("utf-8")).decode("utf-8")
+    return _SECRET_ENVELOPE_PREFIX + token
+
+
+def decrypt_secret(envelope: str) -> str:
+    """Reverse of :func:`encrypt_secret`. Returns the plaintext string.
+
+    Refuses to interpret a non-envelope as plaintext (so a caller never
+    silently trusts an unwrapped value). Raises ``RuntimeError`` when
+    the envelope was minted under a different master key — failing loud
+    beats returning a wrong key.
+    """
+    if not envelope.startswith(_SECRET_ENVELOPE_PREFIX):
+        raise ValueError(
+            f"decrypt_secret: envelope does not start with "
+            f"{_SECRET_ENVELOPE_PREFIX!r}; refusing to interpret as plaintext."
+        )
+    master = derive_master_key()
+    token = envelope[len(_SECRET_ENVELOPE_PREFIX):]
+    try:
+        return Fernet(master).decrypt(token.encode("utf-8")).decode("utf-8")
+    except InvalidToken as exc:
+        raise RuntimeError(
+            "secret envelope cannot be decrypted with the current "
+            f"{_ENV_VAR}. Either the env var was rotated without "
+            "re-encrypting, or the DB came from a different deploy. "
+            "Restore the original passphrase.",
+        ) from exc
+
+
 def _reset_cache_for_tests() -> None:
     """Test hook: drop the PBKDF2 cache so monkeypatched env vars apply."""
     _derive_cached.cache_clear()
@@ -188,7 +249,10 @@ def _reset_cache_for_tests() -> None:
 __all__ = [
     "PKIKeyMissingError",
     "decrypt_pki_payload",
+    "decrypt_secret",
     "derive_master_key",
     "encrypt_pki_payload",
+    "encrypt_secret",
+    "is_secret_envelope",
     "pki_master_key_configured",
 ]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -817,6 +817,20 @@ async def lifespan(app: FastAPI):
     # degrade soft (both None) if identity bootstrap failed above.
     from mcp_proxy.auth.local_keystore import LocalKeyStore
     app.state.local_keystore = LocalKeyStore()
+
+    # F4 (panel 2026-06-05) — at-rest backfill for the Mastio signing key.
+    # ``mastio_keys.privkey_pem`` historically stored a plaintext PEM, so a
+    # DB read yielded the LocalIssuer signing key and let anyone forge
+    # LOCAL_TOKEN/JWT. New writes are now wrapped (enc:sec:v1); convert any
+    # legacy plaintext rows on boot when the master is configured. Idempotent
+    # + CAS-guarded for multi-worker; a no-op in dev (no master). Never block
+    # boot on it — the read path tolerates both forms.
+    try:
+        from mcp_proxy.db import reencrypt_plaintext_mastio_keys
+        await reencrypt_plaintext_mastio_keys()
+    except Exception as exc:  # noqa: BLE001 — backfill must not gate boot
+        _log.warning("F4 mastio_keys at-rest backfill raised %s — continuing", exc)
+
     app.state.local_issuer = None
     if getattr(agent_mgr, "mastio_loaded", False) and org_id:
         if getattr(agent_mgr, "is_sign_halted", False):

--- a/test/unit/test_mastio_signing_key_at_rest.py
+++ b/test/unit/test_mastio_signing_key_at_rest.py
@@ -1,0 +1,214 @@
+"""F4 (panel 2026-06-05) — the Mastio signing key is encrypted at rest.
+
+``mastio_keys.privkey_pem`` historically stored a plaintext PEM. On a
+production ``kms=vault`` deploy (verified live on mastio-demo) the CA was
+in Vault but this row was plaintext, so a DB read (backup, replica, dump)
+yielded the LocalIssuer signing key and let anyone forge LOCAL_TOKEN/JWT
+for any agent.
+
+The fix wraps the key in the ``enc:sec:v1:`` envelope (same Fernet master
+as the CA at-rest path) at the ``db.py`` boundary: encrypt on write,
+decrypt on read, transparently for ``LocalKeyStore``/``LocalIssuer``. A
+boot-time backfill re-wraps legacy plaintext rows. Dev/sandbox without a
+master keeps plaintext (mirrors the CA path); production requires the
+master, so there the key is always encrypted.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from sqlalchemy import text
+
+from mcp_proxy.db import (
+    get_db,
+    get_mastio_keys_active,
+    insert_mastio_key,
+    reencrypt_plaintext_mastio_keys,
+)
+from mcp_proxy.kms import pki_at_rest
+
+_MASTER = "0" * 64  # >= 16 chars, the at-rest passphrase
+
+
+def _fresh_keypair() -> tuple[str, str, str]:
+    from mcp_proxy.auth.local_keystore import compute_kid
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return compute_kid(pub_pem), pub_pem, priv_pem
+
+
+def _set_master(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _MASTER)
+    pki_at_rest._reset_cache_for_tests()
+
+
+def _unset_master(monkeypatch) -> None:
+    monkeypatch.delenv("MCP_PROXY_DB_ENCRYPTION_KEY", raising=False)
+    pki_at_rest._reset_cache_for_tests()
+
+
+async def _raw_privkey(kid: str) -> str:
+    """Read the stored (possibly-enveloped) privkey_pem straight from the DB."""
+    async with get_db() as conn:
+        r = await conn.execute(
+            text("SELECT privkey_pem FROM mastio_keys WHERE kid = :k"),
+            {"k": kid},
+        )
+        return r.scalar_one()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import dispose_db, init_db
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+    pki_at_rest._reset_cache_for_tests()
+
+
+# ── pure envelope primitives ────────────────────────────────────────
+
+
+def test_encrypt_secret_roundtrip(monkeypatch):
+    _set_master(monkeypatch)
+    env = pki_at_rest.encrypt_secret("hello-secret")
+    assert env.startswith("enc:sec:v1:")
+    assert pki_at_rest.is_secret_envelope(env)
+    assert pki_at_rest.decrypt_secret(env) == "hello-secret"
+
+
+def test_decrypt_secret_refuses_plaintext(monkeypatch):
+    _set_master(monkeypatch)
+    with pytest.raises(ValueError):
+        pki_at_rest.decrypt_secret("-----BEGIN PRIVATE KEY-----")
+
+
+def test_encrypt_secret_requires_master(monkeypatch):
+    _unset_master(monkeypatch)
+    with pytest.raises(pki_at_rest.PKIKeyMissingError):
+        pki_at_rest.encrypt_secret("x")
+
+
+# ── write encrypts / read decrypts ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_insert_stores_encrypted_reads_plaintext(proxy_db, monkeypatch):
+    _set_master(monkeypatch)
+    kid, pub, priv = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_now(), activated_at=_now(),
+    )
+
+    # At rest: enveloped, NOT a plaintext PEM.
+    raw = await _raw_privkey(kid)
+    assert raw.startswith("enc:sec:v1:")
+    assert "BEGIN" not in raw
+
+    # Through the reader: transparent plaintext for LocalIssuer.
+    rows = await get_mastio_keys_active()
+    assert len(rows) == 1
+    assert rows[0]["privkey_pem"] == priv
+
+
+@pytest.mark.asyncio
+async def test_dev_without_master_stores_plaintext(proxy_db, monkeypatch):
+    _unset_master(monkeypatch)
+    kid, pub, priv = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_now(), activated_at=_now(),
+    )
+    raw = await _raw_privkey(kid)
+    assert raw == priv  # dev fallback: plaintext, mirrors the CA path
+    rows = await get_mastio_keys_active()
+    assert rows[0]["privkey_pem"] == priv  # read still works
+
+
+# ── backfill ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_reencrypts_and_is_idempotent(proxy_db, monkeypatch):
+    # Seed a legacy plaintext row (no master at insert time).
+    _unset_master(monkeypatch)
+    kid, pub, priv = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_now(), activated_at=_now(),
+    )
+    assert await _raw_privkey(kid) == priv  # plaintext on disk
+
+    # Configure the master and run the boot backfill.
+    _set_master(monkeypatch)
+    n = await reencrypt_plaintext_mastio_keys()
+    assert n == 1
+    assert (await _raw_privkey(kid)).startswith("enc:sec:v1:")
+    # Read still returns the original plaintext.
+    rows = await get_mastio_keys_active()
+    assert rows[0]["privkey_pem"] == priv
+
+    # Idempotent: a second run touches nothing.
+    assert await reencrypt_plaintext_mastio_keys() == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_noop_without_master(proxy_db, monkeypatch):
+    _unset_master(monkeypatch)
+    kid, pub, priv = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_now(), activated_at=_now(),
+    )
+    assert await reencrypt_plaintext_mastio_keys() == 0
+    assert await _raw_privkey(kid) == priv  # untouched
+
+
+# ── end-to-end through the keystore ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_signer_usable_through_keystore_after_encryption(proxy_db, monkeypatch):
+    """The decrypted key round-trips into a usable EC private key, so
+    LocalIssuer signing is unaffected by the at-rest wrap."""
+    _set_master(monkeypatch)
+    kid, pub, priv = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_now(), activated_at=_now(),
+    )
+    from mcp_proxy.auth.local_keystore import LocalKeyStore
+
+    signer = await LocalKeyStore().current_signer()
+    assert signer.kid == kid
+    # load_private_key() deserialises the decrypted PEM into a real EC key.
+    key = signer.load_private_key()
+    sig = key.sign(b"payload", ec.ECDSA(hashes.SHA256()))
+    assert sig  # signing works through the decrypt path


### PR DESCRIPTION
## Finding (panel 2026-06-05, F4)

`mastio_keys.privkey_pem` — the LocalIssuer signing key that mints LOCAL_TOKEN / session JWTs and is published via JWKS — was stored as a **plaintext PEM**. Verified live on mastio-demo (`kms=vault`, `environment=production`, `DB_ENCRYPTION_KEY` set): the CA was in Vault but this row was plaintext. A DB read (backup, replica, dump, SQLi elsewhere) yielded the signing key → forge valid tokens for **any agent**. The `0038` PKI-at-rest work wrapped the CA but left `mastio_keys` untouched.

## Fix

- **`pki_at_rest`**: add a general single-value envelope `encrypt_secret`/`decrypt_secret` (`enc:sec:v1:`), same Fernet master (PBKDF2-600k from `DB_ENCRYPTION_KEY`) the CA already uses. This is the seed of the general named-secret keystore (`imp/keystore-design-2026-06-05.md`).
- **`db.py` boundary**: encrypt on write (`insert_mastio_key`, `swap_active_mastio_key`), decrypt on read (the four `get_mastio_key*` readers). `LocalKeyStore`/`LocalIssuer` are unchanged — they still see a plaintext PEM.
- **No schema migration**: the existing TEXT column is overloaded. A PEM starts with `-----BEGIN`, the envelope with `enc:sec:v1:` — unambiguous.
- **Boot backfill** (`reencrypt_plaintext_mastio_keys`): converts legacy plaintext rows. Idempotent, CAS-guarded for multi-worker, no-op without a master, never blocks boot.

## Invariants

- **Production**: `validate_config` already requires `DB_ENCRYPTION_KEY` (refuses boot otherwise), so the master is always present → the signing key is **always encrypted** in prod.
- **Dev/sandbox** without a master keeps plaintext, mirroring the CA path exactly.
- Read path tolerates both forms, so upgrade is seamless (the existing plaintext row on mastio-demo gets re-wrapped on next boot).

## Tests

8 new (`test_mastio_signing_key_at_rest.py`): envelope round-trip + refuse-plaintext + requires-master; write-encrypts/read-decrypts; dev-plaintext-fallback; backfill re-encrypts + idempotent + no-op-without-master; end-to-end signer usable through `LocalKeyStore`. Existing rotation/concurrency/keystore/validator/agent-dep/migrations suites green (57 passed).

First step of the common-keystore design. F5 (SDK agent key) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)