### PR TITLE
feat(sdk): encrypt the agent DPoP key at rest (F5 step 1)

### DIFF
--- a/cullis_sdk/_keystore.py
+++ b/cullis_sdk/_keystore.py
@@ -1,0 +1,199 @@
+"""At-rest envelope for SDK-held agent key material (F5).
+
+``key.pem`` (mTLS private key) and ``dpop.jwk`` (DPoP private JWK) shipped
+as plaintext files protected only by ``chmod 0600``. That leaves the agent
+identity exposed to disk theft, a leaked VM snapshot or backup, and the
+``identity-bundle.zip`` in transit. This module wraps those secrets in the
+``enc:sec:v1:`` envelope so they are encrypted at rest.
+
+Format compatibility: the envelope is structurally identical to the
+Mastio's ``mcp_proxy.kms.pki_at_rest`` — ``enc:sec:v1:`` prefix, Fernet
+body, a PBKDF2-HMAC-SHA256 600k-iteration master — so a future shared
+``cullis_keystore`` library and its test vectors line up across the two
+surfaces. The salt is per-domain (``cullis-sdk-identity-v1``): the SDK and
+the Mastio custody different material under different passphrases and must
+not cross-decrypt.
+
+Root-of-trust ladder (first provider that yields a passphrase wins):
+
+    1. OS keychain        (pluggable hook — not wired in step 1)
+    2. age-encrypted file (pluggable hook — not wired in step 1)
+    3. env CULLIS_IDENTITY_PASSPHRASE
+    4. None               -> plaintext fallback (dev / back-compat)
+
+Only the env provider is active today. The ladder is an ordered list of
+callables so keychain / age / TPM providers slot in later without changing
+the wrap/unwrap call sites or the on-disk format.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from functools import lru_cache
+from typing import Callable
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+_log = logging.getLogger("cullis_sdk.keystore")
+
+_ENVELOPE_PREFIX = "enc:sec:v1:"
+_SALT = b"cullis-sdk-identity-v1"
+_ITERATIONS = 600_000
+_ENV_VAR = "CULLIS_IDENTITY_PASSPHRASE"
+
+
+class IdentityKeyLockedError(RuntimeError):
+    """An enveloped secret was found but no root passphrase is available.
+
+    Raised on read when ``key.pem`` / ``dpop.jwk`` is encrypted at rest but
+    no root-of-trust provider yields the passphrase (e.g. the operator set
+    ``CULLIS_IDENTITY_PASSPHRASE`` once, encrypted the identity, then lost
+    it). Failing loud beats returning a wrong/empty key.
+    """
+
+
+# ── envelope primitives ─────────────────────────────────────────────
+
+
+def is_secret_envelope(value: str) -> bool:
+    """True when ``value`` is an :func:`encrypt_secret` envelope.
+
+    Lets a reader tell a wrapped secret from a legacy plaintext PEM/JWK:
+    a PEM begins ``-----BEGIN``, a JWK is JSON (``{``), the envelope begins
+    ``enc:sec:v1:`` — all unambiguous.
+    """
+    return value.startswith(_ENVELOPE_PREFIX)
+
+
+@lru_cache(maxsize=8)
+def _derive(passphrase: bytes) -> bytes:
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_SALT,
+        iterations=_ITERATIONS,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(passphrase))
+
+
+def encrypt_secret(plaintext: str, passphrase: str) -> str:
+    """Wrap ``plaintext`` in the ``enc:sec:v1:`` envelope under ``passphrase``."""
+    if not plaintext:
+        raise ValueError("encrypt_secret: plaintext must be non-empty")
+    if not passphrase:
+        raise ValueError("encrypt_secret: passphrase must be non-empty")
+    master = _derive(passphrase.encode("utf-8"))
+    token = Fernet(master).encrypt(plaintext.encode("utf-8")).decode("utf-8")
+    return _ENVELOPE_PREFIX + token
+
+
+def decrypt_secret(envelope: str, passphrase: str) -> str:
+    """Reverse of :func:`encrypt_secret`. Returns the plaintext string."""
+    if not envelope.startswith(_ENVELOPE_PREFIX):
+        raise ValueError(
+            f"decrypt_secret: value does not start with {_ENVELOPE_PREFIX!r}; "
+            "refusing to interpret as plaintext."
+        )
+    master = _derive(passphrase.encode("utf-8"))
+    token = envelope[len(_ENVELOPE_PREFIX):]
+    try:
+        return Fernet(master).decrypt(token.encode("utf-8")).decode("utf-8")
+    except InvalidToken as exc:
+        raise IdentityKeyLockedError(
+            f"identity secret cannot be decrypted with the current "
+            f"{_ENV_VAR}. Either the passphrase changed, or the file came "
+            "from a different host."
+        ) from exc
+
+
+# ── root-of-trust ladder ────────────────────────────────────────────
+
+
+def _env_passphrase() -> str | None:
+    raw = os.environ.get(_ENV_VAR, "").strip()
+    return raw or None
+
+
+# Ordered providers; first non-None wins. Keychain / age / TPM providers
+# append here later without touching the call sites or the on-disk format.
+_ROOT_PROVIDERS: list[Callable[[], "str | None"]] = [
+    # _keychain_passphrase,   # step 2: OS keychain (Secret Service / Keychain)
+    # _age_file_passphrase,   # step 2: age-encrypted key file
+    _env_passphrase,
+]
+
+
+def resolve_root_passphrase() -> str | None:
+    """Return the first passphrase the ladder yields, or None (plaintext)."""
+    for provider in _ROOT_PROVIDERS:
+        value = provider()
+        if value:
+            return value
+    return None
+
+
+# ── high-level wrap / unwrap used by the SDK call sites ──────────────
+
+
+def wrap_identity_secret(plaintext: str) -> str:
+    """Encrypt ``plaintext`` when a root is available, else return it as-is.
+
+    Mirrors the Mastio's dev fallback: with no passphrase configured the
+    SDK keeps the legacy plaintext-0600 behaviour so existing workflows and
+    dev iteration are unaffected. Configure ``CULLIS_IDENTITY_PASSPHRASE``
+    (or a future keychain/age provider) to turn on at-rest encryption.
+    """
+    passphrase = resolve_root_passphrase()
+    if not passphrase:
+        # Make the dev fallback observable: writing key material unencrypted
+        # is a deliberate no-root posture, not an accident. Never logs the
+        # secret itself.
+        _log.warning(
+            "identity material written UNENCRYPTED at rest: no root-of-trust "
+            "configured (set %s to enable the enc:sec:v1 envelope).", _ENV_VAR,
+        )
+        return plaintext
+    return encrypt_secret(plaintext, passphrase)
+
+
+def unwrap_identity_secret(value: str) -> str:
+    """Decrypt ``value`` when it is an envelope, else pass it through.
+
+    Legacy plaintext (pre-F5, or written without a root) is returned
+    untouched. An enveloped value with no available root raises
+    :class:`IdentityKeyLockedError` rather than silently failing.
+    """
+    if not is_secret_envelope(value):
+        return value
+    passphrase = resolve_root_passphrase()
+    if not passphrase:
+        raise IdentityKeyLockedError(
+            f"identity material is encrypted at rest but {_ENV_VAR} is not "
+            "set (and no keychain/age provider yielded a passphrase). Set "
+            "the passphrase the identity was encrypted with."
+        )
+    return decrypt_secret(value, passphrase)
+
+
+def _reset_cache_for_tests() -> None:
+    """Test/rotation hook: drop derived Fernet masters from the LRU.
+
+    Symmetric with the Mastio's ``pki_at_rest._reset_cache_for_tests``. A
+    future caller can also use it to scrub derived masters on logout / key
+    rotation so they do not linger in process memory.
+    """
+    _derive.cache_clear()
+
+
+__all__ = [
+    "IdentityKeyLockedError",
+    "decrypt_secret",
+    "encrypt_secret",
+    "is_secret_envelope",
+    "resolve_root_passphrase",
+    "unwrap_identity_secret",
+    "wrap_identity_secret",
+]

--- a/cullis_sdk/dpop.py
+++ b/cullis_sdk/dpop.py
@@ -98,7 +98,11 @@ class DpopKey:
     @classmethod
     def load(cls, path: Path) -> DpopKey:
         """Read a DpopKey from disk. Raises ``FileNotFoundError`` if absent."""
-        text = path.read_text()
+        from cullis_sdk._keystore import unwrap_identity_secret
+
+        # F5: decrypt the at-rest envelope when present; legacy plaintext
+        # JWK files pass through untouched.
+        text = unwrap_identity_secret(path.read_text())
         blob = json.loads(text)
         priv_jwk = blob.get("private_jwk") or blob
         if "d" not in priv_jwk:
@@ -139,11 +143,16 @@ class DpopKey:
         leaves either the old file or the fully-written new one, never
         a half-written secret.
         """
+        from cullis_sdk._keystore import wrap_identity_secret
+
         path.parent.mkdir(parents=True, exist_ok=True)
         priv_jwk = self.private_jwk()
         payload = json.dumps({"private_jwk": priv_jwk}, separators=(",", ":"))
+        # F5: encrypt at rest when a root passphrase is configured; the
+        # 0600 perm is kept as a second layer. With no root the plaintext
+        # JWK is written, preserving the legacy dev behaviour.
         tmp = path.with_suffix(path.suffix + f".tmp-{_pysecrets.token_hex(8)}")
-        tmp.write_text(payload)
+        tmp.write_text(wrap_identity_secret(payload))
         os.chmod(tmp, 0o600)
         os.replace(tmp, path)
         self.path = path

--- a/test/unit/test_sdk_identity_keystore.py
+++ b/test/unit/test_sdk_identity_keystore.py
@@ -1,0 +1,139 @@
+"""F5 step 1 (panel 2026-06-05) — SDK DPoP key encrypted at rest.
+
+The agent's DPoP private JWK (``dpop.jwk``) shipped as a plaintext file
+protected only by ``chmod 0600``. This wraps it in the ``enc:sec:v1:``
+envelope (format-compatible with the Mastio's ``pki_at_rest``, per-domain
+salt) when a root passphrase is configured, with a plaintext fallback for
+dev / back-compat. Root-of-trust is a pluggable ladder; step 1 wires the
+``CULLIS_IDENTITY_PASSPHRASE`` env provider.
+
+key.pem at rest is deliberately out of scope here: the mTLS path loads the
+key file by path into an ssl context (stdlib ssl cannot load a key from
+memory), so an encrypted key.pem needs decrypt-to-tempfile / in-memory-ssl
+handling — a separate step. The DPoP key is in-memory only (signing happens
+in-process), so it has no such constraint.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cullis_sdk import _keystore as ks
+
+_PASS = "correct horse battery staple ----- 32+ chars"
+
+
+def _set_pass(monkeypatch, value=_PASS):
+    monkeypatch.setenv("CULLIS_IDENTITY_PASSPHRASE", value)
+
+
+def _unset_pass(monkeypatch):
+    monkeypatch.delenv("CULLIS_IDENTITY_PASSPHRASE", raising=False)
+
+
+# ── envelope primitives ─────────────────────────────────────────────
+
+
+def test_envelope_roundtrip():
+    env = ks.encrypt_secret("top-secret", _PASS)
+    assert env.startswith("enc:sec:v1:")
+    assert ks.is_secret_envelope(env)
+    assert ks.decrypt_secret(env, _PASS) == "top-secret"
+
+
+def test_decrypt_refuses_plaintext():
+    with pytest.raises(ValueError):
+        ks.decrypt_secret('{"private_jwk": {}}', _PASS)
+
+
+def test_wrong_passphrase_fails_loud():
+    env = ks.encrypt_secret("x", _PASS)
+    with pytest.raises(ks.IdentityKeyLockedError):
+        ks.decrypt_secret(env, "a different passphrase entirely")
+
+
+# ── root ladder ─────────────────────────────────────────────────────
+
+
+def test_root_ladder_env_provider(monkeypatch):
+    _set_pass(monkeypatch)
+    assert ks.resolve_root_passphrase() == _PASS
+    _unset_pass(monkeypatch)
+    assert ks.resolve_root_passphrase() is None
+
+
+def test_wrap_encrypts_with_root_plaintext_without(monkeypatch):
+    _set_pass(monkeypatch)
+    assert ks.is_secret_envelope(ks.wrap_identity_secret("data"))
+    _unset_pass(monkeypatch)
+    assert ks.wrap_identity_secret("data") == "data"  # dev fallback
+
+
+def test_unwrap_envelope_without_root_raises(monkeypatch):
+    _set_pass(monkeypatch)
+    env = ks.wrap_identity_secret("data")
+    _unset_pass(monkeypatch)
+    with pytest.raises(ks.IdentityKeyLockedError):
+        ks.unwrap_identity_secret(env)
+
+
+def test_unwrap_passes_plaintext_through(monkeypatch):
+    _unset_pass(monkeypatch)
+    assert ks.unwrap_identity_secret('{"private_jwk": {}}') == '{"private_jwk": {}}'
+
+
+# ── DpopKey save/load end-to-end ────────────────────────────────────
+
+
+def test_dpop_key_encrypted_at_rest_roundtrip(tmp_path, monkeypatch):
+    from cullis_sdk.dpop import DpopKey
+
+    _set_pass(monkeypatch)
+    path = tmp_path / "dpop.jwk"
+    key = DpopKey.generate(path=path)
+    key.save(path)
+
+    # On disk: an envelope, NOT a plaintext JWK.
+    raw = path.read_text()
+    assert raw.startswith("enc:sec:v1:")
+    assert '"private_jwk"' not in raw
+    assert '"d"' not in raw
+
+    # Reloads to the same key (private 'd' matches through decryption).
+    reloaded = DpopKey.load(path)
+    assert reloaded.private_jwk()["d"] == key.private_jwk()["d"]
+    assert reloaded.public_jwk == key.public_jwk
+
+
+def test_dpop_key_plaintext_without_root(tmp_path, monkeypatch):
+    from cullis_sdk.dpop import DpopKey
+
+    _unset_pass(monkeypatch)
+    path = tmp_path / "dpop.jwk"
+    key = DpopKey.generate(path=path)
+    key.save(path)
+
+    raw = path.read_text()
+    assert not ks.is_secret_envelope(raw)
+    blob = json.loads(raw)  # legacy plaintext JWK
+    assert "private_jwk" in blob
+    # Loads back fine.
+    assert DpopKey.load(path).private_jwk()["d"] == key.private_jwk()["d"]
+
+
+def test_dpop_key_legacy_plaintext_loads_with_root_set(tmp_path, monkeypatch):
+    """A pre-F5 plaintext dpop.jwk must still load after the operator turns
+    on a passphrase (back-compat read of unencrypted files)."""
+    from cullis_sdk.dpop import DpopKey
+
+    # Write plaintext first (no root).
+    _unset_pass(monkeypatch)
+    path = tmp_path / "dpop.jwk"
+    key = DpopKey.generate(path=path)
+    key.save(path)
+    assert not ks.is_secret_envelope(path.read_text())
+
+    # Now a root is configured; the legacy plaintext file still loads.
+    _set_pass(monkeypatch)
+    assert DpopKey.load(path).private_jwk()["d"] == key.private_jwk()["d"]


### PR DESCRIPTION
## Finding (panel 2026-06-05, F5)

The agent's DPoP private JWK (`dpop.jwk`) shipped as a **plaintext file** guarded only by `chmod 0600`. Disk theft, a leaked VM snapshot/backup, or the `identity-bundle.zip` in transit exposed it. (`dpop.py` serialised with `NoEncryption()`.)

## This step (DPoP key only)

- **New `cullis_sdk._keystore`**: `enc:sec:v1:` envelope (Fernet + PBKDF2-HMAC-SHA256 600k), **structurally identical to the Mastio's `mcp_proxy.kms.pki_at_rest`** (F4) so a future shared `cullis_keystore` lib + test vectors line up. Per-domain salt (`cullis-sdk-identity-v1`) — the two surfaces custody different material under different roots and must not cross-decrypt.
- **Pluggable root-of-trust ladder**: OS keychain → age-file → env `CULLIS_IDENTITY_PASSPHRASE` → plaintext fallback. Step 1 wires only the env provider; keychain/age/TPM are ordered hooks that slot in without touching call sites or the on-disk format (the ladder approach chosen for the keystore design).
- **`DpopKey.save`** encrypts when a root is available; **`DpopKey.load`** decrypts an envelope and passes legacy plaintext JWKs through untouched. Existing identity dirs keep working; dev without a passphrase is unchanged. An enveloped file with no root **fails loud** (`IdentityKeyLockedError`).

## Deliberately out of scope (next step)

`key.pem` at rest: the mTLS path loads the key **by file path** into an ssl context, and stdlib `ssl` cannot load a key from memory — an encrypted `key.pem` needs decrypt-to-tempfile / in-memory-ssl handling, plus the `identity-bundle.zip` encryption + CSR-as-default work. The DPoP key is in-memory only (signing in-process), so it has no such constraint and is the clean first unit.

## Tests

10 new (`test_sdk_identity_keystore.py`): envelope round-trip + refuse-plaintext + wrong-passphrase-fails-loud; root ladder; wrap/unwrap with and without a root; DpopKey save/load encrypted round-trip; plaintext fallback without a root; legacy plaintext loads after a passphrase is turned on. Existing SDK dpop/auth/enrollment suites green (166 passed).

Companion to F4 (`mastio_keys` at rest, merged). Part of the common-keystore design (`imp/keystore-design-2026-06-05.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)