### PR TITLE
feat(sdk): encrypt the agent key.pem at rest via encrypted-PEM (F5 step 2)

### DIFF
--- a/cullis_sdk/_client/_auth.py
+++ b/cullis_sdk/_client/_auth.py
@@ -210,8 +210,11 @@ class _AuthMixin:
             DeprecationWarning,
             stacklevel=2,
         )
+        from cullis_sdk._keystore import unwrap_key_pem
+
         cert_pem = Path(cert_path).read_text()
-        key_pem = Path(key_path).read_text()
+        # F5: decrypt an at-rest encrypted-PEM key for the legacy login path.
+        key_pem = unwrap_key_pem(Path(key_path).read_text())
         # ``login_from_pem`` itself emits a DeprecationWarning; ``login``
         # callers will see both this and the inner one. They point at
         # complementary stack frames (user → login, login → login_from_pem)

--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -361,7 +361,13 @@ class _EnrollmentMixin:
         # (correct for local-key-holders) instead of ``login_via_proxy``
         # (which 404s at Mastio because Mastio doesn't hold this key).
         try:
-            instance._signing_key_pem = Path(key_path).read_text()
+            from cullis_sdk._keystore import unwrap_key_pem
+
+            # F5: decrypt an at-rest encrypted-PEM key.pem for in-process
+            # signing; plaintext passes through untouched.
+            instance._signing_key_pem = unwrap_key_pem(
+                Path(key_path).read_text()
+            )
         except OSError as exc:
             raise RuntimeError(
                 f"from_identity_dir: cannot read key_path={key_path!r} "
@@ -981,8 +987,12 @@ class _EnrollmentMixin:
         if cert_pem:
             (persist_to / "cert.pem").write_text(cert_pem)
         if private_key_pem:
+            from cullis_sdk._keystore import wrap_key_pem
+
             key_file = persist_to / "key.pem"
-            key_file.write_text(private_key_pem)
+            # F5: encrypt at rest (PKCS#8 encrypted-PEM) when a root is
+            # configured; plaintext + 0600 otherwise (dev fallback).
+            key_file.write_text(wrap_key_pem(private_key_pem))
             _os.chmod(key_file, 0o600)
 
     @classmethod
@@ -1061,9 +1071,14 @@ class _EnrollmentMixin:
         # Absent key/cert (legacy layout or a Connector that never
         # completed enrollment) is not fatal — tools that need them
         # surface a clear error at call time.
+        from cullis_sdk._keystore import unwrap_key_pem
+
         key_path = identity_dir / "agent.key"
         cert_path = identity_dir / "agent.crt"
-        instance._signing_key_pem = key_path.read_text() if key_path.exists() else None
+        # F5: decrypt an at-rest encrypted-PEM agent key for in-process signing.
+        instance._signing_key_pem = (
+            unwrap_key_pem(key_path.read_text()) if key_path.exists() else None
+        )
         instance._cert_pem = cert_path.read_text() if cert_path.exists() else None
         # ADR-014: present the agent cert at the TLS handshake when both
         # files exist on disk. nginx in front of the Mastio verifies the
@@ -1448,7 +1463,13 @@ class _EnrollmentMixin:
             encryption_algorithm=_ser.NoEncryption(),
         ).decode("ascii")
 
-        _atomic_write(agent_key_path, enroll_key_pem, mode=0o600)
+        from cullis_sdk._keystore import wrap_key_pem
+
+        # F5: encrypt the agent key at rest (PKCS#8 encrypted-PEM) when a
+        # root is configured. ``from_identity_dir`` (the step-10 hand-off
+        # below) and the mTLS ``load_cert_chain`` both decrypt it; plaintext
+        # is kept when no root is set (dev fallback).
+        _atomic_write(agent_key_path, wrap_key_pem(enroll_key_pem), mode=0o600)
         _atomic_write(agent_crt_path, cert_pem, mode=0o644)
         # B-7 follow-up (2026-05-25): persist DPoP material as the JSON
         # JWK shape the rest of the SDK consumes (``DpopKey.load`` calls

--- a/cullis_sdk/_keystore.py
+++ b/cullis_sdk/_keystore.py
@@ -178,6 +178,90 @@ def unwrap_identity_secret(value: str) -> str:
     return decrypt_secret(value, passphrase)
 
 
+# ── key.pem (mTLS) at rest — native encrypted-PEM, not the Fernet envelope ──
+#
+# key.pem is consumed by ``ssl.SSLContext.load_cert_chain`` which loads the
+# key from a FILE PATH (stdlib ssl cannot load a key from memory). So instead
+# of the enc:sec:v1 Fernet envelope used for the in-memory DPoP key, key.pem
+# is wrapped in the STANDARD PKCS#8 encrypted-PEM format
+# (``-----BEGIN ENCRYPTED PRIVATE KEY-----``), which ssl decrypts natively
+# via the ``password=`` argument — no tempfile, no memfd. Same root-of-trust
+# ladder; the passphrase is the wrapping key.
+
+_ENCRYPTED_PEM_MARKER = "ENCRYPTED PRIVATE KEY"
+
+
+def is_encrypted_pem(pem: str) -> bool:
+    """True when ``pem`` is a PKCS#8 encrypted private key."""
+    return _ENCRYPTED_PEM_MARKER in pem
+
+
+def wrap_key_pem(plaintext_pem: str) -> str:
+    """Re-serialise an unencrypted private-key PEM as PKCS#8 encrypted-PEM
+    under the ladder passphrase. Returns the plaintext unchanged when no
+    root is configured (dev fallback) or when it is already encrypted."""
+    if is_encrypted_pem(plaintext_pem):
+        return plaintext_pem
+    passphrase = resolve_root_passphrase()
+    if not passphrase:
+        _log.warning(
+            "agent key.pem written UNENCRYPTED at rest: no root-of-trust "
+            "configured (set %s to enable PKCS#8 encrypted-PEM).", _ENV_VAR,
+        )
+        return plaintext_pem
+    from cryptography.hazmat.primitives import serialization
+
+    key = serialization.load_pem_private_key(
+        plaintext_pem.encode("utf-8"), password=None,
+    )
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.BestAvailableEncryption(passphrase.encode("utf-8")),
+    ).decode("utf-8")
+
+
+def unwrap_key_pem(pem: str) -> str:
+    """Return a plaintext private-key PEM, decrypting an encrypted-PEM with
+    the ladder passphrase. Plaintext passes through. Raises
+    :class:`IdentityKeyLockedError` when the key is encrypted but no root
+    is available."""
+    if not is_encrypted_pem(pem):
+        return pem
+    passphrase = resolve_root_passphrase()
+    if not passphrase:
+        raise IdentityKeyLockedError(
+            f"agent key.pem is encrypted at rest but {_ENV_VAR} is not set "
+            "(and no keychain/age provider yielded a passphrase)."
+        )
+    from cryptography.hazmat.primitives import serialization
+
+    try:
+        key = serialization.load_pem_private_key(
+            pem.encode("utf-8"), password=passphrase.encode("utf-8"),
+        )
+    except (ValueError, TypeError) as exc:
+        raise IdentityKeyLockedError(
+            f"agent key.pem cannot be decrypted with the current {_ENV_VAR}."
+        ) from exc
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+def key_pem_load_password() -> "bytes | None":
+    """Password bytes for ``ssl.SSLContext.load_cert_chain(..., password=)``.
+
+    Returns the ladder passphrase encoded, or ``None`` when no root is
+    configured. ssl ignores the password for an unencrypted key, so this is
+    always safe to pass; an encrypted key with no root surfaces as an ssl
+    error at load time (fail-closed)."""
+    passphrase = resolve_root_passphrase()
+    return passphrase.encode("utf-8") if passphrase else None
+
+
 def _reset_cache_for_tests() -> None:
     """Test/rotation hook: drop derived Fernet masters from the LRU.
 
@@ -192,8 +276,12 @@ __all__ = [
     "IdentityKeyLockedError",
     "decrypt_secret",
     "encrypt_secret",
+    "is_encrypted_pem",
     "is_secret_envelope",
+    "key_pem_load_password",
     "resolve_root_passphrase",
     "unwrap_identity_secret",
+    "unwrap_key_pem",
     "wrap_identity_secret",
+    "wrap_key_pem",
 ]

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -82,11 +82,15 @@ def _cert_key_pair_matches(
     try:
         from cryptography import x509
         from cryptography.hazmat.primitives import serialization
+        from cullis_sdk._keystore import unwrap_key_pem
+
         cert_obj = x509.load_pem_x509_certificate(
             Path(cert_path).read_bytes(),
         )
+        # F5: tolerate an at-rest encrypted-PEM key.pem; plaintext passes through.
         key_obj = serialization.load_pem_private_key(
-            Path(key_path).read_bytes(), password=None,
+            unwrap_key_pem(Path(key_path).read_text()).encode("utf-8"),
+            password=None,
         )
     except (FileNotFoundError, ValueError, OSError) as exc:
         return False, f"could not load cert+key for pre-flight: {exc}"
@@ -194,8 +198,11 @@ def _build_proxy_http_client(
         insecure_ctx.check_hostname = False
         insecure_ctx.verify_mode = ssl.CERT_NONE
         if mtls_ok:
+            from cullis_sdk._keystore import key_pem_load_password
+
             insecure_ctx.load_cert_chain(
                 certfile=str(cert_path), keyfile=str(key_path),
+                password=key_pem_load_password(),
             )
         return httpx.Client(timeout=timeout, verify=insecure_ctx)
 
@@ -208,8 +215,11 @@ def _build_proxy_http_client(
         # Missing pinned file (pre-TOFU first contact) → fall through
         # to the system CA store the default context already loaded.
     if mtls_ok:
+        from cullis_sdk._keystore import key_pem_load_password
+
         ssl_context.load_cert_chain(
             certfile=str(cert_path), keyfile=str(key_path),
+            password=key_pem_load_password(),
         )
     return httpx.Client(timeout=timeout, verify=ssl_context)
 

--- a/cullis_sdk/providers_compat.py
+++ b/cullis_sdk/providers_compat.py
@@ -257,7 +257,14 @@ def cullis_httpx_client(
         ssl_ctx = ssl.create_default_context(cafile=str(ca))
     else:
         ssl_ctx = ssl.create_default_context()
-    ssl_ctx.load_cert_chain(certfile=str(cert), keyfile=str(key))
+    from cullis_sdk._keystore import key_pem_load_password
+
+    # F5: pass the ladder passphrase so an at-rest encrypted-PEM key.pem
+    # loads; None for a plaintext key, which ssl accepts unchanged.
+    ssl_ctx.load_cert_chain(
+        certfile=str(cert), keyfile=str(key),
+        password=key_pem_load_password(),
+    )
 
     inner = httpx.HTTPTransport(verify=ssl_ctx)
     transport = _DpopTransport(inner, dpop_key)

--- a/test/unit/test_sdk_identity_keystore.py
+++ b/test/unit/test_sdk_identity_keystore.py
@@ -137,3 +137,132 @@ def test_dpop_key_legacy_plaintext_loads_with_root_set(tmp_path, monkeypatch):
     # Now a root is configured; the legacy plaintext file still loads.
     _set_pass(monkeypatch)
     assert DpopKey.load(path).private_jwk()["d"] == key.private_jwk()["d"]
+
+
+# ── key.pem (mTLS) at rest — PKCS#8 encrypted-PEM ───────────────────
+
+
+def _fresh_key_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def test_wrap_key_pem_produces_encrypted_pem(monkeypatch):
+    _set_pass(monkeypatch)
+    enc = ks.wrap_key_pem(_fresh_key_pem())
+    assert enc.startswith("-----BEGIN ENCRYPTED PRIVATE KEY-----")
+    assert ks.is_encrypted_pem(enc)
+
+
+def test_wrap_key_pem_plaintext_without_root(monkeypatch):
+    _unset_pass(monkeypatch)
+    pem = _fresh_key_pem()
+    assert ks.wrap_key_pem(pem) == pem  # dev fallback, unchanged
+
+
+def test_unwrap_key_pem_roundtrip(monkeypatch):
+    _set_pass(monkeypatch)
+    pem = _fresh_key_pem()
+    enc = ks.wrap_key_pem(pem)
+    out = ks.unwrap_key_pem(enc)
+    assert not ks.is_encrypted_pem(out)
+    assert "BEGIN PRIVATE KEY" in out
+
+
+def test_unwrap_key_pem_encrypted_without_root_raises(monkeypatch):
+    _set_pass(monkeypatch)
+    enc = ks.wrap_key_pem(_fresh_key_pem())
+    _unset_pass(monkeypatch)
+    with pytest.raises(ks.IdentityKeyLockedError):
+        ks.unwrap_key_pem(enc)
+
+
+def test_ssl_load_cert_chain_accepts_encrypted_key(tmp_path, monkeypatch):
+    """THE CORE mTLS DE-RISK: ssl must natively load our encrypted-PEM
+    key.pem via the password argument. If this breaks, agent mTLS breaks."""
+    import datetime
+    import ssl
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    _set_pass(monkeypatch)
+    key = ec.generate_private_key(ec.SECP256R1())
+    plain_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    subj = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "agent")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subj).issuer_name(subj)
+        .public_key(key.public_key()).serial_number(1)
+        .not_valid_before(datetime.datetime(2026, 1, 1))
+        .not_valid_after(datetime.datetime(2027, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    cp = tmp_path / "cert.pem"
+    kp = tmp_path / "key.pem"
+    cp.write_text(cert_pem)
+    kp.write_text(ks.wrap_key_pem(plain_pem))  # encrypted-PEM on disk
+    assert ks.is_encrypted_pem(kp.read_text())
+
+    ctx = ssl.create_default_context()
+    # Must not raise: ssl decrypts the key with the ladder passphrase.
+    ctx.load_cert_chain(
+        certfile=str(cp), keyfile=str(kp),
+        password=ks.key_pem_load_password(),
+    )
+
+
+def test_load_cert_chain_plaintext_key_with_root_set(tmp_path, monkeypatch):
+    """Back-compat lock: a root is configured but the on-disk key.pem is a
+    legacy PLAINTEXT PEM. ssl must still load it — the password is passed
+    (non-None) but ignored for an unencrypted key. Mirrors a deploy that
+    turned on a passphrase before re-writing existing identities."""
+    import datetime
+    import ssl
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    _set_pass(monkeypatch)  # root IS set
+    key = ec.generate_private_key(ec.SECP256R1())
+    plain_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    subj = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "agent")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subj).issuer_name(subj)
+        .public_key(key.public_key()).serial_number(1)
+        .not_valid_before(datetime.datetime(2026, 1, 1))
+        .not_valid_after(datetime.datetime(2027, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    cp = tmp_path / "cert.pem"
+    kp = tmp_path / "key.pem"
+    cp.write_text(cert.public_bytes(serialization.Encoding.PEM).decode())
+    kp.write_text(plain_pem)  # PLAINTEXT key on disk
+    assert not ks.is_encrypted_pem(kp.read_text())
+
+    ssl.create_default_context().load_cert_chain(
+        certfile=str(cp), keyfile=str(kp),
+        password=ks.key_pem_load_password(),  # non-None, ignored for plaintext
+    )


### PR DESCRIPTION
## Finding (panel 2026-06-05, F5)

The agent mTLS private key (`key.pem`) shipped as a **plaintext PEM** guarded only by `chmod 0600` — exposed to disk theft, a leaked snapshot/backup, and the `identity-bundle.zip` in transit.

## Why a different mechanism than the DPoP key (step 1)

The DPoP key is loaded into memory and signs in-process, so step 1 wrapped it in the `enc:sec:v1` Fernet envelope. `key.pem` is different: it is consumed by `ssl.SSLContext.load_cert_chain`, which loads the key **from a file path** — stdlib `ssl` cannot load a key from memory. So `key.pem` uses the **standard PKCS#8 encrypted-PEM** format (`-----BEGIN ENCRYPTED PRIVATE KEY-----`), which ssl decrypts natively via the `password=` argument. No tempfile, no memfd.

## Change

`cullis_sdk._keystore` gains `wrap_key_pem` / `unwrap_key_pem` / `is_encrypted_pem` / `key_pem_load_password`, same root ladder as the DPoP key (`CULLIS_IDENTITY_PASSPHRASE` today). Wired at every `key.pem` boundary:

- **write**: the persist flow re-serialises as encrypted-PEM when a root is set.
- **mTLS load**: all three `load_cert_chain` sites (`client.py` ×2, `providers_compat`) pass `password=key_pem_load_password()` — `None` for a plaintext key (ssl accepts unchanged), the passphrase for an encrypted one.
- **in-memory signing**: `from_identity_dir` decrypts `key.pem` to plaintext for in-process JWT/message signing; the pre-flight cert/key pair check unwraps too.
- **back-compat**: plaintext `key.pem` passes through everywhere; an encrypted key with no root fails closed (ssl error / `IdentityKeyLockedError`) rather than prompting or returning a wrong key.

## Tests

5 new, including the **core de-risk**: `ssl.load_cert_chain` natively loads our encrypted-PEM key with the ladder passphrase (a self-signed cert+encrypted-key, real `load_cert_chain` call). If that broke, agent mTLS would break. Existing client/tls/enrollment suites green (240 passed).

Completes F5 at-rest for both agent key surfaces (DPoP #1068 + `key.pem` here). `identity-bundle.zip` encryption + CSR-as-default + keychain/age/TPM providers remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)