### PR TITLE
fix(helm): mint the DPoP nonce secret install-scoped (S-7 Helm leg)

### DIFF
--- a/deploy/helm/cullis-mastio/templates/proxy-secret.yaml
+++ b/deploy/helm/cullis-mastio/templates/proxy-secret.yaml
@@ -21,6 +21,19 @@ stringData:
   MCP_PROXY_DASHBOARD_SIGNING_KEY: {{ .Values.secrets.dashboardSigningKey | default (randAlphaNum 48) | quote }}
   MCP_PROXY_DB_ENCRYPTION_KEY: {{ .Values.secrets.dbEncryptionKey | default (randAlphaNum 48) | quote }}
   MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET: {{ .Values.secrets.pdpWebhookHmacSecret | default (randAlphaNum 48) | quote }}
+  # RFC 9449 §8 server nonce secret. The nonce is derived as
+  # ``HMAC(secret, time_window)``; with >1 replica (replicaCount / HPA) every
+  # pod MUST derive the same nonce, otherwise a client that gets a nonce
+  # challenge from pod A and retries against pod B loops on ``use_dpop_nonce``
+  # 401s (the /v1/llm/chat path requires the nonce). Minting it into the
+  # install-scoped, kept Secret makes every pod read one shared value — the
+  # per-pod file fallback does NOT survive across pods, nor with the Postgres
+  # backend (no ``data`` volume mounted). Unlike the 4 keys above this is NOT a
+  # refuse-to-boot gate: a missing secret degrades to a per-process nonce + a
+  # logged warning (config.py documents it as a multi-replica prod
+  # requirement). Minting it here closes the Helm leg of S-7 (#1050 fixed
+  # compose+bundle).
+  MCP_PROXY_DPOP_NONCE_SECRET: {{ .Values.secrets.dpopNonceSecret | default (randAlphaNum 48) | quote }}
   {{- if .Values.secrets.orgSecret }}
   MCP_PROXY_ORG_SECRET: {{ .Values.secrets.orgSecret | quote }}
   {{- end }}

--- a/deploy/helm/cullis-mastio/values.yaml
+++ b/deploy/helm/cullis-mastio/values.yaml
@@ -446,6 +446,12 @@ secrets:
   # in production. Empty → chart mints a random one. Set to match the
   # broker's POLICY_WEBHOOK_HMAC_SECRET when pairing with an external PDP.
   pdpWebhookHmacSecret: ""
+  # -- Shared HMAC secret for the RFC 9449 server nonce. With replicaCount > 1
+  # or the HPA enabled every pod must derive the same nonce, else DPoP clients
+  # (e.g. the /v1/llm/chat path) loop on ``use_dpop_nonce`` 401s when a retry
+  # lands on a different pod. Empty → chart mints a random one into the kept
+  # Secret (shared across all pods). Pin it to survive a Secret recreation.
+  dpopNonceSecret: ""
   # -- Org-level secret used by the proxy to authenticate to the broker
   # for admin/egress operations (when the broker is configured to require
   # one). Optional.


### PR DESCRIPTION
## Problem

S-7 (DPoP nonce that doesn't survive concurrency → `use_dpop_nonce` 401 loops on `/v1/llm/chat`) was fixed for **compose + bundle** in #1050 (worker-shared `HMAC(secret, window)` nonce + secret wiring). The **Helm** leg was missed.

The chart auto-mints the dashboard signing key, DB encryption key and PDP webhook HMAC into the install-scoped, kept Secret so every replica reads the same value — but it **omitted `MCP_PROXY_DPOP_NONCE_SECRET`**. `config.py` already documents this as a multi-replica production requirement:

```
# Production / multi-replica Helm MUST set ``MCP_PROXY_DPOP_NONCE_SECRET``
```

So on `replicaCount > 1` or with the HPA enabled, each pod fell back to a per-process nonce secret:
- the persisted file (`certs/.mcp_proxy_dpop_nonce_secret`) does **not** survive across pods;
- with the Postgres backend no `data` volume is mounted at all → ephemeral per-pod fs;
- → `os.urandom` per process in the worst case.

A DPoP client that received a nonce challenge from pod A and retried on pod B looped on `use_dpop_nonce` 401s — **the exact S-7 failure mode on a different deploy surface** (same class as the Helm leg of the reload-watcher gap, #1043).

## Fix

Mint `MCP_PROXY_DPOP_NONCE_SECRET` into the same install-scoped, kept Secret using the existing `randAlphaNum 48` default, plus a `secrets.dpopNonceSecret` override in `values.yaml`. Every pod now reads one shared value — robust regardless of RWX PVC or sticky sessions (which the SDK DPoP clients don't carry anyway).

16 lines, no logic change, mirrors the existing 4 refuse-to-boot secret entries 1:1.

## Test

`helm` not available locally; the change is a 1:1 copy of the established pattern. Reviewer can confirm with `helm template t deploy/helm/cullis-mastio --set proxy.replicaCount=3 | grep MCP_PROXY_DPOP_NONCE_SECRET`.