### PR TITLE
fix(site): map per-agent identity to DORA Art. 9, not Art. 28/30

### DIFF
--- a/site/src/pages/index-dark.astro
+++ b/site/src/pages/index-dark.astro
@@ -163,7 +163,7 @@ import Layout from '../layouts/Layout.astro';
               is the agent itself, not a shared API key reused by twelve
               services. Identity rotates on its own schedule, revocation
               propagates in seconds. Addresses EU AI Act Art. 12 logging
-              and DORA Art. 28 cryptographic identity per action.
+              and DORA Art. 9 access and authentication management.
             </p>
             <a class="feature-link" href="https://github.com/cullis-security/cullis#cullis-mastio">Identity model →</a>
           </li>
@@ -305,7 +305,8 @@ import Layout from '../layouts/Layout.astro';
             Cullis-unique. No Anthropic template. Runs on
             <strong>OpenAI GPT-5 via the native OpenAI adapter</strong>
             to prove LLM-agnostic. Per-agent cryptographic identity
-            bound to every reporting action satisfies DORA Art. 28.
+            bound to every reporting action supports DORA Art. 28
+            third-party reporting.
           </p>
         </article>
       </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -76,7 +76,7 @@ import Layout from '../layouts/Layout.astro';
         </li>
         <li>
           <span class="std-name">DORA</span>
-          <span class="std-where">Art. 28</span>
+          <span class="std-where">Art. 9 · Art. 28</span>
         </li>
       </ul>
     </div>
@@ -125,8 +125,8 @@ import Layout from '../layouts/Layout.astro';
             9449. The caller authenticated at the gateway is the agent
             itself, not a shared service account. Rotation on its own
             schedule, revocation propagates in seconds. Designed around EU AI Act
-            Art. 12 and DORA Art. 28 + Art. 30 (ICT third-party risk +
-            key contractual provisions).
+            Art. 12 (record-keeping) and DORA Art. 9 (ICT protection —
+            access and authentication management).
           </p>
           <a class="feature-link" href="https://github.com/cullis-security/cullis#cullis-mastio">Identity model →</a>
         </div>


### PR DESCRIPTION
## Cosa

La homepage mappava l'identità crittografica per-agente a **DORA Art. 28 + Art. 30**, che invece governano il **rischio di terze parti ICT (vendor)**: registro delle informazioni, reporting annuale, clausole contrattuali (data location, audit rights). L'identità per-agente, l'autenticazione forte e l'access management appartengono ad **Art. 9 (Protection and prevention)** dentro il framework ICT risk management.

## Verifica verbatim (Reg. UE 2022/2554)

- **Art. 9(4)(c)** — "...policies that limit the physical or logical access to information assets and ICT assets... that **address access rights**..."
- **Art. 9(4)(d)** — "...protocols for **strong authentication mechanisms**... and **protection measures of cryptographic keys**..."
- **Art. 28(3)** — "**register of information**... report **at least yearly** to the competent authorities..." (use-case Vendor Reporter, corretto)
- **Art. 30(2)(b)/(3)(e)** — data location + "**unrestricted rights of access, inspection and audit**" (clausole contratto, corretto)

## Modifiche

- `index.astro`: feature identità → AI Act Art. 12 + **DORA Art. 9**; strip standard → `Art. 9 · Art. 28`
- `index-dark.astro`: feature identità → **DORA Art. 9**; use-case Vendor Reporter ammorbidito da "satisfies" a "supports DORA Art. 28"

Art. 28/30 restano sul use-case **DORA Vendor Reporter**, dove sono corretti.

## Test

`npm run build` (Astro) verde — 33 pagine, nessun errore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)