### PR TITLE
feat(dashboard): per-provider + per-agent LLM usage view from the audit chain

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -141,6 +141,11 @@ router.include_router(_settings_routes.router)
 from mcp_proxy.dashboard import api_status_routes as _api_status_routes  # noqa: E402
 router.include_router(_api_status_routes.router)
 
+# LLM usage metering — per-provider + per-agent token view derived
+# read-time from the audit chain (no parallel meter table).
+from mcp_proxy.dashboard import usage_routes as _usage_routes  # noqa: E402
+router.include_router(_usage_routes.router)
+
 
 # Helpers (_ctx, _enforce_safe_outbound_url, _login_client_ip,
 # _post_login_redirect, _load_display_name, generate_org_ca,

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -95,6 +95,11 @@
                 Audit Log
                 <span hx-get="/proxy/badge/audit" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            <a href="/proxy/usage"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'usage' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+                Usage
+            </a>
             <a href="/proxy/settings"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'settings' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/></svg>

--- a/mcp_proxy/dashboard/templates/usage.html
+++ b/mcp_proxy/dashboard/templates/usage.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+{% block title %}Usage{% endblock %}
+{% block header_title %}LLM Usage{% endblock %}
+{% block content %}
+<div class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-start justify-between mb-6 gap-6">
+        <div class="min-w-0">
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">LLM Usage</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                Token usage attributed per provider and per agent identity, derived
+                from the signed audit chain — re-verifiable, not a parallel counter.
+            </p>
+        </div>
+
+        <!-- Totals chip: total tokens · prompt · completion -->
+        <div class="flex items-center gap-0 flex-shrink-0 border border-gray-800/60 rounded-md overflow-hidden bg-surface-900/60 backdrop-blur-sm">
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="Total tokens (prompt + completion) summed over the selected window.">
+                <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Tokens</span>
+                <span class="text-sm font-mono text-white">{{ "{:,}".format(totals.total_tokens) }}</span>
+            </div>
+            <div class="w-px h-5 bg-gray-800/80 self-center"></div>
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="Number of egress_llm_chat calls in the window.">
+                <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-blue-400/80">Calls</span>
+                <span class="text-sm font-mono text-blue-400">{{ "{:,}".format(totals.calls) }}</span>
+            </div>
+            {% if totals.has_cost %}
+            <div class="w-px h-5 bg-gray-800/80 self-center"></div>
+            <div class="px-3 py-1.5 flex items-center gap-2"
+                 title="Cost in USD where the upstream provider reported it (best-effort; not all calls carry a cost).">
+                <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-accent-400/80">Cost</span>
+                <span class="text-sm font-mono text-accent-400">${{ "%.2f"|format(totals.cost_usd) }}</span>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Window selector -->
+    <div class="flex items-center gap-2 mb-5">
+        <span class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Window</span>
+        <div class="inline-flex border border-gray-800/60 rounded-md overflow-hidden bg-surface-900/60">
+            {% for w in windows %}
+            <a href="/proxy/usage?window={{ w }}"
+               class="px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider transition-colors {% if window == w %}bg-accent-400/15 text-accent-400{% else %}text-gray-500 hover:text-gray-300 hover:bg-gray-800/40{% endif %}">
+                {{ w }}
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+
+    {% if capped %}
+    <div class="mb-5 px-4 py-2.5 border border-amber-500/40 bg-amber-500/5 rounded-md text-xs text-amber-300/90">
+        Partial totals — the scan was truncated at {{ "{:,}".format(scanned) }} audit rows.
+        Narrow the window or enable a materialised rollup for full-history totals.
+    </div>
+    {% endif %}
+
+    <!-- By provider -->
+    <div class="mb-8">
+        <h3 class="text-[11px] font-heading uppercase tracking-[0.2em] text-gray-500 mb-2">By provider</h3>
+        <div class="border border-gray-800/60 rounded-md overflow-hidden">
+            <table class="w-full text-xs">
+                <thead class="bg-surface-900/60 text-gray-600">
+                    <tr class="text-left uppercase tracking-wider text-[10px]">
+                        <th class="px-4 py-2.5 font-heading">Provider</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Calls</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Prompt</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Completion</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Total tokens</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Cost</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-800/50">
+                    {% for row in by_provider %}
+                    <tr class="hover:bg-gray-800/20">
+                        <td class="px-4 py-2.5 font-mono text-gray-200">{{ row.key }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.calls) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.prompt_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.completion_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-white text-right">{{ "{:,}".format(row.total_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-accent-400 text-right">{% if row.has_cost %}${{ "%.2f"|format(row.cost_usd) }}{% else %}<span class="text-gray-700">—</span>{% endif %}</td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="6" class="px-4 py-6 text-center text-gray-600">No LLM usage recorded in this window.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- By agent -->
+    <div class="mb-4">
+        <h3 class="text-[11px] font-heading uppercase tracking-[0.2em] text-gray-500 mb-2">By agent</h3>
+        <div class="border border-gray-800/60 rounded-md overflow-hidden">
+            <table class="w-full text-xs">
+                <thead class="bg-surface-900/60 text-gray-600">
+                    <tr class="text-left uppercase tracking-wider text-[10px]">
+                        <th class="px-4 py-2.5 font-heading">Agent</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Calls</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Prompt</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Completion</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Total tokens</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Cost</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-800/50">
+                    {% for row in by_agent %}
+                    <tr class="hover:bg-gray-800/20">
+                        <td class="px-4 py-2.5 font-mono text-gray-200">{{ row.key }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.calls) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.prompt_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-400 text-right">{{ "{:,}".format(row.completion_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-white text-right">{{ "{:,}".format(row.total_tokens) }}</td>
+                        <td class="px-4 py-2.5 font-mono text-accent-400 text-right">{% if row.has_cost %}${{ "%.2f"|format(row.cost_usd) }}{% else %}<span class="text-gray-700">—</span>{% endif %}</td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="6" class="px-4 py-6 text-center text-gray-600">No LLM usage recorded in this window.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/mcp_proxy/dashboard/usage_routes.py
+++ b/mcp_proxy/dashboard/usage_routes.py
@@ -1,0 +1,85 @@
+"""Mastio dashboard — LLM usage metering sub-router.
+
+Surfaces per-provider and per-agent token usage of the embedded AI
+gateway. Unlike a commodity gateway's per-API-key counter, the numbers
+here are derived read-time from the append-only audit chain
+(``aggregate_llm_usage`` in :mod:`mcp_proxy.db`): every ``egress_llm_chat``
+row carries the token counts, so what the operator sees is exactly what an
+auditor can re-verify from the signed chain — attribution is per agent
+identity, not per shared key.
+
+Mounted via ``router.include_router(usage_routes.router)`` from
+``mcp_proxy/dashboard/router.py`` so the outer ``/proxy`` prefix is
+inherited.
+
+Routes (1):
+
+  GET  /proxy/usage         per-provider + per-agent token usage view
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard._helpers import _ctx
+from mcp_proxy.dashboard._template_env import build_templates
+from mcp_proxy.dashboard.session import require_login
+from mcp_proxy.db import aggregate_llm_usage
+
+_log = logging.getLogger("mcp_proxy.dashboard")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = build_templates(_TEMPLATE_DIR)
+
+router = APIRouter(tags=["dashboard-usage"])
+
+# Window selector → days of look-back. ``all`` scans the whole chain.
+_WINDOWS: dict[str, int | None] = {"7d": 7, "30d": 30, "all": None}
+_DEFAULT_WINDOW = "30d"
+
+
+def _window_start(window: str) -> str | None:
+    """ISO-8601 UTC cutoff for ``window``; ``None`` for all-time.
+
+    Mirrors the ``datetime.now(timezone.utc).isoformat()`` shape that
+    ``log_audit`` writes, so the ``timestamp >= window_start`` comparison
+    is a valid lexicographic range over identically-formatted strings.
+    """
+    days = _WINDOWS.get(window)
+    if days is None:
+        return None
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+@router.get("/usage", response_class=HTMLResponse)
+async def usage_page(request: Request) -> HTMLResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    window = request.query_params.get("window", _DEFAULT_WINDOW)
+    if window not in _WINDOWS:
+        window = _DEFAULT_WINDOW
+
+    usage = await aggregate_llm_usage(_window_start(window))
+
+    return templates.TemplateResponse(
+        "usage.html",
+        _ctx(
+            request,
+            session,
+            active="usage",
+            window=window,
+            windows=list(_WINDOWS.keys()),
+            by_provider=usage["by_provider"],
+            by_agent=usage["by_agent"],
+            totals=usage["totals"],
+            scanned=usage["scanned"],
+            capped=usage["capped"],
+        ),
+    )

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -973,6 +973,143 @@ async def count_enrolled_agents() -> int:
         return int(row["n"]) if row else 0
 
 
+# ─── LLM usage metering (read-time aggregation from the audit chain) ──────
+#
+# The usage dashboard derives per-provider and per-agent token totals
+# straight from the append-only audit chain: every ``egress_llm_chat`` row
+# carries ``prompt_tokens`` / ``completion_tokens`` / ``cost_usd`` /
+# ``provider`` in its JSON ``detail``. There is deliberately no parallel
+# meter table — the number shown is the number an auditor can re-verify
+# from the signed chain. Tokens are always present; ``cost_usd`` is summed
+# only where the upstream provider reported it (best-effort). A materialised
+# rollup is the documented follow-up if volumes outgrow this read-time scan.
+
+_USAGE_SCAN_CAP = 200_000  # rows scanned before we truncate + flag (no silent cap)
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+async def aggregate_llm_usage(window_start: str | None = None) -> dict:
+    """Aggregate LLM token usage from the audit chain.
+
+    ``window_start`` is an ISO-8601 UTC timestamp; ``egress_llm_chat`` rows
+    with ``timestamp >= window_start`` are summed. ``None`` means all-time.
+    Returns per-provider and per-agent breakdowns (descending by total
+    tokens) plus grand totals. ``scanned`` is the row count examined and
+    ``capped`` is ``True`` when the scan hit :data:`_USAGE_SCAN_CAP` and was
+    truncated — surfaced in the UI so a partial total never reads as full.
+    """
+    conds = ["action = :action"]
+    params: dict[str, Any] = {"action": "egress_llm_chat"}
+    if window_start:
+        conds.append("timestamp >= :start")
+        params["start"] = window_start
+    where = " WHERE " + " AND ".join(conds)
+    # Pull one over the cap so we can detect (and flag) truncation.
+    params["_cap"] = _USAGE_SCAN_CAP + 1
+    sql = (
+        f"SELECT agent_id, detail FROM audit_log{where} "
+        "ORDER BY timestamp DESC LIMIT :_cap"
+    )
+
+    async with get_db() as conn:
+        result = await conn.execute(text(sql), params)
+        rows = result.mappings().all()
+
+    capped = len(rows) > _USAGE_SCAN_CAP
+    if capped:
+        rows = rows[:_USAGE_SCAN_CAP]
+        _log.warning(
+            "aggregate_llm_usage truncated at %d rows (window_start=%s); "
+            "totals are partial — consider a materialised rollup",
+            _USAGE_SCAN_CAP,
+            window_start,
+        )
+
+    by_provider: dict[str, dict] = {}
+    by_agent: dict[str, dict] = {}
+    totals = {
+        "calls": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+        "cost_usd": 0.0,
+        "has_cost": False,
+    }
+
+    def _bump(bucket: dict[str, dict], key: str, prompt: int, completion: int,
+              cost: float, has_cost: bool) -> None:
+        row = bucket.setdefault(
+            key,
+            {
+                "key": key,
+                "calls": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+                "has_cost": False,
+            },
+        )
+        row["calls"] += 1
+        row["prompt_tokens"] += prompt
+        row["completion_tokens"] += completion
+        row["total_tokens"] += prompt + completion
+        if has_cost:
+            row["cost_usd"] += cost
+            row["has_cost"] = True
+
+    for row in rows:
+        detail = row["detail"]
+        if not detail:
+            continue
+        try:
+            payload = json.loads(detail)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        prompt = _coerce_int(payload.get("prompt_tokens"))
+        completion = _coerce_int(payload.get("completion_tokens"))
+        provider = payload.get("provider") or "unknown"
+        agent_id = row["agent_id"] or payload.get("principal_id") or "unknown"
+        raw_cost = payload.get("cost_usd")
+        has_cost = raw_cost is not None
+        cost = _coerce_float(raw_cost)
+
+        _bump(by_provider, provider, prompt, completion, cost, has_cost)
+        _bump(by_agent, agent_id, prompt, completion, cost, has_cost)
+
+        totals["calls"] += 1
+        totals["prompt_tokens"] += prompt
+        totals["completion_tokens"] += completion
+        totals["total_tokens"] += prompt + completion
+        if has_cost:
+            totals["cost_usd"] += cost
+            totals["has_cost"] = True
+
+    _by_total = lambda r: r["total_tokens"]  # noqa: E731
+    return {
+        "by_provider": sorted(by_provider.values(), key=_by_total, reverse=True),
+        "by_agent": sorted(by_agent.values(), key=_by_total, reverse=True),
+        "totals": totals,
+        "scanned": len(rows),
+        "capped": capped,
+    }
+
+
 async def list_user_principals() -> list[dict]:
     """List user principals registered on this Mastio.
 

--- a/test/unit/test_dashboard_usage.py
+++ b/test/unit/test_dashboard_usage.py
@@ -1,0 +1,231 @@
+"""LLM usage metering — aggregation + dashboard view.
+
+The usage page derives per-provider and per-agent token totals read-time
+from the audit chain (``aggregate_llm_usage`` in :mod:`mcp_proxy.db`):
+every ``egress_llm_chat`` row carries ``prompt_tokens`` /
+``completion_tokens`` / ``cost_usd`` / ``provider`` in its JSON ``detail``.
+These tests pin:
+
+1. tokens aggregate correctly per provider and per agent, with grand totals;
+2. non-``egress_llm_chat`` rows and rows with missing token fields don't
+   inflate the totals (missing → 0);
+3. the ``window_start`` cutoff scopes the sum to the time window;
+4. ``cost_usd`` is summed only where the provider reported it (best-effort);
+5. the route wiring maps GET /usage to ``usage_page`` and threads the
+   aggregates into the template context.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import text
+from starlette.datastructures import QueryParams
+
+from mcp_proxy.db import aggregate_llm_usage, dispose_db, get_db, init_db
+
+
+async def _insert_egress(rows: list[dict]) -> None:
+    """Insert ``egress_llm_chat`` audit rows with a JSON ``detail``."""
+    payload = [
+        {
+            "ts": r["ts"],
+            "aid": r["aid"],
+            "act": r.get("act", "egress_llm_chat"),
+            "detail": json.dumps(r["detail"]) if r.get("detail") is not None else None,
+        }
+        for r in rows
+    ]
+    async with get_db() as db:
+        await db.execute(
+            text(
+                "INSERT INTO audit_log (timestamp, agent_id, action, status, detail) "
+                "VALUES (:ts, :aid, :act, 'success', :detail)"
+            ),
+            payload,
+        )
+        await db.commit()
+
+
+@pytest.fixture
+async def usage_db(monkeypatch, tmp_path):
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-usage")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    url = f"sqlite+aiosqlite:///{tmp_path / 'usage.db'}"
+    await init_db(url)
+    yield url
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+def _by_key(rows: list[dict]) -> dict[str, dict]:
+    return {r["key"]: r for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_aggregates_per_provider_and_per_agent(usage_db):
+    await _insert_egress(
+        [
+            {"ts": "2026-06-07T10:00:00+00:00", "aid": "acme::kyc",
+             "detail": {"provider": "anthropic", "prompt_tokens": 100, "completion_tokens": 20}},
+            {"ts": "2026-06-07T10:01:00+00:00", "aid": "acme::kyc",
+             "detail": {"provider": "anthropic", "prompt_tokens": 50, "completion_tokens": 10}},
+            {"ts": "2026-06-07T10:02:00+00:00", "aid": "acme::rebalance",
+             "detail": {"provider": "openai", "prompt_tokens": 200, "completion_tokens": 100}},
+        ]
+    )
+
+    out = await aggregate_llm_usage(None)
+
+    prov = _by_key(out["by_provider"])
+    assert prov["anthropic"]["calls"] == 2
+    assert prov["anthropic"]["prompt_tokens"] == 150
+    assert prov["anthropic"]["completion_tokens"] == 30
+    assert prov["anthropic"]["total_tokens"] == 180
+    assert prov["openai"]["total_tokens"] == 300
+
+    agent = _by_key(out["by_agent"])
+    assert agent["acme::kyc"]["total_tokens"] == 180
+    assert agent["acme::rebalance"]["total_tokens"] == 300
+
+    assert out["totals"]["calls"] == 3
+    assert out["totals"]["total_tokens"] == 480
+    # Descending by total tokens: openai (300) before anthropic (180).
+    assert out["by_provider"][0]["key"] == "openai"
+
+
+@pytest.mark.asyncio
+async def test_non_egress_and_missing_tokens_do_not_inflate(usage_db):
+    await _insert_egress(
+        [
+            # A real egress row.
+            {"ts": "2026-06-07T10:00:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic", "prompt_tokens": 10, "completion_tokens": 5}},
+            # Wrong action — must be ignored entirely.
+            {"ts": "2026-06-07T10:01:00+00:00", "aid": "acme::a", "act": "auth.login",
+             "detail": {"provider": "anthropic", "prompt_tokens": 9999, "completion_tokens": 9999}},
+            # egress but no token fields — counts as a call, 0 tokens.
+            {"ts": "2026-06-07T10:02:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic"}},
+            # egress with null detail — skipped (no payload).
+            {"ts": "2026-06-07T10:03:00+00:00", "aid": "acme::a", "detail": None},
+        ]
+    )
+
+    out = await aggregate_llm_usage(None)
+
+    assert out["totals"]["total_tokens"] == 15, "only the real egress tokens count"
+    # The no-token egress row still counts as a call; the null-detail row does not.
+    assert out["totals"]["calls"] == 2
+    prov = _by_key(out["by_provider"])
+    assert prov["anthropic"]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_window_start_scopes_the_sum(usage_db):
+    await _insert_egress(
+        [
+            {"ts": "2020-01-01T00:00:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic", "prompt_tokens": 1000, "completion_tokens": 0}},
+            {"ts": "2026-06-07T10:00:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic", "prompt_tokens": 7, "completion_tokens": 0}},
+        ]
+    )
+
+    all_time = await aggregate_llm_usage(None)
+    assert all_time["totals"]["total_tokens"] == 1007
+
+    windowed = await aggregate_llm_usage("2026-01-01T00:00:00+00:00")
+    assert windowed["totals"]["total_tokens"] == 7, "old row is outside the window"
+
+
+@pytest.mark.asyncio
+async def test_cost_summed_only_where_present(usage_db):
+    await _insert_egress(
+        [
+            {"ts": "2026-06-07T10:00:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic", "prompt_tokens": 10, "completion_tokens": 0,
+                        "cost_usd": 0.25}},
+            {"ts": "2026-06-07T10:01:00+00:00", "aid": "acme::a",
+             "detail": {"provider": "anthropic", "prompt_tokens": 10, "completion_tokens": 0,
+                        "cost_usd": None}},
+        ]
+    )
+
+    out = await aggregate_llm_usage(None)
+    assert out["totals"]["has_cost"] is True
+    assert out["totals"]["cost_usd"] == pytest.approx(0.25)
+
+
+def test_usage_route_maps_to_usage_page():
+    """GET /usage must decorate ``usage_page`` — guards against a misplaced
+    decorator (the class of bug that turned GET /audit into a 422)."""
+    import mcp_proxy.dashboard.usage_routes as ur
+
+    routes = [
+        r for r in ur.router.routes
+        if getattr(r, "path", None) == "/usage"
+        and "GET" in getattr(r, "methods", set())
+    ]
+    assert routes, "GET /usage route not registered"
+    assert routes[0].endpoint is ur.usage_page
+
+
+@pytest.mark.asyncio
+async def test_usage_page_threads_aggregates_into_context(usage_db):
+    await _insert_egress(
+        [
+            {"ts": "2026-06-07T10:00:00+00:00", "aid": "acme::kyc",
+             "detail": {"provider": "anthropic", "prompt_tokens": 100, "completion_tokens": 20}},
+        ]
+    )
+
+    import mcp_proxy.dashboard.usage_routes as ur
+
+    class _Req:
+        query_params = QueryParams("window=all")
+
+    orig_login = ur.require_login
+    orig_ctx = ur._ctx
+    orig_tr = ur.templates.TemplateResponse
+    ur.require_login = lambda request: {"username": "admin"}
+    ur._ctx = lambda request, session, **kw: kw
+    ur.templates.TemplateResponse = lambda name, ctx: ctx
+    try:
+        ctx = await ur.usage_page(_Req())
+    finally:
+        ur.require_login = orig_login
+        ur._ctx = orig_ctx
+        ur.templates.TemplateResponse = orig_tr
+
+    assert ctx["active"] == "usage"
+    assert ctx["window"] == "all"
+    assert ctx["totals"]["total_tokens"] == 120
+    assert _by_key(ctx["by_provider"])["anthropic"]["total_tokens"] == 120
+    assert _by_key(ctx["by_agent"])["acme::kyc"]["total_tokens"] == 120
+
+
+@pytest.mark.asyncio
+async def test_usage_page_defaults_invalid_window(usage_db):
+    import mcp_proxy.dashboard.usage_routes as ur
+
+    class _Req:
+        query_params = QueryParams("window=bogus")
+
+    orig_login = ur.require_login
+    orig_ctx = ur._ctx
+    orig_tr = ur.templates.TemplateResponse
+    ur.require_login = lambda request: {"username": "admin"}
+    ur._ctx = lambda request, session, **kw: kw
+    ur.templates.TemplateResponse = lambda name, ctx: ctx
+    try:
+        ctx = await ur.usage_page(_Req())
+    finally:
+        ur.require_login = orig_login
+        ur._ctx = orig_ctx
+        ur.templates.TemplateResponse = orig_tr
+
+    assert ctx["window"] == "30d", "unknown window falls back to the default"


### PR DESCRIPTION
## Cosa

Aggiunge una pagina **Usage** read-only (`/proxy/usage`) che attribuisce il consumo di token LLM **per provider** e **per identità-agente**. A differenza del contatore per-API-key dei gateway commodity (Portkey/LiteLLM), i numeri sono **derivati read-time dalla audit chain firmata** — ogni riga `egress_llm_chat` porta già `prompt_tokens`/`completion_tokens`/`cost_usd`/`provider` nel JSON `detail` — quindi ciò che l'operatore vede è esattamente ciò che un auditor può ri-verificare dalla catena. Nessun contatore parallelo che può divergere.

## Architettura

- **`db.aggregate_llm_usage(window_start)`**: scansiona le righe `egress_llm_chat` su una finestra temporale (indice `timestamp`), `json.loads` in Python (segue la grana del codebase — niente SQL-JSON, vedi `audit_routes.py:127`), raggruppa per provider e per agente. Token sempre; `cost_usd` solo dove il provider l'ha riportato (best-effort). Scan cappato a 200k righe con flag `capped=True` esposto in UI (**no silent truncation**, regola progetto).
- **`usage_routes.py` + `usage.html`**: due tabelle (by provider, by agent), chip totali, selettore finestra 7d/30d/all, banner scan-parziale.
- **`base.html`**: voce nav "Usage" dopo Audit Log.

## Scelte V1

- **Token-only**: `$` mostrato solo dove presente. Price-map per-model = follow-up esplicito (evita numeri da mantenere/sbagliare).
- **Read-time, no cache**: `/proxy/usage` è navigata da un umano, non l'hot-path LLM. Cache + materialized rollup = follow-up se i volumi crescono.
- **Budget enforcement per-agente**: PR successiva (tocca l'hot path → vuole `/security-review`).

## Test

`test/unit/test_dashboard_usage.py` (7 test): aggregazione per provider/agente, righe non-egress + senza token non gonfiano i totali, cutoff finestra, cost-where-present, wiring route, default window. Suite unit completa verde (1615 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)