### PR TITLE
feat(gateway): per-agent cumulative LLM token budget enforcement

### DIFF
--- a/mcp_proxy/alembic/versions/0046_agent_llm_budgets.py
+++ b/mcp_proxy/alembic/versions/0046_agent_llm_budgets.py
@@ -1,0 +1,59 @@
+"""Add ``agent_llm_budgets`` — per-agent cumulative LLM token budgets.
+
+Revision ID: 0046_agent_llm_budgets
+Revises: 0045_principal_capabilities
+Create Date: 2026-06-07 12:00:00.000000
+
+The usage dashboard (PR #1073) surfaces per-provider / per-agent token
+consumption derived from the audit chain. This migration adds the
+storage for the enforcement half: an optional per-agent cumulative token
+ceiling over the calendar UTC day / month.
+
+One row per agent that has a budget. ``tokens_per_day`` /
+``tokens_per_month`` of ``0`` mean "no ceiling for that period" (same
+convention as the global ``MCP_PROXY_LLM_TOKENS_PER_DAY`` /
+``_PER_MONTH`` settings, which apply when no enabled row exists). The
+runtime counter lives in Redis (``mcp_proxy.egress.budget``) and is
+seeded from the audit chain on a cold key, so this table only holds the
+*policy* (the ceiling), never the running total.
+
+Idempotent: skips creation when the table already exists, so a
+``metadata.create_all`` bootstrap (tests, ``PROXY_SKIP_MIGRATIONS=1``)
+and the alembic path converge on the same schema.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0046_agent_llm_budgets"
+down_revision: Union[str, Sequence[str], None] = "0045_principal_capabilities"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "agent_llm_budgets"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return
+    op.create_table(
+        _TABLE,
+        sa.Column("agent_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("tokens_per_day", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tokens_per_month", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        op.drop_table(_TABLE)

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -232,6 +232,18 @@ class ProxySettings(BaseSettings):
     # deployment via MCP_PROXY_LLM_TOKENS_PER_MINUTE.
     llm_tokens_per_minute: int = 100_000
 
+    # Per-agent cumulative token budget over the calendar UTC day / month.
+    # These are the GLOBAL defaults; a per-agent override lives in the
+    # ``agent_llm_budgets`` table (migration 0046) and wins when enabled.
+    # ``0`` means "no ceiling for that period" — the default, so the budget
+    # path is a no-op until an operator sets a ceiling. The running total is
+    # a Redis counter (``mcp_proxy.egress.budget``) seeded from the audit
+    # chain; an exhausted budget → 429 ``daily_budget_exceeded`` /
+    # ``monthly_budget_exceeded`` before the request reaches the provider.
+    # Tune via MCP_PROXY_LLM_TOKENS_PER_DAY / MCP_PROXY_LLM_TOKENS_PER_MONTH.
+    llm_tokens_per_day: int = 0
+    llm_tokens_per_month: int = 0
+
     # Shared secret the proxy uses to verify the X-ATN-Signature HMAC
     # on inbound /pdp/policy webhook calls (audit 2026-04-30 lane 3 H3).
     # When set, every POST to /pdp/policy must carry a valid

--- a/mcp_proxy/dashboard/templates/usage.html
+++ b/mcp_proxy/dashboard/templates/usage.html
@@ -124,5 +124,90 @@
         </div>
     </div>
 
+    <!-- Per-agent budgets -->
+    <div class="mb-4 mt-10 pt-8 border-t border-gray-800/60">
+        <h3 class="text-[11px] font-heading uppercase tracking-[0.2em] text-gray-500 mb-1">Per-agent budgets</h3>
+        <p class="text-xs text-gray-600 mb-4">
+            Cumulative token ceiling per calendar UTC day / month. <span class="font-mono">0</span> = no ceiling for that period.
+            An exhausted budget returns <span class="font-mono">429</span> before the call reaches the provider, recorded in the audit chain.
+            Global default:
+            <span class="font-mono text-gray-400">{{ "{:,}".format(default_tokens_per_day) }}/day</span>,
+            <span class="font-mono text-gray-400">{{ "{:,}".format(default_tokens_per_month) }}/month</span>
+            (applies when no enabled per-agent row exists).
+        </p>
+
+        {% if saved == 'budget' %}
+        <div class="mb-4 px-4 py-2 border border-accent-400/40 bg-accent-400/5 rounded-md text-xs text-accent-400">Budget saved.</div>
+        {% elif saved == 'budget-removed' %}
+        <div class="mb-4 px-4 py-2 border border-gray-700/60 bg-gray-800/20 rounded-md text-xs text-gray-400">Budget removed.</div>
+        {% endif %}
+
+        <!-- Set / update a budget -->
+        <form method="post" action="/proxy/usage/budget/save" class="flex flex-wrap items-end gap-3 mb-5">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Agent</label>
+                <input list="usage-agent-ids" name="agent_id" required placeholder="org::agent"
+                       class="bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 font-mono w-64" autocomplete="off">
+                <datalist id="usage-agent-ids">
+                    {% for aid in agent_ids %}<option value="{{ aid }}">{% endfor %}
+                </datalist>
+            </div>
+            <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Tokens / day</label>
+                <input type="number" name="tokens_per_day" min="0" value="0"
+                       class="bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 font-mono w-32">
+            </div>
+            <div class="flex flex-col gap-1">
+                <label class="text-[10px] font-heading uppercase tracking-[0.2em] text-gray-600">Tokens / month</label>
+                <input type="number" name="tokens_per_month" min="0" value="0"
+                       class="bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 font-mono w-32">
+            </div>
+            <label class="flex items-center gap-2 text-xs text-gray-400 pb-2">
+                <input type="checkbox" name="enabled" checked class="accent-accent-400"> Enabled
+            </label>
+            <button type="submit"
+                    class="px-4 py-2 text-xs font-medium uppercase tracking-wider border border-accent-400/40 text-accent-400 bg-accent-400/5 rounded hover:bg-accent-400/15 transition-colors">
+                Save budget
+            </button>
+        </form>
+
+        <!-- Existing budgets -->
+        <div class="border border-gray-800/60 rounded-md overflow-hidden">
+            <table class="w-full text-xs">
+                <thead class="bg-surface-900/60 text-gray-600">
+                    <tr class="text-left uppercase tracking-wider text-[10px]">
+                        <th class="px-4 py-2.5 font-heading">Agent</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Tokens / day</th>
+                        <th class="px-4 py-2.5 font-heading text-right">Tokens / month</th>
+                        <th class="px-4 py-2.5 font-heading text-center">Status</th>
+                        <th class="px-4 py-2.5 font-heading"></th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-800/50">
+                    {% for b in budgets %}
+                    <tr class="hover:bg-gray-800/20">
+                        <td class="px-4 py-2.5 font-mono text-gray-200">{{ b.agent_id }}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-300 text-right">{% if b.tokens_per_day %}{{ "{:,}".format(b.tokens_per_day) }}{% else %}<span class="text-gray-700">∞</span>{% endif %}</td>
+                        <td class="px-4 py-2.5 font-mono text-gray-300 text-right">{% if b.tokens_per_month %}{{ "{:,}".format(b.tokens_per_month) }}{% else %}<span class="text-gray-700">∞</span>{% endif %}</td>
+                        <td class="px-4 py-2.5 text-center">
+                            {% if b.enabled %}<span class="text-accent-400">enabled</span>{% else %}<span class="text-gray-600">disabled</span>{% endif %}
+                        </td>
+                        <td class="px-4 py-2.5 text-right">
+                            <form method="post" action="/proxy/usage/budget/delete" onsubmit="return confirm('Remove budget for {{ b.agent_id }}?');" class="inline">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <input type="hidden" name="agent_id" value="{{ b.agent_id }}">
+                                <button type="submit" class="text-[11px] uppercase tracking-wider text-gray-500 hover:text-red-400 transition-colors">Remove</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% else %}
+                    <tr><td colspan="5" class="px-4 py-6 text-center text-gray-600">No per-agent budgets — the global default applies to every agent.</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
 </div>
 {% endblock %}

--- a/mcp_proxy/dashboard/usage_routes.py
+++ b/mcp_proxy/dashboard/usage_routes.py
@@ -1,20 +1,27 @@
-"""Mastio dashboard — LLM usage metering sub-router.
+"""Mastio dashboard — LLM usage metering + per-agent budget sub-router.
 
 Surfaces per-provider and per-agent token usage of the embedded AI
-gateway. Unlike a commodity gateway's per-API-key counter, the numbers
-here are derived read-time from the append-only audit chain
+gateway, and lets an org admin set a per-agent cumulative token budget.
+Unlike a commodity gateway's per-API-key counter, the usage numbers are
+derived read-time from the append-only audit chain
 (``aggregate_llm_usage`` in :mod:`mcp_proxy.db`): every ``egress_llm_chat``
 row carries the token counts, so what the operator sees is exactly what an
 auditor can re-verify from the signed chain — attribution is per agent
 identity, not per shared key.
 
-Mounted via ``router.include_router(usage_routes.router)`` from
-``mcp_proxy/dashboard/router.py`` so the outer ``/proxy`` prefix is
-inherited.
+Budgets are *policy* rows (``agent_llm_budgets``, migration 0046); the
+running total that enforces them is a Redis calendar counter
+(:mod:`mcp_proxy.egress.budget`) seeded from the same chain. Enforcement
+itself lives on the egress path (``llm_chat_router``); this surface is
+read + configure only.
 
-Routes (1):
+Mounted via ``router.include_router(usage_routes.router)``.
 
-  GET  /proxy/usage         per-provider + per-agent token usage view
+Routes:
+
+  GET  /proxy/usage                  per-provider + per-agent token view
+  POST /proxy/usage/budget/save      upsert a per-agent budget (CSRF)
+  POST /proxy/usage/budget/delete    remove a per-agent budget (CSRF)
 """
 from __future__ import annotations
 
@@ -22,14 +29,21 @@ import logging
 import pathlib
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
-from starlette.responses import RedirectResponse
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
 
+from mcp_proxy.config import get_settings
 from mcp_proxy.dashboard._helpers import _ctx
 from mcp_proxy.dashboard._template_env import build_templates
-from mcp_proxy.dashboard.session import require_login
-from mcp_proxy.db import aggregate_llm_usage
+from mcp_proxy.dashboard.session import require_login, verify_csrf
+from mcp_proxy.db import (
+    aggregate_llm_usage,
+    delete_agent_budget,
+    list_agent_budgets,
+    list_agents,
+    log_audit,
+    upsert_agent_budget,
+)
 
 _log = logging.getLogger("mcp_proxy.dashboard")
 
@@ -56,6 +70,22 @@ def _window_start(window: str) -> str | None:
     return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
 
+def _form_int(value: object) -> int:
+    """Parse a non-negative int from a form field; 0 on anything invalid."""
+    try:
+        return max(0, int(str(value or "0").strip() or "0"))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _updated_by(session) -> str:
+    return (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+
+
 @router.get("/usage", response_class=HTMLResponse)
 async def usage_page(request: Request) -> HTMLResponse:
     session = require_login(request)
@@ -67,6 +97,9 @@ async def usage_page(request: Request) -> HTMLResponse:
         window = _DEFAULT_WINDOW
 
     usage = await aggregate_llm_usage(_window_start(window))
+    budgets = await list_agent_budgets()
+    agents = await list_agents()
+    settings = get_settings()
 
     return templates.TemplateResponse(
         "usage.html",
@@ -81,5 +114,78 @@ async def usage_page(request: Request) -> HTMLResponse:
             totals=usage["totals"],
             scanned=usage["scanned"],
             capped=usage["capped"],
+            budgets=budgets,
+            agent_ids=sorted({a["agent_id"] for a in agents}),
+            default_tokens_per_day=settings.llm_tokens_per_day,
+            default_tokens_per_month=settings.llm_tokens_per_month,
+            saved=request.query_params.get("saved"),
         ),
     )
+
+
+@router.post("/usage/budget/save")
+async def save_budget(request: Request) -> RedirectResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    form = await request.form()
+    agent_id = str(form.get("agent_id") or "").strip()
+    if not agent_id:
+        raise HTTPException(400, "agent_id is required")
+    tokens_per_day = _form_int(form.get("tokens_per_day"))
+    tokens_per_month = _form_int(form.get("tokens_per_month"))
+    enabled = bool(form.get("enabled"))
+    updated_by = _updated_by(session)
+
+    await upsert_agent_budget(
+        agent_id,
+        tokens_per_day=tokens_per_day,
+        tokens_per_month=tokens_per_month,
+        enabled=enabled,
+        updated_by=updated_by,
+    )
+    await log_audit(
+        agent_id=updated_by,
+        action="budget.upsert",
+        status="success",
+        details={
+            "target_agent_id": agent_id,
+            "tokens_per_day": tokens_per_day,
+            "tokens_per_month": tokens_per_month,
+            "enabled": enabled,
+            "via": "dashboard",
+        },
+    )
+    _log.info(
+        "dashboard budget upsert agent=%s day=%d month=%d enabled=%s by=%s",
+        agent_id, tokens_per_day, tokens_per_month, enabled, updated_by,
+    )
+    return RedirectResponse(url="/proxy/usage?saved=budget", status_code=303)
+
+
+@router.post("/usage/budget/delete")
+async def delete_budget(request: Request) -> RedirectResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    form = await request.form()
+    agent_id = str(form.get("agent_id") or "").strip()
+    if not agent_id:
+        raise HTTPException(400, "agent_id is required")
+    updated_by = _updated_by(session)
+
+    await delete_agent_budget(agent_id)
+    await log_audit(
+        agent_id=updated_by,
+        action="budget.delete",
+        status="success",
+        details={"target_agent_id": agent_id, "via": "dashboard"},
+    )
+    _log.info("dashboard budget delete agent=%s by=%s", agent_id, updated_by)
+    return RedirectResponse(url="/proxy/usage?saved=budget-removed", status_code=303)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1110,6 +1110,134 @@ async def aggregate_llm_usage(window_start: str | None = None) -> dict:
     }
 
 
+async def sum_principal_tokens_since(agent_id: str, window_start: str | None) -> int:
+    """Sum ``prompt + completion`` tokens for one agent since ``window_start``.
+
+    ``window_start`` is an ISO-8601 UTC timestamp (``None`` = all-time).
+    Seeds the per-agent budget counter (:mod:`mcp_proxy.egress.budget`) on a
+    cold Redis key: the running total an auditor re-derives from the signed
+    chain IS the enforcement input, so a counter that was lost to a restart
+    is rebuilt from the same source of truth. Bounded by the usage scan cap.
+    """
+    conds = ["action = :action", "agent_id = :aid"]
+    params: dict[str, Any] = {"action": "egress_llm_chat", "aid": agent_id}
+    if window_start:
+        conds.append("timestamp >= :start")
+        params["start"] = window_start
+    where = " WHERE " + " AND ".join(conds)
+    params["_cap"] = _USAGE_SCAN_CAP
+    sql = f"SELECT detail FROM audit_log{where} ORDER BY timestamp DESC LIMIT :_cap"
+
+    async with get_db() as conn:
+        result = await conn.execute(text(sql), params)
+        rows = result.mappings().all()
+
+    total = 0
+    for row in rows:
+        detail = row["detail"]
+        if not detail:
+            continue
+        try:
+            payload = json.loads(detail)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        total += _coerce_int(payload.get("prompt_tokens"))
+        total += _coerce_int(payload.get("completion_tokens"))
+    return total
+
+
+# ─── Per-agent LLM token budgets (migration 0046) ────────────────────────
+#
+# Stores only the *policy* (the cumulative ceiling per calendar day /
+# month); the running total lives in the Redis counter
+# (:mod:`mcp_proxy.egress.budget`), seeded from the audit chain. ``0`` for a
+# period means "no ceiling for that period". A disabled or absent row means
+# the global ``llm_tokens_per_day`` / ``_per_month`` settings apply.
+
+
+def _budget_row_to_dict(row: RowMapping) -> dict:
+    return {
+        "agent_id": row["agent_id"],
+        "tokens_per_day": int(row["tokens_per_day"]),
+        "tokens_per_month": int(row["tokens_per_month"]),
+        "enabled": bool(row["enabled"]),
+        "updated_at": row["updated_at"],
+        "updated_by": row["updated_by"],
+    }
+
+
+_BUDGET_COLS = (
+    "agent_id, tokens_per_day, tokens_per_month, enabled, updated_at, updated_by"
+)
+
+
+async def get_agent_budget(agent_id: str) -> dict | None:
+    """Return the budget row for ``agent_id``, or ``None`` when unset."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(f"SELECT {_BUDGET_COLS} FROM agent_llm_budgets WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+        row = result.mappings().first()
+    return _budget_row_to_dict(row) if row is not None else None
+
+
+async def list_agent_budgets() -> list[dict]:
+    """Return every configured per-agent budget (stable agent_id order)."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(f"SELECT {_BUDGET_COLS} FROM agent_llm_budgets ORDER BY agent_id ASC"),
+        )
+        rows = result.mappings().all()
+    return [_budget_row_to_dict(r) for r in rows]
+
+
+async def upsert_agent_budget(
+    agent_id: str,
+    *,
+    tokens_per_day: int,
+    tokens_per_month: int,
+    enabled: bool = True,
+    updated_by: str | None = None,
+) -> None:
+    """Insert or replace a per-agent token budget."""
+    ts = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO agent_llm_budgets
+                       (agent_id, tokens_per_day, tokens_per_month,
+                        enabled, updated_at, updated_by)
+                   VALUES (:a, :d, :m, :en, :ts, :ub)
+                   ON CONFLICT(agent_id) DO UPDATE SET
+                       tokens_per_day = excluded.tokens_per_day,
+                       tokens_per_month = excluded.tokens_per_month,
+                       enabled = excluded.enabled,
+                       updated_at = excluded.updated_at,
+                       updated_by = excluded.updated_by"""
+            ),
+            {
+                "a": agent_id,
+                "d": max(0, int(tokens_per_day)),
+                "m": max(0, int(tokens_per_month)),
+                "en": enabled,
+                "ts": ts,
+                "ub": updated_by,
+            },
+        )
+
+
+async def delete_agent_budget(agent_id: str) -> None:
+    """Remove a per-agent budget (falls back to the global default)."""
+    async with get_db() as conn:
+        await conn.execute(
+            text("DELETE FROM agent_llm_budgets WHERE agent_id = :a"),
+            {"a": agent_id},
+        )
+
+
 async def list_user_principals() -> list[dict]:
     """List user principals registered on this Mastio.
 

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -756,3 +756,30 @@ class AIProviderCredentials(Base):
     enabled = Column(Boolean, nullable=False, server_default="1")
     updated_at = Column(Text, nullable=False)
     updated_by = Column(Text, nullable=True)
+
+
+class AgentLLMBudget(Base):
+    """Per-agent cumulative LLM token budget for the embedded AI gateway.
+
+    One optional row per agent. ``tokens_per_day`` / ``tokens_per_month``
+    are cumulative ceilings over the calendar UTC day / month; ``0`` means
+    "no ceiling for that period" (same convention as the global
+    ``llm_tokens_per_day`` / ``llm_tokens_per_month`` settings, which apply
+    when no enabled row exists). Enforcement is a fast Redis calendar
+    counter (``mcp_proxy.egress.budget``) seeded from the audit chain, so
+    the number that blocks a call is re-derivable from the signed chain.
+
+    Declared here (not just in the alembic migration) so
+    ``metadata.create_all`` under ``PROXY_SKIP_MIGRATIONS=1`` builds a
+    schema matching the production INSERT shape — same reason the
+    audit_log alembic-only columns are mirrored above.
+    """
+
+    __tablename__ = "agent_llm_budgets"
+
+    agent_id = Column(Text, primary_key=True)
+    tokens_per_day = Column(Integer, nullable=False, server_default="0")
+    tokens_per_month = Column(Integer, nullable=False, server_default="0")
+    enabled = Column(Boolean, nullable=False, server_default="1")
+    updated_at = Column(Text, nullable=False)
+    updated_by = Column(Text, nullable=True)

--- a/mcp_proxy/egress/budget.py
+++ b/mcp_proxy/egress/budget.py
@@ -1,0 +1,189 @@
+"""Per-agent cumulative LLM token budget counter (calendar day / month).
+
+Companion to the per-minute token rate limiter
+(:mod:`mcp_proxy.auth.rate_limit`). Where that bounds burst *rate* over a
+60s sliding window, this bounds *cumulative* spend over the calendar UTC
+day and month — the budget an org sets per agent.
+
+The source of truth is the audit chain. On a cold key the counter is
+seeded from the chain's token sum for the current period
+(``sum_principal_tokens_since``), then advanced by ``INCRBY`` per call. A
+counter lost to a restart is rebuilt from the same signed rows an auditor
+re-derives — the number that blocks a call is always chain-derivable,
+never a free-floating tally.
+
+Backends:
+  * Redis (shared across workers) — ``INCRBY`` + ``EXPIRE`` on a
+    date-stamped key. New period → fresh key automatically; the TTL only
+    garbage-collects the previous one.
+  * In-memory per-process dict — when Redis is unconfigured / down.
+
+Fail-mode: individual Redis errors fail **open** (a cost ceiling must not
+halt the fleet on a Redis blip — distinct from the fail-closed auth
+path). The readyz Redis gate (#1057) already drains a worker whose Redis
+is down, so a degraded per-worker count does not silently under-count the
+live pool while still serving traffic.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+_log = logging.getLogger("mcp_proxy.egress.budget")
+
+_PREFIX = "mcp_proxy:budget:"
+# Date-stamped keys make a new period use a fresh key, so these TTLs only
+# garbage-collect the previous period's key — they need only outlive it.
+_DAY_TTL = 60 * 60 * 36          # 36h
+_MONTH_TTL = 60 * 60 * 24 * 40   # 40d
+
+
+def _day_token(now: datetime) -> str:
+    return now.strftime("%Y%m%d")
+
+
+def _month_token(now: datetime) -> str:
+    return now.strftime("%Y%m")
+
+
+def _day_start_iso(now: datetime) -> str:
+    return now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+
+
+def _month_start_iso(now: datetime) -> str:
+    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0).isoformat()
+
+
+def _day_key(agent_id: str, now: datetime) -> str:
+    return f"{_PREFIX}{agent_id}:day:{_day_token(now)}"
+
+
+def _month_key(agent_id: str, now: datetime) -> str:
+    return f"{_PREFIX}{agent_id}:month:{_month_token(now)}"
+
+
+async def _seed_from_chain(agent_id: str, period_start_iso: str) -> int:
+    from mcp_proxy.db import sum_principal_tokens_since
+
+    try:
+        return await sum_principal_tokens_since(agent_id, period_start_iso)
+    except Exception as exc:  # fail-open: seed 0 rather than block on a read error
+        _log.warning(
+            "budget seed-from-chain failed for %s — seeding 0: %s", agent_id, exc
+        )
+        return 0
+
+
+class _PeriodBudgetCounter:
+    """Calendar-period cumulative token counter, seeded from the audit chain."""
+
+    def __init__(self) -> None:
+        # In-memory fallback: {redis_key: tokens}. Bounded by agents × live
+        # periods; a process restart clears it (re-seeded from the chain on
+        # next touch). ``_seeded`` tracks which keys were warmed from the
+        # chain so we seed exactly once per key.
+        self._mem: dict[str, int] = {}
+        self._seeded: set[str] = set()
+
+    async def current(self, agent_id: str, now: datetime) -> tuple[int, int]:
+        """Return ``(day_tokens, month_tokens)`` already spent this period."""
+        day = await self._get(
+            agent_id, _day_key(agent_id, now), _day_start_iso(now), _DAY_TTL
+        )
+        month = await self._get(
+            agent_id, _month_key(agent_id, now), _month_start_iso(now), _MONTH_TTL
+        )
+        return day, month
+
+    async def add(self, agent_id: str, amount: int, now: datetime) -> None:
+        """Advance both period counters by ``amount`` (no-op when <= 0).
+
+        Callers MUST have run :meth:`current` first (the enforcement check),
+        which seeds the key from the chain — so ``add`` never creates an
+        un-seeded key that a later :meth:`current` would trust as complete.
+        """
+        if amount <= 0:
+            return
+        await self._add(_day_key(agent_id, now), amount, _DAY_TTL)
+        await self._add(_month_key(agent_id, now), amount, _MONTH_TTL)
+
+    async def _get(
+        self, agent_id: str, key: str, period_start_iso: str, ttl: int
+    ) -> int:
+        from mcp_proxy.redis.pool import get_redis
+
+        redis = get_redis()
+        if redis is not None:
+            try:
+                val = await redis.get(key)
+                if val is not None:
+                    return int(val)
+                # Cold key — seed from the chain, then SET NX so a racing
+                # seeder (or a concurrent INCRBY that already created the
+                # key) is never clobbered.
+                seed = await _seed_from_chain(agent_id, period_start_iso)
+                await redis.set(key, seed, ex=ttl, nx=True)
+                got = await redis.get(key)
+                return int(got) if got is not None else seed
+            except Exception as exc:  # fail-open
+                _log.warning(
+                    "budget counter Redis read failed (%s) — failing open: %s",
+                    key,
+                    exc,
+                )
+                return 0
+
+        # In-memory fallback (single-process). Seed once per key.
+        if key not in self._seeded:
+            self._mem[key] = await _seed_from_chain(agent_id, period_start_iso)
+            self._seeded.add(key)
+        return self._mem.get(key, 0)
+
+    async def _add(self, key: str, amount: int, ttl: int) -> None:
+        from mcp_proxy.redis.pool import get_redis
+
+        redis = get_redis()
+        if redis is not None:
+            try:
+                await redis.incrby(key, int(amount))
+                await redis.expire(key, ttl)
+            except Exception as exc:  # fail-open
+                _log.warning(
+                    "budget counter Redis incr failed (%s) — skipped: %s", key, exc
+                )
+            return
+        self._mem[key] = self._mem.get(key, 0) + int(amount)
+        self._seeded.add(key)
+
+
+_counter: _PeriodBudgetCounter | None = None
+
+
+def get_budget_counter() -> _PeriodBudgetCounter:
+    """Return the process-wide budget counter, initialising on first call."""
+    global _counter
+    if _counter is None:
+        _counter = _PeriodBudgetCounter()
+    return _counter
+
+
+def reset_budget_counter() -> None:
+    """Test hook — drop the singleton (and its in-memory state)."""
+    global _counter
+    _counter = None
+
+
+async def effective_budget(agent_id: str, settings) -> tuple[int, int]:
+    """Resolve ``(tokens_per_day, tokens_per_month)`` for an agent.
+
+    An *enabled* per-agent row wins; otherwise the global
+    ``llm_tokens_per_day`` / ``llm_tokens_per_month`` settings apply. ``0``
+    for a period means "no ceiling for that period". When both are 0 the
+    budget path is skipped entirely by the caller (zero overhead).
+    """
+    from mcp_proxy.db import get_agent_budget
+
+    row = await get_agent_budget(agent_id)
+    if row is not None and row["enabled"]:
+        return row["tokens_per_day"], row["tokens_per_month"]
+    return int(settings.llm_tokens_per_day), int(settings.llm_tokens_per_month)

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -24,6 +24,7 @@ import json
 import logging
 import time
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -33,6 +34,7 @@ from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.auth.rate_limit import get_token_sum_limiter
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import list_ai_provider_creds, log_audit
+from mcp_proxy.egress.budget import effective_budget, get_budget_counter
 from mcp_proxy.egress.ai_gateway import (
     GatewayError,
     StreamingDispatch,
@@ -185,9 +187,55 @@ async def chat_completions(
                 },
             )
 
+    # Per-agent cumulative token budget (calendar UTC day / month). Skipped
+    # entirely when no ceiling is configured (per-agent row or global
+    # default), so it is zero-overhead until an operator sets one. The
+    # running total is a Redis counter seeded from the audit chain.
+    budget_day, budget_month = await effective_budget(agent.agent_id, settings)
+    budget_enforced = budget_day > 0 or budget_month > 0
+    if budget_enforced:
+        now = datetime.now(timezone.utc)
+        used_day, used_month = await get_budget_counter().current(agent.agent_id, now)
+        over_day = budget_day > 0 and used_day >= budget_day
+        over_month = budget_month > 0 and used_month >= budget_month
+        if over_day or over_month:
+            reason = "daily_budget_exceeded" if over_day else "monthly_budget_exceeded"
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_llm_chat",
+                status="denied",
+                details={
+                    "event": "llm.chat_completion",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "backend": settings.ai_gateway_backend,
+                    "provider": settings.ai_gateway_provider,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "reason": reason,
+                    "used_day_tokens": used_day,
+                    "used_month_tokens": used_month,
+                    "budget_tokens_per_day": budget_day,
+                    "budget_tokens_per_month": budget_month,
+                    "stream": req.stream,
+                },
+            )
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "reason": reason,
+                    "trace_id": trace_id,
+                    "used_day_tokens": used_day,
+                    "used_month_tokens": used_month,
+                    "budget_tokens_per_day": budget_day,
+                    "budget_tokens_per_month": budget_month,
+                },
+            )
+
     if req.stream:
         return await _handle_stream(
             req=req, agent=agent, settings=settings, trace_id=trace_id,
+            enforce_budget=budget_enforced,
         )
 
     started = time.perf_counter()
@@ -226,9 +274,13 @@ async def chat_completions(
     payload = result.response.model_dump()
     payload.setdefault("cullis_trace_id", trace_id)
 
+    weight = int(result.prompt_tokens) + int(result.completion_tokens)
     if settings.llm_tokens_per_minute > 0:
-        weight = int(result.prompt_tokens) + int(result.completion_tokens)
         await get_token_sum_limiter().consume(_token_bucket_key(agent), weight)
+    if budget_enforced:
+        await get_budget_counter().add(
+            agent.agent_id, weight, datetime.now(timezone.utc),
+        )
 
     await log_audit(
         agent_id=agent.agent_id,
@@ -266,6 +318,7 @@ async def _handle_stream(
     agent: InternalAgent,
     settings,
     trace_id: str,
+    enforce_budget: bool = False,
 ) -> StreamingResponse:
     """Open the upstream stream and fan it out as Server-Sent Events.
 
@@ -462,15 +515,18 @@ async def _handle_stream(
                     },
                 )
             else:
-                if settings.llm_tokens_per_minute > 0:
-                    weight = (
-                        int(streamer.prompt_tokens)
-                        + int(streamer.completion_tokens)
+                weight = (
+                    int(streamer.prompt_tokens)
+                    + int(streamer.completion_tokens)
+                )
+                if settings.llm_tokens_per_minute > 0 and weight > 0:
+                    await get_token_sum_limiter().consume(
+                        _token_bucket_key(agent), weight,
                     )
-                    if weight > 0:
-                        await get_token_sum_limiter().consume(
-                            _token_bucket_key(agent), weight,
-                        )
+                if enforce_budget and weight > 0:
+                    await get_budget_counter().add(
+                        agent.agent_id, weight, datetime.now(timezone.utc),
+                    )
                 await log_audit(
                     agent_id=agent.agent_id,
                     action="egress_llm_chat",

--- a/test/unit/test_agent_llm_budget.py
+++ b/test/unit/test_agent_llm_budget.py
@@ -1,0 +1,356 @@
+"""Per-agent cumulative LLM token budget — counter, resolution, enforcement.
+
+PR follow-up to the usage dashboard (#1073). The display reads the audit
+chain; this is the enforcement half. Pins:
+
+1. ``sum_principal_tokens_since`` sums an agent's egress tokens over a
+   window (the seed-from-chain input for the counter);
+2. the in-memory counter seeds from the chain on a cold key and advances
+   on ``add`` (Redis-less fallback path);
+3. ``effective_budget`` resolves per-agent-override > global default, and
+   a disabled row falls back to the default;
+4. the egress router blocks an over-budget call with 429 +
+   ``daily``/``monthly_budget_exceeded`` and a ``denied`` audit row,
+   without calling dispatch; an under-budget / unbudgeted call passes and
+   advances the counter.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.db import (
+    dispose_db,
+    get_agent_budget,
+    get_db,
+    init_db,
+    sum_principal_tokens_since,
+    upsert_agent_budget,
+)
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.ai_gateway import GatewayResult
+from mcp_proxy.egress.budget import (
+    effective_budget,
+    get_budget_counter,
+    reset_budget_counter,
+)
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+from mcp_proxy.egress.schemas import (
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    ChatMessage,
+)
+from mcp_proxy.models import InternalAgent
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+async def _insert_egress(rows: list[dict]) -> None:
+    payload = [
+        {
+            "ts": r["ts"],
+            "aid": r["aid"],
+            "act": r.get("act", "egress_llm_chat"),
+            "detail": json.dumps(r["detail"]) if r.get("detail") is not None else None,
+        }
+        for r in rows
+    ]
+    async with get_db() as db:
+        await db.execute(
+            text(
+                "INSERT INTO audit_log (timestamp, agent_id, action, status, detail) "
+                "VALUES (:ts, :aid, :act, 'success', :detail)"
+            ),
+            payload,
+        )
+        await db.commit()
+
+
+async def _audit_rows(action: str, status: str) -> list[dict]:
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT agent_id, action, status, detail FROM audit_log "
+                "WHERE action = :a AND status = :s ORDER BY id ASC"
+            ),
+            {"a": action, "s": status},
+        )
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+def _agent(capabilities: list[str], agent_id: str = "acme::alice") -> InternalAgent:
+    return InternalAgent(
+        agent_id=agent_id,
+        display_name="alice",
+        capabilities=capabilities,
+        created_at="2026-05-29T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-test",
+        reach="both",
+    )
+
+
+def _chat_body() -> dict:
+    return {
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 16,
+    }
+
+
+def _gateway_result(prompt: int = 12, completion: int = 3) -> GatewayResult:
+    response = ChatCompletionResponse(
+        id="chatcmpl-test",
+        created=1_700_000_000,
+        model="claude-haiku-4-5",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="pong"),
+                finish_reason="stop",
+            )
+        ],
+        usage=ChatCompletionUsage(
+            prompt_tokens=prompt, completion_tokens=completion,
+            total_tokens=prompt + completion,
+        ),
+        cullis_trace_id="trace_test",
+    )
+    return GatewayResult(
+        response=response,
+        latency_ms=42,
+        upstream_request_id="req_abc",
+        backend="litellm_embedded",
+        provider="anthropic",
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cost_usd=0.0001,
+    )
+
+
+def _today(hour: int = 10) -> str:
+    return datetime.now(timezone.utc).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    ).isoformat()
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "budget.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-default")
+    monkeypatch.setenv("MCP_PROXY_DPOP_JTI_SECRET", "test-dpop-jti-secret")
+    monkeypatch.delenv("MCP_PROXY_REDIS_URL", raising=False)
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    # Redis-less + clean counter so each test starts from the chain.
+    from mcp_proxy.redis.pool import reset_redis_for_tests
+
+    reset_redis_for_tests()
+    reset_budget_counter()
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        reset_budget_counter()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(llm_chat_router)
+    return app
+
+
+# ── 1. sum-tokens helper (seed-from-chain input) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sum_principal_tokens_scopes_agent_and_window(proxy_db):
+    await _insert_egress(
+        [
+            {"ts": _today(), "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 40, "completion_tokens": 10}},
+            {"ts": _today(11), "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 5, "completion_tokens": 5}},
+            # Different agent — must not bleed in.
+            {"ts": _today(), "aid": "acme::bob",
+             "detail": {"provider": "anthropic", "prompt_tokens": 999, "completion_tokens": 999}},
+            # Old row — excluded by the window.
+            {"ts": "2020-01-01T00:00:00+00:00", "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 1000, "completion_tokens": 0}},
+        ]
+    )
+
+    since = "2026-01-01T00:00:00+00:00"
+    assert await sum_principal_tokens_since("acme::alice", since) == 60
+    assert await sum_principal_tokens_since("acme::alice", None) == 1060
+    assert await sum_principal_tokens_since("acme::nobody", None) == 0
+
+
+# ── 2. in-memory counter seeds from the chain + advances ────────────────
+
+
+@pytest.mark.asyncio
+async def test_counter_seeds_from_chain_then_advances(proxy_db):
+    await _insert_egress(
+        [
+            {"ts": _today(), "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 70, "completion_tokens": 30}},
+        ]
+    )
+    now = datetime.now(timezone.utc)
+    counter = get_budget_counter()
+
+    day, month = await counter.current("acme::alice", now)
+    assert day == 100, "cold key seeds from the chain's day sum"
+    assert month == 100
+
+    await counter.add("acme::alice", 25, now)
+    day2, month2 = await counter.current("acme::alice", now)
+    assert day2 == 125
+    assert month2 == 125
+
+
+# ── 3. effective_budget resolution ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_effective_budget_override_and_fallback(proxy_db, monkeypatch):
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_LLM_TOKENS_PER_DAY", "7000")
+    monkeypatch.setenv("MCP_PROXY_LLM_TOKENS_PER_MONTH", "200000")
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    settings = get_settings()
+
+    # No row → global default.
+    assert await effective_budget("acme::alice", settings) == (7000, 200000)
+
+    # Enabled row → override wins.
+    await upsert_agent_budget(
+        "acme::alice", tokens_per_day=10, tokens_per_month=0, enabled=True,
+    )
+    assert await effective_budget("acme::alice", settings) == (10, 0)
+
+    # Disabled row → falls back to the global default.
+    await upsert_agent_budget(
+        "acme::alice", tokens_per_day=10, tokens_per_month=0, enabled=False,
+    )
+    assert await effective_budget("acme::alice", settings) == (7000, 200000)
+
+
+# ── 4. router enforcement ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_over_daily_budget_blocks_with_429_and_audits_denied(proxy_db, monkeypatch):
+    # Prior usage today already exceeds the tiny daily ceiling.
+    await _insert_egress(
+        [
+            {"ts": _today(), "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 60, "completion_tokens": 40}},
+        ]
+    )
+    await upsert_agent_budget("acme::alice", tokens_per_day=10, tokens_per_month=0)
+
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent(["llm.chat"])
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(side_effect=AssertionError("dispatch must not run when over budget")),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 429, r.text
+    assert r.json()["detail"]["reason"] == "daily_budget_exceeded"
+
+    denied = await _audit_rows("egress_llm_chat", "denied")
+    assert len(denied) == 1
+    detail = json.loads(denied[0]["detail"])
+    assert detail["reason"] == "daily_budget_exceeded"
+    assert detail["budget_tokens_per_day"] == 10
+
+
+@pytest.mark.asyncio
+async def test_over_monthly_budget_blocks_with_429(proxy_db, monkeypatch):
+    await _insert_egress(
+        [
+            {"ts": _today(), "aid": "acme::alice",
+             "detail": {"provider": "anthropic", "prompt_tokens": 500, "completion_tokens": 0}},
+        ]
+    )
+    # No daily ceiling (0), tight monthly ceiling.
+    await upsert_agent_budget("acme::alice", tokens_per_day=0, tokens_per_month=100)
+
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent(["llm.chat"])
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(side_effect=AssertionError("dispatch must not run when over budget")),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 429, r.text
+    assert r.json()["detail"]["reason"] == "monthly_budget_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_under_budget_passes_and_advances_counter(proxy_db, monkeypatch):
+    await upsert_agent_budget("acme::alice", tokens_per_day=1_000_000, tokens_per_month=0)
+
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent(["llm.chat"])
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result(prompt=12, completion=3)),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 200, r.text
+    assert not await _audit_rows("egress_llm_chat", "denied")
+
+    # The 15 tokens of this call advanced the counter.
+    day, _ = await get_budget_counter().current("acme::alice", datetime.now(timezone.utc))
+    assert day == 15
+
+
+@pytest.mark.asyncio
+async def test_no_budget_configured_skips_enforcement(proxy_db, monkeypatch):
+    # No per-agent row, global defaults are 0 → budget path is a no-op.
+    assert await get_agent_budget("acme::alice") is None
+
+    app = _build_app()
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = lambda: _agent(["llm.chat"])
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/v1/chat/completions", json=_chat_body())
+
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
## Cosa

Follow-up della usage dashboard (#1073). Il display legge la audit chain; questa PR aggiunge la **metà enforcement**: un tetto cumulativo di token **per-agente** sul giorno/mese UTC, applicato sul path egress **prima** che la chiamata raggiunga il provider.

## Design on-thesis: audit chain = source of truth

Il totale corrente è un **contatore Redis calendar-period** (`egress/budget.py`) **seedato dalla somma token della catena firmata** su key fredda, poi avanzato con `INCRBY` per chiamata. Un contatore perso a un restart si **ricostruisce dalle stesse righe firmate** che un auditor ri-deriva → il numero che blocca una chiamata è **sempre ri-derivabile dalla catena**, non un tally parallelo che un regolatore non può verificare (il contrario di Portkey).

## Componenti

- **`db_models` + migration 0046**: `agent_llm_budgets` (solo *policy* — il tetto, mai il totale). Idempotente, create_all-safe.
- **`config`**: default globali `llm_tokens_per_day` / `_per_month` (0 = disabilitato di default → path no-op finché un operatore non setta un tetto).
- **`egress/budget.py`**: contatore calendar-period (Redis `INCRBY`+`EXPIRE` su key date-stamped), fallback in-memory, seed-from-chain, resolver `effective_budget` (riga per-agente abilitata > default globale).
- **`llm_chat_router`**: check prima del dispatch → `429 daily/monthly_budget_exceeded` + riga audit `denied`; consume dopo il dispatch su **entrambi** i path (streaming + non). Saltato del tutto se nessun tetto è configurato (zero overhead).
- **`db`**: `sum_principal_tokens_since` (input del seed) + CRUD budget.
- **dashboard**: form + tabella budget per-agente su `/proxy/usage` (CSRF + audit `budget.upsert`/`budget.delete`).

## Fail-mode Redis-down

Il singolo check **fail-open** (un cost-ceiling non deve fermare la flotta per un blip Redis — diverso dal path auth fail-closed); il readyz Redis gate (#1057) drena già il worker degradato. Zero codice nuovo di drain.

## Sicurezza

`/security-review` eseguito sul diff (multi-subagent): **nessun finding**. Verificati: SQL injection (tutto parametrizzato, `_BUDGET_COLS` è costante), XSS (autoescape on, nessun valore agent-controlled raggiunge un sink), CSRF/authz sui POST (require_login + verify_csrf), enforcement dopo i gate auth/capability, key Redis cert-derived (no cross-agent), clamp input non-negativo.

## Test

`test/unit/test_agent_llm_budget.py` (7 test): scoping sum-tokens, counter seed-from-chain + advance, resolution budget (override / disabled fallback), enforcement router (over-daily + over-monthly → 429 + audit denied, dispatch non chiamato; under-budget avanza il counter; unbudgeted salta). Suite unit completa verde (**1622 passed**).

## Follow-up

Price-map per-model per il `$`; materialized rollup per scala; budget per-provider/per-model; alert webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)