### PR TITLE
fix(sdk): P0 review fixes — chat timeout, factory init drift, wheel license

### DIFF
--- a/cullis_sdk/_client/_ai_gateway.py
+++ b/cullis_sdk/_client/_ai_gateway.py
@@ -26,6 +26,16 @@ from typing import Iterator
 
 import httpx
 
+# Default per-request timeout for the LLM chat path (seconds). The
+# client-wide httpx default is 10s — sized for control-plane calls
+# (login, tools/list, policy checks), not for a model spending half a
+# minute on a long completion. 2026-06-10 review P0: a non-trivial
+# Claude completion routinely exceeds 10s and surfaced as
+# ``httpx.ReadTimeout`` on the first serious chat. 60s matches the
+# budget ``providers_compat`` already uses for the same upstream.
+# Callers with longer generations override per call via ``timeout=``.
+LLM_CHAT_TIMEOUT_S = 60.0
+
 
 def _coerce_chat_request(request: dict | None, kwargs: dict) -> dict:
     """Normalise the dict-or-kwargs call shape used by
@@ -62,10 +72,21 @@ class _AiGatewayMixin:
 
     # ── ADR-017 — AI gateway egress ────────────────────────────────
     def chat_completion(
-        self, request: dict | None = None, **kwargs
+        self,
+        request: dict | None = None,
+        *,
+        timeout: float | None = None,
+        **kwargs,
     ) -> dict:
         """Forward an OpenAI-compatible chat completion to Mastio's
         ``/v1/llm/chat`` endpoint.
+
+        ``timeout`` overrides the per-request HTTP timeout in seconds
+        (default :data:`LLM_CHAT_TIMEOUT_S`, 60s — NOT the client-wide
+        10s, which is sized for control-plane calls and times out on
+        any non-trivial completion). It is a keyword-only parameter of
+        the method, never part of the request body, so it composes with
+        both calling conventions.
 
         Accepts two equivalent calling conventions, the historical
         dict-only form and the OpenAI / Anthropic SDK kwargs form::
@@ -97,17 +118,28 @@ class _AiGatewayMixin:
         (gateway upstream), 504 (timeout), 501 (not implemented).
         """
         request = _coerce_chat_request(request, kwargs)
-        resp = self._egress_http("post", "/v1/llm/chat", json=request)
+        resp = self._egress_http(
+            "post", "/v1/llm/chat", json=request,
+            timeout=LLM_CHAT_TIMEOUT_S if timeout is None else timeout,
+        )
         resp.raise_for_status()
         return resp.json()
 
     def chat_completion_stream(
-        self, request: dict | None = None, **kwargs
+        self,
+        request: dict | None = None,
+        *,
+        timeout: float | None = None,
+        **kwargs,
     ) -> Iterator[str]:
         """Streaming variant of :meth:`chat_completion`.
 
         Accepts the same dict-or-kwargs calling convention as
-        :meth:`chat_completion` (see that docstring for the rationale).
+        :meth:`chat_completion` (see that docstring for the rationale),
+        including the keyword-only ``timeout`` override (default
+        :data:`LLM_CHAT_TIMEOUT_S`). On the streaming path the read
+        timeout applies between chunks, not to the whole response, so
+        60s only trips when the upstream goes silent.
 
         Forces ``stream=True`` on the request and yields SSE frame
         strings exactly as they arrive from the Mastio, including
@@ -128,10 +160,16 @@ class _AiGatewayMixin:
         body["stream"] = True
         path = "/v1/llm/chat"
         url = f"{self.base}{path}"
+        effective_timeout = (
+            LLM_CHAT_TIMEOUT_S if timeout is None else timeout
+        )
 
         def _open():
             headers = self.proxy_headers("POST", url)
-            return self._http.stream("POST", url, headers=headers, json=body)
+            return self._http.stream(
+                "POST", url, headers=headers, json=body,
+                timeout=effective_timeout,
+            )
 
         cm = _open()
         resp = cm.__enter__()

--- a/cullis_sdk/_client/_enrollment.py
+++ b/cullis_sdk/_client/_enrollment.py
@@ -28,13 +28,16 @@ Methods moved (movement only — byte-perfect):
 * ``from_spiffe_workload_api`` — legacy direct-to-Court SPIFFE auth;
   emits ``DeprecationWarning`` (ADR-011 sunset path).
 
-Every ``cls.__new__(cls)`` factory replicates the full ``__init__``
-attribute surface manually (``_pubkey_cache = {}``, ``_dpop_nonce =
-None``, ``_signing_key_pem = None``, ``server_role = None``, …) —
-preserved byte-identical here. See memory feedback
-``sdk_factory_init_skip``: any drift between the factories and
-``__init__`` re-introduces the ``AttributeError`` class of bugs the
-existing duplication was designed to prevent.
+Every ``cls.__new__(cls)`` factory calls
+``instance._init_common()`` first (the single source of truth for the
+default attribute surface, defined on ``CullisClient``) and then
+overwrites only the attributes it derives from its inputs. The
+factories used to replicate the full ``__init__`` surface by hand;
+that duplication is what kept re-introducing the ``AttributeError``
+class of bugs (memory feedback ``sdk_factory_init_skip``; last hit:
+``_user_session_lock`` missing from all factories, 2026-06-10 review).
+Any NEW default attribute belongs in ``_init_common``, never inline
+in a factory.
 
 The module-level helpers ``_check_insecure_tls`` and
 ``_build_proxy_http_client`` live in :mod:`cullis_sdk.client` (kept
@@ -174,6 +177,7 @@ class _EnrollmentMixin:
         # handshake — the caller is responsible for arranging cert+key
         # delivery (out-of-band, separate enrollment endpoint, etc.).
         instance = cls.__new__(cls)
+        instance._init_common()
         instance.base = config["proxy_url"].rstrip("/")
         instance._verify_tls = verify_tls
         # H10: thread the pinned Org CA into the long-lived runtime
@@ -184,25 +188,13 @@ class _EnrollmentMixin:
             timeout=timeout,
             ca_chain_path=ca_chain_path,
         )
-        instance.token = None
         instance._label = config["agent_id"]
-        instance._signing_key_pem = None
         # H7 audit — see from_identity_dir for the rationale.
         instance._ca_chain_path = Path(ca_chain_path) if ca_chain_path else None
-        instance._pubkey_cache = {}
-        instance._client_seq = {}
-        instance._dpop_privkey = None
-        instance._dpop_pubkey_jwk = None
-        instance._dpop_nonce = None
-        instance._egress_dpop_key = None
-        instance._egress_dpop_nonce = None
         instance._proxy_agent_id = config["agent_id"]
         instance._proxy_org_id = config["org_id"]
         # Dogfood Finding #9 — proxy-bound: see __init__.
         instance._use_egress_for_sessions = True
-        # Mirror __init__: callers may attach the on-disk identity bundle
-        # afterwards (see ``canonical_recipient`` in cullis_connector).
-        instance.identity = None
         # Bug #1 fix — fault in login on the first authed call so
         # ``list_mcp_tools`` / ``call_mcp_tool`` / ``send_oneshot`` /
         # ``chat_completion`` "just work" after ``from_enrollment``.
@@ -291,6 +283,7 @@ class _EnrollmentMixin:
         from cullis_sdk.client import _build_proxy_http_client
 
         instance = cls.__new__(cls)
+        instance._init_common()
         instance.base = mastio_url.rstrip("/")
         instance._verify_tls = verify_tls
 
@@ -350,9 +343,7 @@ class _EnrollmentMixin:
             key_path=key_path,
             ca_chain_path=ca_chain_path,
         )
-        instance.token = None
         instance._label = agent_id or "(client-cert-auth)"
-        instance._signing_key_pem = None
         # ADR-014 + Bug #1 follow-up: ``key_path`` is the agent's TLS
         # client cert private key — it IS the signing key under the
         # "TLS cert is the credential" model. Lifting it into
@@ -375,16 +366,9 @@ class _EnrollmentMixin:
                 f"is required for TLS mTLS handshake."
             ) from exc
         # H7 audit — share the operator-pinned Org CA with the sender-cert
-        # verifier. Without this attribute ``decrypt_oneshot`` crashes with
-        # AttributeError under the cls.__new__(cls) factory route.
+        # verifier, so ``decrypt_oneshot`` chain-validates against the
+        # operator pin rather than any syntactically valid cert.
         instance._ca_chain_path = Path(ca_chain_path) if ca_chain_path else None
-        instance._pubkey_cache = {}
-        instance._client_seq = {}
-        instance._dpop_privkey = None
-        instance._dpop_pubkey_jwk = None
-        instance._dpop_nonce = None
-        instance._egress_dpop_key = None
-        instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
         # Bug #1 follow-up #2: ``login_via_proxy_with_local_key`` also
@@ -452,11 +436,6 @@ class _EnrollmentMixin:
                 )
         # Dogfood Finding #9 — proxy-bound: see __init__.
         instance._use_egress_for_sessions = True
-        # ``_update_nonce`` reads ``self.server_role`` on every response;
-        # since we skip ``__init__`` above (the ``cls.__new__(cls)`` route
-        # that other factories also use), the attribute must exist.
-        instance.server_role = None
-        instance.identity = None
         # Bug #1 fix — fault in login on the first authed call. See the
         # same flag set in ``from_enrollment`` and the lazy branch in
         # ``_AuthMixin._authed_request``. ADR-014 mTLS handshake remains
@@ -921,6 +900,7 @@ class _EnrollmentMixin:
                 key_path_runtime = persist_dir / "key.pem"
 
         instance = cls.__new__(cls)
+        instance._init_common()
         instance.base = mastio_url.rstrip("/")
         instance._verify_tls = verify_tls
         instance._http = _build_proxy_http_client(
@@ -930,24 +910,12 @@ class _EnrollmentMixin:
             key_path=key_path_runtime,
             ca_chain_path=ca_chain_path,
         )
-        instance.token = None
         instance._label = agent_id
-        instance._signing_key_pem = None
-        # H7 audit — see from_identity_dir for the rationale.
-        instance._ca_chain_path = None
-        instance._pubkey_cache = {}
-        instance._client_seq = {}
-        instance._dpop_privkey = None
-        instance._dpop_pubkey_jwk = None
-        instance._dpop_nonce = None
         instance._egress_dpop_key = dpop_key
-        instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
         # Dogfood Finding #9 — proxy-bound: see __init__.
         instance._use_egress_for_sessions = True
-        instance.server_role = None
-        instance.identity = None
 
         log("sdk", f"Enrolled {agent_id} via {endpoint_path}")
         return instance
@@ -1059,11 +1027,10 @@ class _EnrollmentMixin:
             verify_tls = site_url.startswith("https://")
 
         instance = cls.__new__(cls)
+        instance._init_common()
         instance.base = site_url.rstrip("/")
         instance._verify_tls = verify_tls
-        instance.token = None
         instance._label = agent_id
-        instance.server_role = None
         # Load the on-disk signing key + cert eagerly so ``decrypt_oneshot``,
         # ``send_oneshot``, and ``login_via_proxy_with_local_key`` all
         # work out of the box without every caller having to read
@@ -1106,22 +1073,12 @@ class _EnrollmentMixin:
         # then chain-validate the sender's leaf cert against the
         # operator-confirmed CA, not just any syntactically valid cert.
         instance._ca_chain_path = _pinned_ca if _pinned_ca.exists() else None
-        instance._pubkey_cache = {}
-        instance._client_seq = {}
-        instance._dpop_privkey = None
-        instance._dpop_pubkey_jwk = None
-        instance._dpop_nonce = None
-        instance._egress_dpop_key = None
-        instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
         # Dogfood Finding #9 — proxy-bound: route session ops through
         # /v1/egress/sessions* (handles intra-org locally, falls
         # through to broker bridge for cross-org).
         instance._use_egress_for_sessions = True
-        # Mirror __init__: callers may attach the on-disk identity bundle
-        # afterwards (see ``canonical_recipient`` in cullis_connector).
-        instance.identity = None
 
         # F-B-11 Phase 3c + 3d — load the DPoP keypair alongside the
         # rest of the Connector identity. Phase 3d (#181) has the
@@ -1602,11 +1559,10 @@ class _EnrollmentMixin:
             ca_path.write_text(ca_chain_pem)
 
         instance = cls.__new__(cls)
+        instance._init_common()
         instance.base = site_url.rstrip("/")
         instance._verify_tls = verify_tls
-        instance.token = None
         instance._label = agent_id
-        instance.server_role = None
         instance._signing_key_pem = key_pem
         instance._cert_pem = cert_pem
         instance._http = _build_proxy_http_client(
@@ -1617,17 +1573,9 @@ class _EnrollmentMixin:
             ca_chain_path=ca_path,
         )
         instance._ca_chain_path = ca_path
-        instance._pubkey_cache = {}
-        instance._client_seq = {}
-        instance._dpop_privkey = None
-        instance._dpop_pubkey_jwk = None
-        instance._dpop_nonce = None
-        instance._egress_dpop_key = None
-        instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
         instance._use_egress_for_sessions = True
-        instance.identity = None
         # Track the temp dir so ``close()`` / ``__del__`` can wipe the
         # cert + key off disk. The temp files are mode 600 + key 600,
         # but the on-disk dwell-time still wants to be minimised.

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -268,9 +268,30 @@ class CullisClient(_AiGatewayMixin, _AuthMixin, _DiscoveryMixin, _EnrollmentMixi
         timeout: float = 10.0,
     ) -> None:
         _check_insecure_tls(verify_tls)
+        self._init_common()
         self.base = broker_url.rstrip("/")
         self._verify_tls = verify_tls
         self._http = httpx.Client(timeout=timeout, verify=verify_tls)
+
+    def _init_common(self) -> None:
+        """Set the full default attribute surface of a client instance.
+
+        Single source of truth shared by ``__init__`` and every
+        ``cls.__new__(cls)`` factory in
+        :class:`cullis_sdk._client._enrollment._EnrollmentMixin`. The
+        factories used to replicate these assignments by hand, and every
+        attribute added to ``__init__`` but missed in one factory was a
+        latent ``AttributeError`` on that construction path (see memory
+        feedback ``sdk_factory_init_skip``; the 2026-06-10 review caught
+        ``_user_session_lock`` missing from ALL factories). Factories
+        call this first, then overwrite the handful of attributes they
+        derive from their inputs.
+
+        ``base`` / ``_verify_tls`` / ``_http`` are deliberately NOT
+        defaulted here: every construction path must set them
+        explicitly, and a path that forgets should fail loudly rather
+        than carry a half-built client.
+        """
         self.token: str | None = None
         self._label: str = "agent"
         self._signing_key_pem: str | None = None
@@ -373,6 +394,27 @@ class CullisClient(_AiGatewayMixin, _AuthMixin, _DiscoveryMixin, _EnrollmentMixi
         # together. Reader is lock-free (single attribute read under
         # the GIL) for the same hot-path reason.
         self._device_attestation: "dict | None" = None
+
+        # ── Factory-populated identity surface ─────────────────────
+        # Set by the proxy-bound factories (``from_identity_dir`` /
+        # ``from_connector`` / ``from_enrollment`` / ``_do_enroll`` /
+        # ``from_user_principal_pem``); ``None`` on a direct-broker
+        # client. Defaulted here so code reading them never has to
+        # know which construction path built the instance.
+        self._proxy_agent_id: str | None = None
+        self._proxy_org_id: str | None = None
+        # Leaf cert PEM (possibly ``leaf || Intermediate``) loaded from
+        # disk or handed in-memory; consumed by
+        # ``login_via_proxy_with_local_key`` and the oneshot crypto.
+        self._cert_pem: str | None = None
+        # Bug #1 fix — proxy-bound factories flip this so the first
+        # authed call faults in the right login method lazily. See
+        # ``_AuthMixin._authed_request``.
+        self._auto_login_pending: bool = False
+        # ADR-021 PR4c — per-process temp dir holding a user-principal
+        # cert + key; ``close()`` wipes it. Only
+        # ``from_user_principal_pem`` populates it.
+        self._user_principal_tmpdir: "str | None" = None
 
     def __enter__(self) -> CullisClient:
         return self

--- a/packaging/pypi-sdk/build.sh
+++ b/packaging/pypi-sdk/build.sh
@@ -30,14 +30,16 @@ find "${STAGE_DIR}/cullis_sdk" -type d -name __pycache__ -exec rm -rf {} +
 # Package readme for PyPI (lives next to pyproject.toml).
 cp -f "${REPO_ROOT}/cullis_sdk/README.md" "${STAGE_DIR}/README_PKG.md"
 
-# License + notices, required by FSL-1.1-Apache-2.0 distribution terms.
-# The SDK's per-file LICENSE in cullis_sdk/LICENSE already covers
-# the package itself; we additionally ship the repo-root copies so the
-# wheel is self-contained for distributors who only ever see the
-# installed package.
-cp -f "${REPO_ROOT}/LICENSE"            "${STAGE_DIR}/LICENSE"
-cp -f "${REPO_ROOT}/LICENSE-APACHE-2.0" "${STAGE_DIR}/LICENSE-APACHE-2.0"
+# License + notices. The wheel contains ONLY cullis_sdk/, which is
+# Apache-2.0 (see NOTICE) — so the wheel's top-level LICENSE must be
+# the SDK's own Apache text, NOT the repo-root FSL one. Shipping the
+# FSL text as LICENSE here made license scanners (and procurement)
+# read the package as FSL-licensed (2026-06-10 review, P0). NOTICE is
+# kept for the multi-license context of the source repo.
+cp -f "${REPO_ROOT}/cullis_sdk/LICENSE" "${STAGE_DIR}/LICENSE"
 cp -f "${REPO_ROOT}/NOTICE"             "${STAGE_DIR}/NOTICE"
+# Stale staged copy from builds prior to the license fix.
+rm -f "${STAGE_DIR}/LICENSE-APACHE-2.0"
 
 # CHANGELOG.md is authored in-place at ${STAGE_DIR}/CHANGELOG.md (SDK-
 # specific PyPI release history, distinct from the monorepo CHANGELOG

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -24,7 +24,10 @@ version = "0.2.2"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"
-license = { text = "FSL-1.1-Apache-2.0" }
+# The SDK is Apache-2.0 (see cullis_sdk/LICENSE + repo NOTICE). Only
+# the Mastio (mcp_proxy/) is FSL-1.1-Apache-2.0 — that code is not in
+# this wheel.
+license = { text = "Apache-2.0" }
 authors = [
     { name = "Cullis Security", email = "hello@cullis.io" },
 ]
@@ -45,7 +48,7 @@ classifiers = [
     "Topic :: Security",
     "Topic :: Software Development :: Libraries",
     "Topic :: System :: Networking",
-    "License :: Other/Proprietary License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
@@ -89,7 +92,6 @@ include = [
     "cullis_sdk/**/*.py",
     "cullis_sdk/py.typed",
     "LICENSE",
-    "LICENSE-APACHE-2.0",
     "NOTICE",
     "CHANGELOG.md",
     "README_PKG.md",

--- a/test/unit/test_sdk_chat_timeout.py
+++ b/test/unit/test_sdk_chat_timeout.py
@@ -1,0 +1,115 @@
+"""Tests for the LLM-chat per-request timeout (2026-06-10 P0).
+
+The client-wide httpx timeout defaults to 10s — sized for
+control-plane calls. ``chat_completion`` inherited it, so any
+completion that took the model longer than 10s (most non-trivial
+ones) died with ``httpx.ReadTimeout``. The fix gives the
+``/v1/llm/chat`` path its own per-request budget
+(:data:`cullis_sdk._client._ai_gateway.LLM_CHAT_TIMEOUT_S`, 60s,
+matching ``providers_compat``) plus a keyword-only ``timeout=``
+override on both chat methods.
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cullis_sdk._client._ai_gateway import LLM_CHAT_TIMEOUT_S
+
+
+class _FakeHttp:
+    """httpx.Client stand-in recording post/stream kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        self.calls.append(("post", url, kwargs))
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = ""
+        resp.json.return_value = {"id": "chatcmpl-1", "choices": []}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    @contextlib.contextmanager
+    def stream(self, method: str, url: str, **kwargs: Any):
+        self.calls.append((method, url, kwargs))
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        resp.iter_text.return_value = iter(["data: [DONE]\n\n"])
+        yield resp
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    http = _FakeHttp()
+    monkeypatch.setattr(
+        "cullis_sdk.client._build_proxy_http_client",
+        lambda **_kwargs: http,
+    )
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("FAKE-CERT")
+    key.write_text("FAKE-KEY")
+    from cullis_sdk import CullisClient
+
+    c = CullisClient.from_identity_dir(
+        "https://mastio.local:9443",
+        cert_path=cert,
+        key_path=key,
+    )
+    return c, http
+
+
+def test_chat_completion_default_timeout_is_llm_budget(client):
+    c, http = client
+    c.chat_completion(model="m", messages=[{"role": "user", "content": "hi"}])
+    _, url, kwargs = http.calls[-1]
+    assert url.endswith("/v1/llm/chat")
+    assert kwargs["timeout"] == LLM_CHAT_TIMEOUT_S
+    assert LLM_CHAT_TIMEOUT_S == 60.0
+
+
+def test_chat_completion_timeout_override(client):
+    c, http = client
+    c.chat_completion({"model": "m", "messages": []}, timeout=120.0)
+    _, _, kwargs = http.calls[-1]
+    assert kwargs["timeout"] == 120.0
+
+
+def test_chat_completion_timeout_never_lands_in_body(client):
+    """``timeout`` is a method parameter, not a request field — the
+    kwargs calling convention must not leak it into the JSON body.
+    """
+    c, http = client
+    c.chat_completion(model="m", messages=[], timeout=30.0)
+    _, _, kwargs = http.calls[-1]
+    assert "timeout" not in kwargs["json"]
+    assert kwargs["timeout"] == 30.0
+
+
+def test_chat_completion_stream_default_timeout(client):
+    c, http = client
+    frames = list(c.chat_completion_stream(model="m", messages=[]))
+    assert frames == ["data: [DONE]\n\n"]
+    method, url, kwargs = http.calls[-1]
+    assert (method, url.endswith("/v1/llm/chat")) == ("POST", True)
+    assert kwargs["timeout"] == LLM_CHAT_TIMEOUT_S
+    assert kwargs["json"]["stream"] is True
+
+
+def test_chat_completion_stream_timeout_override(client):
+    c, http = client
+    list(c.chat_completion_stream({"model": "m", "messages": []}, timeout=5.0))
+    _, _, kwargs = http.calls[-1]
+    assert kwargs["timeout"] == 5.0

--- a/test/unit/test_sdk_factory_init_common.py
+++ b/test/unit/test_sdk_factory_init_common.py
@@ -1,0 +1,207 @@
+"""Tests for the shared ``_init_common()`` factory surface (2026-06-10 P0).
+
+The ``cls.__new__(cls)`` factories used to replicate the ``__init__``
+attribute surface by hand; every attribute added to ``__init__`` but
+missed in a factory was a latent ``AttributeError`` on that
+construction path. Last hit: ``_user_session_lock`` (used by
+``attach_user_session``) was missing from ALL factories, so the
+ADR-032 user-session binding crashed on any client built via the
+canonical ``from_identity_dir`` route.
+
+The fix routes ``__init__`` and every factory through a single
+``CullisClient._init_common()``. Two layers of coverage here:
+
+1. Regression tests for the concrete crash (``attach_user_session`` /
+   ``detach_user_session`` / ``attach_device_attestation`` on
+   factory-built clients).
+2. A structural parity test: the attribute surface of every
+   factory-built instance must be a superset of the surface a plain
+   ``CullisClient(...)`` gets from ``__init__``. This is the
+   anti-drift net — a NEW attribute added to ``__init__`` (i.e. to
+   ``_init_common``) can never be missing from a factory-built client
+   again, no matter which factory.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeHttp:
+    """Minimal httpx.Client replacement recording verb calls + kwargs."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def _respond(self) -> Any:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.text = ""
+        resp.json.return_value = {"id": "chatcmpl-1", "choices": []}
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        self.calls.append(("post", url, kwargs))
+        return self._respond()
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        self.calls.append(("get", url, kwargs))
+        return self._respond()
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        self.calls.append((method, url, kwargs))
+        return self._respond()
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def fake_http_factory(monkeypatch):
+    """Stub ``_build_proxy_http_client`` so factories don't build a real
+    TLS context from the fake cert/key fixtures on disk.
+    """
+    http = _FakeHttp()
+
+    def _stub(**_kwargs: Any) -> _FakeHttp:  # noqa: ARG001
+        return http
+
+    monkeypatch.setattr(
+        "cullis_sdk.client._build_proxy_http_client", _stub,
+    )
+    return http
+
+
+@pytest.fixture
+def identity_dir(tmp_path):
+    """Minimal on-disk identity for ``from_identity_dir``."""
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("FAKE-CERT")
+    key.write_text("FAKE-KEY")
+    return tmp_path
+
+
+def _identity_client(identity_dir, **kwargs):
+    from cullis_sdk import CullisClient
+
+    return CullisClient.from_identity_dir(
+        "https://mastio.local:9443",
+        cert_path=identity_dir / "cert.pem",
+        key_path=identity_dir / "key.pem",
+        **kwargs,
+    )
+
+
+def _connector_client(tmp_path):
+    import json
+
+    from cullis_sdk import CullisClient
+
+    identity = tmp_path / "connector" / "identity"
+    identity.mkdir(parents=True)
+    (identity / "metadata.json").write_text(json.dumps({
+        "agent_id": "orga::desk-agent",
+        "site_url": "https://mastio.local:9443",
+    }))
+    return CullisClient.from_connector(
+        tmp_path / "connector", enable_dpop=False,
+    )
+
+
+def _user_principal_client():
+    from cullis_sdk import CullisClient
+
+    return CullisClient.from_user_principal_pem(
+        "https://mastio.local:9443",
+        principal_id="td/orga/user/alice",
+        cert_pem="FAKE-CERT",
+        key_pem="FAKE-KEY",
+        enable_dpop=False,
+    )
+
+
+# ── 1. Concrete regression: ADR-032 session binding on factory clients ──
+
+
+def test_attach_user_session_on_identity_dir_client(
+    identity_dir, fake_http_factory,
+):
+    """Pre-fix: AttributeError on ``self._user_session_lock`` because no
+    factory initialised it — on the CANONICAL construction path.
+    """
+    client = _identity_client(identity_dir)
+    client.attach_user_session("sess-token", "td/orga/user/alice")
+    assert client.get_user_session() == ("sess-token", "td/orga/user/alice")
+    client.detach_user_session()
+    assert client.get_user_session() is None
+
+
+def test_attach_device_attestation_on_identity_dir_client(
+    identity_dir, fake_http_factory,
+):
+    client = _identity_client(identity_dir)
+    client.attach_device_attestation({"tier": "managed"})
+    assert client.get_device_attestation() == {"tier": "managed"}
+
+
+def test_user_session_headers_ride_on_egress(
+    identity_dir, fake_http_factory,
+):
+    """End-to-end through ``proxy_headers``: the bound session must show
+    up on the egress wire call, not just in the getter.
+    """
+    client = _identity_client(identity_dir)
+    client.attach_user_session("sess-token", "td/orga/user/alice")
+    client.chat_completion(model="m", messages=[])
+    _, _, kwargs = fake_http_factory.calls[-1]
+    assert kwargs["headers"]["X-Cullis-Session-Token"] == "sess-token"
+    assert (
+        kwargs["headers"]["X-Cullis-On-Behalf-Of-User"]
+        == "td/orga/user/alice"
+    )
+
+
+# ── 2. Structural parity: factory surface ⊇ __init__ surface ────────────
+
+
+def _factory_clients(identity_dir, tmp_path):
+    return {
+        "from_identity_dir": _identity_client(identity_dir),
+        "from_connector": _connector_client(tmp_path),
+        "from_user_principal_pem": _user_principal_client(),
+    }
+
+
+def test_factory_attribute_surface_matches_init(
+    identity_dir, tmp_path, fake_http_factory,
+):
+    """Every attribute ``__init__`` sets must exist on every
+    factory-built instance. Catches the whole class of drift bugs, not
+    just the ``_user_session_lock`` instance of it.
+    """
+    from cullis_sdk import CullisClient
+
+    baseline = set(vars(CullisClient("https://broker.example")))
+    for name, client in _factory_clients(identity_dir, tmp_path).items():
+        missing = baseline - set(vars(client))
+        assert not missing, (
+            f"{name} is missing attributes __init__ sets: {sorted(missing)}. "
+            "Add defaults to CullisClient._init_common, never inline in a "
+            "factory."
+        )
+
+
+def test_factories_share_init_common_defaults(
+    identity_dir, tmp_path, fake_http_factory,
+):
+    """Spot-check the defaults that bit production code paths before."""
+    for client in _factory_clients(identity_dir, tmp_path).values():
+        assert client.server_role is None  # _update_nonce reads it
+        assert client._relogin_callable is None
+        assert client._user_session is None
+        assert client._device_attestation is None

--- a/test/unit/test_sdk_packaging_license.py
+++ b/test/unit/test_sdk_packaging_license.py
@@ -1,0 +1,40 @@
+"""Guard the PyPI ``cullis-sdk`` license metadata (2026-06-10 P0).
+
+The SDK is Apache-2.0 (``cullis_sdk/LICENSE``, repo NOTICE); only the
+Mastio is FSL-1.1-Apache-2.0. The standalone PyPI packaging declared
+FSL + a Proprietary classifier, which is exactly what a procurement
+license scanner reads — a wrong answer to the first due-diligence
+question. These tests pin the wheel metadata to the real license.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPI_DIR = REPO_ROOT / "packaging" / "pypi-sdk"
+
+
+def test_sdk_own_license_is_apache():
+    text = (REPO_ROOT / "cullis_sdk" / "LICENSE").read_text()
+    assert "Apache License" in text
+    assert "Functional Source License" not in text
+
+
+def test_pypi_metadata_declares_apache():
+    import tomllib
+
+    with (PYPI_DIR / "pyproject.toml").open("rb") as fh:
+        project = tomllib.load(fh)["project"]
+    assert project["license"] == {"text": "Apache-2.0"}
+    classifiers = project["classifiers"]
+    assert "License :: OSI Approved :: Apache Software License" in classifiers
+    assert not [c for c in classifiers if "Proprietary" in c]
+
+
+def test_build_stages_sdk_license_not_repo_root_fsl():
+    build_sh = (PYPI_DIR / "build.sh").read_text()
+    assert 'cp -f "${REPO_ROOT}/cullis_sdk/LICENSE" "${STAGE_DIR}/LICENSE"' in build_sh
+    assert 'cp -f "${REPO_ROOT}/LICENSE" ' not in build_sh, (
+        "build.sh must not stage the repo-root FSL LICENSE as the "
+        "wheel's top-level LICENSE"
+    )


### PR DESCRIPTION
## Summary

First PR from the 2026-06-10 internal 4-reviewer code review (P0 SDK items — the first surface a developer or due-diligence reviewer touches).

1. **LLM chat timeout** — the client-wide httpx timeout is 10s, sized for control-plane calls; `chat_completion` / `chat_completion_stream` inherited it, so any completion the model spent >10s on died with `httpx.ReadTimeout`. The `/v1/llm/chat` path now gets its own per-request budget (`LLM_CHAT_TIMEOUT_S = 60s`, matching `providers_compat`) plus a keyword-only `timeout=` override on both methods (keyword-only means it never leaks into the request body under the kwargs calling convention).
2. **Factory init drift** — every `cls.__new__(cls)` factory replicated the `__init__` attribute surface by hand; `_user_session_lock` was missing from ALL of them, so `attach_user_session()` raised `AttributeError` on the canonical `from_identity_dir` route (and `from_enrollment` also lacked `server_role`). `__init__` and all five factories now route through a single `CullisClient._init_common()`; factories overwrite only what they derive from their inputs. A structural parity test pins factory surface as a superset of the `__init__` surface so the whole drift class cannot reappear.
3. **Wheel license metadata** — the PyPI packaging declared `FSL-1.1-Apache-2.0` plus a Proprietary classifier and staged the repo-root FSL text as the wheel LICENSE, while the SDK is Apache-2.0 (`cullis_sdk/LICENSE`, repo NOTICE). Metadata, classifier and staged LICENSE now say Apache-2.0; regression test pins it.

## Test plan

- 13 new unit tests (`test_sdk_factory_init_common.py`, `test_sdk_chat_timeout.py`, `test_sdk_packaging_license.py`)
- Full unit suite: 1635 passed, 2 skipped
- Security review of the diff: no findings (net strengthening — the ADR-032 session-attribution headers now work on factory-built clients instead of crashing; all H7/TOFU pin overrides execute after `_init_common()`)
- ruff: 14 pre-existing findings on `cullis_sdk/`, unchanged by this diff (zero new — the ruff-in-CI gap is the P2 item)