### PR TITLE
fix(auth): F-B-15 prod gate + 90d default TTL for culk_ user API tokens, honest claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ flow until the next `## ` heading.
 
 Polish on `main` accumulating for the next minor. No release tag is cut for each individual patch any more; release cadence is intentionally throttled to one minor every 2-3 weeks plus emergency-only patches, matching the practice of comparable alpha-stage open-core projects.
 
+### Breaking — production deployments using `culk_*` user API tokens
+
+- **F-B-15 boot gate.** `culk_*` user API tokens are plain Bearer credentials (no mTLS client cert, no RFC 9449 DPoP proof). With `MCP_PROXY_ENVIRONMENT=production` the Mastio now **refuses to boot** while the surface is enabled (the default) unless the operator either disables it (`MCP_PROXY_USER_API_TOKENS_ENABLED=false`) or explicitly accepts the risk (`MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true`), mirroring the F-B-11/F-B-14 gates. Listing and revoking existing tokens keeps working with the surface disabled; only authentication and minting are gated. Threat model §5.1 documents the trade-off.
+- **90-day default TTL at mint.** Tokens minted without an explicit expiry now default to 90 days (`MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS`, 0 restores the legacy behaviour). "Never expires" remains available as an explicit choice (`expires_in_days: 0` on the admin API, the new checkbox in the dashboard). Existing tokens are untouched.
+- README and threat model no longer claim "refuses plain Bearer outright" unqualified: the claim is now scoped to agent identity surfaces, with the `culk_*` exception documented instead of implied away.
+
 ## [v0.6.6] — Security super-audit + production-shape resilience hardening — 2026-06-05
 
 Two waves of adversarial work on top of v0.6.5. First, an 11-agent red-team super-audit with adversarial verification closed a batch of trust-boundary bugs (SSRF connect-pin gaps, an unauthenticated bridge path, a weak-key signing floor, a multi-worker PKI race, and audit-chain binding gaps). Second, a destructive prod-shape stress test (Postgres + Vault + `environment=production` + 4 workers, validated live end-to-end and under chaos/fault injection) found and fixed the failures that only surface under a real multi-agent production load: a Postgres-only enrollment crash, a runtime that booted green then 500'd on the first login without Redis, identity-creation events that fell outside the tamper-evident hash chain, and `/v1/llm/chat` 401-churn under worker concurrency. Plus the carry-over fixes from the 48h soak.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **What Cullis gives an autonomous agent:**
 
-- **A real identity.** Each agent gets its own x509 certificate instead of an API key, presented over mTLS with a DPoP proof, so every request is tied to one agent rather than a shared key.
+- **A real identity.** Each agent gets its own x509 certificate instead of an API key, presented over mTLS with a DPoP proof, so every agent request is tied to one cryptographic identity rather than a shared key. (Human users on OpenAI-compatible clients use scoped, revocable API tokens instead — see [Identity](#cullis-mastio).)
 - **Policy before the call.** A decision point evaluates each request before the LLM or MCP tool runs, so an agent only does what you allowed.
 - **A tamper-evident trail.** Every action lands in an append-only, hash-chained audit log an external auditor can verify offline, without trusting Cullis or your IT team.
 
@@ -88,7 +88,7 @@ Copy `deploy/proxy/proxy.env.example` to `deploy/proxy/proxy.env` and fill in th
 
 Mastio is the gateway. One container, one organization, one source of truth for every agent action that touches the LLM or an MCP tool inside that organization. It runs standalone, air-gapped if you need it to be, with no external service dependency.
 
-**Identity.** Each agent receives an x509 leaf certificate signed by an organization-owned CA, bound to a SPIFFE SAN and pinned by thumbprint. The certificate is the credential: Mastio rejects any token presented without the matching client certificate (mTLS RFC 8705 §3) and verifies a DPoP proof (RFC 9449) on every authenticated request, refusing plain Bearer tokens outright.
+**Identity.** Each agent receives an x509 leaf certificate signed by an organization-owned CA, bound to a SPIFFE SAN and pinned by thumbprint. The certificate is the credential: Mastio rejects any token presented without the matching client certificate (mTLS RFC 8705 §3) and verifies a DPoP proof (RFC 9449) on every agent-authenticated request, refusing plain Bearer tokens on agent identity surfaces. The one deliberate exception is user API tokens (`culk_*`): scoped bearer credentials (path + provider scope, bcrypt-hashed at rest, revocable, 90-day default TTL) for human users on OpenAI-compatible clients that cannot perform DPoP — disabled in production unless the operator explicitly opts in (`MCP_PROXY_USER_API_TOKENS_INSECURE_OK`, gate F-B-15; threat model §5.1).
 
 **Policy.** A policy decision point evaluates each request before the LLM or MCP tool is reached. Operators author **Rego in the dashboard**; Mastio compiles it with the bundled `opa build` and evaluates the WebAssembly bundle in-process on every decision. A legacy allowlist (`blocked_agents`, `allowed_orgs`, capability gates per typed principal) backs up the Rego layer for deployments that haven't adopted it. Default-deny for new sessions, default-allow for messages, fail-safe on timeout.
 

--- a/deploy/proxy/proxy.env.example
+++ b/deploy/proxy/proxy.env.example
@@ -203,3 +203,10 @@ MCP_PROXY_REDIS_URL=redis://redis:6379/0
 #   # WebAuthn: single-Mastio pilots opt into the warn posture (no IdP yet);
 #   # IdP-backed deploys set ENFORCEMENT=required + RP_ID + EXPECTED_ORIGIN.
 #   MCP_PROXY_WEBAUTHN_WARN_INSECURE_OK=true
+#   # culk_ user API tokens (ADR-027, gate F-B-15): plain Bearer credentials
+#   # for OpenAI-compat clients (LibreChat, Cursor). Production refuses to
+#   # boot with the surface enabled (the default) unless you either disable
+#   # it or explicitly accept the risk. New mints default to a 90-day TTL.
+#   MCP_PROXY_USER_API_TOKENS_ENABLED=true
+#   MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true   # explicit risk acceptance
+#   MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS=90

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -62,6 +62,15 @@ curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
   }'
 ```
 
+> **Production note (F-B-15).** `culk_*` tokens are plain Bearer
+> credentials (no mTLS, no DPoP), so with
+> `MCP_PROXY_ENVIRONMENT=production` the Mastio refuses to boot while
+> the surface is enabled unless you explicitly accept the trade-off
+> with `MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true` (threat model
+> §5.1). Tokens minted without an expiry now default to a 90-day TTL;
+> pass `"expires_in_days": 0` only if you deliberately want a
+> non-expiring token.
+
 ## 2. Configure Cursor
 
 1. Open Cursor → **Cursor Settings** (`Cmd+,` on Mac).

--- a/docs/integrations/librechat.md
+++ b/docs/integrations/librechat.md
@@ -57,6 +57,15 @@ curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
 Save the cleartext `token` value. You will paste it into LibreChat
 under Alice's profile.
 
+> **Production note (F-B-15).** `culk_*` tokens are plain Bearer
+> credentials (no mTLS, no DPoP), so with
+> `MCP_PROXY_ENVIRONMENT=production` the Mastio refuses to boot while
+> the surface is enabled unless you explicitly accept the trade-off
+> with `MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true` (threat model
+> §5.1). Tokens minted without an expiry now default to a 90-day TTL;
+> pass `"expires_in_days": 0` only if you deliberately want a
+> non-expiring token.
+
 If you prefer the dashboard, see the
 [README mint section](README.md#minting-a-token).
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -150,7 +150,7 @@ pinned TSA roots — a property no MITM gains from being on the wire.
 
 ## 5. DPoP + mTLS binding
 
-Every authenticated request to Mastio carries **both**:
+Every **agent-authenticated** request to Mastio carries **both**:
 
 - An x509 client cert presented over mTLS (RFC 8705 §3).
 - A DPoP proof JWT (RFC 9449) bound to the agent's signing key.
@@ -161,9 +161,45 @@ provided by the JTI store (Redis in production, in-memory in dev for
 single-worker stacks). DPoP `htu` is checked against the operator's
 configured `MCP_PROXY_PROXY_PUBLIC_URL`.
 
-Mastio refuses plain Bearer authentication on every endpoint that
-matters. The dashboard cookie-auth path is bound by httponly + secure
-+ samesite + CSRF token.
+Mastio refuses plain Bearer authentication on every agent identity
+surface. The dashboard cookie-auth path is bound by httponly + secure
++ samesite + CSRF token. The single scoped exception for human users
+is documented in §5.1.
+
+### 5.1 User API tokens (`culk_*`) — scoped bearer exception
+
+ADR-027 user API tokens exist for OpenAI-compatible clients
+(LibreChat, Cursor, Cherry Studio) driven by a **human user**: those
+clients speak `Authorization: Bearer <key>` and cannot present a
+client certificate or sign DPoP proofs. A `culk_*` token therefore
+authenticates **by itself** on the paths it is scoped to (default
+`/v1/*`; in practice `/v1/chat/completions`, `/v1/llm/chat`,
+`/v1/models`) — no mTLS, no proof-of-possession.
+
+**Threat.** Token leak (shell history, client config files,
+unencrypted backups) and replay: whoever holds the bearer string
+authenticates as the user until expiry or revocation. This is the
+same threat class as a leaked OpenAI API key.
+
+**Mitigations.**
+
+- 256-bit entropy; bcrypt (cost 12) at rest, only `last4` displayed
+  after mint.
+- `scope_paths` (default `["/v1/*"]`) enforced at the resolver;
+  `scope_providers` enforced on `/v1/chat/completions`.
+- Immediate revocation (admin API + dashboard); `last_used_at` /
+  `last_used_ip` visible for anomaly review.
+- Default 90-day TTL at mint
+  (`MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS`); "never expires" is
+  an explicit per-token opt-out, not the default.
+- **Off in production unless explicitly accepted**: with
+  `environment=production`, boot refuses while the surface is enabled
+  unless the operator sets `MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true`
+  (gate F-B-15, same family as F-B-11/F-B-14) or disables it via
+  `MCP_PROXY_USER_API_TOKENS_ENABLED=false`. Listing and revoking
+  existing tokens keeps working with the surface disabled.
+- TLS is the transport security boundary, as for every other
+  credential in this model.
 
 ---
 

--- a/mcp_proxy/admin/api_tokens.py
+++ b/mcp_proxy/admin/api_tokens.py
@@ -86,8 +86,17 @@ class MintRequest(BaseModel):
     scope_providers: list[str] = Field(default_factory=list)
     # Default applied by the DB helper when omitted (``["/v1/*"]``).
     scope_paths: Optional[list[str]] = None
-    # ISO-8601 UTC, e.g. ``2026-08-11T00:00:00Z``. Null means never expire.
+    # ISO-8601 UTC, e.g. ``2026-08-11T00:00:00Z``. Omitted = the
+    # configured default TTL applies (90 days unless
+    # MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS overrides it).
+    # Mutually exclusive with ``expires_in_days``.
     expires_at: Optional[str] = Field(None, max_length=64)
+    # Relative expiry helper (F-B-15 claim alignment). None (default) =
+    # apply the configured default TTL. 0 = explicit no-expiry — the
+    # caller must say "never" deliberately, it is no longer the silent
+    # default. N>0 = now + N days. Mutually exclusive with
+    # ``expires_at``.
+    expires_in_days: Optional[int] = Field(None, ge=0, le=3650)
     # The admin can pass an explicit ``created_by`` (e.g. an audit
     # identifier for a Terraform run); when omitted we record the
     # static string ``"admin-secret"`` since the X-Admin-Secret auth
@@ -147,6 +156,37 @@ async def mint_token(body: MintRequest) -> MintResponse:
     will be returned. The caller must capture it now; subsequent reads
     expose only ``token_last4``.
     """
+    # F-B-15 — minting is refused while the culk_ surface is disabled.
+    # List / get / revoke stay available so operators can audit and
+    # clean up existing tokens with the flag off.
+    if not get_settings().user_api_tokens_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "user API tokens are disabled on this Mastio "
+                "(MCP_PROXY_USER_API_TOKENS_ENABLED=false); minting is "
+                "refused. Existing tokens can still be listed and revoked."
+            ),
+        )
+    if body.expires_at is not None and body.expires_in_days is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "expires_at and expires_in_days are mutually exclusive; "
+                "pass one or neither (default TTL applies)"
+            ),
+        )
+    expires_at = body.expires_at
+    no_expiry = False
+    if body.expires_in_days is not None:
+        if body.expires_in_days == 0:
+            no_expiry = True
+        else:
+            from datetime import datetime, timedelta, timezone
+            expires_at = (
+                datetime.now(timezone.utc)
+                + timedelta(days=body.expires_in_days)
+            ).isoformat()
     created_by = body.created_by or "admin-secret"
     try:
         minted = await mint_user_api_token(
@@ -155,7 +195,8 @@ async def mint_token(body: MintRequest) -> MintResponse:
             created_by=created_by,
             scope_providers=body.scope_providers,
             scope_paths=body.scope_paths,
-            expires_at=body.expires_at,
+            expires_at=expires_at,
+            no_expiry=no_expiry,
         )
     except ValueError as exc:
         # mint_user_api_token raises ValueError for unknown principal /

--- a/mcp_proxy/auth/api_token.py
+++ b/mcp_proxy/auth/api_token.py
@@ -23,6 +23,12 @@ handler does not need to know which auth class minted the agent — the
 ``InternalAgent.principal_type=="user"`` is the signal that downstream
 audit code uses to attribute correctly.
 
+F-B-15 (claim-alignment 2026-06-10): the whole surface is gated by
+``settings.user_api_tokens_enabled``. When false the resolver declines
+every request before any DB lookup, and ``validate_config`` refuses a
+production boot with the flag on unless the operator explicitly accepts
+the plain-Bearer risk via ``MCP_PROXY_USER_API_TOKENS_INSECURE_OK``.
+
 Touch tracking:
     Every successful auth updates ``last_used_at`` + ``last_used_ip`` on
     the token row via ``touch_user_api_token``. Best-effort: failures in
@@ -48,6 +54,7 @@ from datetime import datetime, timezone
 
 from fastapi import HTTPException, Request, status
 
+from mcp_proxy.config import get_settings
 from mcp_proxy.db import (
     touch_user_api_token,
     verify_user_api_token,
@@ -169,6 +176,13 @@ async def _maybe_api_token_principal(request: Request) -> InternalAgent | None:
     not "auth failed" — that decision belongs to the resolver chain
     further down the pipeline.
     """
+    # F-B-15 — culk_ surface disabled. Decline before any header parse
+    # or DB lookup so the request falls through to the LOCAL_TOKEN /
+    # cert+DPoP resolvers; a culk_-only client ends in the cert path's
+    # 401. Tokens already in the DB stop authenticating immediately.
+    if not get_settings().user_api_tokens_enabled:
+        return None
+
     token = _extract_bearer_token(request)
     if token is None:
         return None

--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -177,6 +177,10 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
          resolved user principal is returned without going through
          cert + DPoP. The Bearer token IS the proof of identity for
          OpenAI-compat clients (LibreChat, Cursor, Cherry Studio, ...).
+         Gated by ``settings.user_api_tokens_enabled`` (F-B-15): when
+         off the resolver declines and the chain proceeds to step 1;
+         production refuses boot with the surface on unless the
+         operator opts in via MCP_PROXY_USER_API_TOKENS_INSECURE_OK.
       1. ADR-012 LOCAL_TOKEN short-circuit (cross-org Bearer JWT).
       2. ``get_agent_from_client_cert`` — identity from TLS-layer cert,
          pinned against ``internal_agents.cert_pem``, rate-limited.

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -617,6 +617,32 @@ class ProxySettings(BaseSettings):
     #     the existing token TTL has fully expired.
     local_token_require_dpop: bool = False
 
+    # ADR-027 / F-B-15 (claim-alignment, 2026-06-10) — culk_ user API
+    # tokens. ``user_api_tokens_enabled`` controls the entire culk_
+    # surface: the Bearer-resolver short-circuit in
+    # ``get_agent_from_dpop_client_cert`` (step 0) AND minting via the
+    # admin API / dashboard. A culk_ token is a plain Bearer credential
+    # — no mTLS client cert, no RFC 9449 key-possession proof — for
+    # OpenAI-compatible clients (LibreChat, Cursor) that cannot do
+    # DPoP. Default ON for dev / integration ergonomics; production
+    # refuses boot unless the operator either disables this or
+    # explicitly accepts the risk via
+    # ``MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true`` (validate_config
+    # gate, mirrors F-B-11 / F-B-14). Listing and revoking existing
+    # tokens stays available regardless of the flag so operators can
+    # audit and clean up.
+    user_api_tokens_enabled: bool = True
+
+    # ADR-027 §threat-model — default mint TTL in days applied when the
+    # caller does not specify an expiry. The ADR promises "TTL
+    # configurabile (default 90 giorni)"; the original implementation
+    # minted expires_at=NULL (never expire), which contradicted it.
+    # 0 disables the default (mint-time "never", pre-F-B-15 legacy
+    # behaviour); explicit no-expiry per token remains available via
+    # ``expires_in_days=0`` on the admin mint API. Existing rows are
+    # never touched — this only shapes new mints.
+    user_api_token_default_ttl_days: int = 90
+
     # ADR-032 Layer 2 — Connector OIDC login session TTL in seconds.
     # Default 1h aligns with ADR-032 decision D (banking-grade idle).
     # Operators tune via ``MCP_PROXY_USER_SESSION_TTL_SECONDS``.
@@ -1327,6 +1353,38 @@ def validate_config(settings: ProxySettings) -> None:
                     "migration window explicitly opt in via "
                     "MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK=true and track a "
                     "sunset date (F-B-14)."
+                )
+                raise SystemExit(1)
+
+        # F-B-15 (claim-alignment 2026-06-10). ADR-027 culk_ user API
+        # tokens. A culk_ token is a plain Bearer credential: no mTLS
+        # client cert, no RFC 9449 key-possession proof. It is scoped
+        # (path + provider), bcrypt-hashed at rest, revocable and
+        # TTL-bounded (90d default), but a leaked or replayed token
+        # still authenticates as the user until expiry or revocation.
+        # That contradicts the "agent surfaces require mTLS+DPoP, plain
+        # Bearer refused" production posture, so the surface is opt-in
+        # in production: disable it, or declare the accepted risk
+        # explicitly and track a review date, mirroring F-B-11/F-B-14.
+        if settings.user_api_tokens_enabled:
+            insecure_ok = (
+                os.environ.get("MCP_PROXY_USER_API_TOKENS_INSECURE_OK", "")
+                .strip()
+                .lower()
+            ) in {"1", "true", "yes"}
+            if not insecure_ok:
+                _log.critical(
+                    "MCP_PROXY_USER_API_TOKENS_ENABLED=true is not permitted "
+                    "in production without explicit risk acceptance: culk_ "
+                    "user API tokens are plain Bearer credentials — no mTLS "
+                    "client cert, no RFC 9449 key-possession proof — so a "
+                    "leaked or replayed token authenticates as the user "
+                    "until expiry or revocation. Set "
+                    "MCP_PROXY_USER_API_TOKENS_ENABLED=false, or for "
+                    "OpenAI-compatible client deployments (LibreChat, "
+                    "Cursor) explicitly opt in via "
+                    "MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true and track a "
+                    "review date (F-B-15)."
                 )
                 raise SystemExit(1)
 

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -9,7 +9,7 @@ import os
 from functools import lru_cache
 from typing import Annotated
 
-from pydantic import field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 _log = logging.getLogger("mcp_proxy.startup")
@@ -640,8 +640,10 @@ class ProxySettings(BaseSettings):
     # 0 disables the default (mint-time "never", pre-F-B-15 legacy
     # behaviour); explicit no-expiry per token remains available via
     # ``expires_in_days=0`` on the admin mint API. Existing rows are
-    # never touched — this only shapes new mints.
-    user_api_token_default_ttl_days: int = 90
+    # never touched — this only shapes new mints. ``ge=0`` so an
+    # operator typo (negative value) crashes the boot loudly instead
+    # of silently restoring the legacy never-expire default.
+    user_api_token_default_ttl_days: int = Field(default=90, ge=0)
 
     # ADR-032 Layer 2 — Connector OIDC login session TTL in seconds.
     # Default 1h aligns with ADR-032 decision D (banking-grade idle).

--- a/mcp_proxy/dashboard/api_tokens.py
+++ b/mcp_proxy/dashboard/api_tokens.py
@@ -60,6 +60,7 @@ async def create_api_token(
     request: Request,
     label: str = Form(""),
     expires_at: str = Form(""),
+    never_expires: str = Form(""),
     scope_providers: list[str] | None = Form(None),
 ) -> RedirectResponse:
     """Mint a new culk_ token for ``principal_id`` and redirect back to
@@ -71,6 +72,19 @@ async def create_api_token(
     if not await verify_csrf(request, session):
         return _back_to_user(principal_id, "error=csrf")
 
+    # F-B-15 — minting is refused while the culk_ surface is disabled
+    # (revoke below stays available so operators can clean up).
+    from mcp_proxy.config import get_settings
+    if not get_settings().user_api_tokens_enabled:
+        return _back_to_user(
+            principal_id,
+            "token_error="
+            + quote(
+                "API tokens are disabled on this Mastio "
+                "(MCP_PROXY_USER_API_TOKENS_ENABLED=false)."
+            ),
+        )
+
     clean_label = (label or "").strip()
     if not clean_label:
         return _back_to_user(principal_id, "token_error=label+is+required")
@@ -81,6 +95,19 @@ async def create_api_token(
     # (string comparison vs ``datetime.now(UTC).isoformat()``) works.
     if clean_expiry and len(clean_expiry) == 10:
         clean_expiry = f"{clean_expiry}T23:59:59+00:00"
+    # "Never expires" checkbox (F-B-15): an empty date no longer means
+    # "never" — the DB helper applies the 90-day default TTL. Ticking
+    # the checkbox is the explicit opt-out; it wins over a date typo by
+    # being rejected, not silently preferred.
+    wants_never = bool((never_expires or "").strip())
+    if wants_never and clean_expiry:
+        return _back_to_user(
+            principal_id,
+            "token_error="
+            + quote(
+                "Pick an expiry date OR tick Never expires, not both."
+            ),
+        )
 
     scope_list = [s.strip() for s in (scope_providers or []) if s.strip()]
 
@@ -97,6 +124,7 @@ async def create_api_token(
             created_by=created_by,
             scope_providers=scope_list,
             expires_at=clean_expiry,
+            no_expiry=wants_never,
         )
     except ValueError:
         # mint_user_api_token raises ValueError for unknown principal /

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -295,7 +295,11 @@
                     </label>
                     <input type="date" name="expires_at"
                            class="bg-surface-950 border border-gray-800 rounded px-3 py-2 text-sm text-gray-200 font-mono focus:outline-none focus:border-[#00e5c7]">
-                    <p class="text-[10px] text-gray-600 mt-1">Empty = never expire. Rotate via Revoke + Create.</p>
+                    <p class="text-[10px] text-gray-600 mt-1">Empty = default 90-day TTL. Rotate via Revoke + Create.</p>
+                    <label class="inline-flex items-center gap-1.5 cursor-pointer mt-2 text-xs text-gray-300">
+                        <input type="checkbox" name="never_expires" value="1" class="accent-[#00e5c7]">
+                        <span>Never expires (explicit opt-out of the default TTL)</span>
+                    </label>
                 </div>
 
                 <div>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -24,7 +24,7 @@ import logging
 import os
 import secrets
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
 
@@ -2582,6 +2582,7 @@ async def mint_user_api_token(
     scope_providers: list[str] | None = None,
     scope_paths: list[str] | None = None,
     expires_at: str | None = None,
+    no_expiry: bool = False,
 ) -> dict:
     """Mint a new API token for a user principal.
 
@@ -2590,6 +2591,12 @@ async def mint_user_api_token(
     reads (``get_user_api_token``, ``list_user_api_tokens``) return only
     metadata + ``token_last4``.
 
+    This is the single choke point every mint path goes through (admin
+    API, dashboard, any future self-service route), so the F-B-15
+    default-TTL policy lives here: a caller that wants a non-expiring
+    token must say so explicitly via ``no_expiry=True``. Any new mint
+    route must also honour ``settings.user_api_tokens_enabled``.
+
     Arguments:
         principal_id: ``local_user_principals.principal_id`` (user::name)
         label: operator-visible name, e.g. ``"Cursor laptop daniele"``
@@ -2597,7 +2604,13 @@ async def mint_user_api_token(
         scope_providers: empty list = no restriction; ``["anthropic"]`` =
             only that provider. Stored verbatim, not enforced here.
         scope_paths: defaults to ``["/v1/*"]``. Stored verbatim.
-        expires_at: ISO-8601 UTC, or ``None`` for no expiry.
+        expires_at: ISO-8601 UTC. ``None`` without ``no_expiry`` applies
+            the configured default TTL
+            (``settings.user_api_token_default_ttl_days``, 90 days;
+            0 restores the legacy mint-time "never").
+        no_expiry: explicit opt-out of the default TTL (ADR-027 claim
+            alignment — "never expire" is a deliberate choice, not the
+            silent default). Mutually exclusive with ``expires_at``.
     """
     if not principal_id:
         raise ValueError("principal_id is required")
@@ -2605,6 +2618,11 @@ async def mint_user_api_token(
         raise ValueError("label is required")
     if not created_by:
         raise ValueError("created_by is required")
+    if expires_at is not None and no_expiry:
+        raise ValueError(
+            "expires_at and no_expiry are mutually exclusive; pass an "
+            "explicit expiry OR opt out of the default TTL, not both",
+        )
 
     # Audit Wave A C3 (2026-05-11) — pre-fix the mint accepted ANY
     # ``principal_id``, including foreign-org or non-existent values.
@@ -2646,6 +2664,17 @@ async def mint_user_api_token(
             "POST /v1/admin/users or via Frontdesk SSO before minting "
             "tokens for it",
         )
+
+    # F-B-15 — apply the default TTL when the caller neither set an
+    # explicit expiry nor explicitly opted out. ADR-027's threat model
+    # promises a 90-day default; minting expires_at=NULL silently
+    # contradicted it. Existing rows are untouched (mint-time only).
+    if expires_at is None and not no_expiry:
+        ttl_days = settings.user_api_token_default_ttl_days
+        if ttl_days > 0:
+            expires_at = (
+                datetime.now(timezone.utc) + timedelta(days=ttl_days)
+            ).isoformat()
 
     plaintext = _new_api_token_plaintext()
     token_hash = _hash_api_token(plaintext)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -2623,6 +2623,28 @@ async def mint_user_api_token(
             "expires_at and no_expiry are mutually exclusive; pass an "
             "explicit expiry OR opt out of the default TTL, not both",
         )
+    if expires_at is not None:
+        # Crypto-review F-B-15 follow-up: the expiry filter at verify
+        # time is a string comparison against ``datetime.now(UTC)
+        # .isoformat()``, so a non-ISO or non-UTC-normalised value
+        # silently breaks it — a lexicographically high garbage string
+        # would make the token de-facto eternal without the explicit
+        # ``no_expiry`` opt-in. Parse, require a timezone, normalise
+        # to the same UTC isoformat() shape the filter compares with.
+        try:
+            parsed_expiry = datetime.fromisoformat(expires_at)
+        except ValueError as exc:
+            raise ValueError(
+                f"expires_at must be an ISO-8601 timestamp; got "
+                f"{expires_at!r}",
+            ) from exc
+        if parsed_expiry.tzinfo is None:
+            raise ValueError(
+                "expires_at must carry an explicit timezone offset "
+                "(e.g. ...T00:00:00+00:00 or Z); naive timestamps "
+                "compare unsoundly against the UTC verify filter",
+            )
+        expires_at = parsed_expiry.astimezone(timezone.utc).isoformat()
 
     # Audit Wave A C3 (2026-05-11) — pre-fix the mint accepted ANY
     # ``principal_id``, including foreign-org or non-existent values.

--- a/test/unit/test_admin_api_tokens_gate.py
+++ b/test/unit/test_admin_api_tokens_gate.py
@@ -1,0 +1,129 @@
+"""F-B-15 — admin mint endpoint gating + expiry semantics.
+
+Pins the admin REST half of the claim-alignment PR:
+
+  - mint refuses 403 while ``user_api_tokens_enabled`` is off, with an
+    action-oriented message; list / revoke keep working so operators
+    can audit and clean up existing tokens;
+  - ``expires_in_days`` semantics: omitted → default 90d TTL; ``0`` →
+    explicit never-expire; ``N>0`` → now + N days; combined with
+    ``expires_at`` → 400.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.admin.api_tokens import router as admin_tokens_router
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, init_db
+
+_ADMIN_SECRET = "test-admin-secret-tokens"
+_PRINCIPAL = "acme::user::alice"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_SECRET)
+    get_settings.cache_clear()
+    db_path = tmp_path / "admin_tokens.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    from _token_test_helpers import seed_default_test_principals
+    await seed_default_test_principals()
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def client(proxy_db) -> TestClient:
+    app = FastAPI()
+    app.include_router(admin_tokens_router)
+    return TestClient(app)
+
+
+def _set_flag(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", value)
+    get_settings.cache_clear()
+
+
+def _mint(client: TestClient, **extra) -> "TestClient.Response":
+    return client.post(
+        "/v1/admin/api-tokens",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+        json={
+            "principal_id": _PRINCIPAL,
+            "label": extra.pop("label", "gate-test"),
+            **extra,
+        },
+    )
+
+
+def test_mint_403_when_disabled(client, monkeypatch):
+    _set_flag(monkeypatch, "false")
+    resp = _mint(client)
+    assert resp.status_code == 403
+    assert "disabled" in resp.json()["detail"]
+
+
+def test_list_and_revoke_work_when_disabled(client, monkeypatch):
+    """Operators must be able to audit + clean up with the surface off."""
+    _set_flag(monkeypatch, "true")
+    minted = _mint(client, label="to-revoke").json()
+    _set_flag(monkeypatch, "false")
+
+    listed = client.get(
+        "/v1/admin/api-tokens",
+        params={"principal_id": _PRINCIPAL},
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert listed.status_code == 200
+    assert any(t["id"] == minted["id"] for t in listed.json()["tokens"])
+
+    revoked = client.delete(
+        f"/v1/admin/api-tokens/{minted['id']}",
+        headers={"X-Admin-Secret": _ADMIN_SECRET},
+    )
+    assert revoked.status_code in (200, 204)
+
+
+def test_mint_default_ttl_in_response(client, monkeypatch):
+    _set_flag(monkeypatch, "true")
+    resp = _mint(client, label="default-ttl")
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["expires_at"] is not None
+    expiry = datetime.fromisoformat(body["expires_at"])
+    expected = datetime.now(timezone.utc) + timedelta(days=90)
+    assert abs((expiry - expected).total_seconds()) < 300
+
+
+def test_mint_expires_in_days_zero_is_never(client, monkeypatch):
+    _set_flag(monkeypatch, "true")
+    resp = _mint(client, label="never", expires_in_days=0)
+    assert resp.status_code == 201
+    assert resp.json()["expires_at"] is None
+
+
+def test_mint_expires_in_days_positive(client, monkeypatch):
+    _set_flag(monkeypatch, "true")
+    resp = _mint(client, label="week", expires_in_days=7)
+    assert resp.status_code == 201
+    expiry = datetime.fromisoformat(resp.json()["expires_at"])
+    expected = datetime.now(timezone.utc) + timedelta(days=7)
+    assert abs((expiry - expected).total_seconds()) < 300
+
+
+def test_mint_both_expiry_fields_is_400(client, monkeypatch):
+    _set_flag(monkeypatch, "true")
+    future = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+    resp = _mint(
+        client, label="conflict", expires_in_days=7, expires_at=future,
+    )
+    assert resp.status_code == 400
+    assert "mutually exclusive" in resp.json()["detail"]

--- a/test/unit/test_api_token_resolver_flag.py
+++ b/test/unit/test_api_token_resolver_flag.py
@@ -1,0 +1,138 @@
+"""F-B-15 — the culk_ resolver honours ``user_api_tokens_enabled``.
+
+The boot gate (test_user_api_tokens_prod_gate.py) keeps production
+honest at startup; these tests pin the runtime half: with the flag off
+the resolver declines every request BEFORE any DB lookup, so tokens
+already in the database stop authenticating immediately and the auth
+chain falls through to the cert+DPoP path (whose 401 is the final
+answer for a culk_-only client).
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from starlette.requests import Request
+
+from mcp_proxy.db import dispose_db, init_db, mint_user_api_token
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    from _token_test_helpers import seed_default_test_principals
+    await seed_default_test_principals()
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+def _request(token: str | None, path: str = "/v1/chat/completions") -> Request:
+    from types import SimpleNamespace
+
+    headers = []
+    if token is not None:
+        headers.append((b"authorization", f"Bearer {token}".encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "headers": headers,
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+        "server": ("mastio.test", 9443),
+        "scheme": "https",
+        # ``_maybe_local_internal_agent`` (step 1 of the chain) reads
+        # ``request.app.state.local_issuer``; an empty state means "no
+        # local issuer" and the chain proceeds to the cert path.
+        "app": SimpleNamespace(state=SimpleNamespace()),
+    }
+    return Request(scope)
+
+
+async def _mint(label: str = "resolver-test") -> str:
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label=label,
+        created_by="acme::admin",
+    )
+    return minted["token"]
+
+
+def _set_flag(monkeypatch, value: str) -> None:
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", value)
+    get_settings.cache_clear()
+
+
+async def test_flag_on_valid_token_resolves_principal(
+    fresh_db, monkeypatch,
+):
+    _set_flag(monkeypatch, "true")
+    token = await _mint()
+
+    from mcp_proxy.auth.api_token import _maybe_api_token_principal
+
+    agent = await _maybe_api_token_principal(_request(token))
+    assert agent is not None
+    assert agent.agent_id == "acme::user::alice"
+    assert agent.principal_type == "user"
+    assert agent.cert_pem is None and agent.dpop_jkt is None
+
+
+async def test_flag_off_declines_without_db_lookup(fresh_db, monkeypatch):
+    """The decline happens before the bcrypt verify: no DB round-trip,
+    no timing surface, and tokens already minted stop working."""
+    _set_flag(monkeypatch, "true")
+    token = await _mint()
+    _set_flag(monkeypatch, "false")
+
+    import mcp_proxy.auth.api_token as api_token_mod
+
+    calls = {"n": 0}
+
+    async def _counting_verify(*args, **kwargs):
+        calls["n"] += 1
+        raise AssertionError("verify_user_api_token must not be called")
+
+    monkeypatch.setattr(
+        api_token_mod, "verify_user_api_token", _counting_verify,
+    )
+
+    agent = await api_token_mod._maybe_api_token_principal(_request(token))
+    assert agent is None
+    assert calls["n"] == 0
+
+
+async def test_flag_off_chain_ends_in_401_for_culk_only_client(
+    fresh_db, monkeypatch,
+):
+    """End-to-end through ``get_agent_from_dpop_client_cert``: a client
+    that only has a culk_ token (no cert) gets a 401/403, not silent
+    acceptance."""
+    from fastapi import HTTPException
+
+    _set_flag(monkeypatch, "true")
+    token = await _mint(label="e2e")
+    _set_flag(monkeypatch, "false")
+
+    from mcp_proxy.auth.dpop_client_cert import (
+        get_agent_from_dpop_client_cert,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await get_agent_from_dpop_client_cert(_request(token))
+    assert excinfo.value.status_code in (401, 403)

--- a/test/unit/test_audit_anchor_tsa_url_validation.py
+++ b/test/unit/test_audit_anchor_tsa_url_validation.py
@@ -60,6 +60,9 @@ def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # the F-A-406 gate under test is reachable. Provide Redis so the only
     # SystemExit comes from the audit-anchor URL gate.
     monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://localhost:6379/0")
+    # F-B-15 — disable the culk_ surface so the SystemExit in these
+    # TSA-URL-focused tests isolates the knob under test.
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "false")
 
 
 def _fresh_settings():

--- a/test/unit/test_local_token_dpop_required_in_prod.py
+++ b/test/unit/test_local_token_dpop_required_in_prod.py
@@ -64,6 +64,9 @@ def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
     monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
     monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://redis:6379/0")
+    # F-B-15 — disable the culk_ surface so the SystemExit in these
+    # F-B-14-focused tests isolates the knob under test.
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "false")
     # Default the override OFF; the opt-in test sets it explicitly.
     monkeypatch.delenv("MCP_PROXY_LOCAL_TOKEN_DPOP_INSECURE_OK", raising=False)
 

--- a/test/unit/test_proxy_tls_verify.py
+++ b/test/unit/test_proxy_tls_verify.py
@@ -64,6 +64,10 @@ def _prod_settings(**overrides) -> ProxySettings:
         # require Redis at first use. Pin a Redis URL so the SystemExit in
         # these TLS-focused tests isolates the knob under test.
         redis_url="redis://localhost:6379/0",
+        # F-B-15 — prod refuses the culk_ plain-Bearer surface without
+        # an explicit opt-in; disable it so the SystemExit in these
+        # TLS-focused tests isolates the knob under test.
+        user_api_tokens_enabled=False,
     )
     base.update(overrides)
     return ProxySettings(**base)

--- a/test/unit/test_redis_required_in_prod.py
+++ b/test/unit/test_redis_required_in_prod.py
@@ -48,6 +48,9 @@ def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")
     monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
     monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+    # F-B-15 — disable the culk_ surface so the SystemExit in these
+    # Redis-focused tests isolates the knob under test.
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "false")
 
 
 def _fresh_settings():

--- a/test/unit/test_user_api_tokens_db.py
+++ b/test/unit/test_user_api_tokens_db.py
@@ -101,7 +101,13 @@ async def test_mint_returns_cleartext_only_once(fresh_db):
     assert minted["created_by"] == "acme::admin"
     assert minted["scope_providers"] == []
     assert minted["scope_paths"] == ["/v1/*"]
-    assert minted["expires_at"] is None
+    # F-B-15 — a mint without an explicit expiry gets the configured
+    # default TTL (90 days), no longer NULL/never. The never-expire
+    # behaviour is pinned separately in test_mint_no_expiry_explicit.
+    assert minted["expires_at"] is not None
+    default_expiry = datetime.fromisoformat(minted["expires_at"])
+    expected = datetime.now(timezone.utc) + timedelta(days=90)
+    assert abs((default_expiry - expected).total_seconds()) < 300
     assert minted["revoked_at"] is None
 
     # get_user_api_token never returns cleartext
@@ -162,6 +168,87 @@ async def test_mint_two_tokens_for_same_user_are_independent(fresh_db):
     assert a["token_last4"] != b["token_last4"] or True  # collision possible
     rows = await list_user_api_tokens("acme::user::carol")
     assert {r["id"] for r in rows} == {a["id"], b["id"]}
+
+
+# ── default TTL (F-B-15) ──────────────────────────────────────────────
+
+
+async def test_mint_no_expiry_explicit(fresh_db):
+    """``no_expiry=True`` is the deliberate opt-out: NULL expires_at."""
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label="never-expires",
+        created_by="acme::admin",
+        no_expiry=True,
+    )
+    assert minted["expires_at"] is None
+
+
+async def test_mint_default_ttl_env_override(fresh_db, monkeypatch):
+    """MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS shapes the default."""
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS", "30")
+    get_settings.cache_clear()
+    try:
+        minted = await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="short-lived",
+            created_by="acme::admin",
+        )
+        expiry = datetime.fromisoformat(minted["expires_at"])
+        expected = datetime.now(timezone.utc) + timedelta(days=30)
+        assert abs((expiry - expected).total_seconds()) < 300
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_mint_default_ttl_zero_restores_legacy_never(
+    fresh_db, monkeypatch,
+):
+    """TTL_DAYS=0 is the operator-level opt-out: legacy NULL default."""
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS", "0")
+    get_settings.cache_clear()
+    try:
+        minted = await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="legacy-default",
+            created_by="acme::admin",
+        )
+        assert minted["expires_at"] is None
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_mint_explicit_expires_at_passes_verbatim(fresh_db):
+    """An explicit expiry is stored untouched — no default applied."""
+    future = (
+        datetime.now(timezone.utc) + timedelta(days=7)
+    ).isoformat()
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label="one-week",
+        created_by="acme::admin",
+        expires_at=future,
+    )
+    assert minted["expires_at"] == future
+
+
+async def test_mint_expires_at_and_no_expiry_conflict(fresh_db):
+    """Passing both an explicit expiry and the opt-out is a caller bug."""
+    future = (
+        datetime.now(timezone.utc) + timedelta(days=7)
+    ).isoformat()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="conflict",
+            created_by="acme::admin",
+            expires_at=future,
+            no_expiry=True,
+        )
 
 
 # ── verify ────────────────────────────────────────────────────────────

--- a/test/unit/test_user_api_tokens_db.py
+++ b/test/unit/test_user_api_tokens_db.py
@@ -236,6 +236,43 @@ async def test_mint_explicit_expires_at_passes_verbatim(fresh_db):
     assert minted["expires_at"] == future
 
 
+async def test_mint_rejects_non_iso_expires_at(fresh_db):
+    """Garbage expiry strings would compare lexicographically against
+    the UTC now() filter and could make a token de-facto eternal —
+    refused at mint instead (crypto-review F-B-15 follow-up)."""
+    for bad in ("zz-not-a-date", "", "9999"):
+        with pytest.raises(ValueError):
+            await mint_user_api_token(
+                principal_id="acme::user::alice",
+                label=f"bad-expiry-{bad or 'empty'}",
+                created_by="acme::admin",
+                expires_at=bad,
+            )
+
+
+async def test_mint_rejects_naive_expires_at(fresh_db):
+    """Timezone-naive expiry compares unsoundly vs the UTC filter."""
+    with pytest.raises(ValueError, match="timezone"):
+        await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="naive-expiry",
+            created_by="acme::admin",
+            expires_at="2027-01-01T00:00:00",
+        )
+
+
+async def test_mint_normalises_offset_expires_at_to_utc(fresh_db):
+    """A non-UTC offset is accepted but normalised, so the stored
+    string compares correctly against datetime.now(UTC).isoformat()."""
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label="tokyo-expiry",
+        created_by="acme::admin",
+        expires_at="2027-01-01T09:00:00+09:00",
+    )
+    assert minted["expires_at"] == "2027-01-01T00:00:00+00:00"
+
+
 async def test_mint_expires_at_and_no_expiry_conflict(fresh_db):
     """Passing both an explicit expiry and the opt-out is a caller bug."""
     future = (

--- a/test/unit/test_user_api_tokens_prod_gate.py
+++ b/test/unit/test_user_api_tokens_prod_gate.py
@@ -1,0 +1,173 @@
+"""F-B-15 — production gates the culk_ user API token surface.
+
+Claim-alignment review (2026-06-10): a ``culk_*`` token is a plain
+Bearer credential — no mTLS client cert, no RFC 9449 key-possession
+proof — accepted as step 0 of ``get_agent_from_dpop_client_cert`` on
+the OpenAI-compat surface. Strong (256-bit, bcrypt at rest, scoped,
+revocable) but replayable until expiry/revocation, and the surface was
+enabled unconditionally with no production gate, while README and
+threat-model claimed "refuses plain Bearer outright".
+
+The fix mirrors F-B-11/F-B-14: ``user_api_tokens_enabled`` controls the
+surface (resolver + minting), and ``validate_config`` refuses a
+production boot while it is enabled unless the operator explicitly
+accepts the risk via ``MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true``.
+No auto-flip: silently disabling would 401 every existing LibreChat /
+Cursor integration after an upgrade — a loud boot refusal is honest,
+a silent 401 is a support ticket.
+
+  prod + default (enabled) + no opt-in   → SystemExit(1)
+  prod + explicit enabled + no opt-in    → SystemExit(1)
+  prod + enabled + INSECURE_OK=true      → boots
+  prod + disabled                        → boots (gate n/a)
+  dev  + enabled                         → not gated
+  empty MCP_PROXY_USER_API_TOKENS_ENABLED= → loud ValidationError
+"""
+from __future__ import annotations
+
+import pytest
+
+_ADMIN_OK = "test-admin-secret-not-the-default"
+_DB_ENC_OK = "0" * 64
+_DASHBOARD_KEY_OK = "1" * 64
+_PDP_HMAC_OK = "2" * 64
+_VAULT_ADDR_OK = "https://vault.test.example:8200"
+_VAULT_TOKEN_OK = "s.test-token"
+
+
+def _production_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Satisfy every production gate before and after F-B-15 so each
+    test reaches it cleanly. The user-api-token posture is left to the
+    individual test."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", _DASHBOARD_KEY_OK)
+    monkeypatch.setenv("MCP_PROXY_SECRET_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", _VAULT_ADDR_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", _VAULT_TOKEN_OK)
+    monkeypatch.setenv("MCP_PROXY_VAULT_VERIFY_TLS", "true")
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "vault")
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", _DB_ENC_OK)
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_ENFORCEMENT", "required")
+    monkeypatch.setenv("MCP_PROXY_WEBAUTHN_RP_ID", "mastio.example")
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", _PDP_HMAC_OK)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_FAIL_DENY", "true")
+    monkeypatch.setenv("MCP_PROXY_REDIS_URL", "redis://redis:6379/0")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP", "true")
+    # Default the override OFF; the opt-in test sets it explicitly.
+    monkeypatch.delenv("MCP_PROXY_USER_API_TOKENS_INSECURE_OK", raising=False)
+
+
+def _fresh_settings():
+    from mcp_proxy.config import ProxySettings, get_settings
+
+    get_settings.cache_clear()
+    return ProxySettings()
+
+
+@pytest.fixture(autouse=True)
+def _require_webauthn():
+    """Production pins WEBAUTHN_ENFORCEMENT=required; skip if the optional
+    extra is missing so the webauthn gate doesn't mask the F-B-15 gate."""
+    pytest.importorskip("webauthn")
+    yield
+
+
+def test_prod_default_enabled_refuses_to_boot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """THE GATE. The surface defaults to enabled, so an un-configured
+    production boot must stop and force the operator to choose."""
+    _production_env(monkeypatch)
+    monkeypatch.delenv("MCP_PROXY_USER_API_TOKENS_ENABLED", raising=False)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.user_api_tokens_enabled is True
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_prod_explicit_enabled_refuses_to_boot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An explicit enable without risk acceptance is refused the same
+    way — explicitness about the feature is not risk acceptance."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "true")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    with pytest.raises(SystemExit) as excinfo:
+        validate_config(settings)
+    assert excinfo.value.code == 1
+
+
+def test_prod_insecure_optin_boots(monkeypatch: pytest.MonkeyPatch):
+    """The documented OpenAI-compat deployment posture is reachable:
+    enabled + explicit risk acceptance boots."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_INSECURE_OK", "true")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    validate_config(settings)  # must not raise
+
+
+def test_prod_disabled_boots(monkeypatch: pytest.MonkeyPatch):
+    """Disabling the surface satisfies the gate without the opt-in."""
+    _production_env(monkeypatch)
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "false")
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.user_api_tokens_enabled is False
+    validate_config(settings)  # must not raise
+
+
+def test_dev_enabled_is_not_gated(monkeypatch: pytest.MonkeyPatch):
+    """Development keeps the permissive default for local iteration —
+    only production is hardened."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.delenv("MCP_PROXY_USER_API_TOKENS_ENABLED", raising=False)
+    monkeypatch.delenv("MCP_PROXY_USER_API_TOKENS_INSECURE_OK", raising=False)
+
+    from mcp_proxy.config import validate_config
+
+    settings = _fresh_settings()
+    assert settings.user_api_tokens_enabled is True
+    validate_config(settings)  # must not raise
+
+
+def test_empty_enabled_env_fails_loud(monkeypatch: pytest.MonkeyPatch):
+    """An EMPTY ``MCP_PROXY_USER_API_TOKENS_ENABLED`` (manual ``=`` in
+    proxy.env) is rejected by pydantic bool-parsing — a loud boot crash,
+    never a silent posture."""
+    import pydantic
+
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN_OK)
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKENS_ENABLED", "")
+
+    with pytest.raises(pydantic.ValidationError):
+        _fresh_settings()
+
+
+def test_default_ttl_days_env_wired(monkeypatch: pytest.MonkeyPatch):
+    """MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS reaches the setting."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    monkeypatch.setenv("MCP_PROXY_USER_API_TOKEN_DEFAULT_TTL_DAYS", "30")
+
+    settings = _fresh_settings()
+    assert settings.user_api_token_default_ttl_days == 30


### PR DESCRIPTION
## Summary

P1 claim-alignment (review 2026-06-10, item 1 of 2): "never plain Bearer" was refutable from the code — `Bearer culk_...` skips cert+DPoP on `/v1/chat/completions`, `/v1/llm/chat`, `/v1/models` by design (ADR-027), with no production gate and no default expiry.

**Approach: make the claim true AND honest, mirroring the F-B-11/F-B-14 family.**

1. **Gate F-B-15** — new `user_api_tokens_enabled` setting (default true). `validate_config` refuses a production boot while the surface is enabled unless the operator explicitly accepts the risk (`MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true`) or disables it. No auto-flip: a silent disable would 401 every existing LibreChat/Cursor integration post-upgrade; a loud boot refusal is honest. The resolver declines before any DB lookup when off (existing tokens stop authenticating immediately); list/revoke stay available for audit/cleanup.
2. **90-day default TTL at mint** — closes the gap between ADR-027 threat model ("default 90 giorni") and the code (`expires_at=NULL` = never). Never-expire stays available as an explicit choice (`expires_in_days: 0` on the admin API, a dedicated dashboard checkbox). `expires_at` is now validated as tz-aware ISO and normalised to UTC (crypto-review follow-up: garbage strings compared lexicographically and could make a token de-facto eternal).
3. **Honest wording** — README + threat-model claims scoped to *agent identity surfaces*; new threat-model §5.1 documents the culk_ exception (threat: leak/replay; mitigations: scope enforcement, bcrypt, revocation, TTL, F-B-15 gate); production notes in the librechat/cursor guides; env vars in `proxy.env.example`; breaking-change headline in CHANGELOG.

## Breaking

Production deploys currently using culk_ tokens must set `MCP_PROXY_USER_API_TOKENS_INSECURE_OK=true` (or disable the surface) after upgrading — boot refuses otherwise, with an actionable message.

## Test plan

- 19 new tests across `test_user_api_tokens_prod_gate.py` (gate), `test_api_token_resolver_flag.py` (fail-closed resolver, no-DB-lookup decline, e2e 401), `test_admin_api_tokens_gate.py` (mint 403, expiry semantics), `test_user_api_tokens_db.py` (TTL default/override/opt-out, ISO validation)
- Pre-existing prod-gate test helpers pin the surface off so each SystemExit isolates its own knob
- Full unit suite: **1646 passed**
- Security review (crypto-reviewer): **APPROVE-WITH-NOTES**, both in-scope LOW findings fixed in the follow-up commit; dev-mode stays silent like the rest of the F-B-11/F-B-14 family (deliberate)