### PR TITLE
perf(gateway): move blocking CPU/DNS work off the event loop (P2)

### DIFF
--- a/mcp_proxy/dashboard/_helpers.py
+++ b/mcp_proxy/dashboard/_helpers.py
@@ -119,6 +119,10 @@ def generate_org_ca(org_id: str) -> tuple[str, str]:
     Part 1 §5.3.6 — root CAs held offline with long lifetimes).
     All online signing is done by the Mastio intermediate CA minted
     underneath this root; the intermediate rotates on a shorter cycle.
+
+    Blocking: RSA-4096 keygen is seconds of CPU. Async routes call it
+    via ``asyncio.to_thread`` (P2, 2026-06-10) so setup / CA rotation
+    does not freeze every other in-flight request.
     """
     from datetime import datetime, timedelta, timezone
     from cryptography import x509

--- a/mcp_proxy/dashboard/pki_routes.py
+++ b/mcp_proxy/dashboard/pki_routes.py
@@ -21,6 +21,7 @@ handling are preserved verbatim.
 """
 from __future__ import annotations
 
+import asyncio as _asyncio
 import logging
 import pathlib
 from datetime import datetime, timezone
@@ -222,7 +223,7 @@ async def pki_rotate_ca(request: Request):
     if not org_id:
         raise HTTPException(status_code=400, detail="Organization ID not configured. Run setup first.")
 
-    cert_pem, key_pem = generate_org_ca(org_id)
+    cert_pem, key_pem = await _asyncio.to_thread(generate_org_ca, org_id)
     await set_config("org_ca_cert", cert_pem)
     await set_config("org_ca_key", key_pem)
 

--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -23,6 +23,7 @@ so Starlette emits the value unquoted and unescaped. Python ``requests``,
 (``json_payload + "." + signature``) is still accepted on read so a
 worker upgrade does not invalidate every live admin session.
 """
+import asyncio
 import base64
 import binascii
 import hashlib
@@ -456,7 +457,11 @@ async def set_admin_password(plaintext: str) -> None:
         raise ValueError(f"Password must be at least {MIN_PASSWORD_LENGTH} characters")
 
     from mcp_proxy.db import set_config
-    hashed = bcrypt.hashpw(plaintext.encode(), bcrypt.gensalt(rounds=12))
+    # bcrypt cost 12 ≈ 200ms of CPU — off the event loop (P2, review
+    # 2026-06-10); bcrypt releases the GIL in the thread.
+    hashed = await asyncio.to_thread(
+        bcrypt.hashpw, plaintext.encode(), bcrypt.gensalt(rounds=12),
+    )
     await set_config(ADMIN_PASSWORD_KEY, hashed.decode())
 
 
@@ -471,7 +476,11 @@ async def verify_admin_password(plaintext: str) -> bool:
         return False
 
     try:
-        return bcrypt.checkpw(plaintext.encode(), stored.encode())
+        # bcrypt cost 12 ≈ 200ms of CPU on every dashboard login —
+        # off the event loop (P2, review 2026-06-10).
+        return await asyncio.to_thread(
+            bcrypt.checkpw, plaintext.encode(), stored.encode(),
+        )
     except (ValueError, TypeError):
         return False
 

--- a/mcp_proxy/dashboard/setup_routes.py
+++ b/mcp_proxy/dashboard/setup_routes.py
@@ -23,6 +23,7 @@ Shared helpers ``generate_org_ca``, ``_test_vault_connectivity``,
 """
 from __future__ import annotations
 
+import asyncio as _asyncio
 import logging
 import pathlib
 
@@ -301,7 +302,7 @@ async def setup_submit(request: Request):
     # Handle Org CA
     ca_generated = False
     if org_ca_mode == "generate":
-        cert_pem, key_pem = generate_org_ca(org_id)
+        cert_pem, key_pem = await _asyncio.to_thread(generate_org_ca, org_id)
         await set_config("org_ca_cert", cert_pem)
         await set_config("org_ca_key", key_pem)
         ca_generated = True
@@ -576,7 +577,7 @@ async def _setup_submit_standalone(
         # primitive the lifespan uses. We avoid touching it when the
         # in-memory derivation already produced one — regenerate would
         # change org_id and orphan every existing agent cert.
-        cert_pem, key_pem = generate_org_ca(org_id)
+        cert_pem, key_pem = await _asyncio.to_thread(generate_org_ca, org_id)
         await set_config("org_ca_cert", cert_pem)
         await set_config("org_ca_key", key_pem)
         await log_audit(

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -2699,7 +2699,9 @@ async def mint_user_api_token(
             ).isoformat()
 
     plaintext = _new_api_token_plaintext()
-    token_hash = _hash_api_token(plaintext)
+    # bcrypt cost 12 ≈ 200ms of CPU — off the event loop (P2, same
+    # rationale as the verify path).
+    token_hash = await _asyncio.to_thread(_hash_api_token, plaintext)
     last4 = plaintext[-4:]
     token_id = _new_token_id()
     ts = datetime.now(timezone.utc).isoformat()
@@ -2880,7 +2882,13 @@ async def verify_user_api_token(plaintext: str) -> dict | None:
     last4 = plaintext[-4:]
     candidates = await _find_active_token_candidates_by_last4(last4)
     for cand in candidates:
-        if _check_api_token(plaintext, cand["token_hash"]):
+        # P2 (review 2026-06-10): bcrypt cost 12 is ~200-300ms of pure
+        # CPU — inline it would stall the event loop for every other
+        # in-flight request on EVERY culk_-authenticated call. Run it
+        # on the default thread pool; bcrypt releases the GIL.
+        if await _asyncio.to_thread(
+            _check_api_token, plaintext, cand["token_hash"],
+        ):
             # Drop the hash before handing back to caller — never let it
             # leave this function. Defence-in-depth against accidental
             # logging of the row.

--- a/mcp_proxy/egress/adapters/ollama.py
+++ b/mcp_proxy/egress/adapters/ollama.py
@@ -36,6 +36,7 @@ Out of scope for PR-D
 """
 from __future__ import annotations
 
+import asyncio as _asyncio
 import json
 import logging
 import time
@@ -100,6 +101,10 @@ def _safe_api_base(creds: dict[str, str]) -> str:
     follows the existing ``policy_webhook_allow_private_ips`` knob so
     dev/sandbox stacks running Ollama on localhost / 192.168.0.0/16
     keep working.
+
+    Blocking (the SSRF check resolves DNS) — the async chat paths call
+    it via ``asyncio.to_thread`` so the resolve never stalls the event
+    loop (P2, 2026-06-10).
     """
     from mcp_proxy.config import get_settings
     from mcp_proxy.egress.ai_gateway import GatewayError
@@ -567,7 +572,7 @@ class OllamaAdapter:
         )
         from mcp_proxy.egress.schemas import ChatCompletionResponse
 
-        api_base = _safe_api_base(creds)
+        api_base = await _asyncio.to_thread(_safe_api_base, creds)
         body = req.model_dump(exclude_none=True)
         body.pop("stream", None)
         body.pop("stream_options", None)
@@ -669,7 +674,7 @@ class OllamaAdapter:
     ) -> "StreamingDispatch":
         from mcp_proxy.egress.ai_gateway import GatewayError, StreamingDispatch
 
-        api_base = _safe_api_base(creds)
+        api_base = await _asyncio.to_thread(_safe_api_base, creds)
         body = req.model_dump(exclude_none=True)
         body.pop("stream", None)
         body.pop("stream_options", None)

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -399,7 +399,7 @@ async def fetch_ollama_models(api_base: str, *, timeout_s: float = 2.0) -> list[
         return []
     from mcp_proxy.utils.url_safety import (
         UnsafeUrlError,
-        assert_safe_outbound_url,
+        assert_safe_outbound_url_async,
     )
     from mcp_proxy.config import get_settings
 
@@ -407,7 +407,10 @@ async def fetch_ollama_models(api_base: str, *, timeout_s: float = 2.0) -> list[
         getattr(get_settings(), "policy_webhook_allow_private_ips", False)
     )
     try:
-        assert_safe_outbound_url(api_base, allow_private=allow_private)
+        # Async variant — DNS resolve off the event loop (P2).
+        await assert_safe_outbound_url_async(
+            api_base, allow_private=allow_private,
+        )
     except UnsafeUrlError as exc:
         _log.warning(
             "ollama tag fetch refused unsafe api_base %s: %s", api_base, exc,

--- a/mcp_proxy/policy/federation.py
+++ b/mcp_proxy/policy/federation.py
@@ -84,7 +84,7 @@ async def call_remote_tool_call_policy(
     # the attacker-controlled destination on every PDP call.
     from mcp_proxy.utils.url_safety import (
         UnsafeUrlError,
-        assert_safe_outbound_url,
+        assert_safe_outbound_url_async,
     )
     from mcp_proxy.config import get_settings
 
@@ -92,7 +92,11 @@ async def call_remote_tool_call_policy(
         getattr(get_settings(), "policy_webhook_allow_private_ips", False)
     )
     try:
-        assert_safe_outbound_url(federation_url, allow_private=allow_private)
+        # Async variant — DNS resolve off the event loop on the
+        # per-PDP-call path (P2, 2026-06-10).
+        await assert_safe_outbound_url_async(
+            federation_url, allow_private=allow_private,
+        )
     except UnsafeUrlError as exc:
         _log.warning(
             "federation tool-call refused unsafe URL target=%s url=%s err=%s",

--- a/mcp_proxy/tools/http_whitelist.py
+++ b/mcp_proxy/tools/http_whitelist.py
@@ -50,7 +50,7 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
         # to a cloud-metadata side-channel).
         from mcp_proxy.utils.url_safety import (
             UnsafeUrlError,
-            assert_safe_outbound_url,
+            assert_safe_outbound_url_async,
             pin_request_to_ip,
         )
         from mcp_proxy.config import get_settings
@@ -59,7 +59,9 @@ class WhitelistedTransport(httpx.AsyncHTTPTransport):
             getattr(get_settings(), "policy_webhook_allow_private_ips", False)
         )
         try:
-            pinned_ip = assert_safe_outbound_url(
+            # Async variant: the DNS resolve inside must not block the
+            # event loop on a per-tool-call path (P2, 2026-06-10).
+            pinned_ip = await assert_safe_outbound_url_async(
                 str(request.url), allow_private=allow_private,
             )
         except UnsafeUrlError as exc:

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -85,7 +85,7 @@ async def _fetch_upstream_schema(endpoint_url: str, tool_name: str) -> dict | No
     import httpx as _httpx
     from mcp_proxy.utils.url_safety import (
         UnsafeUrlError,
-        assert_safe_outbound_url,
+        assert_safe_outbound_url_async,
     )
     from mcp_proxy.config import get_settings
 
@@ -93,7 +93,10 @@ async def _fetch_upstream_schema(endpoint_url: str, tool_name: str) -> dict | No
         getattr(get_settings(), "policy_webhook_allow_private_ips", False)
     )
     try:
-        assert_safe_outbound_url(endpoint_url, allow_private=allow_private)
+        # Async variant — DNS resolve off the event loop (P2).
+        await assert_safe_outbound_url_async(
+            endpoint_url, allow_private=allow_private,
+        )
     except UnsafeUrlError as exc:
         _log.warning(
             "upstream schema fetch refused unsafe endpoint %s: %s",

--- a/mcp_proxy/utils/ssrf_transport.py
+++ b/mcp_proxy/utils/ssrf_transport.py
@@ -27,6 +27,7 @@ import httpx
 
 from mcp_proxy.utils.url_safety import (
     assert_safe_outbound_url,
+    assert_safe_outbound_url_async,
     pin_request_to_ip,
 )
 
@@ -41,8 +42,10 @@ class SSRFPinnedTransport(httpx.AsyncHTTPTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         # Raises UnsafeUrlError (a ValueError) on a blocked/unresolvable
-        # host — fail closed; the caller surfaces it as an error.
-        pinned_ip = assert_safe_outbound_url(
+        # host — fail closed; the caller surfaces it as an error. Async
+        # variant: the validation resolves DNS, which must not block
+        # the event loop on the hot outbound path (P2, 2026-06-10).
+        pinned_ip = await assert_safe_outbound_url_async(
             str(request.url), allow_private=self._allow_private,
         )
         pin_request_to_ip(request, pinned_ip)

--- a/mcp_proxy/utils/url_safety.py
+++ b/mcp_proxy/utils/url_safety.py
@@ -214,6 +214,29 @@ def assert_safe_outbound_url(
     return pinned_ip
 
 
+async def assert_safe_outbound_url_async(
+    url: str,
+    *,
+    allow_private: bool = False,
+) -> str:
+    """Async wrapper around :func:`assert_safe_outbound_url`.
+
+    P2 (review 2026-06-10): the validation includes a blocking
+    ``socket.getaddrinfo`` — inline in a coroutine it stalls the whole
+    event loop for the duration of a DNS lookup (unbounded on a slow
+    or unreachable resolver) on EVERY outbound LLM / tool / federation
+    call. Same code path as the sync variant (single source of truth
+    for the SSRF rules), just run on the default thread pool. Use this
+    from async per-request paths; config-time / sync callers keep the
+    direct function.
+    """
+    import asyncio
+
+    return await asyncio.to_thread(
+        assert_safe_outbound_url, url, allow_private=allow_private,
+    )
+
+
 def pin_request_to_ip(request, pinned_ip: str) -> None:
     """Rewrite an ``httpx.Request`` to connect to ``pinned_ip`` while keeping
     the original Host header and TLS SNI / cert hostname.

--- a/test/unit/test_ssrf_pin_adapters.py
+++ b/test/unit/test_ssrf_pin_adapters.py
@@ -15,8 +15,14 @@ from mcp_proxy.utils.url_safety import UnsafeUrlError
 
 @pytest.mark.asyncio
 async def test_transport_pins_to_validated_ip(monkeypatch):
+    # P2 (2026-06-10): the transport now validates through the async
+    # wrapper (assert_safe_outbound_url_async, DNS off the event loop),
+    # which calls the sync validator in its OWN module namespace — the
+    # patch target moves from ssrf_transport to url_safety. Patching
+    # the old name silently stopped intercepting and the test resolved
+    # api.openai.com against live DNS.
     monkeypatch.setattr(
-        "mcp_proxy.utils.ssrf_transport.assert_safe_outbound_url",
+        "mcp_proxy.utils.url_safety.assert_safe_outbound_url",
         lambda url, allow_private=False: "93.184.216.34",
     )
     captured: dict = {}
@@ -44,8 +50,9 @@ async def test_transport_refuses_unsafe_before_connect(monkeypatch):
     def _refuse(url, allow_private=False):
         raise UnsafeUrlError("resolves to 169.254.169.254 (metadata)")
 
+    # Same namespace move as above (P2 async wrapper).
     monkeypatch.setattr(
-        "mcp_proxy.utils.ssrf_transport.assert_safe_outbound_url", _refuse,
+        "mcp_proxy.utils.url_safety.assert_safe_outbound_url", _refuse,
     )
     reached = {"super": False}
 

--- a/test/unit/test_url_safety_async.py
+++ b/test/unit/test_url_safety_async.py
@@ -1,0 +1,49 @@
+"""Tests for ``assert_safe_outbound_url_async`` (P2, review 2026-06-10).
+
+The SSRF validation resolves DNS with a blocking ``socket.getaddrinfo``;
+inline in a coroutine it stalled the event loop on every outbound LLM /
+tool / federation call. The async wrapper runs the SAME code path on
+the default thread pool — these tests pin the parity (same accept /
+same reject, same exception type) so the wrapper can never drift into
+a second, weaker validator.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.utils.url_safety import (
+    UnsafeUrlError,
+    assert_safe_outbound_url,
+    assert_safe_outbound_url_async,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_async_wrapper_accepts_what_sync_accepts():
+    """IP-literal path needs no DNS — deterministic in CI."""
+    sync_ip = assert_safe_outbound_url("https://8.8.8.8/x")
+    async_ip = await assert_safe_outbound_url_async("https://8.8.8.8/x")
+    assert async_ip == sync_ip == "8.8.8.8"
+
+
+async def test_async_wrapper_rejects_private_ip():
+    with pytest.raises(UnsafeUrlError):
+        await assert_safe_outbound_url_async("http://169.254.169.254/iam")
+
+
+async def test_async_wrapper_rejects_loopback_hostname():
+    with pytest.raises(UnsafeUrlError):
+        await assert_safe_outbound_url_async("http://localhost:11434/api")
+
+
+async def test_async_wrapper_allow_private_passthrough():
+    ip = await assert_safe_outbound_url_async(
+        "http://127.0.0.1:11434/api", allow_private=True,
+    )
+    assert ip == "127.0.0.1"
+
+
+async def test_async_wrapper_rejects_bad_scheme():
+    with pytest.raises(UnsafeUrlError):
+        await assert_safe_outbound_url_async("ftp://example.com/x")


### PR DESCRIPTION
## Summary

P2 from the 2026-06-10 review: three classes of blocking work ran inline in async handlers, stalling every other in-flight request — under concurrency this is the same failure shape the S-7 stress test exposed (one slow thing freezes the worker for everyone).

1. **bcrypt (cost 12, ~200-300ms pure CPU)** — ran inline on EVERY `culk_`-authenticated request (the `verify_user_api_token` candidate loop) and on every dashboard login, plus the mint / set-password hash paths. All four now run via `asyncio.to_thread` (bcrypt releases the GIL).
2. **SSRF DNS resolve** (`socket.getaddrinfo`, unbounded on a slow resolver) — ran inline on every outbound LLM / tool / federation call. New `assert_safe_outbound_url_async` wraps the **same** sync validator on the thread pool (single source of truth — no second, weaker validator to drift) and is used by `SSRFPinnedTransport`, `WhitelistedTransport`, the federation PDP call, the schema fetch, the Ollama adapter per-call validation, and `fetch_ollama_models`.
3. **RSA-4096 Org CA keygen** (seconds of CPU) in the three async setup / CA-rotation dashboard routes → `to_thread`.

No functional change intended anywhere: validators and primitives are byte-identical, only the scheduling moves.

## Test note

`test_ssrf_pin_adapters` patched `assert_safe_outbound_url` in the `ssrf_transport` namespace; after the refactor that import-time binding silently stopped intercepting and the test was resolving `api.openai.com` against live DNS. The patch target moves to `mcp_proxy.utils.url_safety`, which now intercepts every async consumer (strictly stronger coverage). New `test_url_safety_async.py` pins sync/async parity (same accepts, same rejects, same exception type).

## Test plan
- Full unit suite: **1705 passed**
- Security review (crypto-reviewer): **APPROVE-WITH-NOTES** — validate→pin→connect order intact (no TOCTOU reintroduced), exceptions propagate through `to_thread` with original types, fail-closed paths unchanged. Notes: thread-pool contention cliff on 1-cpu hosts (strictly better than freezing the whole loop; a dedicated bounded executor for DNS is a possible follow-up), sync `validate_creds` / dashboard `_validate_endpoint_url` helpers (config-time, low frequency) left for follow-up.