### PR TITLE
ci: add ruff lint gate and clean the lint baseline (P2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,26 @@ jobs:
         run: |
           python -m compileall -q app mcp_proxy cullis_sdk cullis_connector
 
+  ruff:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run ruff
+        # P2 (review 2026-06-10): ruff was a declared dev-dep that never
+        # ran anywhere — it cannot run on every dev machine (NixOS needs
+        # nix-shell for libstdc++), so THIS job is the authoritative
+        # gate. Config in pyproject.toml [tool.ruff]; baseline cleaned
+        # in the same PR that added this job (F821 latent NameErrors
+        # included). Pinned major so a ruff release adding rules cannot
+        # break main without a deliberate bump.
+        run: |
+          python -m pip install "ruff>=0.4,<0.15"
+          ruff check mcp_proxy cullis_sdk scripts test
+
   pytest:
     name: Core unit + integration tests
     runs-on: ubuntu-latest

--- a/cullis_sdk/_client/_messaging_legacy.py
+++ b/cullis_sdk/_client/_messaging_legacy.py
@@ -540,7 +540,7 @@ class _MessagingLegacyMixin:
                     decrypted = self.decrypt_payload(m, session_id=session_id)
                     result.append(InboxMessage.from_dict(decrypted))
                 return result
-            except httpx.HTTPStatusError as exc:
+            except httpx.HTTPStatusError:
                 # Propagate 409 (session closed) so callers can handle it
                 raise
             except (httpx.ConnectError, httpx.TimeoutException):

--- a/cullis_sdk/auth.py
+++ b/cullis_sdk/auth.py
@@ -114,7 +114,6 @@ def build_client_assertion(
     chain_certs = crypto_x509.load_pem_x509_certificates(cert_bytes)
     if not chain_certs:
         raise ValueError("cert_pem contains no certificate")
-    cert = chain_certs[0]
     x5c = [
         base64.b64encode(c.public_bytes(serialization.Encoding.DER)).decode()
         for c in chain_certs

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -41,17 +41,16 @@ from typing import Callable
 
 import httpx
 
-from cullis_sdk.types import AgentInfo, InboxMessage
 from cullis_sdk._client._ai_gateway import _AiGatewayMixin
 from cullis_sdk._client._auth import _AuthMixin
-from cullis_sdk._client._discovery import PubkeyFetchError, _DiscoveryMixin
+from cullis_sdk._client._discovery import _DiscoveryMixin
 from cullis_sdk._client._enrollment import _EnrollmentMixin
 from cullis_sdk._client._guardian import _GuardianMixin
 from cullis_sdk._client._messaging_legacy import _MessagingLegacyMixin
 from cullis_sdk._client._messaging_oneshot import _MessagingOneshotMixin
 from cullis_sdk._client._rfq import _RfqMixin
 from cullis_sdk._client._sessions import _SessionsMixin
-from cullis_sdk._client._websocket import WebSocketConnection, _WebSocketMixin
+from cullis_sdk._client._websocket import _WebSocketMixin
 
 
 class InsecureTLSWarning(UserWarning):
@@ -234,7 +233,6 @@ def _check_insecure_tls(verify_tls: bool) -> None:
     """
     if verify_tls:
         return
-    import os
     import warnings
     if (
         os.environ.get("CULLIS_ENV", "").lower() == "production"

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -42,11 +42,9 @@ the shared secret only when a deploy ever has to publish :9100.
 """
 from __future__ import annotations
 
-import base64
 import hashlib
 import hmac
 import logging
-import re
 import urllib.parse
 from typing import Optional
 

--- a/mcp_proxy/auth/dependencies.py
+++ b/mcp_proxy/auth/dependencies.py
@@ -48,7 +48,7 @@ async def _get_authenticated_agent_dpop(request: Request) -> TokenPayload:
     """
     from mcp_proxy.main import get_jwks_client
     from mcp_proxy.auth.jwt_validator import decode_token
-    from mcp_proxy.auth.dpop import verify_dpop_proof, _normalize_htu
+    from mcp_proxy.auth.dpop import verify_dpop_proof
     from mcp_proxy.config import get_settings
 
     # -- 1. Authorization header (must be "DPoP <token>")

--- a/mcp_proxy/auth/dpop.py
+++ b/mcp_proxy/auth/dpop.py
@@ -13,7 +13,6 @@ Public API:
 Every validation failure raises HTTPException 401.
 The DPoP JTI is consumed only after all checks pass — no partial state on failure.
 """
-import asyncio
 import base64
 import hashlib
 import hmac as _hmac

--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import base64
 import hmac
 import logging
-import time
 from typing import Any
 
 import jwt as jose_jwt
@@ -35,7 +34,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from mcp_proxy.auth.client_cert import _identity_from_cert
-from mcp_proxy.auth.local_issuer import LOCAL_AUDIENCE, LOCAL_SCOPE, LocalIssuer
+from mcp_proxy.auth.local_issuer import LOCAL_SCOPE, LocalIssuer
 from mcp_proxy.db import get_config
 
 _log = logging.getLogger("mcp_proxy.auth.local_token")

--- a/mcp_proxy/dashboard/audit_routes.py
+++ b/mcp_proxy/dashboard/audit_routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import pathlib
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -30,20 +30,9 @@ in follow-up PRs of this sprint.
 import logging
 import pathlib
 
-import httpx
 
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse
-from starlette.responses import RedirectResponse
+from fastapi import APIRouter
 
-from mcp_proxy.dashboard.session import (
-    get_session,
-    require_login,
-    verify_csrf,
-)
-from mcp_proxy.admin.approval_hook import (
-    maybe_intercept_for_approval,
-)
 
 _log = logging.getLogger("mcp_proxy.dashboard")
 

--- a/mcp_proxy/dashboard/setup_routes.py
+++ b/mcp_proxy/dashboard/setup_routes.py
@@ -27,6 +27,8 @@ import asyncio as _asyncio
 import logging
 import pathlib
 
+import httpx
+from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
@@ -35,7 +37,6 @@ from starlette.responses import RedirectResponse
 from mcp_proxy.dashboard._helpers import (
     _ctx,
     _enforce_safe_outbound_url,
-    _load_display_name,
     _store_ca_key_in_vault,
     _test_vault_connectivity,
     generate_org_ca,

--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -37,7 +37,6 @@ Design notes captured from planning:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Iterable
 
@@ -50,7 +49,6 @@ from starlette.responses import RedirectResponse
 from mcp_proxy.dashboard._template_env import build_templates
 
 from mcp_proxy.dashboard.session import (
-    ProxyDashboardSession,
     require_login,
     verify_csrf,
 )

--- a/mcp_proxy/dashboard/users_routes.py
+++ b/mcp_proxy/dashboard/users_routes.py
@@ -678,7 +678,7 @@ async def users_set_capabilities(principal_id: str, request: Request):
         )).first()
         if row is None:
             return RedirectResponse(
-                f"/proxy/users?error=user+not+found",
+                "/proxy/users?error=user+not+found",
                 status_code=303,
             )
         await conn.execute(

--- a/mcp_proxy/egress/adapters/anthropic.py
+++ b/mcp_proxy/egress/adapters/anthropic.py
@@ -36,7 +36,11 @@ from mcp_proxy.egress.adapters.base import DispatchContext
 
 if TYPE_CHECKING:
     from mcp_proxy.config import ProxySettings as Settings
-    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.ai_gateway import (
+        GatewayError,
+        GatewayResult,
+        StreamingDispatch,
+    )
     from mcp_proxy.egress.schemas import ChatCompletionRequest
 
 
@@ -147,7 +151,6 @@ def _translate_messages(
     """
     system_chunks: list[dict[str, Any]] = []
     out: list[dict[str, Any]] = []
-    pending_assistant_tool_calls: list[dict[str, Any]] = []
 
     def _user_content_blocks(msg: dict[str, Any]) -> list[dict[str, Any]]:
         c = msg.get("content")

--- a/mcp_proxy/egress/adapters/litellm.py
+++ b/mcp_proxy/egress/adapters/litellm.py
@@ -31,7 +31,11 @@ from mcp_proxy.egress.adapters.base import DispatchContext
 
 if TYPE_CHECKING:
     from mcp_proxy.config import ProxySettings as Settings
-    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.ai_gateway import (
+        GatewayError,
+        GatewayResult,
+        StreamingDispatch,
+    )
     from mcp_proxy.egress.schemas import ChatCompletionRequest
 
 

--- a/mcp_proxy/egress/adapters/openai.py
+++ b/mcp_proxy/egress/adapters/openai.py
@@ -31,7 +31,11 @@ from mcp_proxy.egress.adapters.base import DispatchContext
 
 if TYPE_CHECKING:
     from mcp_proxy.config import ProxySettings as Settings
-    from mcp_proxy.egress.ai_gateway import GatewayResult, StreamingDispatch
+    from mcp_proxy.egress.ai_gateway import (
+        GatewayError,
+        GatewayResult,
+        StreamingDispatch,
+    )
     from mcp_proxy.egress.schemas import ChatCompletionRequest
 
 

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -59,7 +59,9 @@ class BrokerBridge:
         countersign_fn = None
         if self._agent_manager.mastio_loaded:
             mgr = self._agent_manager
-            countersign_fn = lambda assertion: mgr.countersign(assertion.encode())
+
+            def countersign_fn(assertion: str) -> bytes:
+                return mgr.countersign(assertion.encode())
 
         client = CullisClient(self._broker_url, verify_tls=self._verify_tls)
         # login_from_pem is synchronous in the SDK — run in thread to avoid blocking

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field

--- a/mcp_proxy/integrations/policy_bridge.py
+++ b/mcp_proxy/integrations/policy_bridge.py
@@ -48,7 +48,6 @@ import hashlib
 import hmac
 import json as _json
 import logging
-from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import JSONResponse

--- a/mcp_proxy/lifespan/intermediate_ca_watcher.py
+++ b/mcp_proxy/lifespan/intermediate_ca_watcher.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 logger = logging.getLogger("mcp_proxy.lifespan.intermediate_ca_watcher")
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -2140,7 +2140,7 @@ async def pdp_policy(request: Request):
     blocked = rules.get("blocked_agents", [])
     if initiator in blocked or target in blocked:
         decision = "deny"
-        reason = f"Agent blocked by policy"
+        reason = "Agent blocked by policy"
 
     allowed_orgs = rules.get("allowed_orgs", [])
     if allowed_orgs:

--- a/mcp_proxy/middleware/db_latency_circuit_breaker.py
+++ b/mcp_proxy/middleware/db_latency_circuit_breaker.py
@@ -58,7 +58,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from mcp_proxy.observability.db_latency import DbLatencyTracker
+    pass
 
 
 _BYPASS_PREFIXES: tuple[str, ...] = (

--- a/mcp_proxy/observability/quarantine.py
+++ b/mcp_proxy/observability/quarantine.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import hmac
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone

--- a/mcp_proxy/policy/tier_matrix.py
+++ b/mcp_proxy/policy/tier_matrix.py
@@ -22,7 +22,6 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import yaml
 

--- a/mcp_proxy/registry/user_principals_webauthn_router.py
+++ b/mcp_proxy/registry/user_principals_webauthn_router.py
@@ -21,7 +21,6 @@ credentials for a principal in org B.
 from __future__ import annotations
 
 import base64
-import json
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status

--- a/mcp_proxy/tools/builtins/query_salesforce.py
+++ b/mcp_proxy/tools/builtins/query_salesforce.py
@@ -39,8 +39,8 @@ async def query_salesforce(ctx: ToolContext) -> dict:
 
     The demo returns static mock data.
     """
-    soql = ctx.parameters.get("soql", "")
-    # TODO: Replace with real Salesforce OAuth + SOQL query
+    # TODO: Replace with real Salesforce OAuth + SOQL query executing
+    # ctx.parameters["soql"]; the demo returns static mock data.
     return {
         "totalSize": 1,
         "done": True,

--- a/mcp_proxy/tools/context.py
+++ b/mcp_proxy/tools/context.py
@@ -6,7 +6,7 @@ httpx client whose transport enforces the tool's domain whitelist.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import httpx

--- a/mcp_proxy/tools/registry.py
+++ b/mcp_proxy/tools/registry.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import importlib
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 import yaml

--- a/mcp_proxy/updates/migrations/org_ca_pathlen_1_20260423.py
+++ b/mcp_proxy/updates/migrations/org_ca_pathlen_1_20260423.py
@@ -142,7 +142,10 @@ class OrgCAPathLenFix(Migration):
         assert old_key_pem is not None
 
         old_cert = x509.load_pem_x509_certificate(old_cert_pem.encode())
-        old_key = serialization.load_pem_private_key(
+        # Parse-validate the stored key before touching anything; the
+        # value itself is unused (the re-sign path reloads what it
+        # needs), but a corrupt key must abort the migration here.
+        serialization.load_pem_private_key(
             old_key_pem.encode(), password=None,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,21 @@ cullis-proxy = "mcp_proxy.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["cullis_sdk"]
 
+[tool.ruff]
+# The CI gate (.github/workflows/ci.yml job "ruff") runs exactly
+# `ruff check mcp_proxy cullis_sdk scripts test`. Ruff does not run on
+# every dev machine (NixOS needs nix-shell for libstdc++), so the CI
+# job is the authoritative lint gate — keep this config in sync with it.
+
+[tool.ruff.lint]
+# Default rule set (E4/E7/E9 + F) minus E402: the codebase deliberately
+# places imports mid-file in two load-bearing patterns — the router
+# mounts in mcp_proxy/main.py (import order IS the mount order) and the
+# lazy per-function imports that break circular dependencies between
+# db/config/auth. Flagging those 65 sites would invite mechanical
+# "fixes" that reintroduce import cycles.
+ignore = ["E402"]
+
 [tool.pytest.ini_options]
 # Aligns the public test surface with the suite the repatriated core
 # tests were written under (cullis-enterprise uses asyncio_mode=auto).

--- a/scripts/bench-rego-eval.py
+++ b/scripts/bench-rego-eval.py
@@ -175,7 +175,7 @@ def main() -> int:
                         help="optional path to write a Markdown report")
     args = parser.parse_args()
 
-    print(f"=== Cullis Rego eval bench ===")
+    print("=== Cullis Rego eval bench ===")
     print(f"Source: in-script representative policy "
           f"({len(_REGO_SOURCE.splitlines())} lines)")
     print(f"Iterations: {args.iterations} (+ {args.warmup} warmup, discarded)")

--- a/test/nightly/benchmarks/dpop_concurrency.py
+++ b/test/nightly/benchmarks/dpop_concurrency.py
@@ -43,7 +43,7 @@ def _probe_loop(agent_id: str, requests: int) -> list[tuple[int, bool]]:
     """Open one client, fire N requests, collect (latency_ms, ok)."""
     try:
         client = load_client(agent_id)
-    except Exception as exc:
+    except Exception:
         return [(0, False) for _ in range(requests)] + [(-1, False)]
 
     out: list[tuple[int, bool]] = []

--- a/test/unit/test_admin_agents_atomic_enroll.py
+++ b/test/unit/test_admin_agents_atomic_enroll.py
@@ -39,7 +39,6 @@ must keep working.
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import Any
 
 import pytest

--- a/test/unit/test_admin_audit_merkle.py
+++ b/test/unit/test_admin_audit_merkle.py
@@ -11,7 +11,6 @@ unanchored chain_seq, 409 on chain_count drift.
 from __future__ import annotations
 
 import hashlib
-from typing import Any
 
 import pytest
 import pytest_asyncio

--- a/test/unit/test_cert_expiry_watcher.py
+++ b/test/unit/test_cert_expiry_watcher.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import asyncio
 import datetime
 from dataclasses import dataclass
-from pathlib import Path
 
 import pytest
 from cryptography import x509

--- a/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
+++ b/test/unit/test_cosmetic_batch_d10_a2_a4_a5_b1.py
@@ -44,7 +44,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.enrollment.router import router as enrollment_router
 
 

--- a/test/unit/test_dpop_htu_permissive.py
+++ b/test/unit/test_dpop_htu_permissive.py
@@ -36,8 +36,6 @@ Five invariants pinned:
 from __future__ import annotations
 
 import base64
-import hashlib
-import json
 import time
 import uuid
 from typing import Any

--- a/test/unit/test_frontdesk_audit_warning.py
+++ b/test/unit/test_frontdesk_audit_warning.py
@@ -30,7 +30,6 @@ os.environ.setdefault("SKIP_ALEMBIC", "1")
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
 
 import pytest
 import pytest_asyncio

--- a/test/unit/test_mastio_keys_invariant_997.py
+++ b/test/unit/test_mastio_keys_invariant_997.py
@@ -24,7 +24,6 @@ These tests pin the fix:
 """
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 
 import pytest

--- a/test/unit/test_mcp_tool_empty_capability_bypass.py
+++ b/test/unit/test_mcp_tool_empty_capability_bypass.py
@@ -28,7 +28,6 @@ os.environ.setdefault("ALLOWED_ORIGINS", "")
 os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
 os.environ.setdefault("SKIP_ALEMBIC", "1")
 
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/test/unit/test_merkle_anchor_watcher.py
+++ b/test/unit/test_merkle_anchor_watcher.py
@@ -11,11 +11,7 @@ upstream.
 """
 from __future__ import annotations
 
-import asyncio
 import hashlib
-import os
-import sys
-from pathlib import Path
 
 import pytest
 import pytest_asyncio

--- a/test/unit/test_policy_bridge.py
+++ b/test/unit/test_policy_bridge.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient

--- a/test/unit/test_policy_helper.py
+++ b/test/unit/test_policy_helper.py
@@ -16,9 +16,7 @@ the docstring; these tests pin:
 from __future__ import annotations
 
 import base64
-from unittest.mock import MagicMock
 
-import pytest
 
 from mcp_proxy.policy import try_rego_decision
 from mcp_proxy.policy.rego_engine import RegoEvalError

--- a/test/unit/test_rego_engine.py
+++ b/test/unit/test_rego_engine.py
@@ -14,7 +14,6 @@ shipped), out of scope for this file.
 from __future__ import annotations
 
 import io
-import json
 import subprocess
 import tarfile
 from unittest.mock import MagicMock

--- a/test/unit/test_session_cookie_python_requests_compat.py
+++ b/test/unit/test_session_cookie_python_requests_compat.py
@@ -35,7 +35,6 @@ import hashlib
 import hmac
 import http.server
 import json
-import os
 import re
 import threading
 import time


### PR DESCRIPTION
## Summary

Closes the second half of the P2 item from the 2026-06-10 internal review: ruff was a declared dev-dependency that never ran anywhere (CI only did compileall + pytest), with lint debt already on main (F541 in `main.py:2143`).

**Stacked on #1078** (`fix/p2-blocking-io-event-loop`) — merge that first.

## Changes

- **New CI job `ruff`** running `ruff check mcp_proxy cullis_sdk scripts test`, major version pinned (`>=0.4,<0.15`) so a ruff release adding rules cannot break main without a deliberate bump. Ruff cannot run on every dev machine (NixOS needs nix-shell for libstdc++), so this job is the authoritative gate.
- **`[tool.ruff]` config in `pyproject.toml`**: default rule set (E4/E7/E9 + F) minus E402 — mid-file imports are load-bearing here (router mount order in `main.py`, lazy imports breaking circular deps); flagging those ~65 sites would invite mechanical fixes that reintroduce import cycles.
- **Baseline cleaned in the same PR** (45 files, mostly deletions): unused imports (F401), f-strings without placeholders (F541), unused locals (F841), a lambda assignment (E731) made a proper `def`, and two latent **F821 NameErrors** fixed for real: `GatewayError` missing from the `TYPE_CHECKING` imports of the anthropic/litellm/openai adapters, and `httpx`/`x509` missing in `setup_routes.py`.

## Test plan

- `ruff check mcp_proxy cullis_sdk scripts test` → all checks passed locally (same invocation as the CI job)
- Full suite: `pytest test/unit test/integration -n auto --dist=loadfile` → **1705 passed, 8 skipped**
- No behavior change intended; the only non-mechanical edits are commented in-diff (migration key parse-validate, salesforce TODO)