### PR TITLE
fix(dashboard): DASH-1 rotate-ca via KMS + DASH-2 culk_ token out of redirect URLs

### DIFF
--- a/mcp_proxy/dashboard/api_tokens.py
+++ b/mcp_proxy/dashboard/api_tokens.py
@@ -8,9 +8,11 @@ handles the two mutations:
 
   POST   /proxy/users/{principal_id}/api-tokens/create
          Form-submit from the "Create new token" panel in the API
-         Tokens tab. Mints a row, then 303-redirects back to the user
-         page with ``?new_token=<cleartext>`` so the template can
-         render the one-time "save it now" banner.
+         Tokens tab. Mints a row, then renders the user page directly
+         in the POST response with the one-time "save it now" banner —
+         the cleartext never rides a redirect query string (DASH-2,
+         blind-spot audit 2026-06-10: nginx access logs go to the
+         SIEM, plus browser history and Referer).
 
   POST   /proxy/users/{principal_id}/api-tokens/{token_id}/revoke
          Form-submit from the per-row Revoke button. 303-redirects
@@ -28,7 +30,7 @@ import logging
 from urllib.parse import quote
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 
 from mcp_proxy.dashboard.session import require_login, verify_csrf
 from mcp_proxy.db import (
@@ -62,9 +64,13 @@ async def create_api_token(
     expires_at: str = Form(""),
     never_expires: str = Form(""),
     scope_providers: list[str] | None = Form(None),
-) -> RedirectResponse:
-    """Mint a new culk_ token for ``principal_id`` and redirect back to
-    the user detail page with the cleartext as a single-use query param.
+) -> Response:
+    """Mint a new culk_ token for ``principal_id``.
+
+    On success the user detail page is rendered directly in this
+    response with the one-time cleartext banner (DASH-2 — never in a
+    redirect query string); failures redirect back with a generic
+    ``token_error`` message.
     """
     session = require_login(request)
     if isinstance(session, RedirectResponse):
@@ -176,9 +182,18 @@ async def create_api_token(
         "dashboard mint api-token id=%s principal=%s label=%s by=%s",
         minted["id"], minted["principal_id"], minted["label"], created_by,
     )
-    return _back_to_user(
-        principal_id,
-        f"new_token={quote(minted['token'])}&new_token_label={quote(minted['label'])}",
+    # DASH-2 (blind-spot audit 2026-06-10): render the one-time
+    # cleartext banner directly in this POST's response body instead
+    # of a ``?new_token=`` redirect — query strings land in nginx
+    # access logs (shipped to the SIEM, a lower trust tier than the
+    # admin), browser history and Referer headers. No PRG here is
+    # deliberate: a refresh re-submits the form (browser warns first)
+    # and at worst mints a second revocable, audit-logged token.
+    from mcp_proxy.dashboard.users_routes import render_user_detail
+    return await render_user_detail(
+        request, session, principal_id,
+        new_api_token=minted["token"],
+        new_api_token_label=minted["label"],
     )
 
 

--- a/mcp_proxy/dashboard/pki_routes.py
+++ b/mcp_proxy/dashboard/pki_routes.py
@@ -16,8 +16,10 @@ Routes (3):
 Shared helpers ``generate_org_ca``, ``_test_vault_connectivity``,
 ``_store_ca_key_in_vault``, ``_ctx`` live in
 ``mcp_proxy/dashboard/_helpers.py`` since F-B-201 PR-1 / PR-3. The
-approval-hook intercept on ``rotate-ca`` and the CA private-key
-handling are preserved verbatim.
+approval-hook intercept on ``rotate-ca`` is preserved verbatim; the
+rotated CA private key goes through the KMS provider (DASH-1,
+blind-spot audit 2026-06-10) instead of a plaintext ``proxy_config``
+row.
 """
 from __future__ import annotations
 
@@ -217,15 +219,32 @@ async def pki_rotate_ca(request: Request):
     if intercept is not None:
         return intercept
 
-    from mcp_proxy.db import get_config, set_config, log_audit
+    from mcp_proxy.db import delete_proxy_config, get_config, set_config, log_audit
+    from mcp_proxy.kms import get_kms_provider
+    from mcp_proxy.kms.pki_at_rest import pki_master_key_configured
 
     org_id = await get_config("org_id")
     if not org_id:
         raise HTTPException(status_code=400, detail="Organization ID not configured. Run setup first.")
 
     cert_pem, key_pem = await _asyncio.to_thread(generate_org_ca, org_id)
+    # DASH-1 (blind-spot audit 2026-06-10): the private key must go
+    # through the KMS provider like the steady-state mint path
+    # (``AgentManager._persist_org_ca``), never as a plaintext
+    # ``proxy_config`` upsert — a ``pg_dump`` taken between rotation and
+    # the next boot-time wipe would otherwise capture the Org Root key
+    # forever. The provider handles at-rest encryption (local + master
+    # key), Vault, or the dev plaintext fallback with its own warning.
+    provider = get_kms_provider()
+    await provider.store_org_ca(key_pem, cert_pem)
+    # Public material only: the legacy ``/pki/ca.crt`` and
+    # connector-bootstrap readers still consume this row.
     await set_config("org_ca_cert", cert_pem)
-    await set_config("org_ca_key", key_pem)
+    if not (provider.name == "local" and not pki_master_key_configured()):
+        # Encrypted store is authoritative — drop any stale plaintext
+        # private-key row so the new cert never sits next to the old
+        # key (the boot-time legacy wipe would see a mismatched pair).
+        await delete_proxy_config("org_ca_key")
 
     # Render the new CA's algorithm label from the freshly minted cert so
     # the audit trail tracks whatever ``generate_org_ca`` actually
@@ -240,7 +259,11 @@ async def pki_rotate_ca(request: Request):
         agent_id="admin",
         action="ca.rotate",
         status="success",
-        detail=f"org_id={org_id}, new self-signed {_new_ca_algo}. All agent certs need re-issue.",
+        detail=(
+            f"org_id={org_id}, new self-signed {_new_ca_algo}, "
+            f"key persisted via kms={provider.name}. "
+            "All agent certs need re-issue."
+        ),
     )
 
     # Store in Vault if configured

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -515,5 +515,11 @@ function switchTab(name) {
     btn.classList.add('border-[#00e5c7]', 'text-white');
     btn.classList.remove('border-transparent', 'text-gray-500');
 }
+{% if new_api_token or api_token_error %}
+// The mint POST renders this page directly (DASH-2: the cleartext
+// token never rides a redirect query string) — land the operator on
+// the API Tokens tab so the one-time banner is actually visible.
+switchTab('api-tokens');
+{% endif %}
 </script>
 {% endblock %}

--- a/mcp_proxy/dashboard/users_routes.py
+++ b/mcp_proxy/dashboard/users_routes.py
@@ -535,13 +535,25 @@ async def users_create(request: Request):
     )
 
 
-@router.get("/users/{principal_id:path}", response_class=HTMLResponse)
-async def user_detail_page(principal_id: str, request: Request):
-    """Per-user detail: Mastio attribution + Frontdesk credential state + audit."""
-    session = require_login(request)
-    if isinstance(session, RedirectResponse):
-        return session
+async def render_user_detail(
+    request: Request,
+    session,
+    principal_id: str,
+    *,
+    action_message: str | None = None,
+    error: str | None = None,
+    new_api_token: str | None = None,
+    new_api_token_label: str | None = None,
+    api_token_error: str | None = None,
+):
+    """Build + render the user detail page.
 
+    Shared by the GET route below and by the API-token mint POST in
+    :mod:`mcp_proxy.dashboard.api_tokens`: the freshly minted ``culk_``
+    cleartext is rendered directly in the POST response body (DASH-2,
+    blind-spot audit 2026-06-10) instead of riding a ``?new_token=``
+    redirect through nginx access logs / browser history / Referer.
+    """
     users, fd_enabled = await _build_user_view()
     user = next(
         (u for u in users if u.get("principal_id") == principal_id),
@@ -579,31 +591,16 @@ async def user_detail_page(principal_id: str, request: Request):
     except Exception:
         org_id, trust_domain = "", "cullis.local"
 
-    # ADR-034 follow-up, passwords are admin-input now, not
-    # server-generated. The Wave B G2 ticket store + ``?new_pw_ticket``
-    # / ``?reset_pw_ticket`` redirect params are removed: the admin
-    # already knows the password (they typed it in the form), so
-    # there is nothing to surface back on this page. Any stale URL
-    # with the legacy params is silently ignored, the bookmark
-    # rendered nothing useful anyway because the ticket store would
-    # have popped on first read.
-    action_message = request.query_params.get("ok")
-    error = request.query_params.get("error")
-
-    # ADR-027, show this user's API tokens inline + render the
-    # one-time cleartext banner when ``?new_token=`` is set (the mint
-    # POST redirects back here with the freshly-minted token in the
-    # URL exactly once; if the operator reloads the page, the query
-    # param is gone and the banner does not re-render).
+    # ADR-027, show this user's API tokens inline. The one-time
+    # cleartext banner renders only when the mint POST passes
+    # ``new_api_token`` directly into this helper — never from a
+    # query param (DASH-2).
     api_tokens: list[dict] = []
     try:
         from mcp_proxy.db import list_user_api_tokens
         api_tokens = await list_user_api_tokens(principal_id)
     except Exception as exc:  # noqa: BLE001
         _log.warning("user_detail_page: api_tokens query failed: %s", exc)
-    new_api_token = request.query_params.get("new_token")
-    new_api_token_label = request.query_params.get("new_token_label")
-    api_token_error = request.query_params.get("token_error")
 
     return templates.TemplateResponse("user_detail.html", _ctx(
         request, session,
@@ -620,6 +617,30 @@ async def user_detail_page(principal_id: str, request: Request):
         new_api_token_label=new_api_token_label,
         api_token_error=api_token_error,
     ))
+
+
+@router.get("/users/{principal_id:path}", response_class=HTMLResponse)
+async def user_detail_page(principal_id: str, request: Request):
+    """Per-user detail: Mastio attribution + Frontdesk credential state + audit.
+
+    ADR-034 follow-up, passwords are admin-input now, not
+    server-generated. The Wave B G2 ticket store + ``?new_pw_ticket``
+    / ``?reset_pw_ticket`` redirect params are removed: the admin
+    already knows the password (they typed it in the form), so there
+    is nothing to surface back on this page. The legacy ``?new_token=``
+    param is likewise gone (DASH-2) — the mint POST renders the banner
+    in its own response body; stale URLs carrying it are ignored.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    return await render_user_detail(
+        request, session, principal_id,
+        action_message=request.query_params.get("ok"),
+        error=request.query_params.get("error"),
+        api_token_error=request.query_params.get("token_error"),
+    )
 
 
 _CAPABILITY_RE = __import__("re").compile(r"^[a-z_][a-z0-9_.]{0,63}$")

--- a/test/unit/test_dashboard_secret_exposure.py
+++ b/test/unit/test_dashboard_secret_exposure.py
@@ -1,0 +1,219 @@
+"""Dashboard secret-exposure fixes — blind-spot audit 2026-06-10.
+
+DASH-1: ``POST /proxy/pki/rotate-ca`` must route the freshly minted Org
+Root CA private key through the KMS provider (Fernet at-rest in
+``pki_key_store`` when the master key is configured) instead of a
+plaintext ``proxy_config`` upsert — a ``pg_dump`` between rotation and
+the next boot-time legacy wipe would otherwise capture the root key
+forever. Only the public cert may stay in ``proxy_config`` (the legacy
+``/pki/ca.crt`` readers consume it).
+
+DASH-2: the API-token mint POST must render the one-time ``culk_``
+cleartext banner directly in its response body, never as a
+``?new_token=`` redirect query param (nginx access logs ship to the
+SIEM, plus browser history and Referer). The GET page must ignore the
+legacy query param entirely.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from starlette.datastructures import QueryParams
+from starlette.responses import RedirectResponse, Response
+
+from mcp_proxy.db import dispose_db, get_config, init_db, set_config
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_AUDIT_CHAIN_DISABLED", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+class _Req:
+    """Minimal request stand-in; every auth/CSRF consumer is patched."""
+
+    def __init__(self, query: str = ""):
+        self.query_params = QueryParams(query)
+
+
+def _patch_dashboard_auth(monkeypatch, module):
+    """Bypass the cookie-session + CSRF gates of a dashboard module."""
+    session = object()
+    monkeypatch.setattr(module, "require_login", lambda request: session)
+
+    async def _csrf_ok(request, sess):
+        return True
+
+    monkeypatch.setattr(module, "verify_csrf", _csrf_ok)
+    return session
+
+
+# ── DASH-1: rotate-ca through the KMS provider ───────────────────────
+
+
+@pytest_asyncio.fixture
+async def rotate_env(fresh_db, monkeypatch):
+    """Org configured + approval hook bypassed + fresh KMS resolution."""
+    import mcp_proxy.dashboard.pki_routes as pki_routes
+    from mcp_proxy.kms.factory import reset_kms_provider
+
+    await set_config("org_id", "testorg0123456789")
+    _patch_dashboard_auth(monkeypatch, pki_routes)
+
+    async def _no_intercept(**kwargs):
+        return None
+
+    monkeypatch.setattr(
+        pki_routes, "maybe_intercept_for_approval", _no_intercept,
+    )
+    reset_kms_provider()
+    try:
+        yield pki_routes
+    finally:
+        reset_kms_provider()
+
+
+async def test_rotate_ca_encrypted_store_no_plaintext_key(
+    rotate_env, monkeypatch,
+):
+    """With the at-rest master key set, the rotated private key lands
+    Fernet-encrypted in ``pki_key_store`` and any stale plaintext
+    ``org_ca_key`` row is dropped; ``proxy_config`` keeps only the cert."""
+    monkeypatch.setenv("MCP_PROXY_DB_ENCRYPTION_KEY", "test-rotate-master-key")
+    # Simulate a pre-hardening deploy that still carries a plaintext row.
+    await set_config("org_ca_key", "-----BEGIN EC PRIVATE KEY-----stale")
+    await set_config("org_ca_cert", "-----BEGIN CERTIFICATE-----stale")
+
+    resp = await rotate_env.pki_rotate_ca(_Req())
+    assert isinstance(resp, RedirectResponse)
+    assert resp.headers["location"] == "/proxy/pki"
+
+    assert await get_config("org_ca_key") is None, (
+        "private key must never sit in plaintext proxy_config after rotate"
+    )
+    new_cert = await get_config("org_ca_cert")
+    assert new_cert and "stale" not in new_cert
+    assert "BEGIN CERTIFICATE" in new_cert
+
+    from mcp_proxy.db import get_active_pki_key
+    from mcp_proxy.kms.pki_at_rest import decrypt_pki_payload
+
+    row = await get_active_pki_key("org_ca")
+    assert row is not None, "rotated key must land in pki_key_store"
+    key_pem, cert_pem = decrypt_pki_payload(row["ciphertext"])
+    assert "PRIVATE KEY" in key_pem and "stale" not in key_pem
+    assert cert_pem == new_cert
+
+
+async def test_rotate_ca_dev_fallback_unchanged(rotate_env, monkeypatch):
+    """Without the master key (dev/test only) the provider keeps the
+    legacy plaintext rows so the next boot still finds the pair."""
+    monkeypatch.delenv("MCP_PROXY_DB_ENCRYPTION_KEY", raising=False)
+
+    resp = await rotate_env.pki_rotate_ca(_Req())
+    assert isinstance(resp, RedirectResponse)
+
+    key_pem = await get_config("org_ca_key")
+    cert_pem = await get_config("org_ca_cert")
+    assert key_pem and "PRIVATE KEY" in key_pem
+    assert cert_pem and "BEGIN CERTIFICATE" in cert_pem
+
+
+# ── DASH-2: mint renders the token in the body, never in the URL ─────
+
+
+async def test_mint_renders_token_in_response_body_not_redirect(
+    fresh_db, monkeypatch,
+):
+    import mcp_proxy.dashboard.api_tokens as api_tokens
+    import mcp_proxy.dashboard.users_routes as users_routes
+
+    from _token_test_helpers import seed_default_test_principals
+    await seed_default_test_principals()
+
+    _patch_dashboard_auth(monkeypatch, api_tokens)
+
+    captured: dict = {}
+    sentinel = Response(content="rendered", media_type="text/html")
+
+    async def _fake_render(request, session, principal_id, **kwargs):
+        captured["principal_id"] = principal_id
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(users_routes, "render_user_detail", _fake_render)
+
+    resp = await api_tokens.create_api_token(
+        "acme::user::alice", _Req(), label="ci-token",
+        expires_at="", never_expires="on", scope_providers=None,
+    )
+
+    assert resp is sentinel, (
+        "success path must render the page, not redirect with the token"
+    )
+    assert captured["principal_id"] == "acme::user::alice"
+    assert captured["new_api_token"].startswith("culk_")
+    assert captured["new_api_token_label"] == "ci-token"
+
+
+async def test_mint_error_paths_still_redirect_without_secrets(
+    fresh_db, monkeypatch,
+):
+    import mcp_proxy.dashboard.api_tokens as api_tokens
+
+    _patch_dashboard_auth(monkeypatch, api_tokens)
+
+    resp = await api_tokens.create_api_token(
+        "acme::user::alice", _Req(), label="",
+        expires_at="", never_expires="", scope_providers=None,
+    )
+    assert isinstance(resp, RedirectResponse)
+    assert "token_error" in resp.headers["location"]
+    assert "culk_" not in resp.headers["location"]
+
+
+async def test_user_detail_get_ignores_legacy_new_token_param(
+    fresh_db, monkeypatch,
+):
+    import mcp_proxy.dashboard.users_routes as users_routes
+
+    monkeypatch.setattr(
+        users_routes, "require_login", lambda request: object(),
+    )
+
+    async def _fake_view():
+        return [{"principal_id": "acme::user::alice", "user_name": "alice"}], False
+
+    monkeypatch.setattr(users_routes, "_build_user_view", _fake_view)
+    monkeypatch.setattr(
+        users_routes, "_ctx", lambda request, session, **kw: kw,
+    )
+    monkeypatch.setattr(
+        users_routes.templates, "TemplateResponse", lambda name, ctx: ctx,
+    )
+
+    ctx = await users_routes.user_detail_page(
+        "acme::user::alice",
+        _Req("new_token=culk_leaked&new_token_label=x"),
+    )
+
+    assert ctx["new_api_token"] is None, (
+        "a stale bookmarked ?new_token= URL must not re-render the banner"
+    )
+    assert ctx["new_api_token_label"] is None


### PR DESCRIPTION
Primi due fix del blind-spot audit 2026-06-10 (`imp/code-audit-blindspots-2026-06-10.md`, P1).

## DASH-1 — rotate-ca scriveva la Org Root CA key in chiaro in proxy_config

`POST /proxy/pki/rotate-ca` faceva `set_config("org_ca_key", key_pem)` (upsert raw, nessuna cifratura) bypassando il KMS che il mint path steady-state (`AgentManager._persist_org_ca`) usa già. Un `pg_dump` tra la rotazione e il wipe al boot successivo catturava la root key per sempre → mint arbitrario di leaf cert = impersonificazione fleet.

Ora la route:
- persiste la chiave via `get_kms_provider().store_org_ca()` (Fernet at-rest in `pki_key_store`, o Vault) — stesso path del mint;
- tiene in `proxy_config` solo il cert pubblico (i reader legacy `/pki/ca.crt` / connector-bootstrap lo consumano);
- nel path cifrato cancella l'eventuale `org_ca_key` plaintext stale, così il legacy wipe al boot non vede mai una coppia mismatched (chiave vecchia + cert nuovo);
- il fallback dev senza master key resta nel provider, col suo warning (invariato, `validate_config` lo rifiuta in production);
- l'audit row `ca.rotate` ora registra anche il provider KMS usato.

Il blocco legacy "Store in Vault if configured" (vault_addr/token da dashboard) è lasciato invariato, fuori scope.

## DASH-2 — token culk_ in chiaro nella query string del redirect

Il mint POST faceva 303 con `?new_token=culk_...` → access log nginx (spediti al SIEM, trust tier più basso dell'admin), history browser, Referer.

Il report suggeriva di riusare il ticket single-consume di `users_provision_to_frontdesk`, ma quel pattern è stato RIMOSSO (ticket store process-local rotto sotto multi-worker, F0.1) — i flussi password oggi usano admin-typed input, non applicabile a un token server-generated. Soluzione: il POST renderizza la pagina utente direttamente nella propria risposta col banner one-time nel body — zero URL, zero storage condiviso, multi-worker safe by construction.

- estratta `render_user_detail()` condivisa tra GET e mint POST;
- il GET ignora il param legacy `?new_token=` (un bookmark stale non ri-renderizza il banner);
- il template auto-apre il tab API Tokens quando il banner è presente (prima restava nascosto dietro un click);
- niente PRG sul success path, deliberato: refresh → il browser avvisa del re-submit, al peggio un secondo token revocabile e audit-loggato. Gli error path restano redirect con messaggi generici.

## Test

`test/unit/test_dashboard_secret_exposure.py` (5 nuovi): rotate con master key → niente plaintext + row Fernet decrittabile + stale row cancellata; fallback dev invariato; mint → render con token nel body, mai redirect; error path senza segreti; GET ignora il param legacy.

Suite completa: 1710 passed, 8 skipped. Ruff pulito.
