### PR TITLE
fix(egress): budget hardening — honest stream accounting, admission reservation, seed-safe counter

### DIFF
--- a/mcp_proxy/egress/adapters/anthropic.py
+++ b/mcp_proxy/egress/adapters/anthropic.py
@@ -873,12 +873,18 @@ class AnthropicAdapter:
                             yield chunk
                 # Final OpenAI chunk with finish_reason + usage.
                 final_chunk = acc.build_final_chunk()
-                dispatch_obj.prompt_tokens = acc.prompt_tokens
-                dispatch_obj.completion_tokens = acc.completion_tokens
                 yield final_chunk
             except Exception as exc:
                 raise _map_anthropic_exception(exc, model=request_model) from exc
             finally:
+                # Copy the accumulator's incremental counts here, not
+                # only after a full drain (EG-1): Anthropic reports
+                # input_tokens on message_start and cumulative
+                # output_tokens on every message_delta, so on a client
+                # disconnect the router still sees the real partial
+                # usage instead of 0/0.
+                dispatch_obj.prompt_tokens = acc.prompt_tokens
+                dispatch_obj.completion_tokens = acc.completion_tokens
                 dispatch_obj.latency_ms = int(
                     (time.perf_counter() - dispatch_obj.started_at) * 1000
                 )

--- a/mcp_proxy/egress/adapters/ollama.py
+++ b/mcp_proxy/egress/adapters/ollama.py
@@ -725,8 +725,6 @@ class OllamaAdapter:
                         for chunk in acc.on_chunk(parsed):
                             yield chunk
                 # Final OpenAI chunk with finish_reason + usage.
-                dispatch_obj.prompt_tokens = acc.prompt_tokens
-                dispatch_obj.completion_tokens = acc.completion_tokens
                 yield acc.build_final_chunk()
             except GatewayError:
                 raise
@@ -735,6 +733,14 @@ class OllamaAdapter:
             except httpx.HTTPError as exc:
                 raise GatewayError(502, "provider_unreachable", detail=str(exc)) from exc
             finally:
+                # Copy the accumulator counts here, not only after a
+                # full drain (EG-1): Ollama reports prompt_eval_count /
+                # eval_count on its final ``done`` line, so a partial
+                # drain usually leaves these at 0 and the router falls
+                # back to its char-count estimate — but whatever the
+                # accumulator did capture still reaches the audit row.
+                dispatch_obj.prompt_tokens = acc.prompt_tokens
+                dispatch_obj.completion_tokens = acc.completion_tokens
                 dispatch_obj.latency_ms = int(
                     (time.perf_counter() - dispatch_obj.started_at) * 1000
                 )

--- a/mcp_proxy/egress/budget.py
+++ b/mcp_proxy/egress/budget.py
@@ -7,10 +7,12 @@ day and month — the budget an org sets per agent.
 
 The source of truth is the audit chain. On a cold key the counter is
 seeded from the chain's token sum for the current period
-(``sum_principal_tokens_since``), then advanced by ``INCRBY`` per call. A
-counter lost to a restart is rebuilt from the same signed rows an auditor
-re-derives — the number that blocks a call is always chain-derivable,
-never a free-floating tally.
+(``sum_principal_tokens_since``), then adjusted per call: an optimistic
+reservation at admission (EG-2) settled to actual usage at end of
+request. The write path never creates a key (EG-3) — only the seed path
+may, via ``SET NX`` — so a counter lost to a restart is always rebuilt
+from the same signed rows an auditor re-derives; the number that blocks
+a call is chain-derivable, never a free-floating tally.
 
 Backends:
   * Redis (shared across workers) — ``INCRBY`` + ``EXPIRE`` on a
@@ -96,16 +98,31 @@ class _PeriodBudgetCounter:
         return day, month
 
     async def add(self, agent_id: str, amount: int, now: datetime) -> None:
-        """Advance both period counters by ``amount`` (no-op when <= 0).
-
-        Callers MUST have run :meth:`current` first (the enforcement check),
-        which seeds the key from the chain — so ``add`` never creates an
-        un-seeded key that a later :meth:`current` would trust as complete.
-        """
+        """Advance both period counters by ``amount`` (no-op when <= 0)."""
         if amount <= 0:
             return
-        await self._add(_day_key(agent_id, now), amount, _DAY_TTL)
-        await self._add(_month_key(agent_id, now), amount, _MONTH_TTL)
+        await self.add_delta(agent_id, amount, now)
+
+    async def add_delta(self, agent_id: str, delta: int, now: datetime) -> None:
+        """Adjust both period counters by ``delta``.
+
+        Positive = spend (or an optimistic reservation, EG-2); negative =
+        refund of the unused part of a reservation. The counter is clamped
+        at 0 so a refund racing a chain re-seed can never drive it negative.
+
+        Callers MUST have run :meth:`current` first (the enforcement check),
+        which seeds the key from the chain. The write path enforces that
+        contract instead of trusting it (EG-3): the adjustment only lands on
+        a key that already exists, so a cold key can only ever be created by
+        the seed path. Pre-fix, an ``INCRBY`` racing a seeder created the
+        key with just this call's tokens and the ``SET NX`` seed lost — the
+        whole chain-derived period sum silently vanished until the next
+        period rollover.
+        """
+        if delta == 0:
+            return
+        await self._apply_delta(_day_key(agent_id, now), delta, _DAY_TTL)
+        await self._apply_delta(_month_key(agent_id, now), delta, _MONTH_TTL)
 
     async def _get(
         self, agent_id: str, key: str, period_start_iso: str, ttl: int
@@ -139,21 +156,41 @@ class _PeriodBudgetCounter:
             self._seeded.add(key)
         return self._mem.get(key, 0)
 
-    async def _add(self, key: str, amount: int, ttl: int) -> None:
+    # EXISTS-gated adjustment (EG-3): never creates the key — only the
+    # seed path in ``_get`` may, via SET NX — and clamps at 0 so a
+    # negative refund delta cannot underflow the period sum. When the key
+    # is missing the delta is dropped: the next ``current`` re-seeds from
+    # the chain, whose audit row already carries these tokens.
+    _DELTA_LUA = """
+    if redis.call('EXISTS', KEYS[1]) == 0 then return -1 end
+    local v = redis.call('INCRBY', KEYS[1], ARGV[1])
+    if v < 0 then
+        redis.call('SET', KEYS[1], 0)
+        v = 0
+    end
+    redis.call('EXPIRE', KEYS[1], ARGV[2])
+    return v
+    """
+
+    async def _apply_delta(self, key: str, delta: int, ttl: int) -> None:
         from mcp_proxy.redis.pool import get_redis
 
         redis = get_redis()
         if redis is not None:
             try:
-                await redis.incrby(key, int(amount))
-                await redis.expire(key, ttl)
+                await redis.eval(self._DELTA_LUA, 1, key, int(delta), ttl)
             except Exception as exc:  # fail-open
                 _log.warning(
-                    "budget counter Redis incr failed (%s) — skipped: %s", key, exc
+                    "budget counter Redis adjust failed (%s) — skipped: %s", key, exc
                 )
             return
-        self._mem[key] = self._mem.get(key, 0) + int(amount)
-        self._seeded.add(key)
+        # In-memory fallback mirrors the same contract: only adjust a key
+        # the seed path created (pre-fix this write marked the key as
+        # seeded, so a later ``current`` trusted a tally that had skipped
+        # the chain seed — the same lost-sum bug as the Redis race).
+        if key not in self._seeded:
+            return
+        self._mem[key] = max(0, self._mem.get(key, 0) + int(delta))
 
 
 _counter: _PeriodBudgetCounter | None = None

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -58,6 +58,43 @@ def _token_bucket_key(agent: InternalAgent) -> str:
     return f"principal:{agent.agent_id}:llm_tokens"
 
 
+# Rough chars-per-token divisor for the estimation fallback (EG-1). The
+# point is denying budget evasion, not billing-grade accounting: an
+# adapter that only learns usage at full drain reports 0 on a truncated
+# stream, so we charge an estimate derived from what actually crossed
+# the wire instead of letting the call ride for free.
+_CHARS_PER_TOKEN = 4
+# Completion-side reservation when the caller did not set ``max_tokens``
+# (EG-2). Deliberately a constant, not a setting: it only bounds the
+# concurrent-admission overshoot window and is settled against the real
+# usage at end of request.
+_DEFAULT_COMPLETION_RESERVE = 1024
+
+
+def _estimate_prompt_tokens(req: ChatCompletionRequest) -> int:
+    """Char-count estimate of the prompt size (EG-1 fallback)."""
+    chars = 0
+    for msg in req.messages:
+        content = msg.content
+        if isinstance(content, str):
+            chars += len(content)
+        elif content:
+            try:
+                chars += len(json.dumps(content, default=str))
+            except (TypeError, ValueError):
+                pass
+    return max(1, chars // _CHARS_PER_TOKEN)
+
+
+def _reservation_tokens(req: ChatCompletionRequest) -> int:
+    """Optimistic admission reservation (EG-2): estimated prompt +
+    requested (or default) completion ceiling. Settled to actual usage
+    when the request finishes, so over-reservation self-corrects."""
+    return _estimate_prompt_tokens(req) + int(
+        req.max_tokens or _DEFAULT_COMPLETION_RESERVE
+    )
+
+
 def _gateway_error_detail(exc: GatewayError, trace_id: str) -> dict:
     """Build the JSON error body for a caught :class:`GatewayError`.
 
@@ -193,6 +230,7 @@ async def chat_completions(
     # running total is a Redis counter seeded from the audit chain.
     budget_day, budget_month = await effective_budget(agent.agent_id, settings)
     budget_enforced = budget_day > 0 or budget_month > 0
+    reserve_tokens = 0
     if budget_enforced:
         now = datetime.now(timezone.utc)
         used_day, used_month = await get_budget_counter().current(agent.agent_id, now)
@@ -231,11 +269,21 @@ async def chat_completions(
                     "budget_tokens_per_month": budget_month,
                 },
             )
+        # EG-2 — optimistic reservation. The admission check above is
+        # read-only, so N concurrent requests at 95% of the ceiling all
+        # used to pass and overshoot it together. Charging an estimate
+        # up-front makes concurrent admissions see each other; the
+        # reservation is settled against actual usage (refund or top-up)
+        # in every terminal path below.
+        reserve_tokens = _reservation_tokens(req)
+        await get_budget_counter().add_delta(
+            agent.agent_id, reserve_tokens, now,
+        )
 
     if req.stream:
         return await _handle_stream(
             req=req, agent=agent, settings=settings, trace_id=trace_id,
-            enforce_budget=budget_enforced,
+            enforce_budget=budget_enforced, reserve_tokens=reserve_tokens,
         )
 
     started = time.perf_counter()
@@ -249,6 +297,13 @@ async def chat_completions(
             settings=settings,
         )
     except GatewayError as exc:
+        if budget_enforced:
+            # Refund the EG-2 reservation in full: a pre-response
+            # gateway failure (bad model id, provider auth, timeout
+            # before first byte) consumed nothing chargeable.
+            await get_budget_counter().add_delta(
+                agent.agent_id, -reserve_tokens, datetime.now(timezone.utc),
+            )
         await log_audit(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
@@ -278,8 +333,9 @@ async def chat_completions(
     if settings.llm_tokens_per_minute > 0:
         await get_token_sum_limiter().consume(_token_bucket_key(agent), weight)
     if budget_enforced:
-        await get_budget_counter().add(
-            agent.agent_id, weight, datetime.now(timezone.utc),
+        # Settle the EG-2 reservation against actual usage.
+        await get_budget_counter().add_delta(
+            agent.agent_id, weight - reserve_tokens, datetime.now(timezone.utc),
         )
 
     await log_audit(
@@ -319,6 +375,7 @@ async def _handle_stream(
     settings,
     trace_id: str,
     enforce_budget: bool = False,
+    reserve_tokens: int = 0,
 ) -> StreamingResponse:
     """Open the upstream stream and fan it out as Server-Sent Events.
 
@@ -328,6 +385,16 @@ async def _handle_stream(
     disconnect). The ``data: [DONE]`` sentinel is appended only on the
     happy path; on upstream error we emit a single ``data: {"error":...}``
     frame so OpenAI-shaped clients see a terminal event.
+
+    Terminal accounting (EG-1): a client disconnect used to land in the
+    success branch with the adapter's drain-time token counts still at
+    0 — no budget charge and a ``success`` audit row claiming 0/0
+    tokens, i.e. indefinite evasion of the #1074 ceiling plus a chain
+    that under-reports real spend (and poisons the seed-from-chain
+    rebuild). Now the stream tracks whether the upstream actually
+    drained; a partial drain settles the budget from the adapter's
+    incremental counts (or a char-count estimate of what crossed the
+    wire) and writes an honest ``truncated`` row instead of ``success``.
     """
     try:
         streamer: StreamingDispatch = await dispatch_stream(
@@ -338,6 +405,11 @@ async def _handle_stream(
             settings=settings,
         )
     except GatewayError as exc:
+        if enforce_budget:
+            # Refund the EG-2 reservation: the stream never opened.
+            await get_budget_counter().add_delta(
+                agent.agent_id, -reserve_tokens, datetime.now(timezone.utc),
+            )
         await log_audit(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
@@ -409,6 +481,13 @@ async def _handle_stream(
 
     async def sse():
         terminated_with_error: GatewayError | None = None
+        # EG-1 bookkeeping: ``upstream_drained`` flips once the adapter's
+        # iterator is exhausted (the only point where drain-time usage
+        # counts are trustworthy); ``observed_completion_chars`` counts
+        # the delta text that actually crossed the wire, feeding the
+        # estimation fallback when the adapter reported nothing.
+        upstream_drained = False
+        observed_completion_chars = 0
         try:
             async for chunk in streamer.aiter():
                 # Inject the trace id on every chunk so a downstream
@@ -426,6 +505,9 @@ async def _handle_stream(
                     if choices:
                         choice0 = choices[0]
                         delta = choice0.get("delta") or {}
+                        content_piece = delta.get("content")
+                        if isinstance(content_piece, str):
+                            observed_completion_chars += len(content_piece)
                         tc_list = delta.get("tool_calls") or []
                         for tc in tc_list:
                             idx = tc.get("index", 0)
@@ -464,6 +546,11 @@ async def _handle_stream(
 
                 yield f"data: {json.dumps(chunk)}\n\n"
 
+            # The upstream iterator is exhausted — drain-time usage on
+            # ``streamer`` is now authoritative. A disconnect on the
+            # trailing frames below still counts as drained.
+            upstream_drained = True
+
             # Trailing summary event the SPA uses to populate the
             # audit panel ("3 tools called in 470ms"). Shape mirrors
             # the mock ambassador (frontend/cullis-chat/mock/ambassador.mjs).
@@ -494,7 +581,54 @@ async def _handle_stream(
             }
             yield f"data: {json.dumps(err_frame)}\n\n"
         finally:
-            if terminated_with_error is not None:
+            # EG-1 settlement — runs on every terminal path: full drain,
+            # upstream error mid-stream, client disconnect (GeneratorExit
+            # reaches this block when Starlette closes the generator).
+            prompt_tokens = int(streamer.prompt_tokens)
+            completion_tokens = int(streamer.completion_tokens)
+            tokens_estimated = False
+            errored = terminated_with_error is not None
+            if not upstream_drained:
+                # Most adapters only learn usage at full drain, so a cut
+                # stream under-reports (often 0/0; Anthropic knows the
+                # prompt from message_start but never sees the final
+                # message_delta). Estimate each missing component from
+                # what provably went through: the full prompt (the
+                # provider processed it) and the delta text observed
+                # before the cut. A gateway error before the first
+                # observed byte is the one case left unestimated — that
+                # request consumed nothing chargeable, same policy as
+                # the pre-stream error path.
+                observed_anything = (
+                    prompt_tokens + completion_tokens > 0
+                    or observed_completion_chars > 0
+                )
+                if observed_anything or not errored:
+                    if prompt_tokens == 0:
+                        prompt_tokens = _estimate_prompt_tokens(req)
+                        tokens_estimated = True
+                    if completion_tokens == 0 and observed_completion_chars > 0:
+                        completion_tokens = (
+                            observed_completion_chars // _CHARS_PER_TOKEN
+                        )
+                        tokens_estimated = True
+            weight = prompt_tokens + completion_tokens
+
+            if settings.llm_tokens_per_minute > 0 and weight > 0:
+                await get_token_sum_limiter().consume(
+                    _token_bucket_key(agent), weight,
+                )
+            if enforce_budget:
+                # Settle the EG-2 reservation against what the stream
+                # actually consumed (refund or top-up). Pre-fix the
+                # error path never charged at all and the disconnect
+                # path charged 0 — both indefinite cap-evasion vectors.
+                await get_budget_counter().add_delta(
+                    agent.agent_id, weight - reserve_tokens,
+                    datetime.now(timezone.utc),
+                )
+
+            if errored:
                 await log_audit(
                     agent_id=agent.agent_id,
                     action="egress_llm_chat",
@@ -510,50 +644,50 @@ async def _handle_stream(
                         "reason": terminated_with_error.reason,
                         "upstream_detail": terminated_with_error.detail,
                         "stream": True,
-                        "prompt_tokens": streamer.prompt_tokens,
-                        "completion_tokens": streamer.completion_tokens,
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "tokens_estimated": tokens_estimated,
                     },
                 )
             else:
-                weight = (
-                    int(streamer.prompt_tokens)
-                    + int(streamer.completion_tokens)
-                )
-                if settings.llm_tokens_per_minute > 0 and weight > 0:
-                    await get_token_sum_limiter().consume(
-                        _token_bucket_key(agent), weight,
-                    )
-                if enforce_budget and weight > 0:
-                    await get_budget_counter().add(
-                        agent.agent_id, weight, datetime.now(timezone.utc),
-                    )
+                # Honest status (EG-1): ``success`` means the upstream
+                # stream drained; a client disconnect mid-stream is
+                # ``truncated``. The chain consumers
+                # (sum_principal_tokens_since, aggregate_llm_usage)
+                # filter on action only, so truncated rows keep feeding
+                # the budget seed and the usage dashboard.
+                status = "success" if upstream_drained else "truncated"
+                details = {
+                    "event": "llm.chat_completion",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "backend": streamer.backend,
+                    "provider": streamer.provider,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "upstream_request_id": streamer.upstream_request_id,
+                    "latency_ms": streamer.latency_ms,
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "cost_usd": streamer.cost_usd,
+                    "cache_hit": False,
+                    "stream": True,
+                }
+                if status == "truncated":
+                    details["reason"] = "stream_not_drained"
+                    details["tokens_estimated"] = tokens_estimated
                 await log_audit(
                     agent_id=agent.agent_id,
                     action="egress_llm_chat",
-                    status="success",
+                    status=status,
                     duration_ms=float(streamer.latency_ms),
-                    details={
-                        "event": "llm.chat_completion",
-                        "principal_id": agent.agent_id,
-                        "principal_type": agent.principal_type,
-                        "backend": streamer.backend,
-                        "provider": streamer.provider,
-                        "model": req.model,
-                        "trace_id": trace_id,
-                        "upstream_request_id": streamer.upstream_request_id,
-                        "latency_ms": streamer.latency_ms,
-                        "prompt_tokens": streamer.prompt_tokens,
-                        "completion_tokens": streamer.completion_tokens,
-                        "cost_usd": streamer.cost_usd,
-                        "cache_hit": False,
-                        "stream": True,
-                    },
+                    details=details,
                 )
                 logger.info(
                     "egress_llm_chat (stream) agent=%s backend=%s model=%s "
-                    "latency_ms=%d trace_id=%s",
+                    "status=%s latency_ms=%d trace_id=%s",
                     agent.agent_id, streamer.backend, req.model,
-                    streamer.latency_ms, trace_id,
+                    status, streamer.latency_ms, trace_id,
                 )
 
     return StreamingResponse(

--- a/test/unit/test_egress_budget_hardening.py
+++ b/test/unit/test_egress_budget_hardening.py
@@ -1,0 +1,487 @@
+"""Budget hardening — EG-1 / EG-2 / EG-3 from the 2026-06-10 blind-spot audit.
+
+EG-1: a client disconnect on ``/v1/chat/completions`` (stream) used to
+land in the success branch with the adapter's drain-time token counts
+still 0/0 — no budget charge and a ``success`` audit row claiming 0
+tokens (indefinite evasion of the #1074 ceiling + falsified chain that
+also poisons the seed-from-chain rebuild). A mid-stream GatewayError
+never charged at all. Now: partial drains settle the budget from the
+adapter's incremental counts or a char-count estimate, and write an
+honest ``truncated`` (or ``error``) row.
+
+EG-2: admission was check-then-spend with no reservation, so N
+concurrent requests at 95% of the ceiling all passed. Now admission
+posts an optimistic reservation that every terminal path settles
+against actual usage.
+
+EG-3: ``add`` could *create* a cold Redis key via INCRBY, making the
+chain seed's ``SET NX`` lose — the whole period sum silently vanished.
+Now the write path only adjusts keys the seed path created (both the
+Redis Lua and the in-memory fallback enforce it), and refunds clamp
+at 0.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import (
+    dispose_db,
+    get_db,
+    init_db,
+    sum_principal_tokens_since,
+    upsert_agent_budget,
+)
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.ai_gateway import GatewayError, StreamingDispatch
+from mcp_proxy.egress.budget import get_budget_counter, reset_budget_counter
+from mcp_proxy.egress.schemas import ChatCompletionRequest
+from mcp_proxy.models import InternalAgent
+
+pytestmark = pytest.mark.asyncio
+
+AGENT_ID = "acme::alice"
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "budget-hardening.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-default")
+    monkeypatch.setenv("MCP_PROXY_DPOP_JTI_SECRET", "test-dpop-jti-secret")
+    monkeypatch.delenv("MCP_PROXY_REDIS_URL", raising=False)
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    from mcp_proxy.redis.pool import reset_redis_for_tests
+
+    reset_redis_for_tests()
+    reset_budget_counter()
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        reset_budget_counter()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+async def _insert_egress(rows: list[dict]) -> None:
+    payload = [
+        {
+            "ts": r["ts"],
+            "aid": r["aid"],
+            "act": r.get("act", "egress_llm_chat"),
+            "status": r.get("status", "success"),
+            "detail": json.dumps(r["detail"]) if r.get("detail") is not None else None,
+        }
+        for r in rows
+    ]
+    async with get_db() as db:
+        await db.execute(
+            text(
+                "INSERT INTO audit_log (timestamp, agent_id, action, status, detail) "
+                "VALUES (:ts, :aid, :act, :status, :detail)"
+            ),
+            payload,
+        )
+        await db.commit()
+
+
+async def _audit_rows(action: str, status: str) -> list[dict]:
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT agent_id, action, status, detail FROM audit_log "
+                "WHERE action = :a AND status = :s ORDER BY id ASC"
+            ),
+            {"a": action, "s": status},
+        )
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+def _agent() -> InternalAgent:
+    return InternalAgent(
+        agent_id=AGENT_ID,
+        display_name="alice",
+        capabilities=["llm.chat"],
+        created_at="2026-05-29T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-test",
+        reach="both",
+    )
+
+
+def _today(hour: int = 10) -> str:
+    return datetime.now(timezone.utc).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    ).isoformat()
+
+
+def _stream_req(content: str = "ping") -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": content}],
+        max_tokens=16,
+        stream=True,
+    )
+
+
+def _fake_streamer(chunks: list[dict], *, final_tokens: tuple[int, int] | None = None,
+                   midstream_error: GatewayError | None = None) -> StreamingDispatch:
+    """Streamer stand-in: yields ``chunks``; optionally raises mid-stream
+    or reports drain-time usage like the real adapters do."""
+    dispatch_obj = StreamingDispatch(
+        backend="cullis_native",
+        provider="anthropic",
+        model="claude-haiku-4-5",
+        trace_id="trace_test",
+    )
+
+    async def _aiter():
+        for c in chunks:
+            yield c
+        if midstream_error is not None:
+            raise midstream_error
+        if final_tokens is not None:
+            dispatch_obj.prompt_tokens, dispatch_obj.completion_tokens = final_tokens
+
+    dispatch_obj._aiter_factory = _aiter
+    return dispatch_obj
+
+
+def _content_chunk(text_piece: str) -> dict:
+    return {"choices": [{"delta": {"content": text_piece}}]}
+
+
+# ── EG-3: the write path never creates a cold key ─────────────────────
+
+
+async def test_add_delta_on_cold_key_is_dropped_not_created(proxy_db):
+    """An adjustment racing the seed must not shadow the chain sum: the
+    delta on an unseeded key is dropped and the next ``current`` seeds
+    the full chain-derived total (which already includes that call's
+    audit row)."""
+    await _insert_egress(
+        [{"ts": _today(), "aid": AGENT_ID,
+          "detail": {"provider": "anthropic", "prompt_tokens": 70, "completion_tokens": 30}}]
+    )
+    now = datetime.now(timezone.utc)
+    counter = get_budget_counter()
+
+    # Write WITHOUT the mandatory prior ``current`` — pre-fix this
+    # created the key with just 5 tokens and the 100-token chain seed
+    # was lost to SET NX.
+    await counter.add_delta(AGENT_ID, 5, now)
+
+    day, month = await counter.current(AGENT_ID, now)
+    assert day == 100, "chain seed must win over a racing increment"
+    assert month == 100
+
+
+async def test_refund_clamps_at_zero(proxy_db):
+    now = datetime.now(timezone.utc)
+    counter = get_budget_counter()
+
+    day, _ = await counter.current(AGENT_ID, now)  # seeds 0 (empty chain)
+    assert day == 0
+    await counter.add(AGENT_ID, 10, now)
+    await counter.add_delta(AGENT_ID, -50, now)
+
+    day, month = await counter.current(AGENT_ID, now)
+    assert day == 0, "an over-refund must clamp at 0, never go negative"
+    assert month == 0
+
+
+async def test_truncated_rows_feed_the_chain_seed(proxy_db):
+    """``sum_principal_tokens_since`` filters on action only — the new
+    ``truncated`` rows must keep feeding the budget seed."""
+    await _insert_egress(
+        [
+            {"ts": _today(), "aid": AGENT_ID, "status": "success",
+             "detail": {"prompt_tokens": 60, "completion_tokens": 0}},
+            {"ts": _today(11), "aid": AGENT_ID, "status": "truncated",
+             "detail": {"prompt_tokens": 30, "completion_tokens": 10, "tokens_estimated": True}},
+        ]
+    )
+    assert await sum_principal_tokens_since(AGENT_ID, None) == 100
+
+
+# ── EG-1: stream terminal accounting ──────────────────────────────────
+
+
+async def _run_stream(streamer, *, reserve_tokens: int, consume_frames: int | None):
+    """Drive ``_handle_stream``'s SSE generator; ``consume_frames=None``
+    drains it fully, an int consumes that many frames then closes the
+    generator (= client disconnect)."""
+    from mcp_proxy.config import get_settings
+
+    resp = await router_module._handle_stream(
+        req=_stream_req(),
+        agent=_agent(),
+        settings=get_settings(),
+        trace_id="trace_test",
+        enforce_budget=True,
+        reserve_tokens=reserve_tokens,
+    )
+    gen = resp.body_iterator
+    if consume_frames is None:
+        async for _ in gen:
+            pass
+        return
+    consumed = 0
+    async for _ in gen:
+        consumed += 1
+        if consumed >= consume_frames:
+            break
+    await gen.aclose()
+
+
+async def _admit(reserve: int) -> None:
+    """Simulate the admission step: seed via ``current`` + post the
+    EG-2 reservation, exactly like the route does."""
+    now = datetime.now(timezone.utc)
+    counter = get_budget_counter()
+    await counter.current(AGENT_ID, now)
+    await counter.add_delta(AGENT_ID, reserve, now)
+
+
+async def test_stream_disconnect_writes_truncated_and_charges_estimate(
+    proxy_db, monkeypatch,
+):
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    # 2 content chunks × 20 chars observed before the disconnect; the
+    # adapter (OpenAI-style) reports usage only at full drain → 0/0.
+    streamer = _fake_streamer(
+        [_content_chunk("x" * 20), _content_chunk("y" * 20), _content_chunk("z" * 20)],
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", AsyncMock(return_value=streamer),
+    )
+
+    reserve = 17  # prompt "ping" → 1 + max_tokens 16
+    await _admit(reserve)
+    await _run_stream(streamer, reserve_tokens=reserve, consume_frames=2)
+
+    truncated = await _audit_rows("egress_llm_chat", "truncated")
+    assert len(truncated) == 1, "a cut stream must not produce a success row"
+    detail = json.loads(truncated[0]["detail"])
+    assert detail["reason"] == "stream_not_drained"
+    assert detail["tokens_estimated"] is True
+    # prompt estimate ("ping" → 1) + observed 40 chars // 4 = 10.
+    assert detail["prompt_tokens"] == 1
+    assert detail["completion_tokens"] == 10
+    assert not await _audit_rows("egress_llm_chat", "success")
+
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 11, "the estimate must be charged (reservation settled)"
+
+
+async def test_stream_disconnect_with_partial_report_estimates_completion(
+    proxy_db, monkeypatch,
+):
+    """Anthropic-style: the adapter knows the prompt from message_start
+    but never sees the final message_delta on a disconnect. The reported
+    prompt must be kept and only the completion estimated."""
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    streamer = _fake_streamer(
+        [_content_chunk("x" * 20), _content_chunk("y" * 20), _content_chunk("z" * 20)],
+    )
+    streamer.prompt_tokens = 50  # incremental report (message_start)
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", AsyncMock(return_value=streamer),
+    )
+
+    reserve = 17
+    await _admit(reserve)
+    await _run_stream(streamer, reserve_tokens=reserve, consume_frames=2)
+
+    truncated = await _audit_rows("egress_llm_chat", "truncated")
+    assert len(truncated) == 1
+    detail = json.loads(truncated[0]["detail"])
+    assert detail["prompt_tokens"] == 50, "reported prompt must win over the estimate"
+    assert detail["completion_tokens"] == 10, "observed 40 chars // 4"
+    assert detail["tokens_estimated"] is True
+
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 60
+
+
+async def test_stream_full_drain_success_charges_reported(proxy_db, monkeypatch):
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    streamer = _fake_streamer(
+        [_content_chunk("hello")], final_tokens=(70, 30),
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", AsyncMock(return_value=streamer),
+    )
+
+    reserve = 17
+    await _admit(reserve)
+    await _run_stream(streamer, reserve_tokens=reserve, consume_frames=None)
+
+    success = await _audit_rows("egress_llm_chat", "success")
+    assert len(success) == 1
+    detail = json.loads(success[0]["detail"])
+    assert detail["prompt_tokens"] == 70
+    assert detail["completion_tokens"] == 30
+    assert "tokens_estimated" not in detail
+    assert not await _audit_rows("egress_llm_chat", "truncated")
+
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 100, "reported usage charged, reservation refunded"
+
+
+async def test_stream_midstream_error_charges_observed(proxy_db, monkeypatch):
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    streamer = _fake_streamer(
+        [_content_chunk("w" * 40)],
+        midstream_error=GatewayError(502, "provider_unreachable", detail="boom"),
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", AsyncMock(return_value=streamer),
+    )
+
+    reserve = 17
+    await _admit(reserve)
+    await _run_stream(streamer, reserve_tokens=reserve, consume_frames=None)
+
+    errors = await _audit_rows("egress_llm_chat", "error")
+    assert len(errors) == 1
+    detail = json.loads(errors[0]["detail"])
+    assert detail["reason"] == "provider_unreachable"
+    assert detail["tokens_estimated"] is True
+    assert detail["prompt_tokens"] == 1
+    assert detail["completion_tokens"] == 10
+
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 11, "mid-stream errors must charge what was observed"
+
+
+async def test_stream_error_before_first_byte_refunds_everything(
+    proxy_db, monkeypatch,
+):
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    streamer = _fake_streamer(
+        [], midstream_error=GatewayError(502, "provider_unreachable", detail="boom"),
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", AsyncMock(return_value=streamer),
+    )
+
+    reserve = 17
+    await _admit(reserve)
+    await _run_stream(streamer, reserve_tokens=reserve, consume_frames=None)
+
+    errors = await _audit_rows("egress_llm_chat", "error")
+    assert len(errors) == 1
+    detail = json.loads(errors[0]["detail"])
+    assert detail["prompt_tokens"] == 0
+    assert detail["completion_tokens"] == 0
+
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 0, "nothing observed → full reservation refund"
+
+
+# ── EG-2: admission reservation visible to concurrent requests ────────
+
+
+async def test_reservation_is_posted_before_dispatch(proxy_db, monkeypatch):
+    """While a request is in flight, its reservation must already count
+    against the budget a concurrent admission reads."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+    from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+
+    seen: dict = {}
+
+    async def _probe_dispatch(**kwargs):
+        day, _ = await get_budget_counter().current(
+            AGENT_ID, datetime.now(timezone.utc),
+        )
+        seen["mid_flight_day"] = day
+        # Reuse the shape helpers from the sibling budget test module.
+        from test_agent_llm_budget import _gateway_result
+
+        return _gateway_result(prompt=12, completion=3)
+
+    monkeypatch.setattr(router_module, "dispatch", _probe_dispatch)
+
+    app = FastAPI()
+    app.include_router(llm_chat_router)
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = _agent
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 16,
+            },
+        )
+
+    assert r.status_code == 200, r.text
+    # Reservation = prompt estimate ("ping" → 1) + max_tokens 16.
+    assert seen["mid_flight_day"] == 17, (
+        "a concurrent admission must see this request's reservation"
+    )
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 15, "settled to actual usage at end of request"
+
+
+async def test_nonstream_gateway_error_refunds_reservation(proxy_db, monkeypatch):
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+    from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+
+    await upsert_agent_budget(AGENT_ID, tokens_per_day=1_000_000, tokens_per_month=0)
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(side_effect=GatewayError(502, "provider_unreachable", detail="boom")),
+    )
+
+    app = FastAPI()
+    app.include_router(llm_chat_router)
+    app.dependency_overrides[get_agent_from_dpop_client_cert] = _agent
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 16,
+            },
+        )
+
+    assert r.status_code == 502
+    day, _ = await get_budget_counter().current(
+        AGENT_ID, datetime.now(timezone.utc),
+    )
+    assert day == 0, "pre-response failure must refund the full reservation"


### PR DESCRIPTION
Step 2 dei fix del blind-spot audit 2026-06-10 (`imp/code-audit-blindspots-2026-06-10.md`): hardening del budget enforcement #1074. Segue #1081 (DASH-1/DASH-2).

## EG-1 (P1) — SSE disconnect = budget mai addebitato + riga audit `success` 0/0

Tutti gli adapter popolano `prompt/completion_tokens` solo a drain completo; su disconnect il `finally` prendeva l'else-branch con weight=0 (nessun charge, riga `success` 0/0) e su `GatewayError` mid-stream l'error-branch non addebitava MAI. Aggravante: le righe 0-token avvelenavano anche `_seed_from_chain` post-restart Redis. Evasione indefinita del cap + chain che sotto-riporta lo spend reale.

Fix:
- il generatore SSE traccia `upstream_drained` (flip quando l'iteratore dell'adapter si esaurisce — l'unico punto in cui i count drain-time sono affidabili) e accumula i char dei delta `content` osservati sul wire;
- drain parziale → riga **`truncated`** (mai più `success`), con charge dai count incrementali dell'adapter o stima per-componente (`prompt` = stima dalla request: il provider l'ha processato comunque; `completion` = char osservati / 4) e flag `tokens_estimated` in audit;
- errore mid-stream → charge di quanto osservato; errore prima del primo byte → refund completo (niente di addebitabile è stato consumato, stessa policy del path pre-stream);
- adapter Anthropic/Ollama copiano i contatori dell'accumulatore nel `finally` (Anthropic riporta `input_tokens` su `message_start` e output cumulativo sui `message_delta` → su disconnect il router vede i parziali reali);
- i consumer della chain (`sum_principal_tokens_since`, `aggregate_llm_usage`) filtrano solo per action → le righe `truncated` continuano ad alimentare seed e usage dashboard (pinnato con test).

## EG-2 (P2) — check-then-spend senza reservation → overshoot concorrente

L'ammissione era read-only: N stream concorrenti al 95% del cap passavano tutti. Ora l'ammissione posta una **reservation ottimistica** (stima prompt + `max_tokens` o default 1024) che ogni path terminale salda contro l'uso reale (refund o top-up). Le ammissioni concorrenti si vedono a vicenda; l'overshoot residuo è bounded dalla finestra di reservation, non più illimitato.

## EG-3 (P3) — seed-from-chain perso se un INCRBY concorrente vince

`add()` poteva *creare* la key Redis fredda via INCRBY: il `SET NX` del seeder perdeva e il sum storico chain-derived spariva fino al rollover del periodo. Ora il write-path è EXISTS-gated (Lua su Redis, contratto speculare sul fallback in-memory, che aveva lo stesso bug): solo il seed path può creare una key; un delta su key fredda viene droppato e il `current()` successivo riseeda dalla chain (che contiene già la riga audit di quella chiamata). I refund clampano a 0.

## Test

`test/unit/test_egress_budget_hardening.py` (10 nuovi): cold-key INCRBY non maschera il seed; refund clamp; righe truncated nel seed; disconnect → truncated + stima + charge; disconnect con report parziale Anthropic-style (prompt riportato vince, completion stimata); drain completo → success + reported; errore mid-stream → charge osservato; errore pre-primo-byte → refund totale; reservation visibile mid-flight a un'ammissione concorrente; GatewayError non-stream → refund.

Suite completa: 1715 passed, 8 skipped. Ruff pulito.

Nota di validazione: la componente multi-worker/Redis reale (Lua path) è coperta a livello di contratto dagli unit sull'in-memory speculare — la conferma live va fatta nello smoke prod-shape con Redis, come per il resto della classe S-7.
