### PR TITLE
fix(dashboard): central write gate — deny mutations to non-writer roles (DASH-3)

### DIFF
--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -35,7 +35,7 @@ import time
 from dataclasses import dataclass
 
 import bcrypt
-from fastapi import Request, Response
+from fastapi import HTTPException, Request, Response
 from starlette.responses import RedirectResponse
 
 _log = logging.getLogger("mcp_proxy.dashboard")
@@ -336,11 +336,49 @@ def clear_session(response: Response) -> None:
     )
 
 
+# DASH-3 (blind-spot audit 2026-06-10) — write gate. Every mutating
+# dashboard route is a POST behind ``require_login``, but role
+# enforcement used to live only on the bundle-download route: with the
+# enterprise ``rbac_multi_admin`` plugin a *viewer* could reset an
+# admin's password, change KMS/OIDC config or apply migrations. Gating
+# centrally here (instead of per-route ``require_role`` decorations)
+# makes write-denial the default for every current and future POST
+# route — a forgotten decoration fails closed, not open. Roles beyond
+# these two stay read-only; finer admin-vs-operator splits remain
+# per-route (e.g. the bundle download's admin-only check).
+_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_WRITER_ROLES = frozenset({"admin", "operator"})
+
+
 def require_login(request: Request) -> ProxyDashboardSession | RedirectResponse:
-    """Return the session if logged in, or a redirect to /proxy/login."""
+    """Return the session if logged in, or a redirect to /proxy/login.
+
+    On write methods the session must also carry a writer role
+    (``admin`` / ``operator`` — community single-admin sessions always
+    do); a ``viewer`` (or any other plugin-minted read-only role) gets
+    a 403 instead of reaching the mutation body. Pre-session routes
+    (login / register) and logout don't call this helper, so they are
+    unaffected.
+    """
     session = get_session(request)
     if not session.logged_in:
         return RedirectResponse(url="/proxy/login", status_code=303)
+    if (
+        request.method in _WRITE_METHODS
+        and not any(r in _WRITER_ROLES for r in session.roles)
+    ):
+        _log.warning(
+            "dashboard write denied: role(s) %s on %s %s",
+            ",".join(session.roles) or "<none>",
+            request.method, request.url.path,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "role_required",
+                "allowed": sorted(_WRITER_ROLES),
+            },
+        )
     return session
 
 

--- a/test/unit/test_dashboard_rbac_write_gate.py
+++ b/test/unit/test_dashboard_rbac_write_gate.py
@@ -1,0 +1,164 @@
+"""DASH-3 (blind-spot audit 2026-06-10) — central dashboard write gate.
+
+Every mutating dashboard route goes through ``require_login``, but role
+enforcement used to exist only on the bundle-download route: with the
+enterprise ``rbac_multi_admin`` plugin a *viewer* session could reset
+an admin's password, change KMS/OIDC config or apply migrations.
+``require_login`` now denies write methods (POST/PUT/PATCH/DELETE) to
+any session without a writer role (``admin`` / ``operator``), so the
+denial is the default for every current and future mutation route —
+a forgotten per-route ``require_role`` fails closed, not open.
+
+Pinned here:
+1. viewer POST → 403 ``role_required`` before the route body runs;
+2. operator + admin POST pass the gate (admin implicit, community
+   single-admin sessions keep working unchanged);
+3. GET stays role-agnostic (viewer dashboards keep rendering);
+4. legacy single-role cookies (``roles`` filled from ``role``) pass;
+5. logged-out behaviour is unchanged (303 to /proxy/login);
+6. end-to-end: a real route (API-token mint) rejects a viewer cookie
+   with 403 and never mints.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.datastructures import URL
+from starlette.responses import RedirectResponse
+
+import mcp_proxy.dashboard.session as session_module
+from mcp_proxy.dashboard.session import ProxyDashboardSession, require_login
+
+
+class _Req:
+    def __init__(self, method: str = "POST", path: str = "/proxy/test"):
+        self.method = method
+        self.url = URL(f"http://t{path}")
+
+
+def _session(*roles: str) -> ProxyDashboardSession:
+    return ProxyDashboardSession(
+        role=roles[0] if roles else "",
+        csrf_token="tok",
+        logged_in=True,
+        roles=tuple(roles),
+    )
+
+
+def _patch_session(monkeypatch, session: ProxyDashboardSession) -> None:
+    monkeypatch.setattr(session_module, "get_session", lambda request: session)
+
+
+# ── unit: the gate itself ─────────────────────────────────────────────
+
+
+def test_viewer_post_denied_403(monkeypatch):
+    _patch_session(monkeypatch, _session("viewer"))
+    with pytest.raises(HTTPException) as exc_info:
+        require_login(_Req("POST"))
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["error"] == "role_required"
+
+
+@pytest.mark.parametrize("method", ["PUT", "PATCH", "DELETE"])
+def test_viewer_other_write_methods_denied(monkeypatch, method):
+    _patch_session(monkeypatch, _session("viewer"))
+    with pytest.raises(HTTPException):
+        require_login(_Req(method))
+
+
+def test_operator_post_passes(monkeypatch):
+    operator = _session("operator")
+    _patch_session(monkeypatch, operator)
+    assert require_login(_Req("POST")) is operator
+
+
+def test_admin_post_passes(monkeypatch):
+    admin = _session("admin")
+    _patch_session(monkeypatch, admin)
+    assert require_login(_Req("POST")) is admin
+
+
+def test_viewer_get_passes(monkeypatch):
+    """Read access stays role-agnostic — the viewer role exists to view."""
+    viewer = _session("viewer")
+    _patch_session(monkeypatch, viewer)
+    assert require_login(_Req("GET")) is viewer
+
+
+def test_legacy_single_role_cookie_passes(monkeypatch):
+    """Pre-multi-role cookies carry only ``role``; ``__post_init__``
+    fills ``roles=(role,)`` and the community admin keeps writing."""
+    legacy = ProxyDashboardSession(role="admin", csrf_token="tok", logged_in=True)
+    _patch_session(monkeypatch, legacy)
+    assert require_login(_Req("POST")) is legacy
+
+
+def test_logged_out_still_redirects(monkeypatch):
+    _patch_session(
+        monkeypatch,
+        ProxyDashboardSession(role="none", csrf_token="", logged_in=False, roles=()),
+    )
+    resp = require_login(_Req("POST"))
+    assert isinstance(resp, RedirectResponse)
+    assert resp.headers["location"] == "/proxy/login"
+
+
+def test_multi_role_with_writer_passes(monkeypatch):
+    """A plugin-minted session with (viewer, operator) carries a writer
+    role and must pass — the gate is any-of, like ``require_role``."""
+    s = _session("viewer", "operator")
+    _patch_session(monkeypatch, s)
+    assert require_login(_Req("POST")) is s
+
+
+# ── end-to-end: a real mutation route rejects a viewer cookie ─────────
+
+
+@pytest.mark.asyncio
+async def test_viewer_cookie_cannot_mint_api_token(monkeypatch, tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    from mcp_proxy.db import dispose_db, init_db
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'rbac.db'}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", "test-admin-secret-not-default")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    try:
+        from mcp_proxy.dashboard.api_tokens import router as tokens_router
+
+        app = FastAPI()
+        app.include_router(tokens_router)
+
+        # The route module imported ``require_login`` by name; patch the
+        # session resolution underneath it so the real gate runs against
+        # a viewer session.
+        _patch_session(monkeypatch, _session("viewer"))
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/proxy/users/acme::user::alice/api-tokens/create",
+                data={"label": "evil", "csrf_token": "tok"},
+            )
+
+        assert r.status_code == 403, r.text
+        assert r.json()["detail"]["error"] == "role_required"
+
+        from sqlalchemy import text
+
+        from mcp_proxy.db import get_db
+
+        async with get_db() as conn:
+            result = await conn.execute(
+                text("SELECT COUNT(*) AS n FROM user_api_tokens"),
+            )
+            assert result.scalar() == 0, "the mint body must never run"
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
Step 3 dei fix del blind-spot audit 2026-06-10 (`imp/code-audit-blindspots-2026-06-10.md`, P1 — il verifier l'aveva alzato a P1). Segue #1081 (DASH-1/2) e #1082 (EG-1/2/3).

## DASH-3 — RBAC operator/viewer mai enforced sulle mutazioni dashboard

Ogni route mutante gatava solo su `require_login` (sessione presente); `require_role`/`has_role` non erano importati da NESSUNA route (unica eccezione inline: bundle download admin-only). Col plugin enterprise `rbac_multi_admin` un **viewer** poteva fare reset-password di un admin, cambiare config KMS/OIDC, applicare migration → takeover.

## Approccio: gate centralizzato, non decorazioni per-route

Invece di decorare ~61 route POST una per una (con il rischio permanente che una route futura venga dimenticata = fail-open), il check ruolo vive dentro `require_login`: i metodi di scrittura (POST/PUT/PATCH/DELETE) richiedono un writer role (`admin`/`operator`), altrimenti 403 `role_required` prima che il body della route giri. **Una decorazione dimenticata ora fail-closed, non fail-open.**

Compatibilità verificata:
- community single-admin: le sessioni portano `admin` → nessun cambiamento;
- cookie legacy single-role: `__post_init__` riempie `roles=(role,)` → invariati (test dedicato);
- GET resta role-agnostic (il viewer esiste per vedere);
- login/register sono pre-sessione e logout usa `get_session` direttamente → mai toccati dal gate (censiti: `auth_routes.py` è l'unico modulo con POST senza `require_login`);
- il check admin-only del bundle download resta come split più fine per-route (private key = solo admin).

Distinzioni più fini admin-vs-operator per route (es. operator non tocca KMS) restano da definire con la matrice di prodotto — questo fix chiude il buco viewer→mutazione che è il takeover path.

## Test

`test/unit/test_dashboard_rbac_write_gate.py` (11): viewer 403 su POST/PUT/PATCH/DELETE; operator/admin passano; GET viewer passa; cookie legacy passa; logged-out invariato (303); multi-role any-of; e2e su route reale (mint API token con sessione viewer → 403, zero righe mintate).

Suite completa: 1716 passed, 8 skipped. Ruff pulito.
